### PR TITLE
Connect production PILOT conversation to AI (rebased)

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,0 +1,65 @@
+import fs from 'node:fs';
+
+const htmlPath = new URL('../index.html', import.meta.url);
+
+const oldComposer = `function sendPreviewMessage(){
+  const input=$('#composer');
+  const text=String(input?.value||'').trim();
+  if(!text)return;
+  const nextId=String(Math.max(0,...messages.map(m=>Number(m.id)||0))+1);
+  messages.push({id:nextId,side:'out',original:text,fb:{ar:text,en:text},previewOnly:true});
+  input.value='';
+  renderMessages();
+  const box=$('#messages');
+  if(box)box.scrollTop=box.scrollHeight;
+  toast('تمت إضافة الرسالة داخل معاينة المحادثة فقط — لم تُرسل إلى قناة خارجية','Message added to the conversation preview only — it was not sent to an external channel');
+}
+$('#sendBtn').onclick=sendPreviewMessage;`;
+
+const aiComposer = `async function sendPreviewMessage(){
+  const input=$('#composer');
+  const sendBtn=$('#sendBtn');
+  const text=String(input?.value||'').trim();
+  if(!text||sendBtn?.disabled)return;
+  const nextId=()=>String(Math.max(0,...messages.map(m=>Number(m.id)||0))+1);
+  messages.push({id:nextId(),side:'in',original:text,fb:{ar:text,en:text},previewOnly:true,syntheticCustomer:true});
+  input.value='';
+  if(sendBtn)sendBtn.disabled=true;
+  renderMessages();
+  const box=$('#messages');
+  if(box)box.scrollTop=box.scrollHeight;
+  try{
+    const r=await fetch('/api/pilot-ai',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({synthetic:true,project:'pilot_clinics',message:text,language:lang})});
+    const j=await r.json().catch(()=>({}));
+    if(!r.ok||!j.ok||!j.reply)throw new Error(j.error||'pilot_ai_unavailable');
+    const reply=String(j.reply).trim();
+    messages.push({id:nextId(),side:'out',original:reply,fb:{ar:reply,en:reply},previewOnly:true,aiGenerated:true});
+    renderMessages();
+    if(box)box.scrollTop=box.scrollHeight;
+    toast('رد PILOT AI فعليًا داخل المعاينة — بدون إرسال خارجي','PILOT AI replied in the preview — no external message was sent');
+  }catch{
+    const fail=lang==='ar'?'تعذر تشغيل PILOT AI الآن. لم يتم تنفيذ أي حجز أو إرسال خارجي.':'PILOT AI is unavailable right now. No booking or external message was performed.';
+    messages.push({id:nextId(),side:'out',original:fail,fb:{ar:fail,en:fail},previewOnly:true,aiGenerated:false});
+    renderMessages();
+    if(box)box.scrollTop=box.scrollHeight;
+  }finally{
+    if(sendBtn)sendBtn.disabled=false;
+  }
+}
+$('#sendBtn').onclick=sendPreviewMessage;`;
+
+export default function handler(req, res) {
+  if (req.method !== 'GET') {
+    return res.status(405).setHeader('allow', 'GET').end('Method Not Allowed');
+  }
+
+  const source = fs.readFileSync(htmlPath, 'utf8');
+  if (!source.includes(oldComposer)) {
+    return res.status(500).setHeader('cache-control', 'no-store').end('PILOT UI contract mismatch');
+  }
+
+  const html = source.replace(oldComposer, aiComposer);
+  res.setHeader('content-type', 'text/html; charset=utf-8');
+  res.setHeader('cache-control', 'no-store');
+  return res.status(200).send(html);
+}

--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -5,16 +5,14 @@ function json(res, status, body) {
 }
 
 export default async function handler(req, res) {
-  if (process.env.VERCEL_ENV !== 'preview') {
-    return json(res, 404, { ok: false, error: 'preview_only_ai' });
-  }
+  const environment = process.env.VERCEL_ENV === 'production' ? 'PRODUCTION_PILOT' : 'PREVIEW_PILOT';
 
   if (req.method === 'GET') {
     const config = getPilotAiConfig();
     return json(res, 200, {
       ok: true,
       service: 'pilot-ai',
-      environment: 'PREVIEW_PILOT',
+      environment,
       provider: config.provider,
       model: config.model,
       configured: config.configured,
@@ -47,7 +45,7 @@ export default async function handler(req, res) {
   return json(res, status, {
     ...result,
     service: 'pilot-ai',
-    environment: 'PREVIEW_PILOT',
+    environment,
     data_mode: 'SYNTHETIC_ONLY',
     external_side_effects: false,
     timestamp: new Date().toISOString(),

--- a/test/production-ai-chat.test.mjs
+++ b/test/production-ai-chat.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const api = fs.readFileSync(new URL('../api/pilot-ai.js', import.meta.url), 'utf8');
+const app = fs.readFileSync(new URL('../api/app.js', import.meta.url), 'utf8');
+const vercel = fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8');
+
+test('PILOT AI endpoint supports production synthetic mode without side effects', () => {
+  assert.doesNotMatch(api, /preview_only_ai/);
+  assert.match(api, /PRODUCTION_PILOT/);
+  assert.match(api, /synthetic_mode_required/);
+  assert.match(api, /data_mode: 'SYNTHETIC_ONLY'/);
+  assert.match(api, /external_side_effects: false/);
+});
+
+test('unified conversation is rendered with a real PILOT AI request and reply', () => {
+  assert.match(app, /fetch\('\/api\/pilot-ai'/);
+  assert.match(app, /synthetic:true,project:'pilot_clinics'/);
+  assert.match(app, /j\.reply/);
+  assert.match(app, /aiGenerated:true/);
+  assert.match(app, /syntheticCustomer:true/);
+});
+
+test('root route serves the AI-enabled unified PILOT interface', () => {
+  const config = JSON.parse(vercel);
+  assert.ok(config.rewrites.some(rule => rule.source === '/' && rule.destination === '/api/app'));
+  assert.equal(config.functions['api/app.js'].includeFiles, 'index.html');
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,16 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "functions": {
+    "api/app.js": {
+      "includeFiles": "index.html"
+    }
+  },
+  "rewrites": [
+    {
+      "source": "/",
+      "destination": "/api/app"
+    }
+  ],
   "headers": [
     {
       "source": "/(.*)",


### PR DESCRIPTION
Rebased on the latest authoritative main, preserving the new employee-access work. Connects the unified PILOT conversation to the existing PILOT AI core in synthetic-only mode, with no external side effects or false booking/channel claims. Includes production routing and regression tests.