### PR TITLE
Harden internal DABBIR SECURITY DEFINER execution

### DIFF
--- a/supabase/migrations/20260826201500_dabbir_security_definer_execute_hardening_v18.sql
+++ b/supabase/migrations/20260826201500_dabbir_security_definer_execute_hardening_v18.sql
@@ -1,0 +1,11 @@
+-- DABBIR security hardening v18.
+-- These functions are internal trigger/seed helpers and must not be public Data API RPCs.
+-- Existing triggers continue to execute through their SECURITY DEFINER owner context.
+
+revoke execute on function public.dabbir_guard_appointment_business_type() from public, anon, authenticated;
+revoke execute on function public.dabbir_seed_activity_tasks(uuid) from public, anon, authenticated;
+revoke execute on function public.dabbir_seed_activity_tasks_trigger() from public, anon, authenticated;
+
+grant execute on function public.dabbir_guard_appointment_business_type() to service_role;
+grant execute on function public.dabbir_seed_activity_tasks(uuid) to service_role;
+grant execute on function public.dabbir_seed_activity_tasks_trigger() to service_role;


### PR DESCRIPTION
Removes unintended Data API/RPC execution rights from three internal DABBIR SECURITY DEFINER helpers while preserving service-role execution and existing trigger behavior.

Live verification completed before PR:
- `anon` EXECUTE = false for all three functions
- `authenticated` EXECUTE = false for all three
- `service_role` EXECUTE = true for all three
- both trigger functions remain attached to their existing tables
- Supabase Security Advisor no longer reports the six SECURITY DEFINER exposure warnings
- no current DABBIR repository code calls `dabbir_seed_activity_tasks` directly; the only database caller is its internal business-create trigger.

The same change is recorded in Supabase migration history as `dabbir_security_definer_execute_hardening_v18`.