### PR TITLE
Add production AI Gateway fallback for PILOT chat

### DIFF
--- a/api/_ai-core.js
+++ b/api/_ai-core.js
@@ -1,13 +1,36 @@
+import { generateText } from 'ai';
+
 const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
 const DEFAULT_MODEL = 'openai/gpt-oss-20b';
+const DEFAULT_GATEWAY_MODEL = 'inclusionai/ling-3.0-tiny-free';
 const PROJECTS = new Set(['pilot_clinics', 'pilot_celebrities']);
 
 export function getPilotAiConfig(env = process.env) {
+  if (env.GROQ_API_KEY) {
+    return {
+      provider: 'groq',
+      endpoint: GROQ_ENDPOINT,
+      model: String(env.PILOT_AI_MODEL || DEFAULT_MODEL),
+      configured: true,
+      cost_mode: 'FREE_TIER_ONLY',
+    };
+  }
+
+  if (env.VERCEL_ENV) {
+    return {
+      provider: 'vercel-ai-gateway',
+      endpoint: 'ai-gateway',
+      model: String(env.PILOT_AI_GATEWAY_MODEL || DEFAULT_GATEWAY_MODEL),
+      configured: true,
+      cost_mode: 'FREE_TIER_ONLY',
+    };
+  }
+
   return {
     provider: 'groq',
     endpoint: GROQ_ENDPOINT,
     model: String(env.PILOT_AI_MODEL || DEFAULT_MODEL),
-    configured: Boolean(env.GROQ_API_KEY),
+    configured: false,
     cost_mode: 'FREE_TIER_ONLY',
   };
 }
@@ -46,12 +69,50 @@ function safeGroundedReply(input, language) {
     : 'I can help with the appointment or inquiry. This preview does not have verified business contact or booking details, so I will not invent a phone number or link. Tell me your preferred day and time and I can prepare the request without claiming it is confirmed.';
 }
 
+function finalizeReply({ reply, input, language, config }) {
+  if (!reply) {
+    return {
+      ok: false,
+      state: 'PROVIDER_ERROR',
+      error: 'empty_ai_response',
+      provider: config.provider,
+      model: config.model,
+      cost_mode: config.cost_mode,
+    };
+  }
+
+  if (containsUnverifiedBusinessContact(reply)) {
+    return {
+      ok: true,
+      state: 'SUCCESS',
+      provider: config.provider,
+      model: config.model,
+      cost_mode: config.cost_mode,
+      reply: safeGroundedReply(input, language),
+      guarded: true,
+      grounding_state: 'UNVERIFIED_BUSINESS_CONTACT_BLOCKED',
+    };
+  }
+
+  return {
+    ok: true,
+    state: 'SUCCESS',
+    provider: config.provider,
+    model: config.model,
+    cost_mode: config.cost_mode,
+    reply,
+    guarded: false,
+    grounding_state: 'NO_UNVERIFIED_CONTACT_DETECTED',
+  };
+}
+
 export async function generatePilotAiReply({
   project,
   message,
   language = 'auto',
   env = process.env,
   fetchImpl = fetch,
+  gatewayGenerateImpl = generateText,
 } = {}) {
   const normalizedProject = String(project || '').toLowerCase();
   if (!PROJECTS.has(normalizedProject)) {
@@ -63,7 +124,8 @@ export async function generatePilotAiReply({
 
   const config = getPilotAiConfig(env);
   const apiKey = String(env.GROQ_API_KEY || '');
-  if (!apiKey) {
+
+  if (!apiKey && !env.VERCEL_ENV) {
     return {
       ok: false,
       state: 'UNCONFIGURED',
@@ -72,6 +134,36 @@ export async function generatePilotAiReply({
       model: config.model,
       cost_mode: config.cost_mode,
     };
+  }
+
+  if (!apiKey && env.VERCEL_ENV) {
+    try {
+      const { text } = await gatewayGenerateImpl({
+        model: config.model,
+        system: systemPrompt(normalizedProject, language),
+        prompt: input,
+        temperature: 0.2,
+        maxOutputTokens: 350,
+        providerOptions: {
+          gateway: {
+            disallowPromptTraining: true,
+            user: 'pilot-production-synthetic-chat',
+            tags: ['product:pilot', 'feature:conversation-ai', `env:${String(env.VERCEL_ENV)}`],
+          },
+        },
+      });
+      return finalizeReply({ reply: String(text || '').trim(), input, language, config });
+    } catch (error) {
+      const status = Number(error?.statusCode || error?.status || 0);
+      return {
+        ok: false,
+        state: status === 429 ? 'RATE_LIMITED' : 'PROVIDER_ERROR',
+        error: status ? `gateway_http_${status}` : 'gateway_runtime_error',
+        provider: config.provider,
+        model: config.model,
+        cost_mode: config.cost_mode,
+      };
+    }
   }
 
   try {
@@ -104,41 +196,12 @@ export async function generatePilotAiReply({
       };
     }
 
-    const reply = String(payload?.choices?.[0]?.message?.content || '').trim();
-    if (!reply) {
-      return {
-        ok: false,
-        state: 'PROVIDER_ERROR',
-        error: 'empty_ai_response',
-        provider: config.provider,
-        model: config.model,
-        cost_mode: config.cost_mode,
-      };
-    }
-
-    if (containsUnverifiedBusinessContact(reply)) {
-      return {
-        ok: true,
-        state: 'SUCCESS',
-        provider: config.provider,
-        model: config.model,
-        cost_mode: config.cost_mode,
-        reply: safeGroundedReply(input, language),
-        guarded: true,
-        grounding_state: 'UNVERIFIED_BUSINESS_CONTACT_BLOCKED',
-      };
-    }
-
-    return {
-      ok: true,
-      state: 'SUCCESS',
-      provider: config.provider,
-      model: config.model,
-      cost_mode: config.cost_mode,
-      reply,
-      guarded: false,
-      grounding_state: 'NO_UNVERIFIED_CONTACT_DETECTED',
-    };
+    return finalizeReply({
+      reply: String(payload?.choices?.[0]?.message?.content || '').trim(),
+      input,
+      language,
+      config,
+    });
   } catch {
     return {
       ok: false,

--- a/api/_ai-core.js
+++ b/api/_ai-core.js
@@ -1,5 +1,3 @@
-import { generateText } from 'ai';
-
 const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
 const DEFAULT_MODEL = 'openai/gpt-oss-20b';
 const DEFAULT_GATEWAY_MODEL = 'inclusionai/ling-3.0-tiny-free';
@@ -112,7 +110,7 @@ export async function generatePilotAiReply({
   language = 'auto',
   env = process.env,
   fetchImpl = fetch,
-  gatewayGenerateImpl = generateText,
+  gatewayGenerateImpl,
 } = {}) {
   const normalizedProject = String(project || '').toLowerCase();
   if (!PROJECTS.has(normalizedProject)) {
@@ -138,7 +136,12 @@ export async function generatePilotAiReply({
 
   if (!apiKey && env.VERCEL_ENV) {
     try {
-      const { text } = await gatewayGenerateImpl({
+      let generate = gatewayGenerateImpl;
+      if (!generate) {
+        const ai = await import('ai');
+        generate = ai.generateText;
+      }
+      const { text } = await generate({
         model: config.model,
         system: systemPrompt(normalizedProject, language),
         prompt: input,

--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -9,6 +9,26 @@ export default async function handler(req, res) {
 
   if (req.method === 'GET') {
     const config = getPilotAiConfig();
+    if (String(req.query?.synthetic || '') === '1') {
+      const result = await generatePilotAiReply({
+        project: 'pilot_clinics',
+        message: 'هلا، ابا موعد باجر العصر',
+        language: 'ar',
+      });
+      const status = result.ok ? 200
+        : result.state === 'UNCONFIGURED' ? 503
+        : result.state === 'RATE_LIMITED' ? 429
+        : 502;
+      return json(res, status, {
+        ...result,
+        service: 'pilot-ai',
+        environment,
+        data_mode: 'SYNTHETIC_ONLY',
+        external_side_effects: false,
+        synthetic_probe: true,
+      });
+    }
+
     return json(res, 200, {
       ok: true,
       service: 'pilot-ai',

--- a/test/pilot-ai.test.mjs
+++ b/test/pilot-ai.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { generatePilotAiReply, getPilotAiConfig } from '../api/_ai-core.js';
 
-test('free Groq AI is fail-closed when key is missing', async () => {
+test('free Groq AI is fail-closed when key is missing outside Vercel', async () => {
   const config = getPilotAiConfig({});
   assert.equal(config.provider, 'groq');
   assert.equal(config.model, 'openai/gpt-oss-20b');
@@ -17,6 +17,29 @@ test('free Groq AI is fail-closed when key is missing', async () => {
   assert.equal(result.ok, false);
   assert.equal(result.state, 'UNCONFIGURED');
   assert.equal(result.error, 'groq_api_key_missing');
+});
+
+test('Vercel AI Gateway fallback works when Groq secret is absent', async () => {
+  let request;
+  const result = await generatePilotAiReply({
+    project: 'pilot_clinics',
+    message: 'ابا موعد باجر العصر',
+    language: 'ar',
+    env: { VERCEL_ENV: 'production' },
+    gatewayGenerateImpl: async (options) => {
+      request = options;
+      return { text: 'أكيد، أقدر أساعدك في تجهيز طلب موعد باجر العصر، لكن ما أقدر أؤكد التوفر قبل التحقق من التقويم.' };
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.provider, 'vercel-ai-gateway');
+  assert.equal(result.model, 'inclusionai/ling-3.0-tiny-free');
+  assert.match(result.reply, /موعد/);
+  assert.equal(result.guarded, false);
+  assert.equal(request.model, 'inclusionai/ling-3.0-tiny-free');
+  assert.match(request.system, /Gulf-friendly Arabic/);
+  assert.equal(request.providerOptions.gateway.disallowPromptTraining, true);
 });
 
 test('free Groq AI uses configured model and returns provider output', async () => {


### PR DESCRIPTION
Keep Groq when configured, but fall back to Vercel AI Gateway with a free model in Vercel runtime so the unified production conversation can generate real synthetic AI replies without requiring a Groq production secret. Preserves grounding guard, synthetic-only data mode, no external side effects, and adds a live GET synthetic probe plus regression tests.