### PR TITLE
Phase 2: privacy lifecycle and patient-data hard gate

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -56,6 +56,16 @@ export async function supabaseAuth(path, options = {}) {
   return fetch(`${SUPABASE_URL}${path}`, { ...options, headers, redirect: 'manual' });
 }
 
+export async function supabaseRest(path, accessToken, options = {}) {
+  if (!accessToken) throw Object.assign(new Error('AUTH_REQUIRED'), { code: 401 });
+  const headers = new Headers(options.headers || {});
+  headers.set('apikey', SUPABASE_PUBLISHABLE_KEY);
+  headers.set('authorization', `Bearer ${accessToken}`);
+  headers.set('accept', 'application/json');
+  if (options.body !== undefined) headers.set('content-type', 'application/json');
+  return fetch(`${SUPABASE_URL}/rest/v1/${path}`, { ...options, headers, cache: 'no-store' });
+}
+
 export async function getVerifiedUser(accessToken) {
   if (!accessToken) return null;
   const response = await supabaseAuth('/auth/v1/user', { headers: { authorization: `Bearer ${accessToken}` } });
@@ -65,14 +75,7 @@ export async function getVerifiedUser(accessToken) {
 }
 
 export async function getBusinessMemberships(accessToken) {
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/pilot_memberships?select=business_id,role`, {
-    headers: {
-      apikey: SUPABASE_PUBLISHABLE_KEY,
-      authorization: `Bearer ${accessToken}`,
-      accept: 'application/json',
-    },
-    cache: 'no-store',
-  });
+  const response = await supabaseRest('pilot_memberships?select=business_id,role', accessToken);
   if (!response.ok) throw new Error('MEMBERSHIP_LOOKUP_FAILED');
   return response.json();
 }

--- a/api/privacy/requests.js
+++ b/api/privacy/requests.js
@@ -1,0 +1,106 @@
+import {
+  ACCESS_COOKIE,
+  getVerifiedUser,
+  json,
+  parseCookies,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+} from '../_auth-core.js';
+import { attachCorrelation, correlationId, logEvent } from '../_observability.js';
+
+const REQUEST_TYPES = new Set(['BUSINESS_EXPORT','BUSINESS_DELETE','CUSTOMER_EXPORT','CUSTOMER_DELETE']);
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+function reply(res, status, body, cid) {
+  attachCorrelation(res, cid);
+  return json(res, status, { ...body, correlation_id: cid });
+}
+
+async function authenticatedContext(req) {
+  const cookies = parseCookies(req.headers.cookie || '');
+  const accessToken = cookies[ACCESS_COOKIE];
+  const user = await getVerifiedUser(accessToken);
+  return user ? { accessToken, user } : null;
+}
+
+export default async function handler(req, res) {
+  const cid = correlationId(req);
+  attachCorrelation(res, cid);
+
+  if (!['GET','POST'].includes(req.method)) {
+    return reply(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, cid);
+  }
+  if (req.method === 'POST' && !requireSameOrigin(req)) {
+    return reply(res, 403, { ok: false, error: 'ORIGIN_REQUIRED' }, cid);
+  }
+
+  try {
+    const context = await authenticatedContext(req);
+    if (!context) return reply(res, 401, { ok: false, error: 'AUTH_REQUIRED' }, cid);
+
+    if (req.method === 'GET') {
+      const response = await supabaseRest(
+        'pilot_privacy_requests?select=id,business_id,customer_id,request_type,status,requested_at,completed_at&order=requested_at.desc&limit=100',
+        context.accessToken,
+      );
+      if (!response.ok) {
+        logEvent('warn', { correlation_id: cid, component: 'privacy', operation: 'list_requests', outcome: 'FAILED', failure_class: 'DATA', status: response.status });
+        return reply(res, response.status === 401 || response.status === 403 ? 403 : 503, { ok: false, error: 'PRIVACY_REQUEST_LOOKUP_FAILED' }, cid);
+      }
+      return reply(res, 200, { ok: true, requests: await response.json() }, cid);
+    }
+
+    const body = await readJsonBody(req, 8192);
+    const businessId = String(body.business_id || '').trim();
+    const customerId = body.customer_id == null ? null : String(body.customer_id).trim();
+    const requestType = String(body.request_type || '').trim().toUpperCase();
+    const requestScope = body.request_scope && typeof body.request_scope === 'object' && !Array.isArray(body.request_scope)
+      ? body.request_scope
+      : {};
+
+    if (!UUID.test(businessId) || !REQUEST_TYPES.has(requestType)) {
+      return reply(res, 400, { ok: false, error: 'INVALID_PRIVACY_REQUEST' }, cid);
+    }
+    const isCustomerRequest = requestType.startsWith('CUSTOMER_');
+    if ((isCustomerRequest && (!customerId || !UUID.test(customerId))) || (!isCustomerRequest && customerId !== null)) {
+      return reply(res, 400, { ok: false, error: 'INVALID_PRIVACY_REQUEST_SCOPE' }, cid);
+    }
+    if (Buffer.byteLength(JSON.stringify(requestScope), 'utf8') > 8192) {
+      return reply(res, 413, { ok: false, error: 'PRIVACY_REQUEST_SCOPE_TOO_LARGE' }, cid);
+    }
+
+    const payload = {
+      business_id: businessId,
+      customer_id: customerId,
+      request_type: requestType,
+      status: 'REQUESTED',
+      requested_by: context.user.id,
+      correlation_id: cid,
+      request_scope: requestScope,
+    };
+    const response = await supabaseRest('pilot_privacy_requests?select=id,business_id,customer_id,request_type,status,requested_at', context.accessToken, {
+      method: 'POST',
+      headers: { prefer: 'return=representation' },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      logEvent('warn', { correlation_id: cid, component: 'privacy', operation: 'create_request', outcome: 'FAILED', failure_class: response.status === 401 || response.status === 403 ? 'AUTHORIZATION' : 'DATA', status: response.status, request_type: requestType });
+      return reply(res, response.status === 401 || response.status === 403 ? 403 : 503, { ok: false, error: 'PRIVACY_REQUEST_REJECTED' }, cid);
+    }
+    const rows = await response.json();
+    const created = Array.isArray(rows) ? rows[0] : null;
+    logEvent('info', { correlation_id: cid, component: 'privacy', operation: 'create_request', outcome: 'VERIFIED_SUCCESS', request_type: requestType, persisted: true });
+    return reply(res, 202, {
+      ok: true,
+      request: created,
+      execution_state: 'REVIEW_REQUIRED',
+      data_exported: false,
+      data_deleted: false,
+    }, cid);
+  } catch (error) {
+    const status = error?.code === 413 ? 413 : error?.code === 400 ? 400 : error?.code === 401 ? 401 : 503;
+    return reply(res, status, { ok: false, error: error?.message === 'PAYLOAD_TOO_LARGE' ? 'PAYLOAD_TOO_LARGE' : error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : 'PRIVACY_SERVICE_UNAVAILABLE' }, cid);
+  }
+}

--- a/db/pilot_phase2_privacy_lifecycle_v4.sql
+++ b/db/pilot_phase2_privacy_lifecycle_v4.sql
@@ -1,0 +1,293 @@
+-- PILOT Phase 2 privacy/data-lifecycle foundation.
+-- This migration creates governance and request workflows only. It does NOT execute exports/deletions
+-- and does NOT authorize real patient data. Patient-data approval remains server/governance controlled.
+
+create table if not exists public.pilot_data_categories (
+  category text primary key,
+  classification text not null check (classification in ('PUBLIC','INTERNAL','CONFIDENTIAL','PERSONAL','SENSITIVE')),
+  requires_legal_gate boolean not null default false,
+  description text not null,
+  created_at timestamptz not null default now()
+);
+
+insert into public.pilot_data_categories(category,classification,requires_legal_gate,description) values
+  ('BUSINESS_PROFILE','INTERNAL',false,'Business profile and operating configuration'),
+  ('CUSTOMER_PROFILE','PERSONAL',false,'Customer profile and contact-linked business records'),
+  ('CUSTOMER_IDENTITY','PERSONAL',false,'Verified or channel-linked customer identifiers'),
+  ('CONVERSATION','PERSONAL',false,'Conversation-level customer context'),
+  ('MESSAGE','PERSONAL',false,'Original customer and business messages'),
+  ('APPOINTMENT','PERSONAL',false,'Scheduling and appointment records'),
+  ('TASK','INTERNAL',false,'Business operational tasks'),
+  ('AUDIT','CONFIDENTIAL',false,'Security and operational audit evidence'),
+  ('INTEGRATION_EVENT','CONFIDENTIAL',false,'External integration event metadata'),
+  ('AI_RUN','CONFIDENTIAL',false,'AI execution metadata and evaluation evidence'),
+  ('ANALYTICS','INTERNAL',false,'Aggregated business operational analytics'),
+  ('PATIENT_DATA','SENSITIVE',true,'Patient or health-related data; production use requires explicit legal/privacy/security approval')
+on conflict (category) do update set
+  classification=excluded.classification,
+  requires_legal_gate=excluded.requires_legal_gate,
+  description=excluded.description;
+
+alter table public.pilot_data_categories enable row level security;
+alter table public.pilot_data_categories force row level security;
+revoke all on public.pilot_data_categories from anon, authenticated;
+grant select on public.pilot_data_categories to authenticated;
+drop policy if exists pilot_data_categories_select on public.pilot_data_categories;
+create policy pilot_data_categories_select on public.pilot_data_categories for select to authenticated using (true);
+
+create table if not exists public.pilot_retention_policies (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  data_category text not null references public.pilot_data_categories(category) on delete restrict,
+  retention_days integer check (retention_days is null or retention_days between 1 and 3650),
+  policy_state text not null default 'UNCONFIGURED' check (policy_state in ('UNCONFIGURED','ACTIVE','LEGAL_HOLD')),
+  source text not null default 'BUSINESS_POLICY' check (source in ('BUSINESS_POLICY','LEGAL_REVIEW','SYSTEM')),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (business_id,data_category)
+);
+
+alter table public.pilot_retention_policies enable row level security;
+alter table public.pilot_retention_policies force row level security;
+revoke all on public.pilot_retention_policies from anon, authenticated;
+grant select,insert,update on public.pilot_retention_policies to authenticated;
+drop policy if exists pilot_retention_policies_select on public.pilot_retention_policies;
+drop policy if exists pilot_retention_policies_insert on public.pilot_retention_policies;
+drop policy if exists pilot_retention_policies_update on public.pilot_retention_policies;
+create policy pilot_retention_policies_select on public.pilot_retention_policies for select to authenticated
+  using (pilot_private.has_permission(business_id,'manage_business'));
+create policy pilot_retention_policies_insert on public.pilot_retention_policies for insert to authenticated
+  with check (pilot_private.has_permission(business_id,'manage_business'));
+create policy pilot_retention_policies_update on public.pilot_retention_policies for update to authenticated
+  using (pilot_private.has_permission(business_id,'manage_business'))
+  with check (pilot_private.has_permission(business_id,'manage_business'));
+
+create table if not exists public.pilot_privacy_controls (
+  business_id uuid primary key references public.pilot_businesses(id) on delete cascade,
+  patient_data_mode text not null default 'SYNTHETIC_ONLY' check (patient_data_mode in ('SYNTHETIC_ONLY','REVIEW_PENDING','APPROVED')),
+  legal_review_status text not null default 'PENDING' check (legal_review_status in ('PENDING','APPROVED','REJECTED')),
+  privacy_review_status text not null default 'PENDING' check (privacy_review_status in ('PENDING','APPROVED','REJECTED')),
+  security_review_status text not null default 'PENDING' check (security_review_status in ('PENDING','APPROVED','REJECTED')),
+  retention_review_status text not null default 'PENDING' check (retention_review_status in ('PENDING','APPROVED','REJECTED')),
+  cross_border_review_status text not null default 'PENDING' check (cross_border_review_status in ('PENDING','APPROVED','REJECTED')),
+  vendor_ai_review_status text not null default 'PENDING' check (vendor_ai_review_status in ('PENDING','APPROVED','REJECTED')),
+  reviewed_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.pilot_privacy_controls enable row level security;
+alter table public.pilot_privacy_controls force row level security;
+revoke all on public.pilot_privacy_controls from anon, authenticated;
+grant select on public.pilot_privacy_controls to authenticated;
+drop policy if exists pilot_privacy_controls_select on public.pilot_privacy_controls;
+create policy pilot_privacy_controls_select on public.pilot_privacy_controls for select to authenticated
+  using (pilot_private.has_permission(business_id,'manage_business'));
+
+create or replace view public.pilot_patient_data_gate
+with (security_invoker=true)
+as
+select
+  b.id as business_id,
+  b.business_type,
+  c.patient_data_mode,
+  c.legal_review_status,
+  c.privacy_review_status,
+  c.security_review_status,
+  c.retention_review_status,
+  c.cross_border_review_status,
+  c.vendor_ai_review_status,
+  (
+    b.business_type='clinic'
+    and c.patient_data_mode='APPROVED'
+    and c.legal_review_status='APPROVED'
+    and c.privacy_review_status='APPROVED'
+    and c.security_review_status='APPROVED'
+    and c.retention_review_status='APPROVED'
+    and c.cross_border_review_status='APPROVED'
+    and c.vendor_ai_review_status='APPROVED'
+  ) as production_patient_data_allowed
+from public.pilot_businesses b
+join public.pilot_privacy_controls c on c.business_id=b.id;
+revoke all on public.pilot_patient_data_gate from anon;
+grant select on public.pilot_patient_data_gate to authenticated;
+
+create table if not exists public.pilot_customer_consents (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  customer_id uuid not null,
+  purpose text not null check (purpose in ('SERVICE_DELIVERY','APPOINTMENT_MANAGEMENT','CUSTOMER_SUPPORT','MARKETING','AI_ASSISTED_PROCESSING','ANALYTICS')),
+  status text not null default 'UNKNOWN' check (status in ('GRANTED','WITHDRAWN','NOT_REQUIRED','UNKNOWN')),
+  source text not null default 'SYSTEM' check (source in ('CUSTOMER','BUSINESS_POLICY','SYSTEM','IMPORTED')),
+  evidence_ref text check (evidence_ref is null or length(evidence_ref) <= 512),
+  captured_at timestamptz,
+  withdrawn_at timestamptz,
+  metadata jsonb not null default '{}'::jsonb check (octet_length(metadata::text) <= 16384),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (business_id,customer_id,purpose),
+  constraint pilot_customer_consents_business_customer_fk foreign key (business_id,customer_id)
+    references public.pilot_customers(business_id,id) on delete cascade
+);
+
+alter table public.pilot_customer_consents enable row level security;
+alter table public.pilot_customer_consents force row level security;
+revoke all on public.pilot_customer_consents from anon, authenticated;
+grant select,insert,update on public.pilot_customer_consents to authenticated;
+drop policy if exists pilot_customer_consents_select on public.pilot_customer_consents;
+drop policy if exists pilot_customer_consents_insert on public.pilot_customer_consents;
+drop policy if exists pilot_customer_consents_update on public.pilot_customer_consents;
+create policy pilot_customer_consents_select on public.pilot_customer_consents for select to authenticated
+  using (pilot_private.has_permission(business_id,'view_customers'));
+create policy pilot_customer_consents_insert on public.pilot_customer_consents for insert to authenticated
+  with check (pilot_private.has_permission(business_id,'edit_customers'));
+create policy pilot_customer_consents_update on public.pilot_customer_consents for update to authenticated
+  using (pilot_private.has_permission(business_id,'edit_customers'))
+  with check (pilot_private.has_permission(business_id,'edit_customers'));
+
+create table if not exists public.pilot_privacy_requests (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  customer_id uuid,
+  request_type text not null check (request_type in ('BUSINESS_EXPORT','BUSINESS_DELETE','CUSTOMER_EXPORT','CUSTOMER_DELETE')),
+  status text not null default 'REQUESTED' check (status in ('REQUESTED','REVIEW_REQUIRED','APPROVED','PROCESSING','COMPLETED','REJECTED','FAILED','CANCELLED')),
+  requested_by uuid default auth.uid(),
+  correlation_id text check (correlation_id is null or correlation_id ~ '^[A-Za-z0-9._:-]{8,120}$'),
+  request_scope jsonb not null default '{}'::jsonb check (octet_length(request_scope::text) <= 8192),
+  result_ref text check (result_ref is null or length(result_ref) <= 1024),
+  requested_at timestamptz not null default now(),
+  completed_at timestamptz,
+  created_at timestamptz not null default now(),
+  constraint pilot_privacy_requests_scope_check check (
+    (request_type in ('BUSINESS_EXPORT','BUSINESS_DELETE') and customer_id is null)
+    or (request_type in ('CUSTOMER_EXPORT','CUSTOMER_DELETE') and customer_id is not null)
+  ),
+  constraint pilot_privacy_requests_business_customer_fk foreign key (business_id,customer_id)
+    references public.pilot_customers(business_id,id) on delete restrict
+);
+
+alter table public.pilot_privacy_requests enable row level security;
+alter table public.pilot_privacy_requests force row level security;
+revoke all on public.pilot_privacy_requests from anon, authenticated;
+grant select,insert on public.pilot_privacy_requests to authenticated;
+drop policy if exists pilot_privacy_requests_select on public.pilot_privacy_requests;
+drop policy if exists pilot_privacy_requests_insert on public.pilot_privacy_requests;
+create policy pilot_privacy_requests_select on public.pilot_privacy_requests for select to authenticated
+  using (requested_by=(select auth.uid()) or pilot_private.has_permission(business_id,'export_data'));
+create policy pilot_privacy_requests_insert on public.pilot_privacy_requests for insert to authenticated
+  with check (
+    requested_by=(select auth.uid()) and (
+      (request_type='BUSINESS_DELETE' and exists(
+        select 1 from public.pilot_memberships m
+        where m.business_id=pilot_privacy_requests.business_id
+          and m.user_id=(select auth.uid()) and m.role='owner'
+      ))
+      or (request_type<>'BUSINESS_DELETE' and pilot_private.has_permission(business_id,'export_data'))
+    )
+  );
+
+create table if not exists public.pilot_privacy_audit (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  actor_user_id uuid,
+  action text not null,
+  target_type text not null,
+  target_id text,
+  privacy_request_id uuid references public.pilot_privacy_requests(id) on delete set null,
+  correlation_id text check (correlation_id is null or correlation_id ~ '^[A-Za-z0-9._:-]{8,120}$'),
+  metadata jsonb not null default '{}'::jsonb check (octet_length(metadata::text) <= 8192),
+  created_at timestamptz not null default now()
+);
+
+alter table public.pilot_privacy_audit enable row level security;
+alter table public.pilot_privacy_audit force row level security;
+revoke all on public.pilot_privacy_audit from anon, authenticated;
+grant select on public.pilot_privacy_audit to authenticated;
+drop policy if exists pilot_privacy_audit_select on public.pilot_privacy_audit;
+create policy pilot_privacy_audit_select on public.pilot_privacy_audit for select to authenticated
+  using (pilot_private.has_permission(business_id,'manage_business'));
+
+create or replace function pilot_private.set_updated_at()
+returns trigger language plpgsql security definer set search_path=public,pg_temp as $$
+begin
+  new.updated_at=now();
+  return new;
+end;
+$$;
+revoke all on function pilot_private.set_updated_at() from public,anon,authenticated;
+
+drop trigger if exists pilot_retention_policies_touch on public.pilot_retention_policies;
+create trigger pilot_retention_policies_touch before update on public.pilot_retention_policies
+for each row execute function pilot_private.set_updated_at();
+drop trigger if exists pilot_customer_consents_touch on public.pilot_customer_consents;
+create trigger pilot_customer_consents_touch before update on public.pilot_customer_consents
+for each row execute function pilot_private.set_updated_at();
+
+create or replace function pilot_private.audit_privacy_row()
+returns trigger language plpgsql security definer set search_path=public,pg_temp as $$
+declare
+  v_row jsonb := case when tg_op='DELETE' then to_jsonb(old) else to_jsonb(new) end;
+  v_business_id uuid := nullif(v_row->>'business_id','')::uuid;
+  v_target_id text := v_row->>'id';
+  v_request_id uuid := case when tg_table_name='pilot_privacy_requests' then nullif(v_row->>'id','')::uuid else null end;
+  v_metadata jsonb := '{}'::jsonb;
+begin
+  if tg_table_name='pilot_privacy_requests' then
+    v_metadata=jsonb_build_object('request_type',v_row->>'request_type','status',v_row->>'status');
+  elsif tg_table_name='pilot_customer_consents' then
+    v_metadata=jsonb_build_object('purpose',v_row->>'purpose','status',v_row->>'status','source',v_row->>'source');
+  elsif tg_table_name='pilot_retention_policies' then
+    v_metadata=jsonb_build_object('data_category',v_row->>'data_category','policy_state',v_row->>'policy_state');
+  end if;
+  insert into public.pilot_privacy_audit(business_id,actor_user_id,action,target_type,target_id,privacy_request_id,correlation_id,metadata)
+  values(v_business_id,(select auth.uid()),tg_table_name||'_'||lower(tg_op),tg_table_name,v_target_id,v_request_id,v_row->>'correlation_id',v_metadata);
+  return case when tg_op='DELETE' then old else new end;
+end;
+$$;
+revoke all on function pilot_private.audit_privacy_row() from public,anon,authenticated;
+
+drop trigger if exists pilot_privacy_requests_audit on public.pilot_privacy_requests;
+create trigger pilot_privacy_requests_audit after insert or update on public.pilot_privacy_requests
+for each row execute function pilot_private.audit_privacy_row();
+drop trigger if exists pilot_customer_consents_audit on public.pilot_customer_consents;
+create trigger pilot_customer_consents_audit after insert or update on public.pilot_customer_consents
+for each row execute function pilot_private.audit_privacy_row();
+drop trigger if exists pilot_retention_policies_audit on public.pilot_retention_policies;
+create trigger pilot_retention_policies_audit after insert or update on public.pilot_retention_policies
+for each row execute function pilot_private.audit_privacy_row();
+
+create or replace function pilot_private.seed_privacy_defaults()
+returns trigger language plpgsql security definer set search_path=public,pg_temp as $$
+begin
+  insert into public.pilot_privacy_controls(business_id) values(new.id) on conflict(business_id) do nothing;
+  insert into public.pilot_retention_policies(business_id,data_category)
+  select new.id,c.category from public.pilot_data_categories c
+  on conflict(business_id,data_category) do nothing;
+  return new;
+end;
+$$;
+revoke all on function pilot_private.seed_privacy_defaults() from public,anon,authenticated;
+
+drop trigger if exists pilot_businesses_seed_privacy on public.pilot_businesses;
+create trigger pilot_businesses_seed_privacy after insert on public.pilot_businesses
+for each row execute function pilot_private.seed_privacy_defaults();
+
+insert into public.pilot_privacy_controls(business_id)
+select id from public.pilot_businesses
+on conflict(business_id) do nothing;
+insert into public.pilot_retention_policies(business_id,data_category)
+select b.id,c.category from public.pilot_businesses b cross join public.pilot_data_categories c
+on conflict(business_id,data_category) do nothing;
+
+create index if not exists pilot_retention_policies_business_state_idx on public.pilot_retention_policies(business_id,policy_state);
+create index if not exists pilot_customer_consents_business_customer_idx on public.pilot_customer_consents(business_id,customer_id);
+create index if not exists pilot_privacy_requests_business_status_idx on public.pilot_privacy_requests(business_id,status,requested_at desc);
+create index if not exists pilot_privacy_requests_customer_idx on public.pilot_privacy_requests(business_id,customer_id) where customer_id is not null;
+create index if not exists pilot_privacy_audit_business_created_idx on public.pilot_privacy_audit(business_id,created_at desc);
+
+comment on table public.pilot_data_categories is 'PILOT data classification catalog. PATIENT_DATA is SENSITIVE and requires a hard legal/privacy/security gate.';
+comment on table public.pilot_retention_policies is 'Retention configuration. UNCONFIGURED means no automatic retention/deletion execution may be assumed.';
+comment on table public.pilot_privacy_controls is 'Server/governance-controlled privacy gates. Authenticated clients have read-only access.';
+comment on table public.pilot_privacy_requests is 'Privacy request intake only. No export/delete is considered complete until a server-side executor verifies completion.';
+comment on table public.pilot_privacy_audit is 'Append-only privacy lifecycle audit generated by controlled triggers; no direct authenticated writes.';
+comment on view public.pilot_patient_data_gate is 'Clinic patient-data production gate. TRUE only after every required review is APPROVED and patient_data_mode is APPROVED.';

--- a/test/phase2-privacy-lifecycle.test.mjs
+++ b/test/phase2-privacy-lifecycle.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const read = async path => readFile(new URL(path, root), 'utf8');
+
+const migration = await read('db/pilot_phase2_privacy_lifecycle_v4.sql');
+const api = await read('api/privacy/requests.js');
+const authCore = await read('api/_auth-core.js');
+
+test('patient data is sensitive and production use is fail-closed behind every required review', () => {
+  assert.match(migration, /'PATIENT_DATA','SENSITIVE',true/i);
+  assert.match(migration, /patient_data_mode text not null default 'SYNTHETIC_ONLY'/i);
+  for (const gate of [
+    'legal_review_status', 'privacy_review_status', 'security_review_status',
+    'retention_review_status', 'cross_border_review_status', 'vendor_ai_review_status',
+  ]) {
+    assert.match(migration, new RegExp(`${gate}='APPROVED'`, 'i'));
+  }
+  assert.match(migration, /c\.patient_data_mode='APPROVED'/i);
+  assert.match(migration, /production_patient_data_allowed/i);
+});
+
+test('authenticated clients cannot self-approve patient data controls', () => {
+  assert.match(migration, /revoke all on public\.pilot_privacy_controls from anon, authenticated/i);
+  assert.match(migration, /grant select on public\.pilot_privacy_controls to authenticated/i);
+  assert.doesNotMatch(migration, /grant (?:insert|update|delete)[^;]*pilot_privacy_controls[^;]*authenticated/i);
+  assert.doesNotMatch(migration, /policy [^\n]*pilot_privacy_controls[^\n]*for update/i);
+});
+
+test('retention is unconfigured by default and cannot imply automatic deletion', () => {
+  assert.match(migration, /policy_state text not null default 'UNCONFIGURED'/i);
+  assert.match(migration, /'UNCONFIGURED','ACTIVE','LEGAL_HOLD'/i);
+  assert.match(migration, /UNCONFIGURED means no automatic retention\/deletion execution may be assumed/i);
+  assert.doesNotMatch(migration, /delete from public\.pilot_(?:customers|messages|conversations|appointments)/i);
+});
+
+test('consent records are tenant-scoped, bounded, and not directly deletable by authenticated clients', () => {
+  assert.match(migration, /pilot_customer_consents_business_customer_fk/i);
+  assert.match(migration, /foreign key \(business_id,customer_id\)[\s\S]*pilot_customers\(business_id,id\)/i);
+  assert.match(migration, /octet_length\(metadata::text\) <= 16384/i);
+  assert.match(migration, /grant select,insert,update on public\.pilot_customer_consents to authenticated/i);
+  assert.doesNotMatch(migration, /grant delete on public\.pilot_customer_consents to authenticated/i);
+});
+
+test('privacy requests are intake-only, owner-gated for business deletion, and cannot be completed by client mutation', () => {
+  for (const type of ['BUSINESS_EXPORT','BUSINESS_DELETE','CUSTOMER_EXPORT','CUSTOMER_DELETE']) assert.match(migration, new RegExp(`'${type}'`));
+  assert.match(migration, /request_type='BUSINESS_DELETE'[\s\S]*m\.role='owner'/i);
+  assert.match(migration, /grant select,insert on public\.pilot_privacy_requests to authenticated/i);
+  assert.doesNotMatch(migration, /grant (?:update|delete)[^;]*pilot_privacy_requests[^;]*authenticated/i);
+  assert.match(migration, /No export\/delete is considered complete until a server-side executor verifies completion/i);
+});
+
+test('privacy audit is append-only to authenticated users and trigger-generated', () => {
+  assert.match(migration, /revoke all on public\.pilot_privacy_audit from anon, authenticated/i);
+  assert.match(migration, /grant select on public\.pilot_privacy_audit to authenticated/i);
+  assert.match(migration, /create trigger pilot_privacy_requests_audit/i);
+  assert.match(migration, /create trigger pilot_customer_consents_audit/i);
+  assert.match(migration, /create trigger pilot_retention_policies_audit/i);
+  assert.doesNotMatch(migration, /grant insert[^;]*pilot_privacy_audit[^;]*authenticated/i);
+});
+
+test('privacy request API requires authenticated cookie flow and same-origin for writes', () => {
+  assert.match(api, /ACCESS_COOKIE/);
+  assert.match(api, /getVerifiedUser/);
+  assert.match(api, /requireSameOrigin\(req\)/);
+  assert.match(api, /readJsonBody\(req, 8192\)/);
+  assert.match(api, /supabaseRest\('pilot_privacy_requests/);
+  assert.match(api, /status: 'REQUESTED'/);
+  assert.match(api, /execution_state: 'REVIEW_REQUIRED'/);
+  assert.match(api, /data_exported: false/);
+  assert.match(api, /data_deleted: false/);
+  assert.doesNotMatch(api, /service[_-]?role/i);
+});
+
+test('authenticated REST helper preserves RLS authority and does not embed privileged credentials', () => {
+  assert.match(authCore, /export async function supabaseRest/);
+  assert.match(authCore, /authorization`, `Bearer \$\{accessToken\}`|authorization', `Bearer \$\{accessToken\}`|authorization.*Bearer/i);
+  assert.match(authCore, /SUPABASE_PUBLISHABLE_KEY/);
+  assert.doesNotMatch(authCore, /SUPABASE_SERVICE_ROLE_KEY/);
+  const secretPrefix = ['sb', 'secret'].join('_') + '_';
+  assert.equal(authCore.includes(secretPrefix), false);
+});


### PR DESCRIPTION
Adds the minimum production privacy/data-lifecycle foundation without enabling real patient data or executing destructive actions.

Scope:
- data classification catalog including PATIENT_DATA=SENSITIVE
- fail-closed clinic patient-data gate requiring legal/privacy/security/retention/cross-border/vendor-AI approvals
- patient privacy controls are read-only to authenticated clients; no self-approval path
- retention policies default UNCONFIGURED; no automatic deletion implied
- tenant-scoped customer consent records
- privacy request intake for business/customer export/delete
- BUSINESS_DELETE request requires owner role
- privacy requests are client insert/read only; no authenticated completion/update/delete
- append-only trigger-generated privacy audit
- authenticated REST helper that preserves user bearer/RLS authority; no service-role runtime key
- `/api/privacy/requests` GET/POST with Auth, same-origin POST, bounded body, correlation IDs, and REVIEW_REQUIRED truth state
- CI contracts covering patient gate, retention, consent, deletion/export request boundaries, audit immutability, and no privileged credentials

Important: this PR does NOT execute export/delete, does NOT permit patient data, and does NOT alter WhatsApp/Calendar connection status. Schema will only be applied to the existing PILOT Supabase project after source/CI is authoritative.