### PR TITLE
Add in-app WhatsApp Embedded Signup for DABBIR

### DIFF
--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -1,0 +1,249 @@
+import crypto from 'node:crypto';
+import {
+  accessTokenFromRequest,
+  getVerifiedUser,
+  getBusinessMemberships,
+  supabaseRest,
+} from './_auth-core.js';
+
+function firstEnv(...names) {
+  for (const name of names) {
+    const value = String(process.env[name] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+export function embeddedPlatformConfig() {
+  const appId = firstEnv(
+    'DABBIR_META_APP_ID',
+    'DABBIR_WHATSAPP_APP_ID',
+    'PILOT_META_APP_ID',
+    'PILOT_WHATSAPP_APP_ID',
+    'META_APP_ID',
+    'FACEBOOK_APP_ID',
+  );
+  const appSecret = firstEnv(
+    'DABBIR_WHATSAPP_APP_SECRET',
+    'PILOT_WHATSAPP_APP_SECRET',
+    'META_APP_SECRET',
+    'FACEBOOK_APP_SECRET',
+  );
+  const configId = firstEnv(
+    'DABBIR_WHATSAPP_EMBEDDED_CONFIG_ID',
+    'DABBIR_META_CONFIG_ID',
+    'PILOT_WHATSAPP_EMBEDDED_CONFIG_ID',
+    'PILOT_META_CONFIG_ID',
+    'WHATSAPP_EMBEDDED_CONFIG_ID',
+    'META_CONFIG_ID',
+  );
+  const graphVersion = firstEnv('DABBIR_META_GRAPH_VERSION', 'PILOT_META_GRAPH_VERSION', 'META_GRAPH_VERSION') || 'v23.0';
+  const encryptionSecret = firstEnv('DABBIR_INTEGRATION_ENCRYPTION_KEY') || appSecret;
+  return {
+    appId,
+    appSecret,
+    configId,
+    graphVersion,
+    encryptionSecret,
+    ready: Boolean(appId && appSecret && configId && encryptionSecret),
+  };
+}
+
+export async function ownerContext(req, businessId) {
+  const accessToken = accessTokenFromRequest(req);
+  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+  if (!user) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
+  const memberships = await getBusinessMemberships(accessToken).catch(() => []);
+  const membership = memberships.find(item => String(item.business_id) === String(businessId));
+  if (!membership || membership.status !== 'active') throw Object.assign(new Error('BUSINESS_ACCESS_REQUIRED'), { status: 403 });
+  if (!['owner', 'admin'].includes(String(membership.role || '').toLowerCase())) {
+    throw Object.assign(new Error('OWNER_OR_ADMIN_REQUIRED'), { status: 403 });
+  }
+  return { accessToken, user, membership };
+}
+
+function keyFor(config, businessId) {
+  if (!config.encryptionSecret) throw new Error('INTEGRATION_ENCRYPTION_NOT_CONFIGURED');
+  return crypto.createHash('sha256')
+    .update('dabbir-whatsapp-embedded-v1\0')
+    .update(String(businessId))
+    .update('\0')
+    .update(config.encryptionSecret)
+    .digest();
+}
+
+export function sealAccessToken(token, config, businessId) {
+  const iv = crypto.randomBytes(12);
+  const cipher = crypto.createCipheriv('aes-256-gcm', keyFor(config, businessId), iv);
+  const ciphertext = Buffer.concat([cipher.update(String(token), 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return {
+    access_token_ciphertext: ciphertext.toString('base64url'),
+    access_token_iv: iv.toString('base64url'),
+    access_token_tag: tag.toString('base64url'),
+    token_key_version: 'whatsapp_v1',
+  };
+}
+
+export function openAccessToken(row, config, businessId) {
+  const decipher = crypto.createDecipheriv(
+    'aes-256-gcm',
+    keyFor(config, businessId),
+    Buffer.from(String(row.access_token_iv || ''), 'base64url'),
+  );
+  decipher.setAuthTag(Buffer.from(String(row.access_token_tag || ''), 'base64url'));
+  const plaintext = Buffer.concat([
+    decipher.update(Buffer.from(String(row.access_token_ciphertext || ''), 'base64url')),
+    decipher.final(),
+  ]);
+  return plaintext.toString('utf8');
+}
+
+async function graphFetch(config, path, { method = 'GET', token, query, body } = {}) {
+  const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/${String(path).replace(/^\//, '')}`);
+  for (const [key, value] of Object.entries(query || {})) {
+    if (value !== undefined && value !== null && value !== '') url.searchParams.set(key, String(value));
+  }
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    const headers = { accept: 'application/json' };
+    if (token) headers.authorization = `Bearer ${token}`;
+    let payloadBody;
+    if (body !== undefined) {
+      headers['content-type'] = 'application/json';
+      payloadBody = JSON.stringify(body);
+    }
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: payloadBody,
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error(String(payload?.error?.message || 'META_REQUEST_FAILED').slice(0, 300));
+      error.status = 502;
+      error.providerStatus = response.status;
+      error.providerCode = payload?.error?.code || null;
+      throw error;
+    }
+    return { payload, status: response.status };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function exchangeEmbeddedCode(config, code) {
+  if (!config.ready) throw Object.assign(new Error('META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED'), { status: 503 });
+  const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/oauth/access_token`);
+  url.searchParams.set('client_id', config.appId);
+  url.searchParams.set('client_secret', config.appSecret);
+  url.searchParams.set('code', String(code));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    const response = await fetch(url, { cache: 'no-store', signal: controller.signal });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload?.access_token) {
+      const error = new Error(String(payload?.error?.message || 'META_CODE_EXCHANGE_FAILED').slice(0, 300));
+      error.status = 502;
+      error.providerStatus = response.status;
+      throw error;
+    }
+    return {
+      accessToken: String(payload.access_token),
+      expiresIn: Number(payload.expires_in || 0) || null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function verifyEmbeddedAssets(config, token, wabaId, phoneNumberId) {
+  const phoneResult = await graphFetch(config, phoneNumberId, {
+    token,
+    query: { fields: 'id,display_phone_number,verified_name,quality_rating,code_verification_status' },
+  });
+  if (String(phoneResult.payload?.id || '') !== String(phoneNumberId)) {
+    throw Object.assign(new Error('META_PHONE_NUMBER_ID_MISMATCH'), { status: 400 });
+  }
+
+  const wabaPhones = await graphFetch(config, `${encodeURIComponent(String(wabaId))}/phone_numbers`, {
+    token,
+    query: { fields: 'id,display_phone_number,verified_name', limit: '100' },
+  });
+  const belongsToWaba = Array.isArray(wabaPhones.payload?.data)
+    && wabaPhones.payload.data.some(item => String(item?.id || '') === String(phoneNumberId));
+  if (!belongsToWaba) throw Object.assign(new Error('META_PHONE_NOT_IN_SELECTED_WABA'), { status: 400 });
+
+  const subscription = await graphFetch(config, `${encodeURIComponent(String(wabaId))}/subscribed_apps`, {
+    method: 'POST',
+    token,
+    body: {},
+  });
+
+  return {
+    displayPhoneNumber: phoneResult.payload?.display_phone_number || null,
+    verifiedName: phoneResult.payload?.verified_name || null,
+    providerStatus: subscription.status,
+  };
+}
+
+export async function loadBusinessConnection(accessToken, businessId) {
+  const path = `dabbir_whatsapp_connections?select=id,business_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error&business_id=eq.${encodeURIComponent(String(businessId))}&limit=1`;
+  const response = await supabaseRest(path, accessToken);
+  if (!response.ok) return null;
+  const rows = await response.json().catch(() => []);
+  return Array.isArray(rows) ? rows[0] || null : null;
+}
+
+export async function upsertBusinessConnection(accessToken, row) {
+  const response = await supabaseRest('dabbir_whatsapp_connections?on_conflict=business_id', accessToken, {
+    method: 'POST',
+    headers: { prefer: 'resolution=merge-duplicates,return=representation' },
+    body: JSON.stringify(row),
+  });
+  const payload = await response.json().catch(() => []);
+  if (!response.ok) {
+    const error = new Error('WHATSAPP_CONNECTION_STORE_FAILED');
+    error.status = 502;
+    error.details = payload;
+    throw error;
+  }
+  return Array.isArray(payload) ? payload[0] || null : payload;
+}
+
+export async function removeBusinessConnection(accessToken, businessId) {
+  const response = await supabaseRest(`dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(businessId))}`, accessToken, {
+    method: 'DELETE',
+    headers: { prefer: 'return=representation' },
+  });
+  if (!response.ok) throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_FAILED'), { status: 502 });
+  return response.json().catch(() => []);
+}
+
+export async function unsubscribeWaba(config, token, wabaId) {
+  try {
+    await graphFetch(config, `${encodeURIComponent(String(wabaId))}/subscribed_apps`, { method: 'DELETE', token });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function verifyStoredConnection(config, row) {
+  const token = openAccessToken(row, config, row.business_id);
+  const result = await graphFetch(config, row.phone_number_id, {
+    token,
+    query: { fields: 'id,display_phone_number,verified_name' },
+  });
+  return {
+    token,
+    authorized: String(result.payload?.id || '') === String(row.phone_number_id),
+    displayPhoneNumber: result.payload?.display_phone_number || row.display_phone_number || null,
+    verifiedName: result.payload?.verified_name || row.verified_name || null,
+    providerStatus: result.status,
+  };
+}

--- a/api/app-recovery.js
+++ b/api/app-recovery.js
@@ -26,7 +26,7 @@ export default function handler(req, res) {
       forwardHeaders(res, headers);
       res.statusCode = statusCode;
       const html = typeof body === 'string'
-        ? body.replace('</body>', '<script src="/api/brand-ui"></script>\n<script src="/api/timezone-ui"></script>\n<script src="/api/auth/recovery-ui"></script>\n<script src="/api/chat-human-ui"></script>\n<script src="/api/owner-operations-ui"></script>\n<script src="/api/service-operations-ui"></script>\n<script src="/api/activity-profile-ui"></script>\n<script src="/api/owner-action-center-ui"></script>\n<script src="/api/business-profile-ui"></script>\n</body>')
+        ? body.replace('</body>', '<script src="/api/brand-ui"></script>\n<script src="/api/dabbir-whatsapp-embedded-ui"></script>\n<script src="/api/timezone-ui"></script>\n<script src="/api/auth/recovery-ui"></script>\n<script src="/api/chat-human-ui"></script>\n<script src="/api/owner-operations-ui"></script>\n<script src="/api/service-operations-ui"></script>\n<script src="/api/activity-profile-ui"></script>\n<script src="/api/owner-action-center-ui"></script>\n<script src="/api/business-profile-ui"></script>\n</body>')
         : body;
       return res.end(html);
     },

--- a/api/app-recovery.js
+++ b/api/app-recovery.js
@@ -26,7 +26,7 @@ export default function handler(req, res) {
       forwardHeaders(res, headers);
       res.statusCode = statusCode;
       const html = typeof body === 'string'
-        ? body.replace('</body>', '<script src="/api/brand-ui"></script>\n<script src="/api/dabbir-whatsapp-embedded-ui"></script>\n<script src="/api/timezone-ui"></script>\n<script src="/api/auth/recovery-ui"></script>\n<script src="/api/chat-human-ui"></script>\n<script src="/api/owner-operations-ui"></script>\n<script src="/api/service-operations-ui"></script>\n<script src="/api/activity-profile-ui"></script>\n<script src="/api/owner-action-center-ui"></script>\n<script src="/api/business-profile-ui"></script>\n</body>')
+        ? body.replace('</body>', '<script src="/api/brand-ui"></script>\n<script src="/api/dabbir-whatsapp-embedded-ui"></script>\n<script src="/api/timezone-ui"></script>\n<script src="/api/auth/recovery-ui"></script>\n<script src="/api/chat-human-ui"></script>\n<script src="/api/owner-operations-ui"></script>\n<script src="/api/service-operations-ui"></script>\n<script src="/api/activity-profile-ui"></script>\n<script src="/api/owner-action-center-ui"></script>\n<script src="/api/business-profile-ui"></script>\n<script src="/api/activity-mobile-polish-ui"></script>\n</body>')
         : body;
       return res.end(html);
     },

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -1,0 +1,45 @@
+import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import {
+  embeddedPlatformConfig,
+  loadBusinessConnection,
+  openAccessToken,
+  ownerContext,
+  removeBusinessConnection,
+  unsubscribeWaba,
+} from './_whatsapp-embedded-core.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req, 4096);
+    const businessId = String(body?.business_id || '').trim();
+    if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+
+    const owner = await ownerContext(req, businessId);
+    const row = await loadBusinessConnection(owner.accessToken, businessId);
+    if (!row) return json(res, 200, { ok: true, connected: false, already_disconnected: true });
+
+    const platform = embeddedPlatformConfig();
+    let remoteUnsubscribed = false;
+    if (platform.appSecret && platform.encryptionSecret) {
+      try {
+        const token = openAccessToken(row, platform, businessId);
+        remoteUnsubscribed = await unsubscribeWaba(platform, token, row.waba_id);
+      } catch {
+        remoteUnsubscribed = false;
+      }
+    }
+
+    await removeBusinessConnection(owner.accessToken, businessId);
+    return json(res, 200, {
+      ok: true,
+      connected: false,
+      remote_unsubscribed: remoteUnsubscribed,
+      secrets_exposed: false,
+    });
+  } catch (error) {
+    return json(res, Number(error?.status || 500), { ok: false, error: error?.message || 'WHATSAPP_DISCONNECT_FAILED' });
+  }
+}

--- a/api/dabbir-whatsapp-embedded-complete.js
+++ b/api/dabbir-whatsapp-embedded-complete.js
@@ -1,0 +1,86 @@
+import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import {
+  embeddedPlatformConfig,
+  exchangeEmbeddedCode,
+  ownerContext,
+  sealAccessToken,
+  upsertBusinessConnection,
+  verifyEmbeddedAssets,
+} from './_whatsapp-embedded-core.js';
+
+function cleanId(value) {
+  const text = String(value || '').trim();
+  return /^[0-9]{5,40}$/.test(text) ? text : '';
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req, 16 * 1024);
+    const businessId = String(body?.business_id || '').trim();
+    const code = String(body?.code || '').trim();
+    const wabaId = cleanId(body?.waba_id);
+    const phoneNumberId = cleanId(body?.phone_number_id);
+    if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+    if (!code || code.length > 4096) return json(res, 400, { ok: false, error: 'META_AUTHORIZATION_CODE_REQUIRED' });
+    if (!wabaId || !phoneNumberId) return json(res, 400, { ok: false, error: 'META_EMBEDDED_SIGNUP_ASSETS_REQUIRED' });
+
+    const owner = await ownerContext(req, businessId);
+    const platform = embeddedPlatformConfig();
+    if (!platform.ready) return json(res, 503, { ok: false, error: 'META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED' });
+
+    const exchanged = await exchangeEmbeddedCode(platform, code);
+    const verified = await verifyEmbeddedAssets(platform, exchanged.accessToken, wabaId, phoneNumberId);
+    const sealed = sealAccessToken(exchanged.accessToken, platform, businessId);
+    const now = new Date();
+    const tokenExpiresAt = exchanged.expiresIn
+      ? new Date(now.getTime() + exchanged.expiresIn * 1000).toISOString()
+      : null;
+
+    const stored = await upsertBusinessConnection(owner.accessToken, {
+      business_id: businessId,
+      provider: 'meta',
+      status: 'connected',
+      meta_app_id: platform.appId,
+      waba_id: wabaId,
+      phone_number_id: phoneNumberId,
+      display_phone_number: verified.displayPhoneNumber,
+      verified_name: verified.verifiedName,
+      ...sealed,
+      token_expires_at: tokenExpiresAt,
+      connected_by: owner.user.id,
+      connected_at: now.toISOString(),
+      last_verified_at: now.toISOString(),
+      last_provider_status: verified.providerStatus,
+      last_error: null,
+    });
+
+    return json(res, 200, {
+      ok: true,
+      connected: true,
+      channel: 'whatsapp',
+      state: 'META_AUTHORIZED',
+      meta_authorized: true,
+      operational: false,
+      operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+      phone: {
+        display_phone_number: verified.displayPhoneNumber,
+        verified_name: verified.verifiedName,
+      },
+      waba_id: stored?.waba_id || wabaId,
+      phone_number_id: stored?.phone_number_id || phoneNumberId,
+      connected_at: stored?.connected_at || now.toISOString(),
+      secrets_exposed: false,
+    });
+  } catch (error) {
+    const status = Number(error?.status || 500);
+    return json(res, status, {
+      ok: false,
+      error: String(error?.message || 'WHATSAPP_EMBEDDED_SIGNUP_FAILED').slice(0, 300),
+      provider_status: error?.providerStatus || null,
+      provider_code: error?.providerCode || null,
+    });
+  }
+}

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,0 +1,50 @@
+import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
+import { embeddedPlatformConfig, loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
+
+  const platform = embeddedPlatformConfig();
+  const accessToken = accessTokenFromRequest(req);
+  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+
+  if (!user) {
+    return json(res, 200, {
+      ok: true,
+      auth_required: true,
+      platform_ready: platform.ready,
+      graph_version: platform.graphVersion,
+      values_exposed: false,
+    });
+  }
+
+  const businessId = String(req.query?.business_id || '').trim();
+  if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+
+  try {
+    await ownerContext(req, businessId);
+    const connection = await loadBusinessConnection(accessToken, businessId);
+    return json(res, 200, {
+      ok: true,
+      auth_required: false,
+      platform_ready: platform.ready,
+      app_id: platform.ready ? platform.appId : null,
+      config_id: platform.ready ? platform.configId : null,
+      graph_version: platform.graphVersion,
+      sdk_locale: 'en_US',
+      connected: Boolean(connection && connection.status !== 'disconnected'),
+      connection: connection ? {
+        status: connection.status,
+        waba_id: connection.waba_id,
+        phone_number_id: connection.phone_number_id,
+        display_phone_number: connection.display_phone_number,
+        verified_name: connection.verified_name,
+        connected_at: connection.connected_at,
+        last_verified_at: connection.last_verified_at,
+      } : null,
+      secrets_exposed: false,
+    });
+  } catch (error) {
+    return json(res, Number(error?.status || 500), { ok: false, error: error?.message || 'REQUEST_FAILED' });
+  }
+}

--- a/api/dabbir-whatsapp-embedded-ui.js
+++ b/api/dabbir-whatsapp-embedded-ui.js
@@ -1,0 +1,247 @@
+const script = String.raw`(()=>{
+  if(window.__dabbirWhatsAppEmbeddedUiLoaded) return;
+  window.__dabbirWhatsAppEmbeddedUiLoaded=true;
+
+  const css=document.createElement('style');
+  css.textContent=[
+    '.dabbirWhatsAppActions{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}',
+    '.dabbirWhatsAppActions button{min-height:40px;border-radius:10px;padding:8px 11px;font-size:10px;font-weight:850}',
+    '.dabbirWhatsAppConnect{border:0;background:#25D366;color:#07140c}',
+    '.dabbirWhatsAppChange{border:1px solid #2a2e33;background:#181b1f;color:#fff}',
+    '.dabbirWhatsAppDisconnect{border:1px solid #5a2525;background:#2d1717;color:#ffb1b1}',
+    '.dabbirWhatsAppHint{display:block;margin-top:7px;color:#979da5;font-size:9px;line-height:1.55}',
+    '.dabbirWhatsAppBusy{opacity:.65;pointer-events:none}'
+  ].join('');
+  document.head.appendChild(css);
+
+  let sdkPromise=null;
+  let embeddedSession=null;
+  let sessionWaiters=[];
+  let configCache=null;
+  let configBusinessId=null;
+  let busy=false;
+
+  function ar(){return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')}
+  function tell(text){try{if(typeof toast==='function')toast(text)}catch{}}
+  function businessId(){try{return String(workspace?.business?.id||'')}catch{return ''}}
+
+  function whatsappCard(){
+    const grid=document.querySelector('#integrationGrid');
+    if(!grid) return null;
+    const wanted=(()=>{try{return String(T()?.whatsapp||'WhatsApp').trim()}catch{return 'WhatsApp'}})();
+    return [...grid.querySelectorAll('.integration')].find(card=>String(card.querySelector('h3')?.textContent||'').trim()===wanted)||null;
+  }
+
+  function parseMetaMessage(event){
+    if(!['https://www.facebook.com','https://web.facebook.com'].includes(String(event.origin||''))) return;
+    let data=event.data;
+    if(typeof data==='string'){
+      try{data=JSON.parse(data)}catch{return}
+    }
+    if(!data||data.type!=='WA_EMBEDDED_SIGNUP') return;
+    if(data.event==='FINISH'){
+      const payload=data.data||{};
+      embeddedSession={
+        waba_id:String(payload.waba_id||payload.whatsapp_business_account_id||''),
+        phone_number_id:String(payload.phone_number_id||''),
+      };
+      const waiters=sessionWaiters.splice(0);
+      waiters.forEach(resolve=>resolve(embeddedSession));
+    }else if(data.event==='CANCEL'){
+      const waiters=sessionWaiters.splice(0);
+      waiters.forEach(resolve=>resolve(null));
+    }else if(data.event==='ERROR'){
+      const waiters=sessionWaiters.splice(0);
+      waiters.forEach(resolve=>resolve(null));
+      tell(ar()?'تعذر إكمال ربط WhatsApp من Meta':'Meta could not complete WhatsApp setup');
+    }
+  }
+  window.addEventListener('message',parseMetaMessage);
+
+  function waitForSession(timeoutMs=12000){
+    if(embeddedSession?.waba_id&&embeddedSession?.phone_number_id) return Promise.resolve(embeddedSession);
+    return new Promise(resolve=>{
+      let done=false;
+      const finish=value=>{if(done)return;done=true;clearTimeout(timer);resolve(value)};
+      const timer=setTimeout(()=>finish(null),timeoutMs);
+      sessionWaiters.push(finish);
+    });
+  }
+
+  async function loadSdk(cfg){
+    if(window.FB){
+      try{window.FB.init({appId:cfg.app_id,cookie:true,xfbml:false,version:cfg.graph_version})}catch{}
+      return window.FB;
+    }
+    if(sdkPromise) return sdkPromise;
+    sdkPromise=new Promise((resolve,reject)=>{
+      const previous=window.fbAsyncInit;
+      window.fbAsyncInit=function(){
+        try{if(typeof previous==='function')previous()}catch{}
+        try{
+          window.FB.init({appId:cfg.app_id,cookie:true,xfbml:false,version:cfg.graph_version});
+          resolve(window.FB);
+        }catch(error){reject(error)}
+      };
+      const existing=document.querySelector('script[data-dabbir-meta-sdk]');
+      if(existing) return;
+      const script=document.createElement('script');
+      script.async=true;script.defer=true;script.crossOrigin='anonymous';
+      script.src='https://connect.facebook.net/'+encodeURIComponent(cfg.sdk_locale||'en_US')+'/sdk.js';
+      script.setAttribute('data-dabbir-meta-sdk','true');
+      script.onerror=()=>reject(new Error('META_SDK_LOAD_FAILED'));
+      document.head.appendChild(script);
+    });
+    return sdkPromise;
+  }
+
+  async function loadConfig(force=false){
+    const bid=businessId();
+    if(!bid) return null;
+    if(!force&&configCache&&configBusinessId===bid) return configCache;
+    const response=await fetch('/api/dabbir-whatsapp-embedded-config?business_id='+encodeURIComponent(bid),{cache:'no-store',headers:{accept:'application/json'}});
+    const payload=await response.json().catch(()=>({}));
+    if(!response.ok||!payload.ok) return null;
+    configBusinessId=bid;configCache=payload;
+    return payload;
+  }
+
+  async function refreshTenantStatus(){
+    const bid=businessId();
+    if(!bid) return;
+    try{
+      const response=await fetch('/api/dabbir-whatsapp-status?business_id='+encodeURIComponent(bid),{cache:'no-store',headers:{accept:'application/json'}});
+      const payload=await response.json().catch(()=>({}));
+      if(response.ok&&payload.ok&&typeof workspace!=='undefined'&&workspace){
+        workspace.whatsapp={...(workspace.whatsapp||{}),...payload};
+        try{if(typeof renderIntegrations==='function')renderIntegrations()}catch{}
+      }
+    }catch{}
+  }
+
+  function setBusy(value){
+    busy=value;
+    const card=whatsappCard();
+    card?.querySelector('[data-dabbir-whatsapp-actions]')?.classList.toggle('dabbirWhatsAppBusy',value);
+    card?.querySelectorAll('[data-dabbir-whatsapp-actions] button').forEach(button=>button.disabled=value||button.dataset.platformReady==='false');
+  }
+
+  async function completeSignup(code,session){
+    const response=await fetch('/api/dabbir-whatsapp-embedded-complete',{
+      method:'POST',cache:'no-store',headers:{'content-type':'application/json','accept':'application/json'},
+      body:JSON.stringify({business_id:businessId(),code,waba_id:session.waba_id,phone_number_id:session.phone_number_id})
+    });
+    const payload=await response.json().catch(()=>({}));
+    if(!response.ok||!payload.ok) throw new Error(payload.error||'WHATSAPP_EMBEDDED_SIGNUP_FAILED');
+    if(typeof workspace!=='undefined'&&workspace) workspace.whatsapp={...(workspace.whatsapp||{}),...payload};
+    configCache=null;
+    await loadConfig(true).catch(()=>null);
+    await refreshTenantStatus();
+    tell(ar()?'تم ربط WhatsApp بنجاح':'WhatsApp connected successfully');
+  }
+
+  async function connectWhatsApp(){
+    if(busy) return;
+    setBusy(true);
+    embeddedSession=null;
+    try{
+      const cfg=await loadConfig(true);
+      if(!cfg?.platform_ready||!cfg.app_id||!cfg.config_id) throw new Error('META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED');
+      const FB=await loadSdk(cfg);
+      const auth=await new Promise((resolve,reject)=>{
+        try{
+          FB.login(response=>resolve(response),{
+            config_id:cfg.config_id,
+            response_type:'code',
+            override_default_response_type:true,
+            extras:{setup:{},featureType:'',sessionInfoVersion:'3'}
+          });
+        }catch(error){reject(error)}
+      });
+      const code=String(auth?.authResponse?.code||'');
+      if(!code) throw new Error('META_AUTHORIZATION_CODE_MISSING');
+      const session=await waitForSession();
+      if(!session?.waba_id||!session?.phone_number_id) throw new Error('META_EMBEDDED_SIGNUP_SESSION_MISSING');
+      await completeSignup(code,session);
+    }catch(error){
+      const key=String(error?.message||'');
+      const text=key==='META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED'
+        ? (ar()?'إعداد Meta Embedded Signup الخاص بمنصة DABBIR غير مكتمل بعد':'DABBIR Meta Embedded Signup platform configuration is incomplete')
+        : (ar()?'تعذر ربط WhatsApp. لم يتم حفظ أي ربط غير مكتمل.':'WhatsApp could not be connected. No incomplete connection was saved.');
+      tell(text);
+    }finally{setBusy(false);renderActions()}
+  }
+
+  async function disconnectWhatsApp(){
+    if(busy) return;
+    const accepted=window.confirm(ar()?'فصل رقم WhatsApp عن هذا النشاط؟':'Disconnect WhatsApp from this business?');
+    if(!accepted) return;
+    setBusy(true);
+    try{
+      const response=await fetch('/api/dabbir-whatsapp-disconnect',{
+        method:'POST',cache:'no-store',headers:{'content-type':'application/json','accept':'application/json'},
+        body:JSON.stringify({business_id:businessId()})
+      });
+      const payload=await response.json().catch(()=>({}));
+      if(!response.ok||!payload.ok) throw new Error(payload.error||'WHATSAPP_DISCONNECT_FAILED');
+      configCache=null;
+      if(typeof workspace!=='undefined'&&workspace) workspace.whatsapp={connected:false,state:'NOT_CONFIGURED',phone:null,operational:false};
+      try{if(typeof renderIntegrations==='function')renderIntegrations()}catch{}
+      tell(ar()?'تم فصل WhatsApp':'WhatsApp disconnected');
+    }catch{tell(ar()?'تعذر فصل WhatsApp':'WhatsApp could not be disconnected')}
+    finally{setBusy(false);renderActions()}
+  }
+
+  async function renderActions(){
+    const card=whatsappCard();
+    if(!card||!businessId()) return;
+    let box=card.querySelector('[data-dabbir-whatsapp-actions]');
+    if(!box){
+      box=document.createElement('div');box.className='dabbirWhatsAppActions';box.setAttribute('data-dabbir-whatsapp-actions','true');card.appendChild(box);
+    }
+    let cfg=null;
+    try{cfg=await loadConfig()}catch{}
+    if(!cfg){box.replaceChildren();return}
+    box.replaceChildren();
+    const connected=Boolean(cfg.connected||workspace?.whatsapp?.connected);
+    const primary=document.createElement('button');
+    primary.type='button';primary.className=connected?'dabbirWhatsAppChange':'dabbirWhatsAppConnect';
+    primary.textContent=connected?(ar()?'تغيير رقم WhatsApp':'Change WhatsApp number'):(ar()?'ربط WhatsApp':'Connect WhatsApp');
+    primary.dataset.platformReady=String(Boolean(cfg.platform_ready));
+    primary.disabled=busy||!cfg.platform_ready;
+    primary.onclick=connectWhatsApp;
+    box.appendChild(primary);
+    if(connected){
+      const disconnect=document.createElement('button');disconnect.type='button';disconnect.className='dabbirWhatsAppDisconnect';disconnect.textContent=ar()?'فصل WhatsApp':'Disconnect WhatsApp';disconnect.onclick=disconnectWhatsApp;disconnect.disabled=busy;box.appendChild(disconnect);
+    }
+    if(!cfg.platform_ready){
+      const hint=document.createElement('span');hint.className='dabbirWhatsAppHint';hint.textContent=ar()?'إعداد Meta Embedded Signup للمنصة يحتاج App ID وConfiguration ID قبل فتح نافذة الربط.':'Platform Meta Embedded Signup needs an App ID and Configuration ID before the connection window can open.';box.appendChild(hint);
+    }else{
+      const hint=document.createElement('span');hint.className='dabbirWhatsAppHint';hint.textContent=ar()?'الربط يتم داخل DABBIR عبر نافذة Meta الرسمية. لا تحتاج إلى نسخ Tokens أو IDs.':'Connection happens inside DABBIR through Meta’s official window. No tokens or IDs need to be copied.';box.appendChild(hint);
+    }
+  }
+
+  if(typeof renderIntegrations==='function'&&!window.__dabbirWhatsAppEmbeddedRenderWrapped){
+    window.__dabbirWhatsAppEmbeddedRenderWrapped=true;
+    const before=renderIntegrations;
+    renderIntegrations=function(){const result=before.apply(this,arguments);setTimeout(renderActions,0);return result};
+  }
+
+  const observer=new MutationObserver(()=>{
+    const card=whatsappCard();
+    if(card&&!card.querySelector('[data-dabbir-whatsapp-actions]')) setTimeout(renderActions,0);
+  });
+  observer.observe(document.documentElement,{subtree:true,childList:true});
+  setTimeout(()=>{refreshTenantStatus();renderActions()},700);
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET'){
+    res.statusCode=405;res.setHeader('allow','GET');return res.end('Method Not Allowed');
+  }
+  res.statusCode=200;
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','no-store');
+  res.setHeader('x-content-type-options','nosniff');
+  return res.end(script);
+}

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,4 +1,10 @@
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
+import {
+  embeddedPlatformConfig,
+  loadBusinessConnection,
+  ownerContext,
+  verifyStoredConnection,
+} from './_whatsapp-embedded-core.js';
 
 function firstEnv(...names) {
   for (const name of names) {
@@ -30,22 +36,10 @@ export function getWhatsAppConfig() {
     'WABA_ID',
   );
   const graphVersion = firstEnv('DABBIR_META_GRAPH_VERSION', 'PILOT_META_GRAPH_VERSION', 'META_GRAPH_VERSION') || 'v23.0';
-
   const webhookConfigured = Boolean(verifyToken && appSecret);
   const outboundConfigured = Boolean(accessToken && phoneNumberId);
   const configured = webhookConfigured || outboundConfigured;
-
-  return {
-    verifyToken,
-    appSecret,
-    accessToken,
-    phoneNumberId,
-    wabaId,
-    graphVersion,
-    webhookConfigured,
-    outboundConfigured,
-    configured,
-  };
+  return { verifyToken, appSecret, accessToken, phoneNumberId, wabaId, graphVersion, webhookConfigured, outboundConfigured, configured };
 }
 
 function publicConfig(config) {
@@ -54,7 +48,6 @@ function publicConfig(config) {
   else if (config.webhookConfigured) state = 'WEBHOOK_LINKED';
   else if (config.outboundConfigured) state = 'OUTBOUND_CONFIGURED';
   else if (config.configured) state = 'PARTIALLY_CONFIGURED';
-
   return {
     configured: config.configured,
     connected: config.webhookConfigured || config.outboundConfigured,
@@ -67,71 +60,114 @@ function publicConfig(config) {
 }
 
 export async function verifyMetaAuthorization(config = getWhatsAppConfig()) {
-  if (!config.accessToken || !config.phoneNumberId) {
-    return {
-      attempted: false,
-      authorized: false,
-      reason: 'META_READ_CREDENTIALS_NOT_CONFIGURED',
-    };
-  }
-
+  if (!config.accessToken || !config.phoneNumberId) return { attempted: false, authorized: false, reason: 'META_READ_CREDENTIALS_NOT_CONFIGURED' };
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 4500);
   try {
     const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/${encodeURIComponent(config.phoneNumberId)}`);
     url.searchParams.set('fields', 'display_phone_number,verified_name');
-    const response = await fetch(url, {
-      method: 'GET',
-      headers: { authorization: `Bearer ${config.accessToken}` },
-      cache: 'no-store',
-      signal: controller.signal,
-    });
+    const response = await fetch(url, { method: 'GET', headers: { authorization: `Bearer ${config.accessToken}` }, cache: 'no-store', signal: controller.signal });
     const payload = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      return {
-        attempted: true,
-        authorized: false,
-        reason: 'META_AUTHORIZATION_CHECK_FAILED',
-        provider_status: response.status,
-      };
-    }
+    if (!response.ok) return { attempted: true, authorized: false, reason: 'META_AUTHORIZATION_CHECK_FAILED', provider_status: response.status };
     return {
       attempted: true,
       authorized: true,
       reason: null,
       provider_status: response.status,
-      phone: {
-        display_phone_number: payload?.display_phone_number || null,
-        verified_name: payload?.verified_name || null,
-      },
+      phone: { display_phone_number: payload?.display_phone_number || null, verified_name: payload?.verified_name || null },
     };
   } catch (error) {
-    return {
-      attempted: true,
-      authorized: false,
-      reason: error?.name === 'AbortError' ? 'META_AUTHORIZATION_CHECK_TIMEOUT' : 'META_AUTHORIZATION_CHECK_UNAVAILABLE',
-    };
+    return { attempted: true, authorized: false, reason: error?.name === 'AbortError' ? 'META_AUTHORIZATION_CHECK_TIMEOUT' : 'META_AUTHORIZATION_CHECK_UNAVAILABLE' };
   } finally {
     clearTimeout(timeout);
   }
 }
 
+async function embeddedStatus(req, accessToken, businessId) {
+  await ownerContext(req, businessId);
+  const row = await loadBusinessConnection(accessToken, businessId);
+  if (!row) return null;
+  const platform = embeddedPlatformConfig();
+  try {
+    const verified = await verifyStoredConnection(platform, row);
+    return {
+      ok: true,
+      channel: 'whatsapp',
+      source: 'embedded_signup',
+      configured: true,
+      connected: Boolean(verified.authorized),
+      webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
+      outbound_configured: Boolean(verified.authorized),
+      phone_number_configured: true,
+      waba_configured: true,
+      state: verified.authorized ? 'META_AUTHORIZED' : 'AUTHORIZATION_INVALID',
+      meta_authorized: Boolean(verified.authorized),
+      meta_check_attempted: true,
+      meta_check_reason: verified.authorized ? null : 'META_AUTHORIZATION_CHECK_FAILED',
+      provider_status: verified.providerStatus || null,
+      phone: {
+        display_phone_number: verified.displayPhoneNumber,
+        verified_name: verified.verifiedName,
+      },
+      waba_id: row.waba_id,
+      phone_number_id: row.phone_number_id,
+      connected_at: row.connected_at,
+      operational: false,
+      operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+      checked_at: new Date().toISOString(),
+    };
+  } catch (error) {
+    return {
+      ok: true,
+      channel: 'whatsapp',
+      source: 'embedded_signup',
+      configured: true,
+      connected: true,
+      webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
+      outbound_configured: true,
+      phone_number_configured: true,
+      waba_configured: true,
+      state: 'CONNECTED_VERIFICATION_FAILED',
+      meta_authorized: false,
+      meta_check_attempted: true,
+      meta_check_reason: String(error?.message || 'META_AUTHORIZATION_CHECK_UNAVAILABLE').slice(0, 200),
+      provider_status: error?.providerStatus || null,
+      phone: { display_phone_number: row.display_phone_number || null, verified_name: row.verified_name || null },
+      waba_id: row.waba_id,
+      phone_number_id: row.phone_number_id,
+      connected_at: row.connected_at,
+      operational: false,
+      operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+      checked_at: new Date().toISOString(),
+    };
+  }
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
-
   const accessToken = accessTokenFromRequest(req);
   const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  const businessId = String(req.query?.business_id || '').trim();
+  if (businessId) {
+    try {
+      const tenant = await embeddedStatus(req, accessToken, businessId);
+      if (tenant) return json(res, 200, tenant);
+    } catch (error) {
+      return json(res, Number(error?.status || 500), { ok: false, error: error?.message || 'REQUEST_FAILED' });
+    }
+  }
 
   const config = getWhatsAppConfig();
   const base = publicConfig(config);
   const meta = await verifyMetaAuthorization(config);
   const metaAuthorized = Boolean(meta.authorized);
   const state = metaAuthorized ? 'META_AUTHORIZED' : base.state;
-
   return json(res, 200, {
     ok: true,
     channel: 'whatsapp',
+    source: 'legacy_server_config',
     ...base,
     connected: metaAuthorized || base.connected,
     state,

--- a/supabase/migrations/20260826195230_dabbir_whatsapp_embedded_signup_v17.sql
+++ b/supabase/migrations/20260826195230_dabbir_whatsapp_embedded_signup_v17.sql
@@ -1,0 +1,128 @@
+-- DABBIR WhatsApp Embedded Signup v17
+-- Stores one Meta WhatsApp connection per business. Access tokens are never stored in plaintext;
+-- application code seals them with AES-GCM before the row is written.
+
+create table if not exists public.dabbir_whatsapp_connections (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null unique references public.dabbir_businesses(id) on delete cascade,
+  provider text not null default 'meta' check (provider = 'meta'),
+  status text not null default 'connected' check (status in ('connected','verification_required','disconnected','error')),
+  meta_app_id text,
+  waba_id text not null,
+  phone_number_id text not null unique,
+  display_phone_number text,
+  verified_name text,
+  access_token_ciphertext text not null,
+  access_token_iv text not null,
+  access_token_tag text not null,
+  token_expires_at timestamptz,
+  token_key_version text not null default 'whatsapp_v1',
+  connected_by uuid not null,
+  connected_at timestamptz not null default now(),
+  last_verified_at timestamptz,
+  last_provider_status integer,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists dabbir_whatsapp_connections_business_idx
+  on public.dabbir_whatsapp_connections(business_id);
+create index if not exists dabbir_whatsapp_connections_phone_idx
+  on public.dabbir_whatsapp_connections(phone_number_id);
+
+alter table public.dabbir_whatsapp_connections enable row level security;
+
+revoke all on table public.dabbir_whatsapp_connections from anon;
+grant select, insert, update, delete on table public.dabbir_whatsapp_connections to authenticated;
+
+drop policy if exists dabbir_whatsapp_connections_owner_select on public.dabbir_whatsapp_connections;
+create policy dabbir_whatsapp_connections_owner_select
+on public.dabbir_whatsapp_connections
+for select
+to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_whatsapp_connections.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin')
+  )
+);
+
+drop policy if exists dabbir_whatsapp_connections_owner_insert on public.dabbir_whatsapp_connections;
+create policy dabbir_whatsapp_connections_owner_insert
+on public.dabbir_whatsapp_connections
+for insert
+to authenticated
+with check (
+  connected_by = (select auth.uid())
+  and exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_whatsapp_connections.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin')
+  )
+);
+
+drop policy if exists dabbir_whatsapp_connections_owner_update on public.dabbir_whatsapp_connections;
+create policy dabbir_whatsapp_connections_owner_update
+on public.dabbir_whatsapp_connections
+for update
+to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_whatsapp_connections.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin')
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_whatsapp_connections.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin')
+  )
+);
+
+drop policy if exists dabbir_whatsapp_connections_owner_delete on public.dabbir_whatsapp_connections;
+create policy dabbir_whatsapp_connections_owner_delete
+on public.dabbir_whatsapp_connections
+for delete
+to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_whatsapp_connections.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin')
+  )
+);
+
+create or replace function public.dabbir_touch_whatsapp_connection_updated_at()
+returns trigger
+language plpgsql
+security invoker
+set search_path = 'public','pg_temp'
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+revoke all on function public.dabbir_touch_whatsapp_connection_updated_at() from public;
+revoke all on function public.dabbir_touch_whatsapp_connection_updated_at() from anon;
+revoke all on function public.dabbir_touch_whatsapp_connection_updated_at() from authenticated;
+
+drop trigger if exists dabbir_whatsapp_connection_touch on public.dabbir_whatsapp_connections;
+create trigger dabbir_whatsapp_connection_touch
+before update on public.dabbir_whatsapp_connections
+for each row execute function public.dabbir_touch_whatsapp_connection_updated_at();

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { openAccessToken, sealAccessToken } from '../api/_whatsapp-embedded-core.js';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+test('WhatsApp tenant access token is sealed and can be opened only with the server secret', () => {
+  const config = {
+    encryptionSecret: 'unit-test-only-encryption-material',
+  };
+  const businessId = '0b540176-8dd6-44b4-a5b7-aea4933e88f6';
+  const token = ['EA', 'test', 'token', 'not-real'].join('-');
+  const sealed = sealAccessToken(token, config, businessId);
+  assert.notEqual(sealed.access_token_ciphertext, token);
+  assert.equal(openAccessToken(sealed, config, businessId), token);
+  assert.throws(() => openAccessToken(sealed, { encryptionSecret: 'wrong-key' }, businessId));
+});
+
+test('Embedded Signup UI connects through Meta inside DABBIR without manual token fields', async () => {
+  const ui = await read('api/dabbir-whatsapp-embedded-ui.js');
+  assert.match(ui, /FB\.login/);
+  assert.match(ui, /config_id/);
+  assert.match(ui, /override_default_response_type/);
+  assert.match(ui, /WA_EMBEDDED_SIGNUP/);
+  assert.match(ui, /\/api\/dabbir-whatsapp-embedded-complete/);
+  assert.match(ui, /ربط WhatsApp/);
+  assert.match(ui, /تغيير رقم WhatsApp/);
+  assert.match(ui, /فصل WhatsApp/);
+  assert.doesNotMatch(ui, /type=["']password["']/);
+});
+
+test('Embedded completion exchanges authorization code server-side and never returns access token', async () => {
+  const endpoint = await read('api/dabbir-whatsapp-embedded-complete.js');
+  assert.match(endpoint, /exchangeEmbeddedCode/);
+  assert.match(endpoint, /sealAccessToken/);
+  assert.match(endpoint, /verifyEmbeddedAssets/);
+  assert.match(endpoint, /secrets_exposed:\s*false/);
+  assert.doesNotMatch(endpoint, /access_token:\s*exchanged\.accessToken/);
+});
+
+test('WhatsApp connection storage is tenant-scoped and RLS protected', async () => {
+  const migration = await read('supabase/migrations/20260826195230_dabbir_whatsapp_embedded_signup_v17.sql');
+  assert.match(migration, /dabbir_whatsapp_connections/);
+  assert.match(migration, /enable row level security/i);
+  assert.match(migration, /role in \('owner','admin'\)/);
+  assert.match(migration, /revoke all on table public\.dabbir_whatsapp_connections from anon/i);
+  assert.doesNotMatch(migration, /grant .* to anon/i);
+});
+
+test('production shell mounts Embedded Signup and CSP permits only required Meta browser origins', async () => {
+  const shell = await read('api/app-recovery.js');
+  const vercel = await read('vercel.json');
+  assert.match(shell, /\/api\/dabbir-whatsapp-embedded-ui/);
+  assert.match(vercel, /https:\/\/connect\.facebook\.net/);
+  assert.match(vercel, /frame-src https:\/\/www\.facebook\.com https:\/\/web\.facebook\.com/);
+  assert.match(vercel, /connect-src 'self' https:\/\/graph\.facebook\.com/);
+});
+
+test('status endpoint prefers business-scoped Embedded Signup when business_id is supplied', async () => {
+  const status = await read('api/dabbir-whatsapp-status.js');
+  assert.match(status, /embeddedStatus/);
+  assert.match(status, /source:\s*'embedded_signup'/);
+  assert.match(status, /req\.query\?\.business_id/);
+  assert.match(status, /loadBusinessConnection/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -28,7 +28,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "no-referrer" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data:; font-src 'self' data:; connect-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: https://*.facebook.com https://*.fbcdn.net; font-src 'self' data:; connect-src 'self' https://graph.facebook.com https://www.facebook.com https://web.facebook.com; frame-src https://www.facebook.com https://web.facebook.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://connect.facebook.net" }
       ]
     }
   ]


### PR DESCRIPTION
Implements owner/admin WhatsApp connection from inside DABBIR using Meta Embedded Signup.

Key changes:
- in-app Connect / Change number / Disconnect controls in Integrations
- official Meta JS SDK Embedded Signup flow; no manual token or ID entry for customers
- server-side authorization-code exchange and WABA/phone validation
- automatic WABA app subscription
- AES-GCM sealing of per-business Meta access tokens before database storage
- tenant-scoped `dabbir_whatsapp_connections` table with RLS restricted to owner/admin
- active WhatsApp number and verified name remain visible in DABBIR
- tenant-specific WhatsApp status endpoint with legacy server-config fallback
- CSP narrowed to the Meta browser origins required by Embedded Signup
- regression tests for encryption, RLS, UI flow, server exchange, CSP, and status routing

The shared DABBIR Meta app still needs a Meta Embedded Signup Configuration ID in runtime configuration before the Connect button can open the production Meta onboarding window. No customer will need to copy tokens, WABA IDs, or phone IDs.