### PR TITLE
PILOT: one-time employee invites and permanent memberships

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -66,6 +66,18 @@ export async function supabaseRest(path, accessToken, options = {}) {
   return fetch(`${SUPABASE_URL}/rest/v1/${path}`, { ...options, headers, cache: 'no-store' });
 }
 
+export function accessTokenFromRequest(req) {
+  return parseCookies(req.headers.cookie || '')[ACCESS_COOKIE] || null;
+}
+
+export async function supabaseRpc(name, accessToken, params = {}) {
+  return supabaseRest(`rpc/${encodeURIComponent(name)}`, accessToken, {
+    method: 'POST',
+    headers: { prefer: 'return=representation' },
+    body: JSON.stringify(params),
+  });
+}
+
 export async function getVerifiedUser(accessToken) {
   if (!accessToken) return null;
   const response = await supabaseAuth('/auth/v1/user', { headers: { authorization: `Bearer ${accessToken}` } });
@@ -75,7 +87,7 @@ export async function getVerifiedUser(accessToken) {
 }
 
 export async function getBusinessMemberships(accessToken) {
-  const response = await supabaseRest('pilot_memberships?select=business_id,role', accessToken);
+  const response = await supabaseRest('pilot_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active', accessToken);
   if (!response.ok) throw new Error('MEMBERSHIP_LOOKUP_FAILED');
   return response.json();
 }
@@ -99,4 +111,23 @@ export function readJsonBody(req, maxBytes = 8192) {
     });
     req.on('error', reject);
   });
+}
+
+export async function readRpcJson(response) {
+  const text = await response.text();
+  if (!text) return null;
+  try { return JSON.parse(text); }
+  catch { return { message: text.slice(0, 500) }; }
+}
+
+export function rpcErrorCode(payload, fallback = 'REQUEST_FAILED') {
+  const raw = String(payload?.message || payload?.error || '').toUpperCase();
+  const known = [
+    'AUTH_REQUIRED','BUSINESS_REQUIRED','INVALID_EMAIL','INVALID_ROLE','INVALID_TOKEN_HASH','INVALID_EXPIRY',
+    'TEAM_MANAGEMENT_REQUIRED','PERMISSION_GRANT_NOT_ALLOWED','INVITATION_ALREADY_PENDING','EMPLOYEE_ALREADY_MEMBER',
+    'INVALID_INVITATION','VERIFIED_EMAIL_REQUIRED','INVITATION_NOT_FOUND','INVITATION_NOT_PENDING','INVITATION_EXPIRED',
+    'INVITATION_EMAIL_MISMATCH','INVITER_NO_LONGER_AUTHORIZED','MEMBERSHIP_ALREADY_EXISTS','MEMBERSHIP_NOT_FOUND',
+    'OWNER_IMMUTABLE','INVALID_STATUS','NEW_INVITATION_REQUIRED'
+  ];
+  return known.find(code => raw.includes(code)) || fallback;
 }

--- a/api/team/accept-invite.js
+++ b/api/team/accept-invite.js
@@ -1,0 +1,42 @@
+import {
+  accessTokenFromRequest,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  readRpcJson,
+  requireSameOrigin,
+  rpcErrorCode,
+  supabaseRpc,
+} from '../_auth-core.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'ORIGIN_REQUIRED' });
+
+  const accessToken = accessTokenFromRequest(req);
+  const user = await getVerifiedUser(accessToken);
+  if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req);
+    const token = String(body.token || '').trim();
+    if (token.length < 32 || token.length > 256) return json(res, 400, { ok: false, error: 'INVALID_INVITATION' });
+
+    const response = await supabaseRpc('pilot_accept_employee_invitation', accessToken, { p_token: token });
+    const payload = await readRpcJson(response);
+    if (!response.ok) {
+      const code = rpcErrorCode(payload, 'INVITATION_ACCEPT_FAILED');
+      const status = code === 'INVITATION_EMAIL_MISMATCH' || code === 'INVITER_NO_LONGER_AUTHORIZED' ? 403 :
+        ['INVITATION_NOT_PENDING','MEMBERSHIP_ALREADY_EXISTS'].includes(code) ? 409 :
+        code === 'INVITATION_NOT_FOUND' ? 404 : 400;
+      return json(res, status, { ok: false, error: code });
+    }
+    const membership = Array.isArray(payload) ? payload[0] : payload;
+    return json(res, 200, { ok: true, membership, invitation_consumed: true });
+  } catch (error) {
+    return json(res, error?.code === 413 ? 413 : error?.code === 400 ? 400 : 500, {
+      ok: false,
+      error: error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : error?.message === 'PAYLOAD_TOO_LARGE' ? 'PAYLOAD_TOO_LARGE' : 'INVITATION_UNAVAILABLE',
+    });
+  }
+}

--- a/api/team/invitations.js
+++ b/api/team/invitations.js
@@ -80,7 +80,7 @@ export default async function handler(req, res) {
       ok: true,
       invitation,
       invite_token: token,
-      invite_path: `/?invite=${encodeURIComponent(token)}`,
+      invite_path: `/team.html?invite=${encodeURIComponent(token)}`,
       delivery: { status: 'prepared', provider_required: true },
     });
   } catch (error) {

--- a/api/team/invitations.js
+++ b/api/team/invitations.js
@@ -1,0 +1,92 @@
+import crypto from 'node:crypto';
+import {
+  accessTokenFromRequest,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  readRpcJson,
+  requireSameOrigin,
+  rpcErrorCode,
+  supabaseRest,
+  supabaseRpc,
+} from '../_auth-core.js';
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const roleSet = new Set(['admin', 'manager', 'employee', 'staff', 'viewer', 'agent']);
+const permissionSet = new Set([
+  'view_business','manage_business','manage_team','view_integrations','manage_integrations',
+  'view_customers','edit_customers','view_conversations','reply_conversations',
+  'view_appointments','manage_appointments','manage_automations','view_analytics',
+  'manage_billing','export_data','view_services','manage_services','view_knowledge',
+  'manage_knowledge','view_quality','manage_handoffs',
+]);
+
+function cleanPermissions(value) {
+  if (!Array.isArray(value)) return [];
+  const out = [...new Set(value.map(v => String(v || '').trim()).filter(Boolean))];
+  if (out.length > 32 || out.some(p => !permissionSet.has(p))) throw Object.assign(new Error('INVALID_PERMISSIONS'), { code: 400 });
+  return out;
+}
+
+export default async function handler(req, res) {
+  const accessToken = accessTokenFromRequest(req);
+  const user = await getVerifiedUser(accessToken);
+  if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  if (req.method === 'GET') {
+    const businessId = String(req.query?.business_id || '').trim();
+    if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+    const query = `pilot_employee_invitations?business_id=eq.${encodeURIComponent(businessId)}&select=id,email,display_name,role,permissions,status,delivery_status,delivery_attempts,expires_at,accepted_at,created_at&order=created_at.desc`;
+    const response = await supabaseRest(query, accessToken);
+    if (!response.ok) return json(res, response.status === 403 ? 403 : 502, { ok: false, error: 'INVITATION_LIST_FAILED' });
+    return json(res, 200, { ok: true, invitations: await response.json() });
+  }
+
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET, POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'ORIGIN_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req);
+    const businessId = String(body.business_id || '').trim();
+    const email = String(body.email || '').trim().toLowerCase();
+    const displayName = String(body.display_name || '').trim().slice(0, 120);
+    const role = String(body.role || 'employee').trim().toLowerCase();
+    const permissions = cleanPermissions(body.permissions);
+    if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+    if (!emailPattern.test(email) || email.length > 254) return json(res, 400, { ok: false, error: 'INVALID_EMAIL' });
+    if (!roleSet.has(role)) return json(res, 400, { ok: false, error: 'INVALID_ROLE' });
+
+    const token = crypto.randomBytes(32).toString('base64url');
+    const tokenHash = crypto.createHash('sha256').update(token).digest('hex');
+    const expiresAt = new Date(Date.now() + 72 * 60 * 60 * 1000).toISOString();
+    const response = await supabaseRpc('pilot_create_employee_invitation', accessToken, {
+      p_business_id: businessId,
+      p_email: email,
+      p_display_name: displayName || null,
+      p_role: role,
+      p_permissions: permissions,
+      p_token_hash: tokenHash,
+      p_expires_at: expiresAt,
+    });
+    const payload = await readRpcJson(response);
+    if (!response.ok) {
+      const code = rpcErrorCode(payload, 'INVITATION_CREATE_FAILED');
+      const status = ['TEAM_MANAGEMENT_REQUIRED','PERMISSION_GRANT_NOT_ALLOWED'].includes(code) ? 403 :
+        ['INVITATION_ALREADY_PENDING','EMPLOYEE_ALREADY_MEMBER'].includes(code) ? 409 : 400;
+      return json(res, status, { ok: false, error: code });
+    }
+    const invitation = Array.isArray(payload) ? payload[0] : payload;
+    return json(res, 201, {
+      ok: true,
+      invitation,
+      invite_token: token,
+      invite_path: `/?invite=${encodeURIComponent(token)}`,
+      delivery: { status: 'prepared', provider_required: true },
+    });
+  } catch (error) {
+    return json(res, error?.code === 413 ? 413 : error?.code === 400 ? 400 : 500, {
+      ok: false,
+      error: error?.message === 'INVALID_PERMISSIONS' ? 'INVALID_PERMISSIONS' : error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : error?.message === 'PAYLOAD_TOO_LARGE' ? 'PAYLOAD_TOO_LARGE' : 'INVITATION_UNAVAILABLE',
+    });
+  }
+}

--- a/api/team/members.js
+++ b/api/team/members.js
@@ -1,0 +1,71 @@
+import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody, readRpcJson, requireSameOrigin, rpcErrorCode, supabaseRpc } from '../_auth-core.js';
+
+const roles = new Set(['admin','manager','employee','staff','viewer','agent']);
+const permissions = new Set(['view_business','manage_business','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs']);
+
+function normalizePermissions(value) {
+  if (!Array.isArray(value)) return [];
+  const result = [...new Set(value.map(v => String(v || '').trim()).filter(Boolean))];
+  if (result.length > 32 || result.some(v => !permissions.has(v))) throw Object.assign(new Error('INVALID_PERMISSIONS'), { code: 400 });
+  return result;
+}
+
+function errorStatus(code) {
+  if (['TEAM_MANAGEMENT_REQUIRED','PERMISSION_GRANT_NOT_ALLOWED','OWNER_IMMUTABLE'].includes(code)) return 403;
+  if (code === 'MEMBERSHIP_NOT_FOUND') return 404;
+  if (code === 'NEW_INVITATION_REQUIRED') return 409;
+  return 400;
+}
+
+export default async function handler(req, res) {
+  const token = accessTokenFromRequest(req);
+  const actor = await getVerifiedUser(token);
+  if (!actor) return json(res, 401, { ok:false, error:'AUTH_REQUIRED' });
+
+  if (req.method === 'GET') {
+    const businessId = String(req.query?.business_id || '').trim();
+    if (!businessId) return json(res, 400, { ok:false, error:'BUSINESS_REQUIRED' });
+    const response = await supabaseRpc('pilot_list_team', token, { p_business_id: businessId });
+    const payload = await readRpcJson(response);
+    if (!response.ok) return json(res, 403, { ok:false, error:rpcErrorCode(payload, 'TEAM_LIST_FAILED') });
+    return json(res, 200, { ok:true, members:Array.isArray(payload) ? payload : [] });
+  }
+
+  if (req.method !== 'PATCH') return json(res, 405, { ok:false, error:'METHOD_NOT_ALLOWED' }, { allow:'GET, PATCH' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok:false, error:'ORIGIN_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req);
+    const businessId = String(body.business_id || '').trim();
+    const userId = String(body.user_id || '').trim();
+    const action = String(body.action || '').trim().toLowerCase();
+    if (!businessId || !userId) return json(res, 400, { ok:false, error:!businessId ? 'BUSINESS_REQUIRED' : 'USER_REQUIRED' });
+    if (userId === actor.id) return json(res, 403, { ok:false, error:'SELF_TEAM_MUTATION_BLOCKED' });
+
+    if (action === 'update_access') {
+      const role = String(body.role || '').trim().toLowerCase();
+      if (!roles.has(role)) return json(res, 400, { ok:false, error:'INVALID_ROLE' });
+      const memberPermissions = normalizePermissions(body.permissions);
+      const response = await supabaseRpc('pilot_update_employee_access', token, { p_business_id:businessId, p_user_id:userId, p_role:role, p_permissions:memberPermissions });
+      const payload = await readRpcJson(response);
+      if (!response.ok) {
+        const code = rpcErrorCode(payload, 'MEMBERSHIP_UPDATE_FAILED');
+        return json(res, errorStatus(code), { ok:false, error:code });
+      }
+      return json(res, 200, { ok:true, member:Array.isArray(payload) ? payload[0] : payload });
+    }
+
+    const nextStatus = action === 'suspend' ? 'suspended' : action === 'reactivate' ? 'active' : action === 'remove' ? 'removed' : null;
+    if (!nextStatus) return json(res, 400, { ok:false, error:'INVALID_ACTION' });
+    const response = await supabaseRpc('pilot_set_employee_status', token, { p_business_id:businessId, p_user_id:userId, p_status:nextStatus });
+    const payload = await readRpcJson(response);
+    if (!response.ok) {
+      const code = rpcErrorCode(payload, 'MEMBERSHIP_STATUS_FAILED');
+      return json(res, errorStatus(code), { ok:false, error:code });
+    }
+    return json(res, 200, { ok:true, member:Array.isArray(payload) ? payload[0] : payload, company_access_active:nextStatus === 'active' });
+  } catch (error) {
+    const code = error?.message === 'INVALID_PERMISSIONS' ? 'INVALID_PERMISSIONS' : error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : error?.message === 'PAYLOAD_TOO_LARGE' ? 'PAYLOAD_TOO_LARGE' : 'TEAM_UPDATE_UNAVAILABLE';
+    return json(res, error?.code === 413 ? 413 : error?.code === 400 ? 400 : 500, { ok:false, error:code });
+  }
+}

--- a/db/pilot_employee_access_v5.sql
+++ b/db/pilot_employee_access_v5.sql
@@ -1,0 +1,298 @@
+-- PILOT one-time employee invite, permanent membership and secure access.
+-- Applied to production as Supabase migrations pilot_employee_access_v5 through v7.
+
+alter table public.pilot_memberships
+  add column if not exists status text not null default 'active',
+  add column if not exists permissions text[] not null default '{}'::text[],
+  add column if not exists display_name text,
+  add column if not exists invited_by uuid references auth.users(id) on delete set null,
+  add column if not exists accepted_at timestamptz,
+  add column if not exists suspended_at timestamptz,
+  add column if not exists removed_at timestamptz,
+  add column if not exists updated_at timestamptz not null default now();
+alter table public.pilot_memberships drop constraint if exists pilot_memberships_role_check;
+alter table public.pilot_memberships add constraint pilot_memberships_role_check check(role in ('owner','admin','manager','employee','staff','viewer','agent'));
+alter table public.pilot_memberships drop constraint if exists pilot_memberships_status_check;
+alter table public.pilot_memberships add constraint pilot_memberships_status_check check(status in ('active','suspended','removed'));
+update public.pilot_memberships set accepted_at=coalesce(accepted_at,created_at),updated_at=now() where accepted_at is null;
+create index if not exists pilot_memberships_business_status_idx on public.pilot_memberships(business_id,status);
+create index if not exists pilot_memberships_user_status_idx on public.pilot_memberships(user_id,status);
+
+create table if not exists public.pilot_employee_invitations(
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.pilot_businesses(id) on delete cascade,
+  email text not null,
+  display_name text,
+  role text not null default 'employee',
+  permissions text[] not null default '{}'::text[],
+  token_hash text not null unique,
+  status text not null default 'pending',
+  delivery_status text not null default 'prepared',
+  delivery_attempts integer not null default 0,
+  invited_by uuid not null references auth.users(id) on delete restrict,
+  accepted_by uuid references auth.users(id) on delete set null,
+  expires_at timestamptz not null,
+  accepted_at timestamptz,
+  revoked_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint pilot_employee_invitations_email_check check(email=lower(email) and length(email) between 3 and 254 and position('@' in email)>1),
+  constraint pilot_employee_invitations_role_check check(role in ('admin','manager','employee','staff','viewer','agent')),
+  constraint pilot_employee_invitations_status_check check(status in ('pending','accepted','expired','revoked')),
+  constraint pilot_employee_invitations_delivery_check check(delivery_status in ('prepared','sent','failed','bounced')),
+  constraint pilot_employee_invitations_token_hash_check check(token_hash ~ '^[0-9a-f]{64}$'),
+  constraint pilot_employee_invitations_expiry_check check(expires_at>created_at)
+);
+create unique index if not exists pilot_employee_invitations_one_pending_idx on public.pilot_employee_invitations(business_id,email) where status='pending';
+create index if not exists pilot_employee_invitations_business_status_idx on public.pilot_employee_invitations(business_id,status,expires_at);
+
+create table if not exists public.pilot_access_audit(
+  id bigint generated always as identity primary key,
+  business_id uuid references public.pilot_businesses(id) on delete set null,
+  actor_user_id uuid references auth.users(id) on delete set null,
+  target_user_id uuid references auth.users(id) on delete set null,
+  invitation_id uuid references public.pilot_employee_invitations(id) on delete set null,
+  action text not null,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  constraint pilot_access_audit_action_check check(action in ('invitation_created','invitation_sent','invitation_accepted','invitation_expired','invitation_revoked','employee_login','employee_logout','employee_suspended','employee_reactivated','employee_removed','role_changed','permission_changed','session_revoked','mfa_changed'))
+);
+create index if not exists pilot_access_audit_business_created_idx on public.pilot_access_audit(business_id,created_at desc);
+alter table public.pilot_employee_invitations enable row level security;
+alter table public.pilot_employee_invitations force row level security;
+alter table public.pilot_access_audit enable row level security;
+alter table public.pilot_access_audit force row level security;
+revoke all on public.pilot_employee_invitations from anon;
+revoke all on public.pilot_access_audit from anon;
+revoke truncate,references,trigger on public.pilot_employee_invitations from authenticated;
+revoke insert,update,delete,truncate,references,trigger on public.pilot_access_audit from authenticated;
+grant select on public.pilot_employee_invitations,public.pilot_access_audit to authenticated;
+
+create or replace function pilot_private.valid_permissions(p_permissions text[])
+returns boolean language sql immutable set search_path=public,pg_temp as $$
+ select coalesce(bool_and(p=any(array['view_business','manage_business','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])),true)
+ from unnest(coalesce(p_permissions,'{}'::text[])) p;
+$$;
+revoke all on function pilot_private.valid_permissions(text[]) from public,anon;
+grant execute on function pilot_private.valid_permissions(text[]) to authenticated,service_role;
+
+create or replace function pilot_private.has_permission(p_business_id uuid,p_permission text)
+returns boolean language sql stable security definer set search_path=public,pg_temp as $$
+select (select auth.uid()) is not null and exists(
+ select 1 from public.pilot_memberships m
+ where m.business_id=p_business_id and m.user_id=(select auth.uid()) and m.status='active' and (
+   (cardinality(m.permissions)>0 and p_permission=any(m.permissions)) or
+   (cardinality(m.permissions)=0 and case m.role
+    when 'owner' then p_permission=any(array['view_business','manage_business','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+    when 'admin' then p_permission=any(array['view_business','manage_business','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+    when 'manager' then p_permission=any(array['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+    when 'employee' then p_permission=any(array['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+    when 'staff' then p_permission=any(array['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+    when 'agent' then p_permission=any(array['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+    when 'viewer' then p_permission=any(array['view_business','view_integrations','view_customers','view_conversations','view_appointments','view_analytics','view_services','view_knowledge','view_quality'])
+    else false end)
+  )
+);
+$$;
+revoke all on function pilot_private.has_permission(uuid,text) from public,anon;
+grant execute on function pilot_private.has_permission(uuid,text) to authenticated,service_role;
+
+create or replace function pilot_private.can_manage_role(p_business_id uuid,p_target_role text)
+returns boolean language sql stable security definer set search_path=public,pg_temp as $$
+select (select auth.uid()) is not null and exists(
+ select 1 from public.pilot_memberships m where m.business_id=p_business_id and m.user_id=(select auth.uid()) and m.status='active' and
+ ((m.role='owner' and p_target_role in ('admin','manager','employee','staff','viewer','agent')) or (m.role='admin' and p_target_role in ('manager','employee','staff','viewer','agent')))
+);
+$$;
+revoke all on function pilot_private.can_manage_role(uuid,text) from public,anon;
+grant execute on function pilot_private.can_manage_role(uuid,text) to authenticated,service_role;
+
+create or replace function pilot_private.can_grant_permissions(p_business_id uuid,p_permissions text[])
+returns boolean language sql stable security definer set search_path=public,pg_temp as $$
+ select pilot_private.valid_permissions(p_permissions) and not exists(select 1 from unnest(coalesce(p_permissions,'{}'::text[])) p where not pilot_private.has_permission(p_business_id,p));
+$$;
+revoke all on function pilot_private.can_grant_permissions(uuid,text[]) from public,anon;
+grant execute on function pilot_private.can_grant_permissions(uuid,text[]) to authenticated,service_role;
+
+create or replace function pilot_private.guard_designated_owner_membership()
+returns trigger language plpgsql security definer set search_path=public,pg_temp as $$
+begin
+ if tg_op='DELETE' and old.role='owner' and exists(select 1 from public.pilot_businesses b where b.id=old.business_id and b.owner_id=old.user_id) then raise exception 'BUSINESS_OWNER_MEMBERSHIP_IMMUTABLE'; end if;
+ if tg_op='UPDATE' and old.role='owner' and exists(select 1 from public.pilot_businesses b where b.id=old.business_id and b.owner_id=old.user_id) and (new.business_id<>old.business_id or new.user_id<>old.user_id or new.role<>'owner' or new.status<>'active') then raise exception 'BUSINESS_OWNER_MEMBERSHIP_IMMUTABLE'; end if;
+ return case when tg_op='DELETE' then old else new end;
+end;$$;
+revoke all on function pilot_private.guard_designated_owner_membership() from public,anon,authenticated;
+
+create or replace function pilot_private.guard_membership_identity()
+returns trigger language plpgsql set search_path=public,pg_temp as $$
+begin
+ if new.business_id<>old.business_id or new.user_id<>old.user_id then raise exception 'MEMBERSHIP_IDENTITY_IMMUTABLE'; end if;
+ new.updated_at:=now(); return new;
+end;$$;
+revoke all on function pilot_private.guard_membership_identity() from public,anon;
+drop trigger if exists pilot_guard_membership_identity on public.pilot_memberships;
+create trigger pilot_guard_membership_identity before update on public.pilot_memberships for each row execute function pilot_private.guard_membership_identity();
+
+-- Active membership is the tenant gate. Non-owner activation is invitation-only; removal is soft-delete.
+drop policy if exists pilot_businesses_member_select on public.pilot_businesses;
+create policy pilot_businesses_member_select on public.pilot_businesses for select to authenticated using(exists(select 1 from public.pilot_memberships m where m.business_id=pilot_businesses.id and m.user_id=(select auth.uid()) and m.status='active'));
+drop policy if exists pilot_memberships_insert on public.pilot_memberships;
+drop policy if exists pilot_memberships_team_insert on public.pilot_memberships;
+drop policy if exists pilot_memberships_select on public.pilot_memberships;
+drop policy if exists pilot_memberships_team_select on public.pilot_memberships;
+drop policy if exists pilot_memberships_team_update on public.pilot_memberships;
+drop policy if exists pilot_memberships_team_delete on public.pilot_memberships;
+create policy pilot_memberships_select on public.pilot_memberships for select to authenticated using(user_id=(select auth.uid()) or pilot_private.has_permission(business_id,'manage_team'));
+create policy pilot_memberships_owner_insert on public.pilot_memberships for insert to authenticated with check(user_id=(select auth.uid()) and role='owner' and status='active' and exists(select 1 from public.pilot_businesses b where b.id=business_id and b.owner_id=(select auth.uid())));
+create policy pilot_memberships_team_update on public.pilot_memberships for update to authenticated using(role<>'owner' and pilot_private.can_manage_role(business_id,role)) with check(role<>'owner' and pilot_private.can_manage_role(business_id,role));
+revoke delete on public.pilot_memberships from authenticated;
+drop policy if exists pilot_employee_invitations_team_select on public.pilot_employee_invitations;
+create policy pilot_employee_invitations_team_select on public.pilot_employee_invitations for select to authenticated using(pilot_private.has_permission(business_id,'manage_team'));
+drop policy if exists pilot_access_audit_team_select on public.pilot_access_audit;
+create policy pilot_access_audit_team_select on public.pilot_access_audit for select to authenticated using(business_id is not null and pilot_private.has_permission(business_id,'manage_team'));
+
+create or replace function pilot_private.pilot_create_employee_invitation(p_business_id uuid,p_email text,p_display_name text,p_role text default 'employee',p_permissions text[] default '{}'::text[],p_token_hash text default null,p_expires_at timestamptz default(now()+interval '72 hours'))
+returns table(invitation_id uuid,business_id uuid,email text,role text,status text,expires_at timestamptz)
+language plpgsql security definer set search_path=public,extensions,pg_temp as $$
+declare v_actor uuid:=auth.uid(); v_email text:=lower(trim(coalesce(p_email,''))); v_inv public.pilot_employee_invitations%rowtype; v_existing_status text;
+begin
+ if v_actor is null then raise exception 'AUTH_REQUIRED'; end if;
+ if p_business_id is null then raise exception 'BUSINESS_REQUIRED'; end if;
+ if length(v_email)<3 or length(v_email)>254 or position('@' in v_email)<=1 then raise exception 'INVALID_EMAIL'; end if;
+ if p_role not in ('admin','manager','employee','staff','viewer','agent') then raise exception 'INVALID_ROLE'; end if;
+ if p_token_hash is null or p_token_hash !~ '^[0-9a-f]{64}$' then raise exception 'INVALID_TOKEN_HASH'; end if;
+ if p_expires_at<=now() or p_expires_at>now()+interval '14 days' then raise exception 'INVALID_EXPIRY'; end if;
+ if not pilot_private.can_manage_role(p_business_id,p_role) then raise exception 'TEAM_MANAGEMENT_REQUIRED'; end if;
+ if not pilot_private.can_grant_permissions(p_business_id,coalesce(p_permissions,'{}'::text[])) then raise exception 'PERMISSION_GRANT_NOT_ALLOWED'; end if;
+ update public.pilot_employee_invitations set status='expired',updated_at=now() where business_id=p_business_id and email=v_email and status='pending' and expires_at<=now();
+ if exists(select 1 from public.pilot_employee_invitations i where i.business_id=p_business_id and i.email=v_email and i.status='pending') then raise exception 'INVITATION_ALREADY_PENDING'; end if;
+ select m.status into v_existing_status from auth.users u join public.pilot_memberships m on m.user_id=u.id where m.business_id=p_business_id and lower(u.email)=v_email limit 1;
+ if v_existing_status in ('active','suspended') then raise exception 'EMPLOYEE_ALREADY_MEMBER'; end if;
+ insert into public.pilot_employee_invitations(business_id,email,display_name,role,permissions,token_hash,status,delivery_status,invited_by,expires_at)
+ values(p_business_id,v_email,nullif(trim(coalesce(p_display_name,'')),''),p_role,coalesce(p_permissions,'{}'::text[]),p_token_hash,'pending','prepared',v_actor,p_expires_at) returning * into v_inv;
+ insert into public.pilot_access_audit(business_id,actor_user_id,invitation_id,action,metadata) values(p_business_id,v_actor,v_inv.id,'invitation_created',jsonb_build_object('role',p_role));
+ return query select v_inv.id,v_inv.business_id,v_inv.email,v_inv.role,v_inv.status,v_inv.expires_at;
+end;$$;
+revoke all on function pilot_private.pilot_create_employee_invitation(uuid,text,text,text,text[],text,timestamptz) from public,anon;
+grant execute on function pilot_private.pilot_create_employee_invitation(uuid,text,text,text,text[],text,timestamptz) to authenticated;
+
+create or replace function pilot_private.pilot_accept_employee_invitation(p_token text)
+returns table(business_id uuid,role text,status text)
+language plpgsql security definer set search_path=public,extensions,pg_temp as $$
+declare v_user uuid:=auth.uid(); v_email text:=lower(coalesce(auth.jwt()->>'email','')); v_hash text; v_inv public.pilot_employee_invitations%rowtype; v_existing public.pilot_memberships%rowtype;
+begin
+ if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+ if v_email='' then raise exception 'VERIFIED_EMAIL_REQUIRED'; end if;
+ if p_token is null or length(p_token)<32 or length(p_token)>256 then raise exception 'INVALID_INVITATION'; end if;
+ v_hash:=encode(extensions.digest(p_token,'sha256'),'hex');
+ select * into v_inv from public.pilot_employee_invitations where token_hash=v_hash for update;
+ if not found then raise exception 'INVITATION_NOT_FOUND'; end if;
+ if v_inv.status<>'pending' then raise exception 'INVITATION_NOT_PENDING'; end if;
+ if v_inv.expires_at<=now() then raise exception 'INVITATION_EXPIRED'; end if;
+ if lower(v_inv.email)<>v_email then raise exception 'INVITATION_EMAIL_MISMATCH'; end if;
+ if not exists(select 1 from public.pilot_memberships m where m.business_id=v_inv.business_id and m.user_id=v_inv.invited_by and m.status='active' and ((m.role='owner' and v_inv.role in ('admin','manager','employee','staff','viewer','agent')) or (m.role='admin' and v_inv.role in ('manager','employee','staff','viewer','agent')))) then raise exception 'INVITER_NO_LONGER_AUTHORIZED'; end if;
+ select * into v_existing from public.pilot_memberships where business_id=v_inv.business_id and user_id=v_user for update;
+ if found and v_existing.status in ('active','suspended') then raise exception 'MEMBERSHIP_ALREADY_EXISTS'; end if;
+ if found and v_existing.status='removed' then
+  update public.pilot_memberships set role=v_inv.role,permissions=v_inv.permissions,display_name=v_inv.display_name,status='active',invited_by=v_inv.invited_by,accepted_at=now(),suspended_at=null,removed_at=null,updated_at=now() where business_id=v_inv.business_id and user_id=v_user;
+ else
+  insert into public.pilot_memberships(business_id,user_id,role,status,permissions,display_name,invited_by,accepted_at) values(v_inv.business_id,v_user,v_inv.role,'active',v_inv.permissions,v_inv.display_name,v_inv.invited_by,now());
+ end if;
+ update public.pilot_employee_invitations set status='accepted',accepted_by=v_user,accepted_at=now(),updated_at=now() where id=v_inv.id;
+ update public.pilot_employee_invitations set status='revoked',revoked_at=now(),updated_at=now() where business_id=v_inv.business_id and email=v_inv.email and status='pending' and id<>v_inv.id;
+ insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,invitation_id,action,metadata) values(v_inv.business_id,v_user,v_user,v_inv.id,'invitation_accepted',jsonb_build_object('role',v_inv.role));
+ return query select v_inv.business_id,v_inv.role,'active'::text;
+end;$$;
+revoke all on function pilot_private.pilot_accept_employee_invitation(text) from public,anon;
+grant execute on function pilot_private.pilot_accept_employee_invitation(text) to authenticated;
+
+create or replace function pilot_private.pilot_update_employee_access(p_business_id uuid,p_user_id uuid,p_role text,p_permissions text[] default '{}'::text[])
+returns table(user_id uuid,role text,status text,permissions text[])
+language plpgsql security definer set search_path=public,pg_temp as $$
+declare v_actor uuid:=auth.uid(); v_old public.pilot_memberships%rowtype; v_new public.pilot_memberships%rowtype;
+begin
+ if v_actor is null then raise exception 'AUTH_REQUIRED'; end if;
+ select * into v_old from public.pilot_memberships where business_id=p_business_id and user_id=p_user_id for update;
+ if not found then raise exception 'MEMBERSHIP_NOT_FOUND'; end if;
+ if v_old.role='owner' or p_role='owner' then raise exception 'OWNER_IMMUTABLE'; end if;
+ if not pilot_private.can_manage_role(p_business_id,v_old.role) or not pilot_private.can_manage_role(p_business_id,p_role) then raise exception 'TEAM_MANAGEMENT_REQUIRED'; end if;
+ if p_role not in ('admin','manager','employee','staff','viewer','agent') then raise exception 'INVALID_ROLE'; end if;
+ if not pilot_private.can_grant_permissions(p_business_id,coalesce(p_permissions,'{}'::text[])) then raise exception 'PERMISSION_GRANT_NOT_ALLOWED'; end if;
+ update public.pilot_memberships set role=p_role,permissions=coalesce(p_permissions,'{}'::text[]),updated_at=now() where business_id=p_business_id and user_id=p_user_id returning * into v_new;
+ if v_old.role<>v_new.role then insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata) values(p_business_id,v_actor,p_user_id,'role_changed',jsonb_build_object('from',v_old.role,'to',v_new.role)); end if;
+ if v_old.permissions is distinct from v_new.permissions then insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata) values(p_business_id,v_actor,p_user_id,'permission_changed',jsonb_build_object('count',cardinality(v_new.permissions))); end if;
+ return query select v_new.user_id,v_new.role,v_new.status,v_new.permissions;
+end;$$;
+revoke all on function pilot_private.pilot_update_employee_access(uuid,uuid,text,text[]) from public,anon;
+grant execute on function pilot_private.pilot_update_employee_access(uuid,uuid,text,text[]) to authenticated;
+
+create or replace function pilot_private.pilot_set_employee_status(p_business_id uuid,p_user_id uuid,p_status text)
+returns table(user_id uuid,role text,status text)
+language plpgsql security definer set search_path=public,pg_temp as $$
+declare v_actor uuid:=auth.uid(); v_old public.pilot_memberships%rowtype; v_new public.pilot_memberships%rowtype; v_email text; v_action text;
+begin
+ if v_actor is null then raise exception 'AUTH_REQUIRED'; end if;
+ if p_status not in ('active','suspended','removed') then raise exception 'INVALID_STATUS'; end if;
+ select * into v_old from public.pilot_memberships where business_id=p_business_id and user_id=p_user_id for update;
+ if not found then raise exception 'MEMBERSHIP_NOT_FOUND'; end if;
+ if v_old.role='owner' then raise exception 'OWNER_IMMUTABLE'; end if;
+ if not pilot_private.can_manage_role(p_business_id,v_old.role) then raise exception 'TEAM_MANAGEMENT_REQUIRED'; end if;
+ if v_old.status='removed' and p_status='active' then raise exception 'NEW_INVITATION_REQUIRED'; end if;
+ update public.pilot_memberships set status=p_status,suspended_at=case when p_status='suspended' then now() else null end,removed_at=case when p_status='removed' then now() else null end,updated_at=now() where business_id=p_business_id and user_id=p_user_id returning * into v_new;
+ if p_status='suspended' then v_action:='employee_suspended'; elsif p_status='removed' then v_action:='employee_removed'; elsif v_old.status='suspended' and p_status='active' then v_action:='employee_reactivated'; else v_action:=null; end if;
+ if p_status='removed' then select lower(email) into v_email from auth.users where id=p_user_id; if v_email is not null then update public.pilot_employee_invitations set status='revoked',revoked_at=now(),updated_at=now() where business_id=p_business_id and email=v_email and status='pending'; end if; end if;
+ if v_action is not null then insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata) values(p_business_id,v_actor,p_user_id,v_action,jsonb_build_object('from',v_old.status,'to',v_new.status)); end if;
+ return query select v_new.user_id,v_new.role,v_new.status;
+end;$$;
+revoke all on function pilot_private.pilot_set_employee_status(uuid,uuid,text) from public,anon;
+grant execute on function pilot_private.pilot_set_employee_status(uuid,uuid,text) to authenticated;
+
+create or replace function pilot_private.pilot_list_team(p_business_id uuid)
+returns table(user_id uuid,email text,display_name text,role text,status text,permissions text[],accepted_at timestamptz,created_at timestamptz)
+language sql stable security definer set search_path=public,pg_temp as $$
+ select m.user_id,u.email,m.display_name,m.role,m.status,m.permissions,m.accepted_at,m.created_at from public.pilot_memberships m join auth.users u on u.id=m.user_id where m.business_id=p_business_id and pilot_private.has_permission(p_business_id,'manage_team') order by case m.role when 'owner' then 0 when 'admin' then 1 when 'manager' then 2 else 3 end,m.created_at;
+$$;
+revoke all on function pilot_private.pilot_list_team(uuid) from public,anon;
+grant execute on function pilot_private.pilot_list_team(uuid) to authenticated;
+
+-- Public RPCs are SECURITY INVOKER wrappers; privileged implementations remain in pilot_private.
+create or replace function public.pilot_create_employee_invitation(p_business_id uuid,p_email text,p_display_name text,p_role text default 'employee',p_permissions text[] default '{}'::text[],p_token_hash text default null,p_expires_at timestamptz default(now()+interval '72 hours'))
+returns table(invitation_id uuid,business_id uuid,email text,role text,status text,expires_at timestamptz)
+language sql security invoker set search_path=public,pilot_private,pg_temp as $$ select * from pilot_private.pilot_create_employee_invitation(p_business_id,p_email,p_display_name,p_role,p_permissions,p_token_hash,p_expires_at); $$;
+create or replace function public.pilot_accept_employee_invitation(p_token text)
+returns table(business_id uuid,role text,status text)
+language sql security invoker set search_path=public,pilot_private,pg_temp as $$ select * from pilot_private.pilot_accept_employee_invitation(p_token); $$;
+create or replace function public.pilot_update_employee_access(p_business_id uuid,p_user_id uuid,p_role text,p_permissions text[] default '{}'::text[])
+returns table(user_id uuid,role text,status text,permissions text[])
+language sql security invoker set search_path=public,pilot_private,pg_temp as $$ select * from pilot_private.pilot_update_employee_access(p_business_id,p_user_id,p_role,p_permissions); $$;
+create or replace function public.pilot_set_employee_status(p_business_id uuid,p_user_id uuid,p_status text)
+returns table(user_id uuid,role text,status text)
+language sql security invoker set search_path=public,pilot_private,pg_temp as $$ select * from pilot_private.pilot_set_employee_status(p_business_id,p_user_id,p_status); $$;
+create or replace function public.pilot_list_team(p_business_id uuid)
+returns table(user_id uuid,email text,display_name text,role text,status text,permissions text[],accepted_at timestamptz,created_at timestamptz)
+language sql stable security invoker set search_path=public,pilot_private,pg_temp as $$ select * from pilot_private.pilot_list_team(p_business_id); $$;
+revoke all on function public.pilot_create_employee_invitation(uuid,text,text,text,text[],text,timestamptz) from public,anon;
+revoke all on function public.pilot_accept_employee_invitation(text) from public,anon;
+revoke all on function public.pilot_update_employee_access(uuid,uuid,text,text[]) from public,anon;
+revoke all on function public.pilot_set_employee_status(uuid,uuid,text) from public,anon;
+revoke all on function public.pilot_list_team(uuid) from public,anon;
+grant execute on function public.pilot_create_employee_invitation(uuid,text,text,text,text[],text,timestamptz) to authenticated;
+grant execute on function public.pilot_accept_employee_invitation(text) to authenticated;
+grant execute on function public.pilot_update_employee_access(uuid,uuid,text,text[]) to authenticated;
+grant execute on function public.pilot_set_employee_status(uuid,uuid,text) to authenticated;
+grant execute on function public.pilot_list_team(uuid) to authenticated;
+
+create or replace function public.pilot_create_business(p_name text,p_business_type text,p_locale text default 'ar-AE')
+returns table(business_id uuid,business_slug text)
+language plpgsql security invoker set search_path=public,pg_temp as $$
+declare v_user uuid:=auth.uid(); v_id uuid:=gen_random_uuid(); v_slug text;
+begin
+ if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+ if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
+ if p_business_type not in ('store','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
+ v_slug:='pilot-'||substr(replace(v_id::text,'-',''),1,16);
+ insert into public.pilot_businesses(id,slug,name,business_type,owner_id,locale,demo_mode) values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),true);
+ insert into public.pilot_memberships(business_id,user_id,role,status,accepted_at) values(v_id,v_user,'owner','active',now());
+ insert into public.pilot_channels(business_id,channel_type,status,metadata) values (v_id,'whatsapp','configured','{"reason":"runtime_verification_required"}'::jsonb),(v_id,'instagram','configured','{"reason":"runtime_verification_required"}'::jsonb) on conflict(business_id,channel_type) do nothing;
+ return query select v_id,v_slug;
+end;$$;

--- a/db/pilot_employee_access_v9_fix.sql
+++ b/db/pilot_employee_access_v9_fix.sql
@@ -1,0 +1,83 @@
+-- PILOT employee access v9: fix ambiguous membership references and record business-scope session revocation.
+
+create or replace function pilot_private.pilot_set_employee_status(p_business_id uuid,p_user_id uuid,p_status text)
+returns table(user_id uuid,role text,status text)
+language plpgsql security definer set search_path=public,pg_temp as $$
+declare
+  v_actor uuid:=auth.uid();
+  v_old public.pilot_memberships%rowtype;
+  v_new public.pilot_memberships%rowtype;
+  v_email text;
+  v_action text;
+begin
+  if v_actor is null then raise exception 'AUTH_REQUIRED'; end if;
+  if p_status not in ('active','suspended','removed') then raise exception 'INVALID_STATUS'; end if;
+  select m.* into v_old from public.pilot_memberships m where m.business_id=p_business_id and m.user_id=p_user_id for update;
+  if not found then raise exception 'MEMBERSHIP_NOT_FOUND'; end if;
+  if v_old.role='owner' then raise exception 'OWNER_IMMUTABLE'; end if;
+  if not pilot_private.can_manage_role(p_business_id,v_old.role) then raise exception 'TEAM_MANAGEMENT_REQUIRED'; end if;
+  if v_old.status='removed' and p_status='active' then raise exception 'NEW_INVITATION_REQUIRED'; end if;
+
+  update public.pilot_memberships m
+  set status=p_status,
+      suspended_at=case when p_status='suspended' then now() else null end,
+      removed_at=case when p_status='removed' then now() else null end,
+      updated_at=now()
+  where m.business_id=p_business_id and m.user_id=p_user_id returning m.* into v_new;
+
+  if p_status='suspended' then v_action:='employee_suspended';
+  elsif p_status='removed' then v_action:='employee_removed';
+  elsif v_old.status='suspended' and p_status='active' then v_action:='employee_reactivated';
+  else v_action:=null;
+  end if;
+
+  if p_status='removed' then
+    select lower(u.email) into v_email from auth.users u where u.id=p_user_id;
+    if v_email is not null then
+      update public.pilot_employee_invitations i
+      set status='revoked',revoked_at=now(),updated_at=now()
+      where i.business_id=p_business_id and i.email=v_email and i.status='pending';
+    end if;
+  end if;
+
+  if v_action is not null then
+    insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata)
+    values(p_business_id,v_actor,p_user_id,v_action,jsonb_build_object('from',v_old.status,'to',v_new.status));
+  end if;
+  if p_status in ('suspended','removed') then
+    insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata)
+    values(p_business_id,v_actor,p_user_id,'session_revoked',jsonb_build_object('scope','business_membership','reason',p_status));
+  end if;
+  return query select v_new.user_id,v_new.role,v_new.status;
+end;$$;
+
+create or replace function pilot_private.pilot_update_employee_access(p_business_id uuid,p_user_id uuid,p_role text,p_permissions text[] default '{}'::text[])
+returns table(user_id uuid,role text,status text,permissions text[])
+language plpgsql security definer set search_path=public,pg_temp as $$
+declare
+  v_actor uuid:=auth.uid();
+  v_old public.pilot_memberships%rowtype;
+  v_new public.pilot_memberships%rowtype;
+begin
+  if v_actor is null then raise exception 'AUTH_REQUIRED'; end if;
+  select m.* into v_old from public.pilot_memberships m where m.business_id=p_business_id and m.user_id=p_user_id for update;
+  if not found then raise exception 'MEMBERSHIP_NOT_FOUND'; end if;
+  if v_old.role='owner' or p_role='owner' then raise exception 'OWNER_IMMUTABLE'; end if;
+  if not pilot_private.can_manage_role(p_business_id,v_old.role) or not pilot_private.can_manage_role(p_business_id,p_role) then raise exception 'TEAM_MANAGEMENT_REQUIRED'; end if;
+  if p_role not in ('admin','manager','employee','staff','viewer','agent') then raise exception 'INVALID_ROLE'; end if;
+  if not pilot_private.can_grant_permissions(p_business_id,coalesce(p_permissions,'{}'::text[])) then raise exception 'PERMISSION_GRANT_NOT_ALLOWED'; end if;
+
+  update public.pilot_memberships m
+  set role=p_role,permissions=coalesce(p_permissions,'{}'::text[]),updated_at=now()
+  where m.business_id=p_business_id and m.user_id=p_user_id returning m.* into v_new;
+
+  if v_old.role<>v_new.role then
+    insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata)
+    values(p_business_id,v_actor,p_user_id,'role_changed',jsonb_build_object('from',v_old.role,'to',v_new.role));
+  end if;
+  if v_old.permissions is distinct from v_new.permissions then
+    insert into public.pilot_access_audit(business_id,actor_user_id,target_user_id,action,metadata)
+    values(p_business_id,v_actor,p_user_id,'permission_changed',jsonb_build_object('count',cardinality(v_new.permissions)));
+  end if;
+  return query select v_new.user_id,v_new.role,v_new.status,v_new.permissions;
+end;$$;

--- a/team.html
+++ b/team.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="theme-color" content="#090a0b">
+<title>PILOT — Team</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#111315;--panel2:#17191c;--line:#292d32;--text:#f6f7f8;--muted:#979da6;--accent:#d7ff5f;--green:#83e69a;--warn:#ffd87a;--red:#ff9696}
+*{box-sizing:border-box}body{margin:0;min-height:100vh;background:radial-gradient(circle at 50% -10%,#202429,#090a0b 48%,#08090a);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif}.wrap{max-width:980px;margin:auto;padding:22px 16px 80px}.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}.brand{font-weight:950;font-size:18px}.brand span{color:var(--accent)}a,button,input,select{font:inherit;min-height:44px}.back,.secondary,.primary,.danger{border-radius:12px;padding:9px 13px;font-weight:850;font-size:12px}.back,.secondary{border:1px solid var(--line);background:#17191c;color:#fff;text-decoration:none}.primary{border:0;background:var(--accent);color:#10120d}.danger{border:1px solid #5a3030;background:#261616;color:#ffb0b0}.card{background:linear-gradient(180deg,#15171a,#0f1113);border:1px solid var(--line);border-radius:18px;padding:16px;margin-bottom:13px}.hero h1{margin:0 0 6px;font-size:24px}.hero p,.muted{color:var(--muted);font-size:11px;line-height:1.6}.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:10px}.field label{display:block;color:var(--muted);font-size:10px;margin:0 0 5px}.field input,.field select{width:100%;border:1px solid var(--line);background:#17191c;color:#fff;border-radius:11px;padding:10px}.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.row{display:flex;align-items:center;gap:10px;padding:12px;border:1px solid #262a2f;border-radius:14px;margin-top:8px;background:#15171a}.grow{flex:1;min-width:0}.row b{font-size:12px;display:block}.row small{font-size:9px;color:var(--muted)}.badge{display:inline-flex;border-radius:99px;padding:5px 8px;font-size:9px;font-weight:900}.active{background:#14331e;color:#8ce6a1}.suspended{background:#3a3014;color:#ffd87a}.removed{background:#3b1717;color:#ffaaaa}.pending{background:#15283a;color:#97ccff}.hidden{display:none!important}.notice{border:1px solid #475225;background:#19200f;border-radius:14px;padding:12px;font-size:11px;line-height:1.6}.error{border-color:#603333;background:#251515;color:#ffc0c0}.ok{color:var(--green)}.inviteBox{word-break:break-all;background:#0d0f10;border:1px dashed #3a4148;padding:10px;border-radius:10px;font-size:10px;direction:ltr;text-align:left}.login{max-width:500px;margin:8vh auto}.login h2{margin:0 0 5px}.seg{display:flex;gap:6px;margin-bottom:12px}.seg button{flex:1}.memberActions{display:flex;gap:6px;flex-wrap:wrap}.memberActions button{min-height:36px;padding:6px 9px}.lang{font-size:10px;color:var(--muted)}
+@media(max-width:700px){.grid{grid-template-columns:1fr}.row{align-items:flex-start;flex-wrap:wrap}.memberActions{width:100%}.memberActions button{flex:1}.hero h1{font-size:20px}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <div class="top"><div class="brand">PILOT <span>TEAM</span></div><a class="back" href="/">← التطبيق</a></div>
+
+  <section id="authCard" class="card login hidden">
+    <h2>تسجيل الدخول</h2>
+    <p class="muted">سجّل الدخول بحسابك. إذا كانت لديك دعوة موظف فسيتم ربطها بالحساب مرة واحدة فقط.</p>
+    <div class="field"><label>البريد الإلكتروني</label><input id="authEmail" type="email" autocomplete="email"></div>
+    <div class="field" style="margin-top:8px"><label>كلمة المرور</label><input id="authPassword" type="password" autocomplete="current-password"></div>
+    <div class="actions"><button class="primary" id="loginBtn">تسجيل الدخول</button><button class="secondary" id="signupBtn">إنشاء حساب</button></div>
+    <p id="authMessage" class="muted"></p>
+  </section>
+
+  <section id="inviteCard" class="card hidden">
+    <div class="hero"><h1>دعوة فريق</h1><p>هذه الدعوة تستخدم مرة واحدة ثم تتحول إلى عضوية دائمة. لن تحتاج لهذا الرابط في تسجيلات الدخول القادمة.</p></div>
+    <div id="inviteMessage" class="notice">تم العثور على دعوة. بعد تسجيل الدخول اضغط قبول.</div>
+    <div class="actions"><button class="primary" id="acceptInviteBtn">قبول الدعوة وربط الحساب</button></div>
+  </section>
+
+  <main id="teamApp" class="hidden">
+    <section class="card hero"><h1>الفريق والموظفون</h1><p>دعوة واحدة لكل موظف، ثم عضوية دائمة ودخول طبيعي. التعليق أو الإزالة يوقف وصول الشركة فورًا عبر RLS.</p><div id="identity" class="muted"></div></section>
+
+    <section id="ownerPanel" class="card hidden">
+      <h3 style="margin-top:0">إضافة موظف</h3>
+      <div class="grid">
+        <div class="field"><label>الاسم</label><input id="employeeName" maxlength="120"></div>
+        <div class="field"><label>البريد الإلكتروني</label><input id="employeeEmail" type="email"></div>
+        <div class="field"><label>الدور</label><select id="employeeRole"><option value="employee">Employee</option><option value="manager">Manager</option><option value="admin">Admin</option><option value="viewer">Viewer</option></select></div>
+        <div class="field"><label>صلاحيات مخصصة (اختياري)</label><select id="permissionPreset"><option value="">حسب الدور</option><option value="support">المحادثات والعملاء</option><option value="readonly">قراءة فقط</option></select></div>
+      </div>
+      <div class="actions"><button class="primary" id="createInviteBtn">إنشاء الدعوة الواحدة</button></div>
+      <div id="createdInvite" class="hidden" style="margin-top:12px"><div class="notice">تم إنشاء الدعوة. شارك هذا الرابط مرة واحدة فقط مع الموظف.</div><div id="inviteUrl" class="inviteBox" style="margin-top:8px"></div><div class="actions"><button class="secondary" id="copyInviteBtn">نسخ الرابط</button></div></div>
+      <p id="ownerMessage" class="muted"></p>
+    </section>
+
+    <section class="card">
+      <h3 style="margin-top:0">أعضاء الفريق</h3>
+      <div id="members"><p class="muted">جاري التحميل…</p></div>
+    </section>
+
+    <section id="invitationListCard" class="card hidden">
+      <h3 style="margin-top:0">الدعوات</h3>
+      <div id="invitations"></div>
+    </section>
+  </main>
+</div>
+<script>
+const $=id=>document.getElementById(id);
+const inviteToken=new URLSearchParams(location.search).get('invite')||'';
+let session=null,businessId=null,isTeamManager=false,lastInviteUrl='';
+const presets={support:['view_business','view_customers','edit_customers','view_conversations','reply_conversations'],readonly:['view_business','view_customers','view_conversations','view_appointments','view_services']};
+
+async function api(path,options={}){const r=await fetch(path,{credentials:'same-origin',headers:{'content-type':'application/json',...(options.headers||{})},...options});let p={};try{p=await r.json()}catch{}return{r,p}}
+function msg(el,text,bad=false){el.textContent=text;el.className=bad?'muted error':'muted'}
+function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+
+async function loadSession(){
+ const {r,p}=await api('/api/auth/session',{method:'GET'});
+ if(!r.ok||!p.authenticated){$('authCard').classList.remove('hidden');$('teamApp').classList.add('hidden');if(inviteToken)$('inviteCard').classList.remove('hidden');return false}
+ session=p;$('authCard').classList.add('hidden');$('teamApp').classList.remove('hidden');$('identity').textContent=p.user?.email||'';
+ if(inviteToken)$('inviteCard').classList.remove('hidden');
+ const memberships=Array.isArray(p.memberships)?p.memberships:[];
+ const preferred=memberships.find(m=>['owner','admin'].includes(m.role))||memberships[0];
+ businessId=preferred?.business_id||null;isTeamManager=!!memberships.find(m=>m.business_id===businessId&&['owner','admin'].includes(m.role));
+ if(isTeamManager)$('ownerPanel').classList.remove('hidden');
+ if(businessId)await loadTeam();else $('members').innerHTML='<p class="muted">لا توجد عضوية شركة نشطة بعد. إذا كانت لديك دعوة فاقبلها أولاً.</p>';
+ return true;
+}
+
+$('loginBtn').onclick=async()=>{const email=$('authEmail').value.trim(),password=$('authPassword').value;const {r,p}=await api('/api/auth/login',{method:'POST',body:JSON.stringify({email,password})});if(!r.ok)return msg($('authMessage'),p.error||'فشل تسجيل الدخول',true);msg($('authMessage'),'تم تسجيل الدخول');await loadSession()};
+$('signupBtn').onclick=async()=>{const email=$('authEmail').value.trim(),password=$('authPassword').value;const {r,p}=await api('/api/auth/signup',{method:'POST',body:JSON.stringify({email,password})});if(!r.ok)return msg($('authMessage'),p.error||'تعذر إنشاء الحساب',true);msg($('authMessage'),p.authenticated?'تم إنشاء الحساب وتسجيل الدخول.':'تم إنشاء الحساب. تحقق من بريدك الإلكتروني ثم سجّل الدخول.')};
+
+$('acceptInviteBtn').onclick=async()=>{if(!inviteToken)return;const {r,p}=await api('/api/team/accept-invite',{method:'POST',body:JSON.stringify({token:inviteToken})});if(!r.ok){if(r.status===401){$('authCard').classList.remove('hidden');return msg($('inviteMessage'), 'سجّل الدخول أولاً ثم عد لقبول الدعوة.',true)}return msg($('inviteMessage'),p.error||'تعذر قبول الدعوة',true)}msg($('inviteMessage'),'تم قبول الدعوة. عضويتك الآن دائمة ويمكنك الدخول لاحقًا بدون هذا الرابط.');$('acceptInviteBtn').classList.add('hidden');history.replaceState({},'', '/team.html');await loadSession()};
+
+$('createInviteBtn').onclick=async()=>{if(!businessId)return;const role=$('employeeRole').value,preset=$('permissionPreset').value;const body={business_id:businessId,email:$('employeeEmail').value.trim(),display_name:$('employeeName').value.trim(),role,permissions:presets[preset]||[]};const {r,p}=await api('/api/team/invitations',{method:'POST',body:JSON.stringify(body)});if(!r.ok)return msg($('ownerMessage'),p.error||'تعذر إنشاء الدعوة',true);lastInviteUrl=new URL(p.invite_path,location.origin).href;$('inviteUrl').textContent=lastInviteUrl;$('createdInvite').classList.remove('hidden');msg($('ownerMessage'),'تم. لا تُنشئ دعوة جديدة لهذا الموظف بعد قبولها.');await loadInvitations()};
+$('copyInviteBtn').onclick=async()=>{if(!lastInviteUrl)return;await navigator.clipboard.writeText(lastInviteUrl);msg($('ownerMessage'),'تم نسخ رابط الدعوة.')};
+
+async function loadTeam(){
+ const {r,p}=await api('/api/team/members?business_id='+encodeURIComponent(businessId));
+ if(!r.ok){$('members').innerHTML='<p class="muted">حسابك عضو في الشركة ولا يملك صلاحية إدارة الفريق.</p>';return}
+ $('ownerPanel').classList.remove('hidden');isTeamManager=true;
+ $('members').innerHTML=(p.members||[]).map(m=>`<div class="row"><div class="grow"><b>${esc(m.display_name||m.email)}</b><small>${esc(m.email)} · ${esc(m.role)}</small></div><span class="badge ${esc(m.status)}">${esc(m.status)}</span>${m.role==='owner'?'':`<div class="memberActions">${m.status==='active'?`<button class="secondary" onclick="memberAction('${m.user_id}','suspend')">تعليق</button>`:''}${m.status==='suspended'?`<button class="secondary" onclick="memberAction('${m.user_id}','reactivate')">إعادة تفعيل</button>`:''}${m.status!=='removed'?`<button class="danger" onclick="memberAction('${m.user_id}','remove')">إزالة</button>`:''}</div>`}</div>`).join('')||'<p class="muted">لا يوجد أعضاء.</p>';
+ await loadInvitations();
+}
+
+window.memberAction=async(userId,action)=>{const {r,p}=await api('/api/team/members',{method:'PATCH',body:JSON.stringify({business_id:businessId,user_id:userId,action})});if(!r.ok)return alert(p.error||'تعذر تحديث العضو');await loadTeam()};
+async function loadInvitations(){if(!isTeamManager||!businessId)return;const {r,p}=await api('/api/team/invitations?business_id='+encodeURIComponent(businessId));if(!r.ok)return;$('invitationListCard').classList.remove('hidden');$('invitations').innerHTML=(p.invitations||[]).map(i=>`<div class="row"><div class="grow"><b>${esc(i.display_name||i.email)}</b><small>${esc(i.email)} · ${esc(i.role)} · ${new Date(i.expires_at).toLocaleString()}</small></div><span class="badge ${esc(i.status)}">${esc(i.status)}</span></div>`).join('')||'<p class="muted">لا توجد دعوات.</p>'}
+
+loadSession();
+</script>
+</body>
+</html>

--- a/test/employee-access-contract.test.mjs
+++ b/test/employee-access-contract.test.mjs
@@ -1,0 +1,77 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+const migration = await read('db/pilot_employee_access_v5.sql');
+const authCore = await read('api/_auth-core.js');
+const invitations = await read('api/team/invitations.js');
+const accept = await read('api/team/accept-invite.js');
+const members = await read('api/team/members.js');
+
+test('employee invitations are one-time hashed tenant-scoped records', () => {
+  assert.match(migration, /pilot_employee_invitations/);
+  assert.match(migration, /token_hash text not null unique/i);
+  assert.match(migration, /token_hash ~ '\^\[0-9a-f\]\{64\}\$'/i);
+  assert.match(migration, /unique index[\s\S]*business_id,email[\s\S]*status='pending'/i);
+  assert.match(migration, /p_business_id uuid/);
+  assert.match(migration, /extensions\.digest\(p_token,'sha256'\)/i);
+  assert.match(migration, /INVITATION_EMAIL_MISMATCH/);
+  assert.match(migration, /status='accepted'/);
+  assert.match(migration, /INVITATION_NOT_PENDING/);
+});
+
+test('non-owner membership activation is invitation-only and removal is soft', () => {
+  assert.match(migration, /pilot_memberships_owner_insert/);
+  assert.match(migration, /user_id=\(select auth\.uid\(\)\) and role='owner'/i);
+  assert.match(migration, /revoke delete on public\.pilot_memberships from authenticated/i);
+  assert.match(migration, /status in \('active','suspended','removed'\)/i);
+  assert.match(migration, /NEW_INVITATION_REQUIRED/);
+  assert.match(migration, /found and v_existing\.status='removed'[\s\S]*status='active'/i);
+});
+
+test('active status is part of every tenant permission decision', () => {
+  assert.match(migration, /m\.status='active'/);
+  assert.match(migration, /pilot_businesses_member_select[\s\S]*m\.status='active'/i);
+  assert.match(authCore, /status=eq\.active/);
+});
+
+test('explicit permissions restrict role defaults and grants cannot exceed actor permissions', () => {
+  assert.match(migration, /cardinality\(m\.permissions\)>0 and p_permission=any\(m\.permissions\)/i);
+  assert.match(migration, /pilot_private\.valid_permissions/);
+  assert.match(migration, /pilot_private\.can_grant_permissions/);
+  assert.match(migration, /PERMISSION_GRANT_NOT_ALLOWED/);
+  assert.match(migration, /'employee'/);
+});
+
+test('privileged RPC implementations are private and public wrappers are security invoker', () => {
+  for (const name of ['pilot_create_employee_invitation','pilot_accept_employee_invitation','pilot_update_employee_access','pilot_set_employee_status','pilot_list_team']) {
+    assert.match(migration, new RegExp(`pilot_private\\.${name}`));
+    assert.match(migration, new RegExp(`public\\.${name}[\\s\\S]*?security invoker`, 'i'));
+  }
+  assert.doesNotMatch(migration, /create or replace function public\.pilot_(?:create_employee_invitation|accept_employee_invitation|update_employee_access|set_employee_status|list_team)[\s\S]{0,500}?security definer/i);
+});
+
+test('team APIs require authenticated identity and same-origin for mutations', () => {
+  for (const source of [invitations, accept, members]) assert.match(source, /getVerifiedUser/);
+  for (const source of [invitations, accept, members]) assert.match(source, /requireSameOrigin\(req\)/);
+  assert.match(invitations, /crypto\.randomBytes\(32\)/);
+  assert.match(invitations, /createHash\('sha256'\)/);
+  assert.doesNotMatch([invitations, accept, members].join('\n'), /mail\.tm|api\.mail/i);
+});
+
+test('employee cannot mutate self through team management API', () => {
+  assert.match(members, /SELF_TEAM_MUTATION_BLOCKED/);
+  assert.match(members, /pilot_update_employee_access/);
+  assert.match(members, /pilot_set_employee_status/);
+});
+
+test('audit and owner immutability cover lifecycle-sensitive changes', () => {
+  for (const event of ['invitation_created','invitation_accepted','employee_suspended','employee_reactivated','employee_removed','role_changed','permission_changed']) {
+    assert.match(migration, new RegExp(event));
+  }
+  assert.match(migration, /BUSINESS_OWNER_MEMBERSHIP_IMMUTABLE/);
+  assert.match(migration, /new\.status<>'active'/);
+});

--- a/test/employee-access-contract.test.mjs
+++ b/test/employee-access-contract.test.mjs
@@ -6,6 +6,7 @@ const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
 
 const migration = await read('db/pilot_employee_access_v5.sql');
+const fix = await read('db/pilot_employee_access_v9_fix.sql');
 const authCore = await read('api/_auth-core.js');
 const invitations = await read('api/team/invitations.js');
 const accept = await read('api/team/accept-invite.js');
@@ -74,4 +75,17 @@ test('audit and owner immutability cover lifecycle-sensitive changes', () => {
   }
   assert.match(migration, /BUSINESS_OWNER_MEMBERSHIP_IMMUTABLE/);
   assert.match(migration, /new\.status<>'active'/);
+});
+
+test('status and access mutation functions qualify membership columns to avoid PLpgSQL output-name ambiguity', () => {
+  assert.match(fix, /select m\.\* into v_old from public\.pilot_memberships m where m\.business_id=p_business_id and m\.user_id=p_user_id/i);
+  assert.match(fix, /update public\.pilot_memberships m[\s\S]*where m\.business_id=p_business_id and m\.user_id=p_user_id/i);
+  assert.doesNotMatch(fix, /where business_id=p_business_id and user_id=p_user_id/i);
+});
+
+test('suspension and removal record business-scoped session revocation while preserving multi-tenant login semantics', () => {
+  assert.match(fix, /'session_revoked'/);
+  assert.match(fix, /jsonb_build_object\('scope','business_membership','reason',p_status\)/i);
+  assert.match(fix, /p_status in \('suspended','removed'\)/i);
+  assert.match(authCore, /pilot_memberships\?select=business_id,role,status,permissions,accepted_at&status=eq\.active/);
 });


### PR DESCRIPTION
Implements one-time employee invitation tokens, permanent membership lifecycle, live RLS suspension/removal, permission delegation controls, team APIs, Team UI, audit records, and regression contracts. Supabase migrations pilot_employee_access_v5-v7 are already applied additively to the existing PILOT project. No new repository or app copy is created.