### PR TITLE
Auto-discover Meta App ID from existing WhatsApp authorization

### DIFF
--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -14,6 +14,15 @@ function firstEnv(...names) {
   return '';
 }
 
+function legacyWhatsAppAccessToken() {
+  return firstEnv(
+    'DABBIR_WHATSAPP_ACCESS_TOKEN',
+    'PILOT_WHATSAPP_ACCESS_TOKEN',
+    'WHATSAPP_ACCESS_TOKEN',
+    'META_WHATSAPP_ACCESS_TOKEN',
+  );
+}
+
 export function embeddedPlatformConfig() {
   const appId = firstEnv(
     'DABBIR_META_APP_ID',
@@ -45,7 +54,50 @@ export function embeddedPlatformConfig() {
     configId,
     graphVersion,
     encryptionSecret,
+    appIdSource: appId ? 'environment' : null,
+    legacyAccessTokenAvailable: Boolean(legacyWhatsAppAccessToken()),
     ready: Boolean(appId && appSecret && configId && encryptionSecret),
+  };
+}
+
+let discoveredAppIdCache = null;
+let discoveredAppIdExpiresAt = 0;
+
+async function discoverAppIdFromExistingToken(config) {
+  if (config.appId) return config.appId;
+  if (discoveredAppIdCache && Date.now() < discoveredAppIdExpiresAt) return discoveredAppIdCache;
+  const token = legacyWhatsAppAccessToken();
+  if (!token) return '';
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 5000);
+  try {
+    const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/app`);
+    url.searchParams.set('fields', 'id');
+    url.searchParams.set('access_token', token);
+    const response = await fetch(url, { method: 'GET', cache: 'no-store', signal: controller.signal });
+    const payload = await response.json().catch(() => ({}));
+    const id = String(payload?.id || '').trim();
+    if (!response.ok || !/^[0-9]{5,40}$/.test(id)) return '';
+    discoveredAppIdCache = id;
+    discoveredAppIdExpiresAt = Date.now() + 15 * 60 * 1000;
+    return id;
+  } catch {
+    return '';
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+export async function resolveEmbeddedPlatformConfig() {
+  const base = embeddedPlatformConfig();
+  if (base.appId) return base;
+  const appId = await discoverAppIdFromExistingToken(base);
+  return {
+    ...base,
+    appId,
+    appIdSource: appId ? 'existing_whatsapp_token' : null,
+    ready: Boolean(appId && base.appSecret && base.configId && base.encryptionSecret),
   };
 }
 

--- a/api/dabbir-whatsapp-embedded-complete.js
+++ b/api/dabbir-whatsapp-embedded-complete.js
@@ -1,8 +1,8 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
 import {
-  embeddedPlatformConfig,
   exchangeEmbeddedCode,
   ownerContext,
+  resolveEmbeddedPlatformConfig,
   sealAccessToken,
   upsertBusinessConnection,
   verifyEmbeddedAssets,
@@ -28,7 +28,7 @@ export default async function handler(req, res) {
     if (!wabaId || !phoneNumberId) return json(res, 400, { ok: false, error: 'META_EMBEDDED_SIGNUP_ASSETS_REQUIRED' });
 
     const owner = await ownerContext(req, businessId);
-    const platform = embeddedPlatformConfig();
+    const platform = await resolveEmbeddedPlatformConfig();
     if (!platform.ready) return json(res, 503, { ok: false, error: 'META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED' });
 
     const exchanged = await exchangeEmbeddedCode(platform, code);

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,5 +1,5 @@
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
-import { embeddedPlatformConfig, loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+import { loadBusinessConnection, ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
 
 function readiness(platform) {
   return {
@@ -7,13 +7,15 @@ function readiness(platform) {
     app_secret_configured: Boolean(platform.appSecret),
     embedded_config_id_configured: Boolean(platform.configId),
     encryption_configured: Boolean(platform.encryptionSecret),
+    existing_whatsapp_token_available: Boolean(platform.legacyAccessTokenAvailable),
+    app_id_source: platform.appIdSource || null,
   };
 }
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
 
-  const platform = embeddedPlatformConfig();
+  const platform = await resolveEmbeddedPlatformConfig();
   const accessToken = accessTokenFromRequest(req);
   const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
   const platformReadiness = readiness(platform);

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -36,6 +36,8 @@ test('Embedded completion exchanges authorization code server-side and never ret
   assert.match(endpoint, /exchangeEmbeddedCode/);
   assert.match(endpoint, /sealAccessToken/);
   assert.match(endpoint, /verifyEmbeddedAssets/);
+  assert.match(endpoint, /resolveEmbeddedPlatformConfig/);
+  assert.match(endpoint, /await resolveEmbeddedPlatformConfig\(\)/);
   assert.match(endpoint, /secrets_exposed:\s*false/);
   assert.doesNotMatch(endpoint, /access_token:\s*exchanged\.accessToken/);
 });
@@ -64,4 +66,30 @@ test('status endpoint prefers business-scoped Embedded Signup when business_id i
   assert.match(status, /source:\s*'embedded_signup'/);
   assert.match(status, /req\.query\?\.business_id/);
   assert.match(status, /loadBusinessConnection/);
+});
+
+test('Meta App ID can be discovered server-side from the existing WhatsApp authorization', async () => {
+  const core = await read('api/_whatsapp-embedded-core.js');
+  const configEndpoint = await read('api/dabbir-whatsapp-embedded-config.js');
+
+  assert.match(core, /export async function resolveEmbeddedPlatformConfig/);
+  assert.match(core, /discoverAppIdFromExistingToken/);
+  assert.match(core, /\/app`\)/);
+  assert.match(core, /fields', 'id'/);
+  assert.match(core, /appIdSource:\s*appId \? 'existing_whatsapp_token'/);
+  assert.match(core, /legacyAccessTokenAvailable/);
+  assert.match(configEndpoint, /await resolveEmbeddedPlatformConfig\(\)/);
+  assert.match(configEndpoint, /existing_whatsapp_token_available/);
+  assert.match(configEndpoint, /app_id_source/);
+});
+
+test('automatic Meta App ID discovery never exposes the legacy access token to the browser', async () => {
+  const core = await read('api/_whatsapp-embedded-core.js');
+  const configEndpoint = await read('api/dabbir-whatsapp-embedded-config.js');
+
+  assert.match(core, /legacyWhatsAppAccessToken/);
+  assert.doesNotMatch(configEndpoint, /access_token\s*:/i);
+  assert.doesNotMatch(configEndpoint, /legacyAccessToken\s*:/);
+  assert.match(configEndpoint, /values_exposed:\s*false/);
+  assert.match(configEndpoint, /secrets_exposed:\s*false/);
 });


### PR DESCRIPTION
Reduces DABBIR owner setup by reusing the existing WhatsApp authorization to discover the Meta App ID server-side when it is not explicitly configured.

- preserves environment App ID as first priority
- otherwise asks Meta `/app` using the already configured legacy WhatsApp access token
- caches only the discovered numeric App ID, never the token
- exposes only safe readiness booleans and the App ID source
- Embedded Signup config/completion both use the resolved platform config
- adds regression tests proving the token is never returned to the browser

If Meta does not permit `/app` for the current token, the system safely falls back to the existing missing-App-ID state. The Embedded Signup Configuration ID remains a separate platform prerequisite.