### PR TITLE
Skip DABBIR Vercel builds for non-runtime-only changes

### DIFF
--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const sourceScript = path.resolve('vercel-ignore-if-unaffected.sh');
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function setupRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dabbir-vercel-ignore-'));
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.email', 'dabbir-ci@example.invalid');
+  git(dir, 'config', 'user.name', 'DABBIR CI');
+  fs.copyFileSync(sourceScript, path.join(dir, 'vercel-ignore-if-unaffected.sh'));
+  fs.mkdirSync(path.join(dir, 'api'));
+  fs.mkdirSync(path.join(dir, 'test'));
+  fs.writeFileSync(path.join(dir, 'api', 'app.js'), 'export default 1;\n');
+  fs.writeFileSync(path.join(dir, 'test', 'base.test.mjs'), 'export {};\n');
+  git(dir, 'add', '.');
+  git(dir, 'commit', '-qm', 'base');
+  return dir;
+}
+
+function runGuard(cwd, previous, current) {
+  return spawnSync('bash', ['vercel-ignore-if-unaffected.sh'], {
+    cwd,
+    env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previous, VERCEL_GIT_COMMIT_SHA: current },
+    encoding: 'utf8',
+  });
+}
+
+test('test-only changes skip Vercel deployment', () => {
+  const dir = setupRepo();
+  const base = git(dir, 'rev-parse', 'HEAD');
+  fs.writeFileSync(path.join(dir, 'test', 'new.test.mjs'), 'export {};\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'test only');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, base, head).status, 0);
+});
+
+test('runtime API changes continue Vercel deployment', () => {
+  const dir = setupRepo();
+  const base = git(dir, 'rev-parse', 'HEAD');
+  fs.writeFileSync(path.join(dir, 'api', 'app.js'), 'export default 2;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'runtime');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, base, head).status, 1);
+});
+
+test('unknown root paths fail safe and build', () => {
+  const dir = setupRepo();
+  const base = git(dir, 'rev-parse', 'HEAD');
+  fs.writeFileSync(path.join(dir, 'new-runtime-entry.js'), 'export default 1;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'unknown root');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, base, head).status, 1);
+});
+
+test('missing previous SHA fails safe and builds', () => {
+  const dir = setupRepo();
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, '', head).status, 1);
+});

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -u
+
+# Vercel ignoreCommand contract:
+#   exit 0 => skip/ignore deployment
+#   exit 1 => continue building
+# Fail safe: any uncertainty or unknown path builds.
+previous="${VERCEL_GIT_PREVIOUS_SHA:-}"
+current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
+
+if [[ -z "$previous" ]]; then
+  echo "No VERCEL_GIT_PREVIOUS_SHA; build for safety."
+  exit 1
+fi
+if ! git cat-file -e "${previous}^{commit}" 2>/dev/null; then
+  echo "Previous commit unavailable; build for safety."
+  exit 1
+fi
+if ! git cat-file -e "${current}^{commit}" 2>/dev/null; then
+  echo "Current commit unavailable; build for safety."
+  exit 1
+fi
+
+changed="$(git diff --name-only "$previous" "$current" --)"
+if [[ -z "$changed" ]]; then
+  echo "No changed files; skip deployment."
+  exit 0
+fi
+
+while IFS= read -r path; do
+  case "$path" in
+    .github/*|docs/*|test/*|db/*|supabase/*|README.md|.gitignore)
+      ;;
+    *)
+      echo "Runtime or unknown path changed: $path; continue deployment."
+      exit 1
+      ;;
+  esac
+done <<< "$changed"
+
+echo "Only non-runtime DABBIR paths changed; skip Vercel deployment."
+exit 0

--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "functions": {
     "api/app.js": {
       "includeFiles": "index.html"


### PR DESCRIPTION
Reduce unnecessary DABBIR Vercel deployment churn without hiding runtime changes.

Observed evidence: PR #33 contained three small capacity guard/test commits and Vercel produced three full Preview deployments plus the final Production deployment.

Changes:
- add fail-safe `ignoreCommand` to `vercel.json`;
- skip only when every changed file is known non-runtime (`test/`, `docs/`, `.github/`, `db/`, `supabase/`, README, gitignore);
- any `api/`, UI/runtime/config/package/vercel change or any unknown path continues building;
- if previous/current commit identity cannot be proven, build rather than skip;
- regression tests cover test-only skip, API build, unknown-root build, and missing-previous-SHA build.

This reduces preview/build churn while preserving safe production deployment behavior.