### PR TITLE
Fail closed before DABBIR production capacity load

### DIFF
--- a/test/dabbir-capacity-safety.mjs
+++ b/test/dabbir-capacity-safety.mjs
@@ -1,0 +1,38 @@
+export const PRODUCTION_CAPACITY_ACK = 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION';
+
+const KNOWN_PRODUCTION_HOSTS = new Set([
+  'pilot-taupe.vercel.app',
+]);
+
+function hostname(origin) {
+  try {
+    return new URL(String(origin || '')).hostname.toLowerCase();
+  } catch {
+    throw new Error('CAPACITY_ORIGIN_INVALID');
+  }
+}
+
+export function classifyCapacityTarget(origin, declaredTarget = '') {
+  const host = hostname(origin);
+  const declared = String(declaredTarget || '').trim().toLowerCase();
+
+  // A known production host always wins over a caller-supplied label so that
+  // CAPACITY_TARGET=staging cannot be used to bypass the production guard.
+  if (KNOWN_PRODUCTION_HOSTS.has(host)) return 'production';
+  if (declared === 'production') return 'production';
+  if (['staging', 'preview', 'local'].includes(declared)) return declared;
+  return 'unknown';
+}
+
+export function assertCapacityLoadAllowed({ origin, declaredTarget = '', ack = '' } = {}) {
+  const target = classifyCapacityTarget(origin, declaredTarget);
+
+  if (target === 'production' && String(ack || '') !== PRODUCTION_CAPACITY_ACK) {
+    throw new Error('PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK');
+  }
+  if (target === 'unknown') {
+    throw new Error('CAPACITY_TARGET_MUST_BE_EXPLICIT_FOR_UNKNOWN_ORIGIN');
+  }
+
+  return { target, production_acknowledged: target === 'production' };
+}

--- a/test/dabbir-capacity-safety.test.mjs
+++ b/test/dabbir-capacity-safety.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  PRODUCTION_CAPACITY_ACK,
+  assertCapacityLoadAllowed,
+  classifyCapacityTarget,
+} from './dabbir-capacity-safety.mjs';
+
+test('known production origin is blocked without explicit acknowledgement', () => {
+  assert.throws(
+    () => assertCapacityLoadAllowed({ origin: 'https://pilot-taupe.vercel.app' }),
+    /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
+  );
+});
+
+test('caller cannot relabel known production as staging', () => {
+  assert.equal(
+    classifyCapacityTarget('https://pilot-taupe.vercel.app', 'staging'),
+    'production',
+  );
+  assert.throws(
+    () => assertCapacityLoadAllowed({
+      origin: 'https://pilot-taupe.vercel.app',
+      declaredTarget: 'staging',
+    }),
+    /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
+  );
+});
+
+test('production load is allowed only with the exact acknowledgement', () => {
+  assert.deepEqual(
+    assertCapacityLoadAllowed({
+      origin: 'https://pilot-taupe.vercel.app',
+      ack: PRODUCTION_CAPACITY_ACK,
+    }),
+    { target: 'production', production_acknowledged: true },
+  );
+});
+
+test('unknown external origin requires an explicit non-production target', () => {
+  assert.throws(
+    () => assertCapacityLoadAllowed({ origin: 'https://capacity.example.test' }),
+    /CAPACITY_TARGET_MUST_BE_EXPLICIT_FOR_UNKNOWN_ORIGIN/,
+  );
+});
+
+test('explicit staging target is allowed for a non-production origin', () => {
+  assert.deepEqual(
+    assertCapacityLoadAllowed({
+      origin: 'https://capacity.example.test',
+      declaredTarget: 'staging',
+    }),
+    { target: 'staging', production_acknowledged: false },
+  );
+});


### PR DESCRIPTION
Closed as superseded by current main. Verified current main already contains `test/dabbir-capacity-safety.mjs`, its regression tests, and `test/dabbir-capacity-load.mjs` imports and executes `assertCapacityLoadAllowed()` before any load-test network work. Keeping this branch open would duplicate an already-landed production-safety guard.