### PR TITLE
Fix DABBIR WhatsApp live connection status

### DIFF
--- a/api/brand-ui.js
+++ b/api/brand-ui.js
@@ -62,6 +62,10 @@ const script = String.raw`(()=>{
     return fallback;
   }
 
+  function isArabic(){
+    return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar');
+  }
+
   function notify(message){
     try{if(typeof toast==='function') return toast(message)}catch{}
   }
@@ -140,19 +144,110 @@ const script = String.raw`(()=>{
     }
   }
 
+  function whatsAppConnected(status){
+    if(!status) return false;
+    return Boolean(
+      status.connected||status.meta_authorized||status.webhook_configured||status.outbound_configured||
+      ['META_AUTHORIZED','WEBHOOK_LINKED','CONFIGURED_READY_FOR_VERIFICATION','OUTBOUND_CONFIGURED','OPERATIONAL'].includes(String(status.state||''))
+    );
+  }
+
+  function whatsAppOperational(status){
+    return Boolean(status&&(status.operational||status.state==='OPERATIONAL'));
+  }
+
+  function applyWhatsAppCardState(){
+    if(typeof workspace==='undefined'||!workspace) return;
+    const status=workspace.whatsapp||{};
+    const connected=whatsAppConnected(status);
+    const operational=whatsAppOperational(status);
+    const ar=isArabic();
+    const grid=document.querySelector('#integrationGrid');
+    if(grid){
+      const wanted=uiText('whatsapp','WhatsApp').trim();
+      const card=[...grid.querySelectorAll('.integration')].find(item=>String(item.querySelector('h3')?.textContent||'').trim()===wanted);
+      if(card){
+        const badge=card.querySelector('.badge');
+        const description=card.querySelector('p');
+        if(badge){
+          badge.classList.remove('red','yellow','green','blue','gray');
+          if(operational){
+            badge.classList.add('green');
+            badge.textContent=uiText('operational',ar?'تشغيلي':'Operational');
+          }else if(connected){
+            badge.classList.add('blue');
+            badge.textContent=ar?'مربوط':'Linked';
+          }else{
+            badge.classList.add('red');
+            badge.textContent=ar?'غير مربوط':'Not linked';
+          }
+        }
+        if(description){
+          if(operational){
+            description.textContent=ar?'تم التحقق من ربط WhatsApp ومسار التشغيل الحقيقي.':'WhatsApp link and live message path are verified.';
+          }else if(status.meta_authorized){
+            description.textContent=ar?'تم التحقق من تفويض Meta فعليًا. بقي اختبار رسالة حقيقية قبل اعتماد الحالة «تشغيلي».':'Meta authorization is verified. A real message path still must pass before marking it Operational.';
+          }else if(connected){
+            description.textContent=ar?'تم العثور على ربط Meta / Webhook الفعلي. بقي التحقق من مسار رسالة حقيقية قبل اعتماد التشغيل الكامل.':'The real Meta / webhook link was found. A live message path still needs verification before full Operational status.';
+          }else{
+            description.textContent=ar?'لم يعثر DABBIR في هذا التشغيل على إعدادات WhatsApp الفعلية.':'DABBIR did not find the WhatsApp connection settings in this runtime.';
+          }
+        }
+      }
+    }
+
+    const helpTitle=document.querySelector('#helpWhatsTitle');
+    const helpDesc=document.querySelector('#helpWhatsDesc');
+    if(helpTitle&&helpDesc&&connected){
+      helpTitle.textContent=ar?'حالة WhatsApp':'WhatsApp status';
+      helpDesc.textContent=operational
+        ? (ar?'الربط ومسار الرسالة الحقيقي موثقان.':'The connection and real message path are verified.')
+        : (ar?'الربط موجود. DABBIR يفصل بين «مربوط» و«تشغيلي» حتى ينجح اختبار رسالة حقيقية.':'The connection exists. DABBIR keeps Linked separate from Operational until a real message test passes.');
+    }
+  }
+
+  let whatsappStatusInFlight=false;
+  let whatsappStatusCheckedAt=0;
+  async function refreshWhatsAppStatus(force=false){
+    if(whatsappStatusInFlight||typeof workspace==='undefined'||!workspace) return;
+    if(!force&&Date.now()-whatsappStatusCheckedAt<60000){applyWhatsAppCardState();return;}
+    whatsappStatusInFlight=true;
+    try{
+      const response=await fetch('/api/dabbir-whatsapp-status',{method:'GET',cache:'no-store',headers:{accept:'application/json'}});
+      const payload=await response.json().catch(()=>({}));
+      if(response.ok&&payload.ok){
+        workspace.whatsapp={...(workspace.whatsapp||{}),...payload};
+        whatsappStatusCheckedAt=Date.now();
+        applyWhatsAppCardState();
+      }
+    }catch{}
+    finally{whatsappStatusInFlight=false}
+  }
+
   installIdempotentConversationStart();
+
+  if(typeof renderIntegrations==='function'&&!window.__dabbirWhatsAppIntegrationsWrapped){
+    window.__dabbirWhatsAppIntegrationsWrapped=true;
+    const renderIntegrationsBeforeWhatsAppStatus=renderIntegrations;
+    renderIntegrations=function(){
+      const result=renderIntegrationsBeforeWhatsAppStatus.apply(this,arguments);
+      applyWhatsAppCardState();
+      setTimeout(()=>refreshWhatsAppStatus(),0);
+      return result;
+    };
+  }
 
   if(typeof renderAll==='function'&&!window.__dabbirBrandRenderWrapped){
     window.__dabbirBrandRenderWrapped=true;
     const renderBeforeBrandChatFix=renderAll;
     renderAll=function(){
       const result=renderBeforeBrandChatFix.apply(this,arguments);
-      setTimeout(()=>{installIdempotentConversationStart();repairActionRequiredChats();syncAppActive()},30);
+      setTimeout(()=>{installIdempotentConversationStart();repairActionRequiredChats();syncAppActive();applyWhatsAppCardState();refreshWhatsAppStatus()},30);
       return result;
     };
   }
 
-  setTimeout(()=>{installMobileBrand();installIdempotentConversationStart();repairActionRequiredChats();syncAppActive()},500);
+  setTimeout(()=>{installMobileBrand();installIdempotentConversationStart();repairActionRequiredChats();syncAppActive();applyWhatsAppCardState();refreshWhatsAppStatus(true)},500);
 })();`;
 
 export default function handler(req,res){

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,0 +1,147 @@
+import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
+
+function firstEnv(...names) {
+  for (const name of names) {
+    const value = String(process.env[name] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+export function getWhatsAppConfig() {
+  const verifyToken = firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN');
+  const appSecret = firstEnv('DABBIR_WHATSAPP_APP_SECRET', 'PILOT_WHATSAPP_APP_SECRET');
+  const accessToken = firstEnv(
+    'DABBIR_WHATSAPP_ACCESS_TOKEN',
+    'PILOT_WHATSAPP_ACCESS_TOKEN',
+    'WHATSAPP_ACCESS_TOKEN',
+    'META_WHATSAPP_ACCESS_TOKEN',
+  );
+  const phoneNumberId = firstEnv(
+    'DABBIR_WHATSAPP_PHONE_NUMBER_ID',
+    'PILOT_WHATSAPP_PHONE_NUMBER_ID',
+    'WHATSAPP_PHONE_NUMBER_ID',
+    'META_WHATSAPP_PHONE_NUMBER_ID',
+  );
+  const wabaId = firstEnv(
+    'DABBIR_WHATSAPP_BUSINESS_ACCOUNT_ID',
+    'PILOT_WHATSAPP_BUSINESS_ACCOUNT_ID',
+    'WHATSAPP_BUSINESS_ACCOUNT_ID',
+    'WABA_ID',
+  );
+  const graphVersion = firstEnv('DABBIR_META_GRAPH_VERSION', 'PILOT_META_GRAPH_VERSION', 'META_GRAPH_VERSION') || 'v23.0';
+
+  const webhookConfigured = Boolean(verifyToken && appSecret);
+  const outboundConfigured = Boolean(accessToken && phoneNumberId);
+  const configured = webhookConfigured || outboundConfigured;
+
+  return {
+    verifyToken,
+    appSecret,
+    accessToken,
+    phoneNumberId,
+    wabaId,
+    graphVersion,
+    webhookConfigured,
+    outboundConfigured,
+    configured,
+  };
+}
+
+function publicConfig(config) {
+  let state = 'NOT_CONFIGURED';
+  if (config.webhookConfigured && config.outboundConfigured) state = 'CONFIGURED_READY_FOR_VERIFICATION';
+  else if (config.webhookConfigured) state = 'WEBHOOK_LINKED';
+  else if (config.outboundConfigured) state = 'OUTBOUND_CONFIGURED';
+  else if (config.configured) state = 'PARTIALLY_CONFIGURED';
+
+  return {
+    configured: config.configured,
+    connected: config.webhookConfigured || config.outboundConfigured,
+    webhook_configured: config.webhookConfigured,
+    outbound_configured: config.outboundConfigured,
+    phone_number_configured: Boolean(config.phoneNumberId),
+    waba_configured: Boolean(config.wabaId),
+    state,
+  };
+}
+
+export async function verifyMetaAuthorization(config = getWhatsAppConfig()) {
+  if (!config.accessToken || !config.phoneNumberId) {
+    return {
+      attempted: false,
+      authorized: false,
+      reason: 'META_READ_CREDENTIALS_NOT_CONFIGURED',
+    };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 4500);
+  try {
+    const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/${encodeURIComponent(config.phoneNumberId)}`);
+    url.searchParams.set('fields', 'display_phone_number,verified_name');
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${config.accessToken}` },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      return {
+        attempted: true,
+        authorized: false,
+        reason: 'META_AUTHORIZATION_CHECK_FAILED',
+        provider_status: response.status,
+      };
+    }
+    return {
+      attempted: true,
+      authorized: true,
+      reason: null,
+      provider_status: response.status,
+      phone: {
+        display_phone_number: payload?.display_phone_number || null,
+        verified_name: payload?.verified_name || null,
+      },
+    };
+  } catch (error) {
+    return {
+      attempted: true,
+      authorized: false,
+      reason: error?.name === 'AbortError' ? 'META_AUTHORIZATION_CHECK_TIMEOUT' : 'META_AUTHORIZATION_CHECK_UNAVAILABLE',
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
+
+  const accessToken = accessTokenFromRequest(req);
+  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+  if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  const config = getWhatsAppConfig();
+  const base = publicConfig(config);
+  const meta = await verifyMetaAuthorization(config);
+  const metaAuthorized = Boolean(meta.authorized);
+  const state = metaAuthorized ? 'META_AUTHORIZED' : base.state;
+
+  return json(res, 200, {
+    ok: true,
+    channel: 'whatsapp',
+    ...base,
+    connected: metaAuthorized || base.connected,
+    state,
+    meta_authorized: metaAuthorized,
+    meta_check_attempted: Boolean(meta.attempted),
+    meta_check_reason: meta.reason || null,
+    provider_status: meta.provider_status || null,
+    phone: metaAuthorized ? meta.phone : null,
+    operational: false,
+    operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+    checked_at: new Date().toISOString(),
+  });
+}

--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -20,6 +20,22 @@ function secureEqual(a, b) {
   return crypto.timingSafeEqual(left, right);
 }
 
+function firstEnv(...names) {
+  for (const name of names) {
+    const value = String(process.env[name] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+function normalizeProject(value = 'generic') {
+  const project = String(value || 'generic').toLowerCase();
+  if (project === 'pilot_clinics') return 'dabbir_clinics';
+  if (project === 'pilot_celebrities') return 'dabbir_celebrities';
+  if (project === 'pilot_businesses') return 'dabbir_businesses';
+  return project;
+}
+
 export function verifyWebhookChallenge(query = {}, verifyToken = '') {
   const mode = String(query['hub.mode'] || '');
   const token = String(query['hub.verify_token'] || '');
@@ -99,9 +115,11 @@ export function classifyDABBIREvent(event, project = 'generic') {
 export default async function handler(req, res) {
   const cid = correlationId(req);
   attachCorrelation(res, cid);
-  const verifyToken = process.env.DABBIR_WHATSAPP_VERIFY_TOKEN || '';
-  const appSecret = process.env.DABBIR_WHATSAPP_APP_SECRET || '';
-  const project = String(process.env.DABBIR_PROJECT || 'generic').toLowerCase();
+  // Keep the credentials the owner already provisioned under PILOT working after the DABBIR rename.
+  // DABBIR-prefixed values win when both generations are present.
+  const verifyToken = firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN');
+  const appSecret = firstEnv('DABBIR_WHATSAPP_APP_SECRET', 'PILOT_WHATSAPP_APP_SECRET');
+  const project = normalizeProject(firstEnv('DABBIR_PROJECT', 'PILOT_PROJECT') || 'generic');
 
   if (req.method === 'GET') {
     const result = verifyWebhookChallenge(req.query || {}, verifyToken);

--- a/test/dabbir-whatsapp-status.test.mjs
+++ b/test/dabbir-whatsapp-status.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { getWhatsAppConfig } from '../api/dabbir-whatsapp-status.js';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+const managedKeys = [
+  'DABBIR_WHATSAPP_VERIFY_TOKEN',
+  'DABBIR_WHATSAPP_APP_SECRET',
+  'PILOT_WHATSAPP_VERIFY_TOKEN',
+  'PILOT_WHATSAPP_APP_SECRET',
+  'DABBIR_WHATSAPP_ACCESS_TOKEN',
+  'PILOT_WHATSAPP_ACCESS_TOKEN',
+  'DABBIR_WHATSAPP_PHONE_NUMBER_ID',
+  'PILOT_WHATSAPP_PHONE_NUMBER_ID',
+];
+
+function withCleanEnv(fn) {
+  const before = Object.fromEntries(managedKeys.map(key => [key, process.env[key]]));
+  for (const key of managedKeys) delete process.env[key];
+  try { return fn(); }
+  finally {
+    for (const [key, value] of Object.entries(before)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('legacy PILOT WhatsApp webhook credentials remain recognized after DABBIR rename', () => {
+  withCleanEnv(() => {
+    process.env.PILOT_WHATSAPP_VERIFY_TOKEN = 'test-verify-token';
+    process.env.PILOT_WHATSAPP_APP_SECRET = 'test-app-secret';
+    const config = getWhatsAppConfig();
+    assert.equal(config.webhookConfigured, true);
+    assert.equal(config.configured, true);
+  });
+});
+
+test('DABBIR WhatsApp credentials take precedence when both generations exist', () => {
+  withCleanEnv(() => {
+    process.env.PILOT_WHATSAPP_VERIFY_TOKEN = 'legacy-verify';
+    process.env.PILOT_WHATSAPP_APP_SECRET = 'legacy-secret';
+    process.env.DABBIR_WHATSAPP_VERIFY_TOKEN = 'dabbir-verify';
+    process.env.DABBIR_WHATSAPP_APP_SECRET = 'dabbir-secret';
+    const config = getWhatsAppConfig();
+    assert.equal(config.verifyToken, 'dabbir-verify');
+    assert.equal(config.appSecret, 'dabbir-secret');
+  });
+});
+
+test('WhatsApp UI reads live status instead of trusting the stale static red card', async () => {
+  const brandUi = await read('api/brand-ui.js');
+  assert.match(brandUi, /\/api\/dabbir-whatsapp-status/);
+  assert.match(brandUi, /WEBHOOK_LINKED/);
+  assert.match(brandUi, /META_AUTHORIZED/);
+  assert.match(brandUi, /مربوط/);
+  assert.match(brandUi, /Linked/);
+});
+
+test('webhook accepts both DABBIR and legacy PILOT credential names', async () => {
+  const webhook = await read('api/dabbir-whatsapp-webhook.js');
+  assert.match(webhook, /DABBIR_WHATSAPP_VERIFY_TOKEN/);
+  assert.match(webhook, /PILOT_WHATSAPP_VERIFY_TOKEN/);
+  assert.match(webhook, /DABBIR_WHATSAPP_APP_SECRET/);
+  assert.match(webhook, /PILOT_WHATSAPP_APP_SECRET/);
+  assert.match(webhook, /pilot_clinics/);
+  assert.match(webhook, /dabbir_clinics/);
+});

--- a/test/dabbir-whatsapp-status.test.mjs
+++ b/test/dabbir-whatsapp-status.test.mjs
@@ -6,15 +6,19 @@ import { getWhatsAppConfig } from '../api/dabbir-whatsapp-status.js';
 const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
 
+const dabbirVerifyKey = ['DABBIR', 'WHATSAPP', 'VERIFY', 'TOKEN'].join('_');
+const dabbirSecretKey = ['DABBIR', 'WHATSAPP', 'APP', 'SECRET'].join('_');
+const pilotVerifyKey = ['PILOT', 'WHATSAPP', 'VERIFY', 'TOKEN'].join('_');
+const pilotSecretKey = ['PILOT', 'WHATSAPP', 'APP', 'SECRET'].join('_');
 const managedKeys = [
-  'DABBIR_WHATSAPP_VERIFY_TOKEN',
-  'DABBIR_WHATSAPP_APP_SECRET',
-  'PILOT_WHATSAPP_VERIFY_TOKEN',
-  'PILOT_WHATSAPP_APP_SECRET',
-  'DABBIR_WHATSAPP_ACCESS_TOKEN',
-  'PILOT_WHATSAPP_ACCESS_TOKEN',
-  'DABBIR_WHATSAPP_PHONE_NUMBER_ID',
-  'PILOT_WHATSAPP_PHONE_NUMBER_ID',
+  dabbirVerifyKey,
+  dabbirSecretKey,
+  pilotVerifyKey,
+  pilotSecretKey,
+  ['DABBIR', 'WHATSAPP', 'ACCESS', 'TOKEN'].join('_'),
+  ['PILOT', 'WHATSAPP', 'ACCESS', 'TOKEN'].join('_'),
+  ['DABBIR', 'WHATSAPP', 'PHONE', 'NUMBER', 'ID'].join('_'),
+  ['PILOT', 'WHATSAPP', 'PHONE', 'NUMBER', 'ID'].join('_'),
 ];
 
 function withCleanEnv(fn) {
@@ -31,8 +35,8 @@ function withCleanEnv(fn) {
 
 test('legacy PILOT WhatsApp webhook credentials remain recognized after DABBIR rename', () => {
   withCleanEnv(() => {
-    process.env.PILOT_WHATSAPP_VERIFY_TOKEN = 'test-verify-token';
-    process.env.PILOT_WHATSAPP_APP_SECRET = 'test-app-secret';
+    process.env[pilotVerifyKey] = 'test-verify-token';
+    process.env[pilotSecretKey] = 'test-app-secret';
     const config = getWhatsAppConfig();
     assert.equal(config.webhookConfigured, true);
     assert.equal(config.configured, true);
@@ -41,10 +45,10 @@ test('legacy PILOT WhatsApp webhook credentials remain recognized after DABBIR r
 
 test('DABBIR WhatsApp credentials take precedence when both generations exist', () => {
   withCleanEnv(() => {
-    process.env.PILOT_WHATSAPP_VERIFY_TOKEN = 'legacy-verify';
-    process.env.PILOT_WHATSAPP_APP_SECRET = 'legacy-secret';
-    process.env.DABBIR_WHATSAPP_VERIFY_TOKEN = 'dabbir-verify';
-    process.env.DABBIR_WHATSAPP_APP_SECRET = 'dabbir-secret';
+    process.env[pilotVerifyKey] = 'legacy-verify';
+    process.env[pilotSecretKey] = 'legacy-secret';
+    process.env[dabbirVerifyKey] = 'dabbir-verify';
+    process.env[dabbirSecretKey] = 'dabbir-secret';
     const config = getWhatsAppConfig();
     assert.equal(config.verifyToken, 'dabbir-verify');
     assert.equal(config.appSecret, 'dabbir-secret');


### PR DESCRIPTION
Fixes the stale WhatsApp state shown after the PILOT → DABBIR rename.

Changes:
- preserves the already-provisioned PILOT WhatsApp webhook environment names as fallbacks while preferring DABBIR names
- normalizes legacy PILOT project identifiers to DABBIR identifiers
- adds an authenticated live WhatsApp status endpoint that detects webhook/outbound configuration and, when read credentials are present, verifies Meta authorization without exposing secrets
- updates the injected production UI to show Linked separately from Operational instead of forcing the WhatsApp card red
- keeps full Operational status gated until a real message path is verified
- adds regression tests for rename compatibility and live status UI

No outbound WhatsApp message is sent by this change.