### PR TITLE
Reduce DABBIR runtime auth bottleneck (rebased)

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -1,6 +1,7 @@
 const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
 // Supabase publishable keys are intentionally safe for public/client use. Never place a service-role key here.
 const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const ACCESS_COOKIE = '__Host-dabbir_access';
 export const REFRESH_COOKIE = '__Host-dabbir_refresh';
@@ -100,9 +101,47 @@ export async function getVerifiedUser(accessToken) {
   return { id: user.id, email: user.email ?? null, aud: user.aud ?? null };
 }
 
+function decodeJwtPayload(accessToken) {
+  try {
+    const parts = String(accessToken || '').split('.');
+    if (parts.length !== 3 || !parts[1]) return null;
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+// IMPORTANT: this helper does not verify the JWT signature itself. Call it only
+// after the same access token has already been accepted by a Supabase API that
+// verifies JWTs (for example the Data API membership lookup). This lets hot
+// authenticated reads avoid a second /auth/v1/user round trip while preserving
+// Supabase as the authority that validates the token.
+export function userClaimsFromValidatedAccessToken(accessToken, nowSeconds = Math.floor(Date.now() / 1000)) {
+  const payload = decodeJwtPayload(accessToken);
+  if (!payload || !UUID_RE.test(String(payload.sub || ''))) return null;
+  if (String(payload.iss || '') !== `${SUPABASE_URL}/auth/v1`) return null;
+  if (String(payload.role || '') !== 'authenticated') return null;
+  const audiences = Array.isArray(payload.aud) ? payload.aud.map(String) : [String(payload.aud || '')];
+  if (!audiences.includes('authenticated')) return null;
+  const exp = Number(payload.exp || 0);
+  if (!Number.isFinite(exp) || exp <= Number(nowSeconds)) return null;
+  const nbf = payload.nbf == null ? null : Number(payload.nbf);
+  if (nbf != null && (!Number.isFinite(nbf) || nbf > Number(nowSeconds))) return null;
+  return {
+    id: String(payload.sub),
+    email: payload.email == null ? null : String(payload.email),
+    aud: payload.aud ?? null,
+  };
+}
+
 export async function getBusinessMemberships(accessToken) {
   const response = await supabaseRest('dabbir_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active', accessToken);
-  if (!response.ok) throw new Error('MEMBERSHIP_LOOKUP_FAILED');
+  if (!response.ok) {
+    const status = Number(response.status || 500);
+    const error = new Error(status === 401 || status === 403 ? 'AUTH_REQUIRED' : 'MEMBERSHIP_LOOKUP_FAILED');
+    error.code = status;
+    throw error;
+  }
   return response.json();
 }
 
@@ -113,7 +152,7 @@ export function readJsonBody(req, maxBytes = 8192) {
     req.on('data', chunk => {
       size += chunk.length;
       if (size > maxBytes) {
-        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 }));
+        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 });
         req.destroy();
         return;
       }

--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -152,7 +152,7 @@ export function readJsonBody(req, maxBytes = 8192) {
     req.on('data', chunk => {
       size += chunk.length;
       if (size > maxBytes) {
-        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 });
+        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 }));
         req.destroy();
         return;
       }

--- a/api/dabbir-runtime-fast.js
+++ b/api/dabbir-runtime-fast.js
@@ -4,6 +4,7 @@ import {
   getVerifiedUser,
   json,
   supabaseRest,
+  userClaimsFromValidatedAccessToken,
 } from './_auth-core.js';
 import { getDABBIRAiConfig } from './_ai-core.js';
 import dabbirRuntimeHandler from './dabbir-runtime.js';
@@ -91,10 +92,24 @@ async function handleFastGet(req, res) {
   const accessToken = accessTokenFromRequest(req);
   if (!accessToken) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
-  const [user, memberships] = await Promise.all([
-    getVerifiedUser(accessToken).catch(() => null),
-    getBusinessMemberships(accessToken).catch(() => []),
-  ]);
+  // The membership read goes through Supabase Data API, which validates the
+  // same JWT before applying RLS. Reuse that successful validation instead of
+  // sending every hot-path request through /auth/v1/user as well.
+  let memberships;
+  try {
+    memberships = await getBusinessMemberships(accessToken);
+  } catch (error) {
+    const status = Number(error?.code || 500);
+    if (status === 401 || status === 403) {
+      return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
+    }
+    return json(res, 503, { ok: false, authenticated: false, error: 'AUTH_VERIFICATION_UNAVAILABLE' });
+  }
+
+  let user = userClaimsFromValidatedAccessToken(accessToken);
+  // Compatibility fallback for an unexpected/legacy token shape. Normal
+  // Supabase Auth access tokens stay on the local claims path above.
+  if (!user) user = await getVerifiedUser(accessToken).catch(() => null);
   if (!user) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
   const requestedBusinessId = safeId(req.query?.business_id);
@@ -202,7 +217,7 @@ async function handleFastGet(req, res) {
 
   const duration = Date.now() - started;
   res.setHeader('server-timing', `dabbir;dur=${duration}`);
-  res.setHeader('x-dabbir-runtime', 'fast-v3');
+  res.setHeader('x-dabbir-runtime', 'fast-v4');
   return json(res, 200, {
     ok: true,
     authenticated: true,
@@ -228,7 +243,7 @@ async function handleFastGet(req, res) {
       state: aiConfig.configured ? 'OPERATIONAL_PROVIDER_READY' : 'UNCONFIGURED',
     },
     whatsapp: { state: 'NOT_OPERATIONAL', blocker: 'META_AUTHORIZATION_NOT_COMPLETED' },
-    performance: { runtime_ms: duration, summary_only: summaryOnly, conversation_dedupe: true },
+    performance: { runtime_ms: duration, summary_only: summaryOnly, conversation_dedupe: true, auth_fast_path: true },
   });
 }
 

--- a/test/dabbir-auth-fastpath.test.mjs
+++ b/test/dabbir-auth-fastpath.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { userClaimsFromValidatedAccessToken } from '../api/_auth-core.js';
+
+const root = new URL('../', import.meta.url);
+const runtimeSource = await readFile(new URL('api/dabbir-runtime-fast.js', root), 'utf8');
+
+const now = 1_800_000_000;
+const userId = '11111111-1111-4111-8111-111111111111';
+
+function token(payload) {
+  const header = Buffer.from(JSON.stringify({ alg: 'ES256', typ: 'JWT' })).toString('base64url');
+  const body = Buffer.from(JSON.stringify(payload)).toString('base64url');
+  return `${header}.${body}.test-signature`;
+}
+
+function validPayload(overrides = {}) {
+  return {
+    iss: 'https://spohjzrsymsmzsseygtw.supabase.co/auth/v1',
+    sub: userId,
+    role: 'authenticated',
+    aud: 'authenticated',
+    email: 'owner@example.test',
+    exp: now + 3600,
+    ...overrides,
+  };
+}
+
+test('validated Supabase token claims are read without a second Auth request', () => {
+  assert.deepEqual(userClaimsFromValidatedAccessToken(token(validPayload()), now), {
+    id: userId,
+    email: 'owner@example.test',
+    aud: 'authenticated',
+  });
+});
+
+test('validated-token claims fail closed for wrong issuer, role, audience, expiry, nbf or subject', () => {
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ iss: 'https://example.test/auth/v1' })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ role: 'anon' })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ aud: 'anon' })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ aud: ['anon', 'service_role'] })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ exp: now })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ nbf: now + 30 })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ sub: 'not-a-uuid' })), now), null);
+  assert.equal(userClaimsFromValidatedAccessToken('not-a-jwt', now), null);
+});
+
+test('fast runtime validates membership before trusting decoded claims and retains fallback verification', () => {
+  const membershipLookup = runtimeSource.indexOf('memberships = await getBusinessMemberships(accessToken)');
+  const claimsRead = runtimeSource.indexOf('userClaimsFromValidatedAccessToken(accessToken)');
+  const fallback = runtimeSource.indexOf('getVerifiedUser(accessToken)');
+  assert.ok(membershipLookup >= 0, 'membership validation must exist');
+  assert.ok(claimsRead > membershipLookup, 'claims may only be trusted after Supabase Data API accepts the token');
+  assert.ok(fallback > claimsRead, 'legacy/unexpected token shapes must retain server verification fallback');
+  assert.match(runtimeSource, /AUTH_VERIFICATION_UNAVAILABLE/);
+  assert.match(runtimeSource, /x-dabbir-runtime', 'fast-v4'/);
+});


### PR DESCRIPTION
Rebased onto the latest DABBIR main after runtime/AI capacity tests were split.

- Removes redundant `/auth/v1/user` from the hot authenticated GET path after Supabase Data API has already validated the same JWT and applied RLS.
- Fails closed on issuer, role, audience, expiry, nbf, and subject.
- Keeps `/auth/v1/user` as compatibility fallback for unexpected token shapes.
- Returns 503 for upstream verification outage instead of misclassifying it as bad credentials.
- Adds regression tests for ordering and claim validation.

No RLS bypass. No service-role key. Production remains unchanged until CI and preview gates pass.