### PR TITLE
DABBIR: remove final PILOT routes and internal dependency

### DIFF
--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { classifyClinicMessage, classifyCelebrityMessage } from './pilot-runtime.js';
+import { classifyClinicMessage, classifyCelebrityMessage } from './dabbir-runtime.js';
 import { attachCorrelation, correlationId, logEvent } from './_observability.js';
 
 function json(res, status, body, cid) {
@@ -83,9 +83,9 @@ export function classifyDABBIREvent(event, project = 'generic') {
 export default async function handler(req, res) {
   const cid = correlationId(req);
   attachCorrelation(res, cid);
-  const verifyToken = process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || '';
-  const appSecret = process.env.DABBIR_WHATSAPP_APP_SECRET || process.env.DABBIR_WHATSAPP_APP_SECRET || '';
-  const project = String(process.env.DABBIR_PROJECT || process.env.DABBIR_PROJECT || 'generic').toLowerCase();
+  const verifyToken = process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || '';
+  const appSecret = process.env.DABBIR_WHATSAPP_APP_SECRET || '';
+  const project = String(process.env.DABBIR_PROJECT || 'generic').toLowerCase();
 
   if (req.method === 'GET') {
     const result = verifyWebhookChallenge(req.query || {}, verifyToken);
@@ -133,7 +133,7 @@ export default async function handler(req, res) {
 
   return json(res, 200, {
     ok: true,
-    service: 'pilot-whatsapp-webhook',
+    service: 'dabbir-whatsapp-webhook',
     project,
     state: 'CONFIGURED_NOT_OPERATIONAL',
     signature_verified: true,

--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-ai.js';
-export * from './dabbir-ai.js';

--- a/api/pilot-runtime.js
+++ b/api/pilot-runtime.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-runtime.js';
-export * from './dabbir-runtime.js';

--- a/api/pilot-whatsapp-webhook.js
+++ b/api/pilot-whatsapp-webhook.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-whatsapp-webhook.js';
-export * from './dabbir-whatsapp-webhook.js';


### PR DESCRIPTION
Removes the obsolete `/api/pilot-ai`, `/api/pilot-runtime`, and `/api/pilot-whatsapp-webhook` aliases and fixes the DABBIR WhatsApp webhook to import `dabbir-runtime.js`, use only DABBIR environment variables, and report `dabbir-whatsapp-webhook`. This PR is opened from the corrected branch so CI validates the final legacy-free route state.