### PR TITLE
Block DABBIR production capacity load by default

### DIFF
--- a/test/dabbir-capacity-load.mjs
+++ b/test/dabbir-capacity-load.mjs
@@ -1,7 +1,15 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
+import { assertCapacityLoadAllowed } from './dabbir-capacity-safety.mjs';
 
 const ORIGIN=String(process.env.PRODUCTION_ORIGIN||'https://pilot-taupe.vercel.app').replace(/\/$/,'');
+const CAPACITY_TARGET=String(process.env.CAPACITY_TARGET||'').trim();
+const CAPACITY_PRODUCTION_ACK=String(process.env.CAPACITY_PRODUCTION_ACK||'').trim();
+const CAPACITY_SAFETY=assertCapacityLoadAllowed({
+  origin:ORIGIN,
+  declaredTarget:CAPACITY_TARGET,
+  ack:CAPACITY_PRODUCTION_ACK,
+});
 const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'spohjzrsymsmzsseygtw').trim();
 const QA_CONTROL_URL=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE='dabbir-ai-qa';
@@ -17,6 +25,8 @@ const RUN_AI=String(process.env.RUN_AI||'true').toLowerCase()!=='false';
 const report={
   run_id:RUN_ID,
   production_origin:ORIGIN,
+  capacity_target:CAPACITY_SAFETY.target,
+  production_capacity_acknowledged:CAPACITY_SAFETY.production_acknowledged,
   started_at:new Date().toISOString(),
   completed_at:null,
   verdict:'RUNNING',

--- a/test/dabbir-capacity-safety.mjs
+++ b/test/dabbir-capacity-safety.mjs
@@ -1,0 +1,38 @@
+export const PRODUCTION_CAPACITY_ACK = 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION';
+
+const KNOWN_PRODUCTION_HOSTS = new Set([
+  'pilot-taupe.vercel.app',
+]);
+
+function hostname(origin) {
+  try {
+    return new URL(String(origin || '')).hostname.toLowerCase();
+  } catch {
+    throw new Error('CAPACITY_ORIGIN_INVALID');
+  }
+}
+
+export function classifyCapacityTarget(origin, declaredTarget = '') {
+  const host = hostname(origin);
+  const declared = String(declaredTarget || '').trim().toLowerCase();
+
+  // A known production host always wins over a caller-supplied label so that
+  // CAPACITY_TARGET=staging cannot be used to bypass the production guard.
+  if (KNOWN_PRODUCTION_HOSTS.has(host)) return 'production';
+  if (declared === 'production') return 'production';
+  if (['staging', 'preview', 'local'].includes(declared)) return declared;
+  return 'unknown';
+}
+
+export function assertCapacityLoadAllowed({ origin, declaredTarget = '', ack = '' } = {}) {
+  const target = classifyCapacityTarget(origin, declaredTarget);
+
+  if (target === 'production' && String(ack || '') !== PRODUCTION_CAPACITY_ACK) {
+    throw new Error('PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK');
+  }
+  if (target === 'unknown') {
+    throw new Error('CAPACITY_TARGET_MUST_BE_EXPLICIT_FOR_UNKNOWN_ORIGIN');
+  }
+
+  return { target, production_acknowledged: target === 'production' };
+}

--- a/test/dabbir-capacity-safety.test.mjs
+++ b/test/dabbir-capacity-safety.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PRODUCTION_CAPACITY_ACK,
+  assertCapacityLoadAllowed,
+  classifyCapacityTarget,
+} from './dabbir-capacity-safety.mjs';
+
+test('known production origin is blocked without explicit acknowledgement', () => {
+  assert.throws(
+    () => assertCapacityLoadAllowed({ origin: 'https://pilot-taupe.vercel.app' }),
+    /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
+  );
+});
+
+test('caller cannot relabel known production as staging', () => {
+  assert.equal(
+    classifyCapacityTarget('https://pilot-taupe.vercel.app', 'staging'),
+    'production',
+  );
+  assert.throws(
+    () => assertCapacityLoadAllowed({
+      origin: 'https://pilot-taupe.vercel.app',
+      declaredTarget: 'staging',
+    }),
+    /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
+  );
+});
+
+test('production load is allowed only with the exact acknowledgement', () => {
+  assert.deepEqual(
+    assertCapacityLoadAllowed({
+      origin: 'https://pilot-taupe.vercel.app',
+      ack: PRODUCTION_CAPACITY_ACK,
+    }),
+    { target: 'production', production_acknowledged: true },
+  );
+});
+
+test('unknown external origin requires an explicit non-production target', () => {
+  assert.throws(
+    () => assertCapacityLoadAllowed({ origin: 'https://capacity.example.test' }),
+    /CAPACITY_TARGET_MUST_BE_EXPLICIT_FOR_UNKNOWN_ORIGIN/,
+  );
+});
+
+test('explicit staging target is allowed for a non-production origin', () => {
+  assert.deepEqual(
+    assertCapacityLoadAllowed({
+      origin: 'https://capacity.example.test',
+      declaredTarget: 'staging',
+    }),
+    { target: 'staging', production_acknowledged: false },
+  );
+});


### PR DESCRIPTION
Fail-closed guard for DABBIR capacity/load testing after a production saturation window caused shared Supabase contention and coincided with ZAJEL 504/546 timeouts.

Changes:
- classify the capacity target before any network request;
- known production host `pilot-taupe.vercel.app` always classifies as production even if a caller labels it staging;
- production load requires the exact explicit acknowledgement `CAPACITY_PRODUCTION_ACK=ALLOW_CAPACITY_LOAD_ON_PRODUCTION`;
- unknown origins require an explicit `CAPACITY_TARGET` of staging/preview/local;
- add regression tests for production blocking, relabel bypass prevention, exact acknowledgement, and unknown-origin fail-closed behavior;
- record target and acknowledgement state in the capacity report.

This preserves staging/preview/local capacity testing and does not change normal DABBIR runtime, auth, customer journey, WhatsApp, payment, or commercial behavior.