### PR TITLE
DABBIR: remove final legacy PILOT API aliases

### DIFF
--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-ai.js';
-export * from './dabbir-ai.js';

--- a/api/pilot-runtime.js
+++ b/api/pilot-runtime.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-runtime.js';
-export * from './dabbir-runtime.js';

--- a/api/pilot-whatsapp-webhook.js
+++ b/api/pilot-whatsapp-webhook.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-whatsapp-webhook.js';
-export * from './dabbir-whatsapp-webhook.js';


### PR DESCRIPTION
Removes the three obsolete compatibility routes `/api/pilot-ai`, `/api/pilot-runtime`, and `/api/pilot-whatsapp-webhook`. All production code and current integrations now use DABBIR routes; Meta WhatsApp is not live, so the legacy webhook alias has no production dependency. CI must pass before merge.