### PR TITLE
DABBIR: final removal of PILOT route legacy

### DIFF
--- a/.github/workflows/dabbir-final-legacy-validation.yml
+++ b/.github/workflows/dabbir-final-legacy-validation.yml
@@ -1,0 +1,38 @@
+name: DABBIR final legacy validation
+
+on:
+  push:
+    branches:
+      - rename/remove-pilot-route-aliases-v2
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+      - name: Run DABBIR tests
+        run: npm test
+      - name: Verify PILOT route aliases are gone
+        shell: bash
+        run: |
+          test ! -e api/pilot-ai.js
+          test ! -e api/pilot-runtime.js
+          test ! -e api/pilot-whatsapp-webhook.js
+          ! grep -RIn --exclude-dir=.git -E "\./pilot-runtime\.js|service: 'pilot-whatsapp-webhook'" api
+      - name: Reject committed secrets
+        shell: bash
+        run: |
+          set -euo pipefail
+          if grep -RInE --exclude-dir=.git --exclude='ci.yml' --exclude='dabbir-final-legacy-validation.yml' '(sk_live_|sb_secret_|BEGIN (RSA |EC |OPENSSH )?PRIVATE KEY|SUPABASE_SERVICE_ROLE_KEY[[:space:]]*=|VERCEL_TOKEN[[:space:]]*=|(DABBIR|PILOT)_WHATSAPP_APP_SECRET[[:space:]]*=)' .; then
+            echo 'Potential secret material detected.'
+            exit 1
+          fi
+          echo 'Secret pattern scan PASS'

--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { classifyClinicMessage, classifyCelebrityMessage } from './pilot-runtime.js';
+import { classifyClinicMessage, classifyCelebrityMessage } from './dabbir-runtime.js';
 import { attachCorrelation, correlationId, logEvent } from './_observability.js';
 
 function json(res, status, body, cid) {
@@ -83,9 +83,9 @@ export function classifyDABBIREvent(event, project = 'generic') {
 export default async function handler(req, res) {
   const cid = correlationId(req);
   attachCorrelation(res, cid);
-  const verifyToken = process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || '';
-  const appSecret = process.env.DABBIR_WHATSAPP_APP_SECRET || process.env.DABBIR_WHATSAPP_APP_SECRET || '';
-  const project = String(process.env.DABBIR_PROJECT || process.env.DABBIR_PROJECT || 'generic').toLowerCase();
+  const verifyToken = process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || '';
+  const appSecret = process.env.DABBIR_WHATSAPP_APP_SECRET || '';
+  const project = String(process.env.DABBIR_PROJECT || 'generic').toLowerCase();
 
   if (req.method === 'GET') {
     const result = verifyWebhookChallenge(req.query || {}, verifyToken);
@@ -133,7 +133,7 @@ export default async function handler(req, res) {
 
   return json(res, 200, {
     ok: true,
-    service: 'pilot-whatsapp-webhook',
+    service: 'dabbir-whatsapp-webhook',
     project,
     state: 'CONFIGURED_NOT_OPERATIONAL',
     signature_verified: true,

--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-ai.js';
-export * from './dabbir-ai.js';

--- a/api/pilot-runtime.js
+++ b/api/pilot-runtime.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-runtime.js';
-export * from './dabbir-runtime.js';

--- a/api/pilot-whatsapp-webhook.js
+++ b/api/pilot-whatsapp-webhook.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-whatsapp-webhook.js';
-export * from './dabbir-whatsapp-webhook.js';


### PR DESCRIPTION
Closed after safe partial reconciliation via PR #42 (merged as `525c9d36d6da513a84a17fd129180eca6c996cdd`). Internal DABBIR code and runtime registry now point directly to `dabbir-runtime.js`. The remaining changes in this old PR—deleting `/api/pilot-*` compatibility routes and removing PILOT-prefixed WhatsApp environment fallbacks—are intentionally NOT applied yet because Vercel showed compatibility-route traffic within the last 24 hours and the connected Vercel tool does not expose environment-variable names/settings needed to prove DABBIR-secret migration. Keeping this old all-or-nothing PR open would encourage an unsafe deletion.