### PR TITLE
DABBIR: show verified work handled today

### DIFF
--- a/api/owner-action-center-ui.js
+++ b/api/owner-action-center-ui.js
@@ -1,13 +1,13 @@
 const css=String.raw`
 .dabbir-action-center{margin-bottom:12px;border-color:#343a31;background:linear-gradient(180deg,#171b17,#101311)}
-.dac-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.dac-head strong{font-size:15px}.dac-status{font-size:9px;color:var(--muted);margin-top:4px}.dac-brief{margin:12px 0;color:#dfe4e7;font-size:11px;line-height:1.75}.dac-metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.dac-metric{border:1px solid #2b3031;background:#121518;border-radius:13px;padding:10px}.dac-metric strong{display:block;font-size:20px}.dac-metric span{font-size:8px;color:var(--muted)}.dac-metric.critical strong{color:var(--red)}.dac-metric.warning strong{color:var(--yellow)}.dac-items{display:flex;flex-direction:column;gap:7px;margin-top:10px}.dac-item{display:flex;align-items:center;gap:9px;border:1px solid #292e31;background:#15181a;border-radius:13px;padding:10px}.dac-item.critical{border-inline-start:3px solid var(--red)}.dac-item.warning{border-inline-start:3px solid var(--yellow)}.dac-item.info{border-inline-start:3px solid var(--blue)}.dac-item-body{flex:1;min-width:0}.dac-item-body b{display:block;font-size:10px}.dac-item-body span{display:block;color:#b6bcc3;font-size:9px;line-height:1.55;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dac-item-body small{display:block;color:#777f87;font-size:8px;margin-top:4px}.dac-open{min-width:62px;padding:7px 9px;font-size:9px}.dac-empty{padding:16px;text-align:center;color:var(--green);font-size:10px;border:1px dashed #314034;border-radius:12px}.dac-more-wrap{display:flex;justify-content:center;margin-top:9px}.dac-more{min-height:36px;padding:7px 12px;font-size:9px;color:var(--muted)}@media(max-width:700px){.dac-metrics{gap:6px}.dac-metric{padding:9px}.dac-item{align-items:flex-start}.dac-open{min-height:40px}.dac-more{min-height:42px}.dac-item-body span{white-space:normal;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}}
+.dac-head{display:flex;align-items:center;justify-content:space-between;gap:12px}.dac-head strong{font-size:15px}.dac-status{font-size:9px;color:var(--muted);margin-top:4px}.dac-brief{margin:12px 0;color:#dfe4e7;font-size:11px;line-height:1.75}.dac-metrics{display:grid;grid-template-columns:repeat(3,1fr);gap:8px}.dac-metric{border:1px solid #2b3031;background:#121518;border-radius:13px;padding:10px}.dac-metric strong{display:block;font-size:20px}.dac-metric span{font-size:8px;color:var(--muted)}.dac-metric.critical strong{color:var(--red)}.dac-metric.warning strong{color:var(--yellow)}.dac-metric.handled strong{color:var(--green)}.dac-items{display:flex;flex-direction:column;gap:7px;margin-top:10px}.dac-item{display:flex;align-items:center;gap:9px;border:1px solid #292e31;background:#15181a;border-radius:13px;padding:10px}.dac-item.critical{border-inline-start:3px solid var(--red)}.dac-item.warning{border-inline-start:3px solid var(--yellow)}.dac-item.info{border-inline-start:3px solid var(--blue)}.dac-item-body{flex:1;min-width:0}.dac-item-body b{display:block;font-size:10px}.dac-item-body span{display:block;color:#b6bcc3;font-size:9px;line-height:1.55;margin-top:3px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dac-item-body small{display:block;color:#777f87;font-size:8px;margin-top:4px}.dac-open{min-width:62px;padding:7px 9px;font-size:9px}.dac-empty{padding:16px;text-align:center;color:var(--green);font-size:10px;border:1px dashed #314034;border-radius:12px}.dac-more-wrap{display:flex;justify-content:center;margin-top:9px}.dac-more{min-height:36px;padding:7px 12px;font-size:9px;color:var(--muted)}@media(max-width:700px){.dac-metrics{gap:6px}.dac-metric{padding:9px}.dac-item{align-items:flex-start}.dac-open{min-height:40px}.dac-more{min-height:42px}.dac-item-body span{white-space:normal;display:-webkit-box;-webkit-line-clamp:2;-webkit-box-orient:vertical;overflow:hidden}}
 `;
 
 const client=String.raw`
 (()=>{
   if(document.querySelector('style[data-dabbir-action-center]'))return;
   const style=document.createElement('style');
-  style.dataset.dabbirActionCenter='v2';
+  style.dataset.dabbirActionCenter='v3';
   style.textContent=${JSON.stringify(css)};
   document.head.append(style);
 
@@ -20,9 +20,9 @@ const client=String.raw`
   let expanded=false;
 
   const text=()=>lang==='ar'?{
-    title:'اليوم في دَبِّر',refresh:'تحديث',loading:'دَبِّر يراجع النشاط…',urgent:'يحتاج تدخلك',warning:'راقب اليوم',total:'إجمالي الأولويات',empty:'كل شيء تحت السيطرة الآن',open:'فتح',error:'تعذر تحميل مركز الأولويات',showLess:'عرض الأهم فقط'
+    title:'اليوم في دَبِّر',refresh:'تحديث',loading:'دَبِّر يراجع النشاط…',handled:'عالجها دَبِّر',urgent:'يحتاج تدخلك',warning:'راقب اليوم',empty:'كل شيء تحت السيطرة الآن',open:'فتح',error:'تعذر تحميل مركز الأولويات',showLess:'عرض الأهم فقط'
   }:{
-    title:'Today in DABBIR',refresh:'Refresh',loading:'DABBIR is reviewing the business…',urgent:'Needs you',warning:'Watch today',total:'Total priorities',empty:'Everything is under control right now',open:'Open',error:'Could not load action center',showLess:'Show top 3 only'
+    title:'Today in DABBIR',refresh:'Refresh',loading:'DABBIR is reviewing the business…',handled:'Handled by DABBIR',urgent:'Needs you',warning:'Watch today',empty:'Everything is under control right now',open:'Open',error:'Could not load action center',showLess:'Show top 3 only'
   };
 
   function ensurePanel(){
@@ -79,11 +79,13 @@ const client=String.raw`
     status.textContent=data?.status==='needs_attention'?(lang==='ar'?'هناك عناصر حرجة':'Critical items need attention'):data?.status==='watch'?(lang==='ar'?'هناك أمور تحتاج متابعة':'Some items need monitoring'):(lang==='ar'?'لا توجد عناصر حرجة':'No critical items');
     panel.querySelector('#dacBrief').textContent=(lang==='ar'?data?.brief?.ar:data?.brief?.en)||t.empty;
 
+    const handledAvailable=data?.handled?.available===true;
+    const handledValue=handledAvailable?(data?.handled?.verified_autonomous_today??0):'—';
     const metrics=panel.querySelector('#dacMetrics');
     metrics.replaceChildren(
+      metric(t.handled,handledValue,'handled'),
       metric(t.urgent,data?.metrics?.urgent,'critical'),
-      metric(t.warning,data?.metrics?.warning,'warning'),
-      metric(t.total,data?.metrics?.total,'')
+      metric(t.warning,data?.metrics?.warning,'warning')
     );
 
     const list=panel.querySelector('#dacItems');
@@ -185,7 +187,7 @@ const client=String.raw`
     };
   }
 
-  window.__dabbirOwnerActionCenter={refresh:()=>loadActionCenter(true),version:'owner-action-center-v2'};
+  window.__dabbirOwnerActionCenter={refresh:()=>loadActionCenter(true),version:'owner-action-center-v3'};
 })();
 `;
 
@@ -193,6 +195,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
-  res.setHeader('x-dabbir-owner-action-center-ui','v2');
+  res.setHeader('x-dabbir-owner-action-center-ui','v3');
   return res.status(200).send(client);
 }

--- a/api/owner-action-center.js
+++ b/api/owner-action-center.js
@@ -57,6 +57,19 @@ function addItem(items,item){
   });
 }
 
+function dubaiDayStartIso(nowMs){
+  const dubaiOffsetMs=4*60*60*1000;
+  const dubaiDay=new Date(nowMs+dubaiOffsetMs).toISOString().slice(0,10);
+  return new Date(`${dubaiDay}T00:00:00+04:00`).toISOString();
+}
+
+function handledLabel(operationType){
+  if(operationType==='followup.capture_internal'){
+    return {ar:'التقط متابعة عميل تلقائيًا',en:'Captured a customer follow-up automatically'};
+  }
+  return {ar:'أكمل إجراءً موثقًا تلقائيًا',en:'Completed a verified action automatically'};
+}
+
 export default async function handler(req,res){
   if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
   const context=await authenticatedContext(req,res);
@@ -70,8 +83,16 @@ export default async function handler(req,res){
     const now=Date.now();
     const in24h=now+24*60*60*1000;
     const in2h=now+2*60*60*1000;
+    const dayStart=dubaiDayStartIso(now);
 
-    const [conversations,handoffs,followups,appointments,products,inventory,orders,channels,customers]=await Promise.all([
+    const handledLookup=rest(
+      context.token,
+      `dabbir_operation_outcomes?select=operation_type,outcome,autonomous,estimated_manual_seconds,completed_at&business_id=eq.${businessId}&outcome=eq.VERIFIED_SUCCESS&autonomous=eq.true&completed_at=gte.${dayStart}&order=completed_at.desc&limit=20`,
+      'VERIFIED_OUTCOMES_LOOKUP_FAILED'
+    ).then(rows=>({available:true,rows:Array.isArray(rows)?rows:[]}))
+      .catch(error=>({available:false,rows:[],status:Number(error?.status||0)||null}));
+
+    const [conversations,handoffs,followups,appointments,products,inventory,orders,channels,customers,handledResult]=await Promise.all([
       rest(context.token,`dabbir_conversations?select=id,customer_id,state,channel_type,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=100`,'CONVERSATIONS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_handoffs?select=id,conversation_id,customer_id,state,priority,reason,summary,assigned_user_id,created_at,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=100`,'HANDOFFS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_followups?select=id,conversation_id,customer_id,status,reason,due_at,recommended_message,blocked_reason,send_count,max_sends&business_id=eq.${businessId}&order=due_at.asc&limit=100`,'FOLLOWUPS_LOOKUP_FAILED'),
@@ -81,10 +102,10 @@ export default async function handler(req,res){
       rest(context.token,`dabbir_orders?select=id,customer_id,status,total_aed,simulated,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'ORDERS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_channels?select=id,channel_type,status,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=50`,'CHANNELS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_customers?select=id,display_name&business_id=eq.${businessId}&limit=200`,'CUSTOMERS_LOOKUP_FAILED'),
+      handledLookup,
     ]);
 
     const customerName=new Map((customers||[]).map(row=>[row.id,row.display_name||null]));
-    const productById=new Map((products||[]).map(row=>[row.id,row]));
     const stockByProduct=new Map((inventory||[]).map(row=>[row.product_id,row]));
     const items=[];
 
@@ -146,8 +167,16 @@ export default async function handler(req,res){
     const urgent=items.filter(item=>item.severity==='critical').length;
     const warning=items.filter(item=>item.severity==='warning').length;
     const top=items.slice(0,3);
-    const briefAr=top.length?`أهم ما يحتاج تدخلك الآن: ${top.map(item=>item.title_ar).join('، ')}.`:'لا توجد عناصر حرجة أو مستحقة خلال 24 ساعة. دَبِّر يراقب النشاط.';
-    const briefEn=top.length?`What needs your attention now: ${top.map(item=>item.title_en).join(', ')}.`:'No critical or due items in the next 24 hours. DABBIR is monitoring the business.';
+    const handledRows=handledResult.available?handledResult.rows:[];
+    const handledLatest=handledRows.slice(0,3).map(row=>{
+      const label=handledLabel(row.operation_type);
+      return {operation_type:row.operation_type,title_ar:label.ar,title_en:label.en,completed_at:row.completed_at};
+    });
+    const handledCount=handledRows.length;
+    const handledPrefixAr=handledResult.available&&handledCount>0?`دَبِّر أنجز ${handledCount} إجراءً موثقًا تلقائيًا اليوم. `:'';
+    const handledPrefixEn=handledResult.available&&handledCount>0?`DABBIR completed ${handledCount} verified autonomous ${handledCount===1?'action':'actions'} today. `:'';
+    const briefAr=handledPrefixAr+(top.length?`أهم ما يحتاج تدخلك الآن: ${top.map(item=>item.title_ar).join('، ')}.`:'لا توجد عناصر حرجة أو مستحقة خلال 24 ساعة. دَبِّر يراقب النشاط.');
+    const briefEn=handledPrefixEn+(top.length?`What needs your attention now: ${top.map(item=>item.title_en).join(', ')}.`:'No critical or due items in the next 24 hours. DABBIR is monitoring the business.');
 
     return json(res,200,{
       ok:true,
@@ -156,10 +185,11 @@ export default async function handler(req,res){
       generated_at:new Date().toISOString(),
       timezone:'Asia/Dubai',
       status:urgent>0?'needs_attention':warning>0?'watch':'clear',
-      metrics:{urgent,warning,total:items.length,upcoming_24h:items.filter(item=>item.type==='appointment'||item.type==='followup').length,low_stock:items.filter(item=>item.type==='inventory').length,orders_needing_action:items.filter(item=>item.type==='order').length},
+      metrics:{urgent,warning,total:items.length,handled_verified_today:handledResult.available?handledCount:null,upcoming_24h:items.filter(item=>item.type==='appointment'||item.type==='followup').length,low_stock:items.filter(item=>item.type==='inventory').length,orders_needing_action:items.filter(item=>item.type==='order').length},
+      handled:{available:handledResult.available,verified_autonomous_today:handledResult.available?handledCount:null,latest:handledResult.available?handledLatest:[]},
       brief:{ar:briefAr,en:briefEn},
       items:items.slice(0,12),
-      truth:{source:'live_dabbir_tenant_data',simulated_orders_excluded:true,simulated_appointments_excluded:true,empty_automation_tables_not_presented_as_live_features:true},
+      truth:{source:'live_dabbir_tenant_data',simulated_orders_excluded:true,simulated_appointments_excluded:true,handled_counts_only_verified_success_autonomous_outcomes:true,handled_unavailable_is_not_zero:true},
     });
   }catch(error){
     const status=Number(error?.status||500);

--- a/test/dabbir-owner-action-center-handled-contract.test.mjs
+++ b/test/dabbir-owner-action-center-handled-contract.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here=dirname(fileURLToPath(import.meta.url));
+const source=readFileSync(resolve(here,'../api/owner-action-center.js'),'utf8');
+
+function must(pattern,message){assert.match(source,pattern,message)}
+function mustNot(pattern,message){assert.doesNotMatch(source,pattern,message)}
+
+test('handled work counts verified autonomous outcomes only',()=>{
+  must(/dabbir_operation_outcomes\?select=/,'owner action center must read the outcome ledger');
+  must(/outcome=eq\.VERIFIED_SUCCESS/,'handled query must require VERIFIED_SUCCESS');
+  must(/autonomous=eq\.true/,'handled query must require autonomous=true');
+  must(/completed_at=gte\.\$\{dayStart\}/,'handled query must be scoped to the current Dubai day');
+  must(/handled_counts_only_verified_success_autonomous_outcomes:true/,'response truth contract must state the handled filter');
+});
+
+test('handled lookup degrades without lying',()=>{
+  must(/catch\(error=>\(\{available:false,rows:\[\],status:/,'supplementary handled lookup must not break the owner priority view');
+  must(/handled_verified_today:handledResult\.available\?handledCount:null/,'unavailable verification must be null, not zero');
+  must(/handled_unavailable_is_not_zero:true/,'truth contract must preserve unavailable versus zero');
+});
+
+test('owner time saved is not inferred in the Today view',()=>{
+  must(/estimated_manual_seconds/,'ledger read may carry the measured field for future use');
+  mustNot(/hours_saved|owner_hours_saved|manual_seconds_saved/i,'Today view must not invent or display time savings before calibrated evidence exists');
+});
+
+test('handled response exposes only operation label and completion time',()=>{
+  must(/return \{operation_type:row\.operation_type,title_ar:label\.ar,title_en:label\.en,completed_at:row\.completed_at\}/,'handled items must be privacy-minimized');
+  mustNot(/select=[^`]*metadata/,'handled query must not fetch outcome metadata into the owner summary');
+});

--- a/test/dabbir-owner-action-center-ui.test.mjs
+++ b/test/dabbir-owner-action-center-ui.test.mjs
@@ -16,17 +16,22 @@ function renderClient() {
   return { statusCode, headers, body };
 }
 
-test('owner action center defaults to the top three priorities and keeps progressive disclosure', () => {
+test('owner action center keeps top three priorities and surfaces verified handled work', () => {
   const result = renderClient();
   assert.equal(result.statusCode, 200);
-  assert.equal(result.headers.get('x-dabbir-owner-action-center-ui'), 'v2');
+  assert.equal(result.headers.get('x-dabbir-owner-action-center-ui'), 'v3');
   assert.match(result.body, /const DEFAULT_VISIBLE=3;/);
   assert.match(result.body, /const MAX_VISIBLE=8;/);
   assert.match(result.body, /visibleLimit=expanded\?MAX_VISIBLE:DEFAULT_VISIBLE/);
+  assert.match(result.body, /عالجها دَبِّر/);
+  assert.match(result.body, /Handled by DABBIR/);
+  assert.match(result.body, /handledAvailable=data\?\.handled\?\.available===true/);
+  assert.match(result.body, /handledAvailable\?\(data\?\.handled\?\.verified_autonomous_today\?\?0\):'—'/);
+  assert.match(result.body, /metric\(t\.handled,handledValue,'handled'\)/);
   assert.match(result.body, /عرض بقية الأولويات/);
   assert.match(result.body, /Show top 3 only/);
   assert.match(result.body, /aria-expanded/);
-  assert.match(result.body, /owner-action-center-v2/);
+  assert.match(result.body, /owner-action-center-v3/);
 });
 
 test('generated owner action center client is valid JavaScript', () => {


### PR DESCRIPTION
## Customer value
The owner should see both sides of the owner-by-exception model: what still needs attention and what DABBIR already completed safely. This extends the existing Today/Action Center instead of creating another dashboard.

## Change
- Reads only `dabbir_operation_outcomes` rows with `outcome=VERIFIED_SUCCESS` and `autonomous=true` for the current Asia/Dubai day.
- Adds a `Handled by DABBIR / عالجها دَبِّر` metric while keeping the dashboard at three metrics.
- Preserves the existing top-three priority progressive disclosure.
- If outcome verification is unavailable, displays `—` rather than claiming zero.
- Keeps handled detail privacy-minimized: operation label + completion time only.
- Does not display owner-hours-saved until calibrated evidence exists.

## Truth contract
No demo count, no inferred success, no PARTIAL/UNKNOWN/FAILED operations, and no synthetic time-saved claim can contribute to the handled metric.

## Verification
New regression contracts cover verified-only filtering, Dubai-day scoping, unavailable-vs-zero truthfulness, privacy minimization, and generated UI validity.