### PR TITLE
Focus DABBIR Today view on top three owner priorities

### DIFF
--- a/api/owner-action-center-ui.js
+++ b/api/owner-action-center-ui.js
@@ -1,25 +1,28 @@
 const css=String.raw`
 .dabbir-action-center{margin-bottom:12px;border-color:#343a31;background:linear-gradient(180deg,#171b17,#101311)}
-.dac-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.dac-head strong{font-size:15px}.dac-status{font-size:9px;color:var(--muted);margin-top:4px}.dac-brief{margin:12px 0;color:#dfe4e7;font-size:11px;line-height:1.75}.dac-metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.dac-metric{border:1px solid #2b3031;background:#121518;border-radius:13px;padding:10px}.dac-metric strong{display:block;font-size:20px}.dac-metric span{font-size:8px;color:var(--muted)}.dac-metric.critical strong{color:var(--red)}.dac-metric.warning strong{color:var(--yellow)}.dac-items{display:flex;flex-direction:column;gap:7px;margin-top:10px}.dac-item{display:flex;align-items:center;gap:9px;border:1px solid #292e31;background:#15181a;border-radius:13px;padding:10px}.dac-item.critical{border-inline-start:3px solid var(--red)}.dac-item.warning{border-inline-start:3px solid var(--yellow)}.dac-item.info{border-inline-start:3px solid var(--blue)}.dac-item-body{flex:1;min-width:0}.dac-item-body b{display:block;font-size:10px}.dac-item-body span{display:block;color:#b6bcc3;font-size:9px;line-height:1.55;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dac-item-body small{display:block;color:#777f87;font-size:8px;margin-top:4px}.dac-open{min-width:62px;padding:7px 9px;font-size:9px}.dac-empty{padding:16px;text-align:center;color:var(--green);font-size:10px;border:1px dashed #314034;border-radius:12px}@media(max-width:700px){.dac-metrics{gap:6px}.dac-metric{padding:9px}.dac-item{align-items:flex-start}.dac-open{min-height:40px}.dac-item-body span{white-space:normal;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}}
+.dac-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.dac-head strong{font-size:15px}.dac-status{font-size:9px;color:var(--muted);margin-top:4px}.dac-brief{margin:12px 0;color:#dfe4e7;font-size:11px;line-height:1.75}.dac-metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.dac-metric{border:1px solid #2b3031;background:#121518;border-radius:13px;padding:10px}.dac-metric strong{display:block;font-size:20px}.dac-metric span{font-size:8px;color:var(--muted)}.dac-metric.critical strong{color:var(--red)}.dac-metric.warning strong{color:var(--yellow)}.dac-items{display:flex;flex-direction:column;gap:7px;margin-top:10px}.dac-item{display:flex;align-items:center;gap:9px;border:1px solid #292e31;background:#15181a;border-radius:13px;padding:10px}.dac-item.critical{border-inline-start:3px solid var(--red)}.dac-item.warning{border-inline-start:3px solid var(--yellow)}.dac-item.info{border-inline-start:3px solid var(--blue)}.dac-item-body{flex:1;min-width:0}.dac-item-body b{display:block;font-size:10px}.dac-item-body span{display:block;color:#b6bcc3;font-size:9px;line-height:1.55;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dac-item-body small{display:block;color:#777f87;font-size:8px;margin-top:4px}.dac-open{min-width:62px;padding:7px 9px;font-size:9px}.dac-empty{padding:16px;text-align:center;color:var(--green);font-size:10px;border:1px dashed #314034;border-radius:12px}.dac-more-wrap{display:flex;justify-content:center;margin-top:9px}.dac-more{min-height:36px;padding:7px 12px;font-size:9px;color:var(--muted)}@media(max-width:700px){.dac-metrics{gap:6px}.dac-metric{padding:9px}.dac-item{align-items:flex-start}.dac-open{min-height:40px}.dac-more{min-height:42px}.dac-item-body span{white-space:normal;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}}
 `;
 
 const client=String.raw`
 (()=>{
   if(document.querySelector('style[data-dabbir-action-center]'))return;
   const style=document.createElement('style');
-  style.dataset.dabbirActionCenter='v1';
+  style.dataset.dabbirActionCenter='v2';
   style.textContent=${JSON.stringify(css)};
   document.head.append(style);
 
   const CACHE_MS=20000;
+  const DEFAULT_VISIBLE=3;
+  const MAX_VISIBLE=8;
   let lastBusinessId=null;
   let lastLoadedAt=0;
   let loading=false;
+  let expanded=false;
 
   const text=()=>lang==='ar'?{
-    title:'اليوم في دَبِّر',refresh:'تحديث',loading:'دَبِّر يراجع النشاط…',urgent:'يحتاج تدخلك',warning:'راقب اليوم',total:'إجمالي الأولويات',empty:'كل شيء تحت السيطرة الآن',open:'فتح',error:'تعذر تحميل مركز الأولويات'
+    title:'اليوم في دَبِّر',refresh:'تحديث',loading:'دَبِّر يراجع النشاط…',urgent:'يحتاج تدخلك',warning:'راقب اليوم',total:'إجمالي الأولويات',empty:'كل شيء تحت السيطرة الآن',open:'فتح',error:'تعذر تحميل مركز الأولويات',showLess:'عرض الأهم فقط'
   }:{
-    title:'Today in DABBIR',refresh:'Refresh',loading:'DABBIR is reviewing the business…',urgent:'Needs you',warning:'Watch today',total:'Total priorities',empty:'Everything is under control right now',open:'Open',error:'Could not load action center'
+    title:'Today in DABBIR',refresh:'Refresh',loading:'DABBIR is reviewing the business…',urgent:'Needs you',warning:'Watch today',total:'Total priorities',empty:'Everything is under control right now',open:'Open',error:'Could not load action center',showLess:'Show top 3 only'
   };
 
   function ensurePanel(){
@@ -30,11 +33,15 @@ const client=String.raw`
     panel=document.createElement('section');
     panel.id='dabbirActionCenter';
     panel.className='dabbir-action-center card';
-    panel.innerHTML='<div class="dac-head"><div><strong id="dacTitle"></strong><div id="dacStatus" class="dac-status"></div></div><button id="dacRefresh" class="secondary" type="button"></button></div><p id="dacBrief" class="dac-brief"></p><div id="dacMetrics" class="dac-metrics"></div><div id="dacItems" class="dac-items"></div>';
+    panel.innerHTML='<div class="dac-head"><div><strong id="dacTitle"></strong><div id="dacStatus" class="dac-status"></div></div><button id="dacRefresh" class="secondary" type="button"></button></div><p id="dacBrief" class="dac-brief"></p><div id="dacMetrics" class="dac-metrics"></div><div id="dacItems" class="dac-items"></div><div id="dacMoreWrap" class="dac-more-wrap" hidden><button id="dacMore" class="secondary dac-more" type="button"></button></div>';
     const cards=document.querySelector('#dashCards');
     if(cards&&cards.parentNode)cards.parentNode.insertBefore(panel,cards);
     else dash.prepend(panel);
     panel.querySelector('#dacRefresh')?.addEventListener('click',()=>loadActionCenter(true));
+    panel.querySelector('#dacMore')?.addEventListener('click',()=>{
+      expanded=!expanded;
+      if(workspace?.owner_action_center)render(workspace.owner_action_center);
+    });
     return panel;
   }
 
@@ -54,6 +61,11 @@ const client=String.raw`
     const date=new Date(value);
     if(Number.isNaN(date.getTime()))return '';
     try{return new Intl.DateTimeFormat(lang==='ar'?'ar-AE':'en-AE',{timeZone:'Asia/Dubai',day:'numeric',month:'short',hour:'numeric',minute:'2-digit'}).format(date)}catch{return ''}
+  }
+
+  function moreLabel(hiddenCount,t){
+    if(expanded)return t.showLess;
+    return lang==='ar'?`عرض بقية الأولويات (${hiddenCount})`:`Show ${hiddenCount} more`;
   }
 
   function render(data){
@@ -77,15 +89,19 @@ const client=String.raw`
     const list=panel.querySelector('#dacItems');
     list.replaceChildren();
     const rows=Array.isArray(data?.items)?data.items:[];
+    const moreWrap=panel.querySelector('#dacMoreWrap');
+    const moreButton=panel.querySelector('#dacMore');
     if(!rows.length){
       const empty=document.createElement('div');
       empty.className='dac-empty';
       empty.textContent=t.empty;
       list.append(empty);
+      if(moreWrap)moreWrap.hidden=true;
       return;
     }
 
-    for(const item of rows.slice(0,8)){
+    const visibleLimit=expanded?MAX_VISIBLE:DEFAULT_VISIBLE;
+    for(const item of rows.slice(0,visibleLimit)){
       const row=document.createElement('article');
       row.className='dac-item '+(item.severity||'info');
       const body=document.createElement('div');
@@ -108,11 +124,20 @@ const client=String.raw`
       row.append(body,button);
       list.append(row);
     }
+
+    const canExpand=rows.length>DEFAULT_VISIBLE;
+    if(moreWrap)moreWrap.hidden=!canExpand;
+    if(moreButton&&canExpand){
+      const hiddenCount=Math.max(0,Math.min(rows.length,MAX_VISIBLE)-DEFAULT_VISIBLE);
+      moreButton.textContent=moreLabel(hiddenCount,t);
+      moreButton.setAttribute('aria-expanded',expanded?'true':'false');
+    }
   }
 
   async function loadActionCenter(force=false){
     const businessId=workspace?.business?.id;
     if(!businessId||loading)return;
+    if(lastBusinessId&&businessId!==lastBusinessId)expanded=false;
     const now=Date.now();
     if(!force&&businessId===lastBusinessId&&now-lastLoadedAt<CACHE_MS&&workspace?.owner_action_center){
       render(workspace.owner_action_center);
@@ -160,7 +185,7 @@ const client=String.raw`
     };
   }
 
-  window.__dabbirOwnerActionCenter={refresh:()=>loadActionCenter(true),version:'owner-action-center-v1'};
+  window.__dabbirOwnerActionCenter={refresh:()=>loadActionCenter(true),version:'owner-action-center-v2'};
 })();
 `;
 
@@ -168,6 +193,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
-  res.setHeader('x-dabbir-owner-action-center-ui','v1');
+  res.setHeader('x-dabbir-owner-action-center-ui','v2');
   return res.status(200).send(client);
 }

--- a/api/owner-action-center-ui.js
+++ b/api/owner-action-center-ui.js
@@ -65,7 +65,7 @@ const client=String.raw`
 
   function moreLabel(hiddenCount,t){
     if(expanded)return t.showLess;
-    return lang==='ar'?`عرض بقية الأولويات (${hiddenCount})`:`Show ${hiddenCount} more`;
+    return lang==='ar'?'عرض بقية الأولويات ('+hiddenCount+')':'Show '+hiddenCount+' more';
   }
 
   function render(data){

--- a/test/dabbir-owner-action-center-ui.test.mjs
+++ b/test/dabbir-owner-action-center-ui.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/owner-action-center-ui.js';
+
+function renderClient() {
+  const headers = new Map();
+  let statusCode = 200;
+  let body = '';
+  const res = {
+    status(code) { statusCode = code; return this; },
+    setHeader(name, value) { headers.set(String(name).toLowerCase(), String(value)); return this; },
+    send(value) { body = String(value ?? ''); return this; },
+    end(value = '') { body = String(value ?? ''); return this; },
+  };
+  handler({ method: 'GET' }, res);
+  return { statusCode, headers, body };
+}
+
+test('owner action center defaults to the top three priorities and keeps progressive disclosure', () => {
+  const result = renderClient();
+  assert.equal(result.statusCode, 200);
+  assert.equal(result.headers.get('x-dabbir-owner-action-center-ui'), 'v2');
+  assert.match(result.body, /const DEFAULT_VISIBLE=3;/);
+  assert.match(result.body, /const MAX_VISIBLE=8;/);
+  assert.match(result.body, /visibleLimit=expanded\?MAX_VISIBLE:DEFAULT_VISIBLE/);
+  assert.match(result.body, /عرض بقية الأولويات/);
+  assert.match(result.body, /Show top 3 only/);
+  assert.match(result.body, /aria-expanded/);
+  assert.match(result.body, /owner-action-center-v2/);
+});
+
+test('generated owner action center client is valid JavaScript', () => {
+  const { body } = renderClient();
+  assert.doesNotThrow(() => new Function(body));
+});


### PR DESCRIPTION
Evidence-backed simplification from the DABBIR customer-needs study.

## Why
The existing Owner Action Center already ranks exceptions correctly, but the UI shows up to eight items at once. Research indicates the owner needs a rapid decision brief, not another long task list.

## Change
- Keep the existing Today in DABBIR screen and backend.
- Show the top 3 priorities by default.
- Add progressive disclosure for remaining ranked items.
- Preserve total/urgent/watch metrics.
- Bilingual Arabic/English controls.
- Reset expansion when switching businesses.
- Add regression coverage that compiles the generated client JavaScript.

## Safety
No schema, business-rule, payment, AI-policy, or Production data changes. This is a reversible presentation-only change on top of the existing ranked Action Center.