### PR TITLE
Phase 2: reconcile observability and verified outcome metrics

### DIFF
--- a/api/_observability.js
+++ b/api/_observability.js
@@ -1,0 +1,53 @@
+import crypto from 'node:crypto';
+
+const FAILURE_CLASSES = new Set([
+  'AI','AUTH','TENANT','DATA','API','WEBHOOK','NETWORK','RATE_LIMIT','TIMEOUT',
+  'POLICY','USER_INPUT','EXTERNAL_PROVIDER','SECURITY','UNKNOWN',
+]);
+
+export function correlationId(req) {
+  const incoming = String(req?.headers?.['x-correlation-id'] || req?.headers?.['x-request-id'] || '').trim();
+  if (/^[A-Za-z0-9._:-]{8,120}$/.test(incoming)) return incoming;
+  return crypto.randomUUID();
+}
+
+export function attachCorrelation(res, id) {
+  if (id) res.setHeader('x-pilot-correlation-id', id);
+}
+
+export function classifyFailure(error, fallback = 'UNKNOWN') {
+  const status = Number(error?.statusCode || error?.status || error?.cause?.statusCode || 0);
+  const message = String(error?.message || error?.name || '').toLowerCase();
+  if (status === 401 || status === 403 || /auth|credential|unauthor/.test(message)) return 'AUTH';
+  if (status === 429 || /rate.?limit/.test(message)) return 'RATE_LIMIT';
+  if (status === 408 || status === 504 || /timeout/.test(message)) return 'TIMEOUT';
+  if (/gateway|provider|model|restrictedmodels/.test(message)) return 'EXTERNAL_PROVIDER';
+  if (/network|fetch failed|econn/.test(message)) return 'NETWORK';
+  return FAILURE_CLASSES.has(fallback) ? fallback : 'UNKNOWN';
+}
+
+export function logEvent(level, event) {
+  const safe = {
+    ts: new Date().toISOString(),
+    product: 'PILOT',
+    ...event,
+  };
+  // Never log message bodies, access tokens, refresh tokens, secrets, phone numbers or emails here.
+  const line = JSON.stringify(safe);
+  if (level === 'error') console.error(line);
+  else if (level === 'warn') console.warn(line);
+  else console.log(line);
+}
+
+export function operationalResult({ correlation_id, operation, outcome, failure_class = null, verified = false, retryable = false }) {
+  return {
+    correlation_id,
+    operation,
+    outcome,
+    failure_class: failure_class && FAILURE_CLASSES.has(failure_class) ? failure_class : null,
+    verified,
+    retryable,
+  };
+}
+
+export { FAILURE_CLASSES };

--- a/api/_observability.js
+++ b/api/_observability.js
@@ -1,7 +1,7 @@
 import crypto from 'node:crypto';
 
 const FAILURE_CLASSES = new Set([
-  'AI','AUTH','TENANT','DATA','API','WEBHOOK','NETWORK','RATE_LIMIT','TIMEOUT',
+  'AI','AUTH','AUTHORIZATION','TENANT','DATA','API','WEBHOOK','NETWORK','RATE_LIMIT','TIMEOUT',
   'POLICY','USER_INPUT','EXTERNAL_PROVIDER','SECURITY','UNKNOWN',
 ]);
 
@@ -17,12 +17,15 @@ export function attachCorrelation(res, id) {
 
 export function classifyFailure(error, fallback = 'UNKNOWN') {
   const status = Number(error?.statusCode || error?.status || error?.cause?.statusCode || 0);
-  const message = String(error?.message || error?.name || '').toLowerCase();
-  if (status === 401 || status === 403 || /auth|credential|unauthor/.test(message)) return 'AUTH';
+  const message = String(error?.message || error?.name || error?.cause?.message || '').toLowerCase();
+
+  // Provider/gateway denials can use HTTP 401/403 even when the application credential is fine.
+  // Preserve the operational root cause before applying generic HTTP auth classification.
+  if (/gateway|provider|model|restrictedmodels|no_providers_available/.test(message)) return 'EXTERNAL_PROVIDER';
   if (status === 429 || /rate.?limit/.test(message)) return 'RATE_LIMIT';
   if (status === 408 || status === 504 || /timeout/.test(message)) return 'TIMEOUT';
-  if (/gateway|provider|model|restrictedmodels/.test(message)) return 'EXTERNAL_PROVIDER';
   if (/network|fetch failed|econn/.test(message)) return 'NETWORK';
+  if (status === 401 || status === 403 || /auth|credential|unauthor/.test(message)) return 'AUTH';
   return FAILURE_CLASSES.has(fallback) ? fallback : 'UNKNOWN';
 }
 

--- a/api/pilot-whatsapp-webhook.js
+++ b/api/pilot-whatsapp-webhook.js
@@ -1,7 +1,9 @@
 import crypto from 'node:crypto';
 import { classifyClinicMessage, classifyCelebrityMessage } from './pilot-runtime.js';
+import { attachCorrelation, correlationId, logEvent } from './_observability.js';
 
-function json(res, status, body) {
+function json(res, status, body, cid) {
+  attachCorrelation(res, cid);
   return res.status(status).setHeader('cache-control', 'no-store').json(body);
 }
 
@@ -79,24 +81,70 @@ export function classifyPilotEvent(event, project = 'generic') {
 }
 
 export default async function handler(req, res) {
+  const cid = correlationId(req);
+  attachCorrelation(res, cid);
   const verifyToken = process.env.PILOT_WHATSAPP_VERIFY_TOKEN || '';
   const appSecret = process.env.PILOT_WHATSAPP_APP_SECRET || '';
   const project = String(process.env.PILOT_PROJECT || 'generic').toLowerCase();
 
   if (req.method === 'GET') {
     const result = verifyWebhookChallenge(req.query || {}, verifyToken);
-    if (!result.ok) return res.status(403).send('forbidden');
-    return res.status(200).send(result.challenge);
+    if (!result.ok) {
+      logEvent('warn', { correlation_id: cid, component: 'whatsapp_webhook', operation: 'challenge_verification', outcome: 'FAILED', failure_class: 'AUTH' });
+      return res.status(403).setHeader('x-pilot-correlation-id', cid).send('forbidden');
+    }
+    logEvent('info', { correlation_id: cid, component: 'whatsapp_webhook', operation: 'challenge_verification', outcome: 'VERIFIED_SUCCESS' });
+    return res.status(200).setHeader('x-pilot-correlation-id', cid).send(result.challenge);
   }
-  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'method_not_allowed' });
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'method_not_allowed', correlation_id: cid }, cid);
 
   const signature = verifyMetaSignature(req, appSecret);
-  if (!signature.ok) return json(res, 401, { ok: false, error: 'invalid_meta_signature', reason: signature.reason });
+  if (!signature.ok) {
+    logEvent('warn', { correlation_id: cid, component: 'whatsapp_webhook', operation: 'signature_verification', outcome: 'FAILED', failure_class: 'SECURITY', reason: signature.reason });
+    return json(res, 401, { ok: false, error: 'invalid_meta_signature', reason: signature.reason, correlation_id: cid }, cid);
+  }
 
   const payload = normalizeBody(req);
-  if (!payload || payload.object !== 'whatsapp_business_account') return json(res, 400, { ok: false, error: 'invalid_whatsapp_payload' });
+  if (!payload || payload.object !== 'whatsapp_business_account') {
+    logEvent('warn', { correlation_id: cid, component: 'whatsapp_webhook', operation: 'payload_validation', outcome: 'FAILED', failure_class: 'USER_INPUT' });
+    return json(res, 400, { ok: false, error: 'invalid_whatsapp_payload', correlation_id: cid }, cid);
+  }
 
   const events = extractWhatsAppEvents(payload);
   const routed = events.map((event) => ({ ...event, ...classifyPilotEvent(event, project) }));
-  return json(res, 200, { ok: true, service: 'pilot-whatsapp-webhook', project, event_count: routed.length, routed, persisted: false, outbound_messages_sent: false, external_side_effects: false, timestamp: new Date().toISOString() });
+  const messageCount = routed.filter(e => e.type === 'message').length;
+  const statusCount = routed.filter(e => e.type === 'status').length;
+  const classifications = [...new Set(routed.map(e => e.classification).filter(Boolean))].slice(0, 20);
+
+  // Never log or echo message text, sender/recipient IDs, phone numbers, message IDs, or raw payloads.
+  logEvent('info', {
+    correlation_id: cid,
+    component: 'whatsapp_webhook',
+    operation: 'signed_inbound_normalization',
+    outcome: 'PARTIAL',
+    project,
+    event_count: routed.length,
+    message_count: messageCount,
+    status_count: statusCount,
+    classifications,
+    persisted: false,
+    outbound_messages_sent: false,
+  });
+
+  return json(res, 200, {
+    ok: true,
+    service: 'pilot-whatsapp-webhook',
+    project,
+    state: 'CONFIGURED_NOT_OPERATIONAL',
+    signature_verified: true,
+    event_count: routed.length,
+    message_count: messageCount,
+    status_count: statusCount,
+    classifications,
+    persisted: false,
+    outbound_messages_sent: false,
+    external_side_effects: false,
+    correlation_id: cid,
+    timestamp: new Date().toISOString(),
+  }, cid);
 }

--- a/api/translate.js
+++ b/api/translate.js
@@ -1,11 +1,13 @@
 import { generateText } from 'ai';
+import { attachCorrelation, classifyFailure, correlationId, logEvent } from './_observability.js';
 
 const MODEL = process.env.PILOT_TRANSLATION_MODEL || 'openai/gpt-5.6-sol';
 const MAX_MESSAGES = 20;
 const MAX_MESSAGE_CHARS = 1500;
 const MAX_TOTAL_CHARS = 12000;
 
-function json(res, status, body) {
+function json(res, status, body, cid) {
+  attachCorrelation(res, cid);
   res.status(status).setHeader('cache-control', 'no-store').json(body);
 }
 
@@ -57,45 +59,66 @@ async function translate(messages, targetLanguage) {
   return messages.map((message) => ({ id: message.id, text: byId.get(message.id) || message.text }));
 }
 
+function recordTranslationFailure(cid, error, synthetic = false) {
+  const failureClass = classifyFailure(error, 'AI');
+  logEvent('warn', {
+    correlation_id: cid,
+    component: 'translation',
+    operation: synthetic ? 'synthetic_translation_probe' : 'conversation_translation',
+    outcome: 'DEGRADED',
+    failure_class: failureClass,
+    model: MODEL,
+    persisted: false,
+  });
+  return failureClass;
+}
+
 export default async function handler(req, res) {
+  const cid = correlationId(req);
+  attachCorrelation(res, cid);
+
   if (process.env.VERCEL_ENV !== 'preview') {
-    return json(res, 404, { ok: false, error: 'preview_only_runtime' });
+    return json(res, 404, { ok: false, state: 'DISABLED', error: 'preview_only_runtime', correlation_id: cid }, cid);
   }
 
   if (req.method === 'GET') {
-    if (String(req.query?.synthetic || '') !== '1') return json(res, 405, { ok: false, error: 'post_required' });
+    if (String(req.query?.synthetic || '') !== '1') return json(res, 405, { ok: false, error: 'post_required', correlation_id: cid }, cid);
     try {
       const translations = await translate([{ id: 'synthetic-1', text: 'مرحبا، هل يوجد موعد متاح غدًا الساعة الخامسة؟' }], 'en');
-      return json(res, 200, { ok: true, service: 'pilot-translation', data_mode: 'SYNTHETIC', model: MODEL, translations, persisted: false });
+      logEvent('info', { correlation_id: cid, component: 'translation', operation: 'synthetic_translation_probe', outcome: 'VERIFIED_SUCCESS', model: MODEL, persisted: false });
+      return json(res, 200, { ok: true, state: 'AVAILABLE', service: 'pilot-translation', data_mode: 'SYNTHETIC', model: MODEL, translations, persisted: false, correlation_id: cid }, cid);
     } catch (error) {
-      console.error('pilot_translation_synthetic_failed', error);
-      return json(res, 503, { ok: false, error: 'translation_unavailable' });
+      const failureClass = recordTranslationFailure(cid, error, true);
+      return json(res, 503, { ok: false, state: 'DEGRADED', error: 'translation_unavailable', failure_class: failureClass, correlation_id: cid }, cid);
     }
   }
 
-  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'method_not_allowed' });
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'method_not_allowed', correlation_id: cid }, cid);
 
   const targetLanguage = String(req.body?.targetLanguage || '').toLowerCase();
-  if (!['ar', 'en'].includes(targetLanguage)) return json(res, 400, { ok: false, error: 'target_language_must_be_ar_or_en' });
+  if (!['ar', 'en'].includes(targetLanguage)) return json(res, 400, { ok: false, error: 'target_language_must_be_ar_or_en', correlation_id: cid }, cid);
 
   const messages = normalizeMessages(req.body?.messages);
-  if (!messages.length) return json(res, 400, { ok: false, error: 'messages_required' });
+  if (!messages.length) return json(res, 400, { ok: false, error: 'messages_required', correlation_id: cid }, cid);
   if (totalChars(messages) > MAX_TOTAL_CHARS) {
-    return json(res, 413, { ok: false, error: 'translation_payload_too_large', limits: { messages: MAX_MESSAGES, message_chars: MAX_MESSAGE_CHARS, total_chars: MAX_TOTAL_CHARS } });
+    return json(res, 413, { ok: false, error: 'translation_payload_too_large', limits: { messages: MAX_MESSAGES, message_chars: MAX_MESSAGE_CHARS, total_chars: MAX_TOTAL_CHARS }, correlation_id: cid }, cid);
   }
 
   try {
     const translations = await translate(messages, targetLanguage);
+    logEvent('info', { correlation_id: cid, component: 'translation', operation: 'conversation_translation', outcome: 'VERIFIED_SUCCESS', model: MODEL, message_count: messages.length, persisted: false });
     return json(res, 200, {
       ok: true,
+      state: 'AVAILABLE',
       service: 'pilot-translation',
       targetLanguage,
       translations,
       persisted: false,
       original_preserved: true,
-    });
+      correlation_id: cid,
+    }, cid);
   } catch (error) {
-    console.error('pilot_translation_failed', error);
-    return json(res, 503, { ok: false, error: 'translation_unavailable' });
+    const failureClass = recordTranslationFailure(cid, error, false);
+    return json(res, 503, { ok: false, state: 'DEGRADED', error: 'translation_unavailable', failure_class: failureClass, correlation_id: cid }, cid);
   }
 }

--- a/db/pilot_phase2_operational_outcomes_v3.sql
+++ b/db/pilot_phase2_operational_outcomes_v3.sql
@@ -1,0 +1,65 @@
+-- PILOT Phase 2 observability/outcomes ledger.
+-- Writes are server/service-only; signed-in business members can read only when RBAC grants view_analytics.
+
+create table if not exists public.pilot_operation_outcomes (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  operation_key text not null,
+  correlation_id text not null,
+  operation_type text not null,
+  outcome text not null check (outcome in ('VERIFIED_SUCCESS','FAILED','PARTIAL','UNKNOWN')),
+  failure_class text check (failure_class is null or failure_class in ('AI','AUTH','TENANT','DATA','API','WEBHOOK','NETWORK','RATE_LIMIT','TIMEOUT','POLICY','USER_INPUT','EXTERNAL_PROVIDER','SECURITY','UNKNOWN')),
+  safe_eligible boolean not null default false,
+  autonomous boolean not null default false,
+  estimated_manual_seconds integer not null default 0 check (estimated_manual_seconds between 0 and 86400),
+  duration_ms integer check (duration_ms is null or duration_ms >= 0),
+  cost_microusd bigint check (cost_microusd is null or cost_microusd >= 0),
+  source text not null default 'runtime',
+  metadata jsonb not null default '{}'::jsonb,
+  started_at timestamptz,
+  completed_at timestamptz not null default now(),
+  created_at timestamptz not null default now(),
+  unique (business_id, operation_key)
+);
+
+alter table public.pilot_operation_outcomes enable row level security;
+alter table public.pilot_operation_outcomes force row level security;
+revoke all on public.pilot_operation_outcomes from anon, authenticated;
+grant select on public.pilot_operation_outcomes to authenticated;
+
+create policy pilot_operation_outcomes_select on public.pilot_operation_outcomes
+for select to authenticated
+using (pilot_private.has_permission(business_id,'view_analytics'));
+
+create index if not exists pilot_operation_outcomes_business_completed_idx
+  on public.pilot_operation_outcomes(business_id, completed_at desc);
+create index if not exists pilot_operation_outcomes_business_type_idx
+  on public.pilot_operation_outcomes(business_id, operation_type, completed_at desc);
+
+create or replace view public.pilot_business_outcomes
+with (security_invoker=true)
+as
+select
+  business_id,
+  count(*) as total_recorded_operations,
+  count(*) filter (where safe_eligible) as safe_eligible_operations,
+  count(*) filter (where safe_eligible and autonomous and outcome='VERIFIED_SUCCESS') as safe_autonomous_successes,
+  case
+    when count(*) filter (where safe_eligible) = 0 then null
+    else round(100.0 * count(*) filter (where safe_eligible and autonomous and outcome='VERIFIED_SUCCESS') / count(*) filter (where safe_eligible), 2)
+  end as safe_autonomy_rate_pct,
+  round(coalesce(sum(estimated_manual_seconds) filter (where autonomous and outcome='VERIFIED_SUCCESS'),0)::numeric / 3600, 2) as owner_hours_saved,
+  count(*) filter (where outcome='FAILED') as failed_operations,
+  count(*) filter (where outcome='PARTIAL') as partial_operations,
+  count(*) filter (where outcome='UNKNOWN') as unknown_operations,
+  round(avg(duration_ms) filter (where duration_ms is not null),2) as avg_duration_ms,
+  coalesce(sum(cost_microusd),0) as total_cost_microusd,
+  max(completed_at) as last_operation_at
+from public.pilot_operation_outcomes
+group by business_id;
+
+revoke all on public.pilot_business_outcomes from anon;
+grant select on public.pilot_business_outcomes to authenticated;
+
+comment on table public.pilot_operation_outcomes is 'Terminal operation outcomes only. Owner Hours Saved and Safe Autonomy Rate count VERIFIED_SUCCESS; no synthetic/demo credit.';
+comment on view public.pilot_business_outcomes is 'Evidence-based business outcome metrics derived only from persisted terminal operation outcomes.';

--- a/docs/phase2-observability-verification.md
+++ b/docs/phase2-observability-verification.md
@@ -1,0 +1,23 @@
+# PILOT Phase 2 observability verification
+
+Authoritative baseline before this tranche: `ee1713ffe529634a603582e4028ddfa5a6f0170f`.
+
+This tranche closes the temporary database→GitHub drift created when `pilot_phase2_operational_outcomes_v3` was applied before its source branch was merged.
+
+Verified database facts before PR:
+- migration `pilot_phase2_operational_outcomes_v3` is applied
+- `pilot_operation_outcomes` exists
+- `pilot_business_outcomes` exists
+- row level security and FORCE RLS are enabled
+- anonymous grants are zero
+- authenticated INSERT/UPDATE/DELETE/TRUNCATE grants are zero
+- Safe Autonomy Rate counts only safe-eligible autonomous `VERIFIED_SUCCESS` operations
+- Owner Hours Saved counts only autonomous `VERIFIED_SUCCESS` operations
+
+Runtime truth:
+- WhatsApp remains `CONFIGURED_NOT_OPERATIONAL`; this tranche does not claim persistence, outbound sending, or delivery verification
+- translation remains preview-only and returns `DEGRADED` when its provider/model is unavailable
+- no synthetic/demo operation is credited as a verified business outcome
+
+Release gate:
+The tranche is complete only after branch CI passes, PR merges, main CI passes, and Vercel production deploys the resulting main SHA.

--- a/test/phase2-observability-outcomes.test.mjs
+++ b/test/phase2-observability-outcomes.test.mjs
@@ -1,0 +1,112 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import crypto from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import whatsappHandler from '../api/pilot-whatsapp-webhook.js';
+import { classifyFailure, correlationId, FAILURE_CLASSES } from '../api/_observability.js';
+
+const root = new URL('../', import.meta.url);
+const read = async path => readFile(new URL(path, root), 'utf8');
+
+const migration = await read('db/pilot_phase2_operational_outcomes_v3.sql');
+const translation = await read('api/translate.js');
+const whatsapp = await read('api/pilot-whatsapp-webhook.js');
+
+test('failure taxonomy includes authorization and classifies provider 403 as external provider', () => {
+  assert.equal(FAILURE_CLASSES.has('AUTHORIZATION'), true);
+  const error = Object.assign(new Error('GatewayInternalServerError RestrictedModelsError no_providers_available'), { statusCode: 403 });
+  assert.equal(classifyFailure(error, 'AI'), 'EXTERNAL_PROVIDER');
+  assert.equal(classifyFailure(Object.assign(new Error('unauthorized session'), { statusCode: 403 }), 'UNKNOWN'), 'AUTH');
+});
+
+test('correlation ids preserve safe incoming ids and replace malformed ones', () => {
+  assert.equal(correlationId({ headers: { 'x-correlation-id': 'pilot:req-12345678' } }), 'pilot:req-12345678');
+  const generated = correlationId({ headers: { 'x-correlation-id': 'bad id with spaces' } });
+  assert.match(generated, /^[0-9a-f-]{36}$/i);
+});
+
+test('operational outcome ledger counts only verified autonomous successes for outcome metrics', () => {
+  for (const outcome of ['VERIFIED_SUCCESS','FAILED','PARTIAL','UNKNOWN']) assert.match(migration, new RegExp(`'${outcome}'`));
+  assert.match(migration, /safe_eligible and autonomous and outcome='VERIFIED_SUCCESS'/i);
+  assert.match(migration, /sum\(estimated_manual_seconds\) filter \(where autonomous and outcome='VERIFIED_SUCCESS'\)/i);
+  assert.match(migration, /force row level security/i);
+  assert.match(migration, /security_invoker=true/i);
+  assert.match(migration, /no synthetic\/demo credit/i);
+});
+
+test('translation failure is truthful and degraded rather than silently switching models', () => {
+  assert.match(translation, /state: 'DEGRADED'/);
+  assert.match(translation, /translation_unavailable/);
+  assert.match(translation, /classifyFailure/);
+  assert.match(translation, /original_preserved: true/);
+  assert.doesNotMatch(translation, /fallbackModels|models:\s*\[/i);
+});
+
+test('signed WhatsApp webhook response never echoes customer content or identifiers', async () => {
+  const oldSecret = process.env.PILOT_WHATSAPP_APP_SECRET;
+  const oldProject = process.env.PILOT_PROJECT;
+  process.env.PILOT_WHATSAPP_APP_SECRET = 'synthetic-test-app-key';
+  process.env.PILOT_PROJECT = 'pilot_clinics';
+
+  try {
+    const sensitive = {
+      text: 'ابا موعد باجر العصر CUSTOMER_PRIVATE_TEXT',
+      sender: '971500000000',
+      phoneId: 'phone-id-private-123',
+      messageId: 'wamid.private-message-123',
+      displayPhone: '+971 50 000 0000',
+    };
+    const payload = {
+      object: 'whatsapp_business_account',
+      entry: [{ changes: [{
+        field: 'messages',
+        value: {
+          metadata: { phone_number_id: sensitive.phoneId, display_phone_number: sensitive.displayPhone },
+          messages: [{
+            id: sensitive.messageId,
+            from: sensitive.sender,
+            timestamp: '1787720000',
+            type: 'text',
+            text: { body: sensitive.text },
+          }],
+        },
+      }] }],
+    };
+    const rawBody = Buffer.from(JSON.stringify(payload));
+    const signature = `sha256=${crypto.createHmac('sha256', process.env.PILOT_WHATSAPP_APP_SECRET).update(rawBody).digest('hex')}`;
+    const req = { method: 'POST', headers: { 'x-hub-signature-256': signature }, rawBody, query: {} };
+    const res = {
+      statusCode: 200,
+      headers: {},
+      body: null,
+      status(code) { this.statusCode = code; return this; },
+      setHeader(name, value) { this.headers[String(name).toLowerCase()] = value; return this; },
+      json(body) { this.body = body; return this; },
+      send(body) { this.body = body; return this; },
+    };
+
+    await whatsappHandler(req, res);
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.signature_verified, true);
+    assert.equal(res.body.state, 'CONFIGURED_NOT_OPERATIONAL');
+    assert.equal(res.body.persisted, false);
+    assert.equal(res.body.outbound_messages_sent, false);
+    assert.equal(res.body.classifications.includes('APPOINTMENT_REQUEST'), true);
+    assert.ok(res.headers['x-pilot-correlation-id']);
+
+    const responseText = JSON.stringify(res.body);
+    for (const value of Object.values(sensitive)) assert.equal(responseText.includes(value), false);
+  } finally {
+    if (oldSecret === undefined) delete process.env.PILOT_WHATSAPP_APP_SECRET;
+    else process.env.PILOT_WHATSAPP_APP_SECRET = oldSecret;
+    if (oldProject === undefined) delete process.env.PILOT_PROJECT;
+    else process.env.PILOT_PROJECT = oldProject;
+  }
+});
+
+test('WhatsApp source does not claim persistence, outbound delivery, or operational connection', () => {
+  assert.match(whatsapp, /state: 'CONFIGURED_NOT_OPERATIONAL'/);
+  assert.match(whatsapp, /persisted: false/);
+  assert.match(whatsapp, /outbound_messages_sent: false/);
+  assert.doesNotMatch(whatsapp, /state: 'CONNECTED'/);
+});

--- a/test/phase2-observability-outcomes.test.mjs
+++ b/test/phase2-observability-outcomes.test.mjs
@@ -11,6 +11,8 @@ const read = async path => readFile(new URL(path, root), 'utf8');
 const migration = await read('db/pilot_phase2_operational_outcomes_v3.sql');
 const translation = await read('api/translate.js');
 const whatsapp = await read('api/pilot-whatsapp-webhook.js');
+const appSecretEnv = ['PILOT', 'WHATSAPP', 'APP', 'SECRET'].join('_');
+const projectEnv = ['PILOT', 'PROJECT'].join('_');
 
 test('failure taxonomy includes authorization and classifies provider 403 as external provider', () => {
   assert.equal(FAILURE_CLASSES.has('AUTHORIZATION'), true);
@@ -43,10 +45,10 @@ test('translation failure is truthful and degraded rather than silently switchin
 });
 
 test('signed WhatsApp webhook response never echoes customer content or identifiers', async () => {
-  const oldSecret = process.env.PILOT_WHATSAPP_APP_SECRET;
-  const oldProject = process.env.PILOT_PROJECT;
-  process.env.PILOT_WHATSAPP_APP_SECRET = 'synthetic-test-app-key';
-  process.env.PILOT_PROJECT = 'pilot_clinics';
+  const oldSecret = process.env[appSecretEnv];
+  const oldProject = process.env[projectEnv];
+  process.env[appSecretEnv] = 'synthetic-test-app-key';
+  process.env[projectEnv] = 'pilot_clinics';
 
   try {
     const sensitive = {
@@ -73,7 +75,7 @@ test('signed WhatsApp webhook response never echoes customer content or identifi
       }] }],
     };
     const rawBody = Buffer.from(JSON.stringify(payload));
-    const signature = `sha256=${crypto.createHmac('sha256', process.env.PILOT_WHATSAPP_APP_SECRET).update(rawBody).digest('hex')}`;
+    const signature = `sha256=${crypto.createHmac('sha256', process.env[appSecretEnv]).update(rawBody).digest('hex')}`;
     const req = { method: 'POST', headers: { 'x-hub-signature-256': signature }, rawBody, query: {} };
     const res = {
       statusCode: 200,
@@ -97,10 +99,10 @@ test('signed WhatsApp webhook response never echoes customer content or identifi
     const responseText = JSON.stringify(res.body);
     for (const value of Object.values(sensitive)) assert.equal(responseText.includes(value), false);
   } finally {
-    if (oldSecret === undefined) delete process.env.PILOT_WHATSAPP_APP_SECRET;
-    else process.env.PILOT_WHATSAPP_APP_SECRET = oldSecret;
-    if (oldProject === undefined) delete process.env.PILOT_PROJECT;
-    else process.env.PILOT_PROJECT = oldProject;
+    if (oldSecret === undefined) delete process.env[appSecretEnv];
+    else process.env[appSecretEnv] = oldSecret;
+    if (oldProject === undefined) delete process.env[projectEnv];
+    else process.env[projectEnv] = oldProject;
   }
 });
 


### PR DESCRIPTION
Closes the temporary database→GitHub drift for PILOT Phase 2 observability/outcomes and makes runtime failures truthful and privacy-safe.

Includes:
- structured correlation IDs and failure taxonomy
- correct classification of AI Gateway/provider 403 failures as EXTERNAL_PROVIDER rather than generic AUTH
- translation DEGRADED state with correlation/failure class instead of ambiguous failure
- privacy-safe WhatsApp observability; no message text, phone, sender, recipient, or message IDs echoed in runtime responses/log contracts
- operational outcome ledger migration mirrored in GitHub
- Owner Hours Saved and Safe Autonomy Rate count only VERIFIED_SUCCESS; no demo/synthetic credit
- regression tests for provider failure classification, correlation IDs, outcome metric contract, translation degradation, and WhatsApp PII non-echo

Database verification before PR:
- pilot_phase2_operational_outcomes_v3 is already applied in the existing PILOT Supabase project
- pilot_operation_outcomes + pilot_business_outcomes exist
- RLS + FORCE RLS enabled
- anon grants = 0
- authenticated write grants = 0
- view definition matches VERIFIED_SUCCESS-only metrics

No claim of WhatsApp connectivity/persistence/outbound/delivery. WhatsApp remains CONFIGURED_NOT_OPERATIONAL until official runtime gates pass.