### PR TITLE
Fix DABBIR Vercel ignored-build comparison

### DIFF
--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -26,43 +26,60 @@ function setupRepo() {
   return dir;
 }
 
-function runGuard(cwd, previous, current) {
+function runGuard(cwd, current, previousDeployment = '') {
   return spawnSync('bash', ['vercel-ignore-if-unaffected.sh'], {
     cwd,
-    env: { ...process.env, VERCEL_GIT_PREVIOUS_SHA: previous, VERCEL_GIT_COMMIT_SHA: current },
+    env: {
+      ...process.env,
+      VERCEL_GIT_COMMIT_SHA: current,
+      VERCEL_GIT_PREVIOUS_SHA: previousDeployment,
+    },
     encoding: 'utf8',
   });
 }
 
 test('test-only changes skip Vercel deployment', () => {
   const dir = setupRepo();
-  const base = git(dir, 'rev-parse', 'HEAD');
   fs.writeFileSync(path.join(dir, 'test', 'new.test.mjs'), 'export {};\n');
   git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'test only');
   const head = git(dir, 'rev-parse', 'HEAD');
-  assert.equal(runGuard(dir, base, head).status, 0);
+  assert.equal(runGuard(dir, head).status, 0);
+});
+
+test('last successful deployment may lag branch history without forcing a test-only build', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+
+  fs.writeFileSync(path.join(dir, 'api', 'app.js'), 'export default 2;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'runtime commit already built');
+
+  fs.writeFileSync(path.join(dir, 'test', 'later.test.mjs'), 'export {};\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'test-only follow-up');
+  const head = git(dir, 'rev-parse', 'HEAD');
+
+  // VERCEL_GIT_PREVIOUS_SHA intentionally points two commits back. The guard
+  // must compare the current commit to its direct parent and skip this build.
+  assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 0);
 });
 
 test('runtime API changes continue Vercel deployment', () => {
   const dir = setupRepo();
-  const base = git(dir, 'rev-parse', 'HEAD');
   fs.writeFileSync(path.join(dir, 'api', 'app.js'), 'export default 2;\n');
   git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'runtime');
   const head = git(dir, 'rev-parse', 'HEAD');
-  assert.equal(runGuard(dir, base, head).status, 1);
+  assert.equal(runGuard(dir, head).status, 1);
 });
 
 test('unknown root paths fail safe and build', () => {
   const dir = setupRepo();
-  const base = git(dir, 'rev-parse', 'HEAD');
   fs.writeFileSync(path.join(dir, 'new-runtime-entry.js'), 'export default 1;\n');
   git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'unknown root');
   const head = git(dir, 'rev-parse', 'HEAD');
-  assert.equal(runGuard(dir, base, head).status, 1);
+  assert.equal(runGuard(dir, head).status, 1);
 });
 
-test('missing previous SHA fails safe and builds', () => {
+test('commit without an available parent fails safe and builds', () => {
   const dir = setupRepo();
-  const head = git(dir, 'rev-parse', 'HEAD');
-  assert.equal(runGuard(dir, '', head).status, 1);
+  const rootCommit = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, rootCommit).status, 1);
 });

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -4,24 +4,26 @@ set -u
 # Vercel ignoreCommand contract:
 #   exit 0 => skip/ignore deployment
 #   exit 1 => continue building
-# Fail safe: any uncertainty or unknown path builds.
-previous="${VERCEL_GIT_PREVIOUS_SHA:-}"
+# Compare the triggering commit to its direct parent. VERCEL_GIT_PREVIOUS_SHA is
+# the last successful deployment, not necessarily the prior commit in a PR.
+# Fail safe: any uncertainty, unavailable parent, or unknown path builds.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 
-if [[ -z "$previous" ]]; then
-  echo "No VERCEL_GIT_PREVIOUS_SHA; build for safety."
-  exit 1
-fi
-if ! git cat-file -e "${previous}^{commit}" 2>/dev/null; then
-  echo "Previous commit unavailable; build for safety."
-  exit 1
-fi
 if ! git cat-file -e "${current}^{commit}" 2>/dev/null; then
   echo "Current commit unavailable; build for safety."
   exit 1
 fi
 
-changed="$(git diff --name-only "$previous" "$current" --)"
+parent="$(git rev-parse "${current}^" 2>/dev/null)" || {
+  echo "Current commit parent unavailable; build for safety."
+  exit 1
+}
+if ! git cat-file -e "${parent}^{commit}" 2>/dev/null; then
+  echo "Current commit parent unavailable in checkout; build for safety."
+  exit 1
+fi
+
+changed="$(git diff --name-only "$parent" "$current" --)"
 if [[ -z "$changed" ]]; then
   echo "No changed files; skip deployment."
   exit 0
@@ -38,5 +40,5 @@ while IFS= read -r path; do
   esac
 done <<< "$changed"
 
-echo "Only non-runtime DABBIR paths changed; skip Vercel deployment."
+echo "Only non-runtime DABBIR paths changed in current commit; skip Vercel deployment."
 exit 0


### PR DESCRIPTION
Closed as superseded by PR #41, which reapplied the same direct-parent Vercel ignored-build correction on the latest main and passed DABBIR CI before merge. The fix is now in main via merge commit `72314a58807c69a142722c643330c46e5e0d08ca`.