### PR TITLE
DABBIR: remove Auth server from Today hot path

### DIFF
--- a/api/owner-action-center.js
+++ b/api/owner-action-center.js
@@ -4,6 +4,7 @@ import {
   getVerifiedUser,
   json,
   supabaseRest,
+  userClaimsFromValidatedAccessToken,
 } from './_auth-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -29,10 +30,22 @@ const rest=(token,path,fallback)=>supabaseRest(path,token).then(r=>readData(r,fa
 async function authenticatedContext(req,res){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
-  const [user,memberships]=await Promise.all([
-    getVerifiedUser(token).catch(()=>null),
-    getBusinessMemberships(token).catch(()=>[]),
-  ]);
+
+  // Membership lookup goes through the Supabase Data API, which validates the
+  // same JWT before applying tenant RLS. Reuse that successful validation and
+  // keep /auth/v1/user off this high-frequency dashboard path.
+  let memberships;
+  try{
+    memberships=await getBusinessMemberships(token);
+  }catch(error){
+    const status=Number(error?.code||500);
+    if(status===401||status===403){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+    json(res,503,{ok:false,error:'AUTH_VERIFICATION_UNAVAILABLE'});return null;
+  }
+
+  let user=userClaimsFromValidatedAccessToken(token);
+  // Compatibility fallback for unexpected/legacy token shapes only.
+  if(!user)user=await getVerifiedUser(token).catch(()=>null);
   if(!user){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   return {token,user,memberships};
 }
@@ -178,6 +191,7 @@ export default async function handler(req,res){
     const briefAr=handledPrefixAr+(top.length?`أهم ما يحتاج تدخلك الآن: ${top.map(item=>item.title_ar).join('، ')}.`:'لا توجد عناصر حرجة أو مستحقة خلال 24 ساعة. دَبِّر يراقب النشاط.');
     const briefEn=handledPrefixEn+(top.length?`What needs your attention now: ${top.map(item=>item.title_en).join(', ')}.`:'No critical or due items in the next 24 hours. DABBIR is monitoring the business.');
 
+    res.setHeader('x-dabbir-owner-action-center-auth','fast-v1');
     return json(res,200,{
       ok:true,
       business_id:businessId,
@@ -189,7 +203,7 @@ export default async function handler(req,res){
       handled:{available:handledResult.available,verified_autonomous_today:handledResult.available?handledCount:null,latest:handledResult.available?handledLatest:[]},
       brief:{ar:briefAr,en:briefEn},
       items:items.slice(0,12),
-      truth:{source:'live_dabbir_tenant_data',simulated_orders_excluded:true,simulated_appointments_excluded:true,handled_counts_only_verified_success_autonomous_outcomes:true,handled_unavailable_is_not_zero:true},
+      truth:{source:'live_dabbir_tenant_data',auth_fast_path:true,simulated_orders_excluded:true,simulated_appointments_excluded:true,handled_counts_only_verified_success_autonomous_outcomes:true,handled_unavailable_is_not_zero:true},
     });
   }catch(error){
     const status=Number(error?.status||500);

--- a/test/dabbir-owner-action-center-auth-fastpath.test.mjs
+++ b/test/dabbir-owner-action-center-auth-fastpath.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here=dirname(fileURLToPath(import.meta.url));
+const source=readFileSync(resolve(here,'../api/owner-action-center.js'),'utf8');
+
+function must(pattern,message){assert.match(source,pattern,message)}
+function mustNot(pattern,message){assert.doesNotMatch(source,pattern,message)}
+
+test('Today view validates membership before trusting local claims',()=>{
+  const membershipIndex=source.indexOf('memberships=await getBusinessMemberships(token)');
+  const claimsIndex=source.indexOf('userClaimsFromValidatedAccessToken(token)');
+  assert.ok(membershipIndex>=0,'membership validation must exist');
+  assert.ok(claimsIndex>membershipIndex,'claims may be read only after Supabase Data API accepts the token');
+  must(/userClaimsFromValidatedAccessToken/,'validated-token helper must be imported');
+});
+
+test('Today view keeps Auth server only as compatibility fallback',()=>{
+  const claimsIndex=source.indexOf('userClaimsFromValidatedAccessToken(token)');
+  const fallbackIndex=source.indexOf('getVerifiedUser(token)');
+  assert.ok(fallbackIndex>claimsIndex,'/auth/v1/user fallback must happen only after claims parsing fails');
+  must(/if\(!user\)user=await getVerifiedUser\(token\)\.catch\(\(\)=>null\)/,'fallback must be narrow and explicit');
+  mustNot(/Promise\.all\(\[\s*getVerifiedUser\(token\)/,'hot path must not call Auth and membership lookup in parallel');
+});
+
+test('Today view fails closed when membership verification is unavailable',()=>{
+  must(/status===401\|\|status===403/,'401/403 membership failures must remain authentication failures');
+  must(/AUTH_VERIFICATION_UNAVAILABLE/,'non-auth upstream failures must fail closed as unavailable');
+  mustNot(/getBusinessMemberships\(token\)\.catch\(\(\)=>\[\]\)/,'membership failures must not silently become an empty tenant list');
+});
+
+test('Today view exposes production-verifiable fast-path evidence',()=>{
+  must(/x-dabbir-owner-action-center-auth','fast-v1'/,'response header must identify fast-path contract');
+  must(/auth_fast_path:true/,'response truth block must expose fast-path state');
+});


### PR DESCRIPTION
## Why
The owner Today/Action Center refreshed through `/auth/v1/user` on every authenticated load, repeating the same Auth-server hot-path pattern that previously degraded DABBIR runtime capacity.

## Change
- Validate the access token first through the tenant membership read on Supabase Data API/RLS.
- Reuse that validated token and parse validated claims locally.
- Keep `/auth/v1/user` only as a compatibility fallback for unexpected/legacy token shapes.
- Fail closed with `AUTH_VERIFICATION_UNAVAILABLE` for non-auth membership verification failures instead of silently converting them to an empty membership list.
- Add `x-dabbir-owner-action-center-auth: fast-v1` and `truth.auth_fast_path=true` for production verification.

## Non-goals
No owner-priority ranking, handled-work metric, business data, or permissions behavior changes.

## Verification
Static regression tests enforce membership-before-claims, fallback ordering, fail-closed behavior, and production-verifiable evidence.