### PR TITLE
Use current free Gateway model for production PILOT AI

### DIFF
--- a/api/_ai-core.js
+++ b/api/_ai-core.js
@@ -1,6 +1,6 @@
 const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
 const DEFAULT_MODEL = 'openai/gpt-oss-20b';
-const DEFAULT_GATEWAY_MODEL = 'inclusionai/ling-3.0-tiny-free';
+const DEFAULT_GATEWAY_MODEL = 'minimax/minimax-m2.7-free';
 const PROJECTS = new Set(['pilot_clinics', 'pilot_celebrities']);
 
 export function getPilotAiConfig(env = process.env) {

--- a/test/pilot-ai.test.mjs
+++ b/test/pilot-ai.test.mjs
@@ -34,10 +34,10 @@ test('Vercel AI Gateway fallback works when Groq secret is absent', async () => 
 
   assert.equal(result.ok, true);
   assert.equal(result.provider, 'vercel-ai-gateway');
-  assert.equal(result.model, 'inclusionai/ling-3.0-tiny-free');
+  assert.equal(result.model, 'minimax/minimax-m2.7-free');
   assert.match(result.reply, /موعد/);
   assert.equal(result.guarded, false);
-  assert.equal(request.model, 'inclusionai/ling-3.0-tiny-free');
+  assert.equal(request.model, 'minimax/minimax-m2.7-free');
   assert.match(request.system, /Gulf-friendly Arabic/);
   assert.equal(request.providerOptions.gateway.disallowPromptTraining, true);
 });


### PR DESCRIPTION
Follow-up to the production AI connection. The previously selected free Gateway model now returns 404. Switch the fallback to the currently available Vercel AI Gateway model minimax/minimax-m2.7-free and update the regression contract. No external side effects are enabled.