### PR TITLE
Make DABBIR runtime authoritative internally

### DIFF
--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -1,5 +1,5 @@
 import crypto from 'node:crypto';
-import { classifyClinicMessage, classifyCelebrityMessage } from './pilot-runtime.js';
+import { classifyClinicMessage, classifyCelebrityMessage } from './dabbir-runtime.js';
 import { attachCorrelation, correlationId, logEvent } from './_observability.js';
 
 export const config = {

--- a/config/runtime-registry.json
+++ b/config/runtime-registry.json
@@ -1,7 +1,7 @@
 {
   "version": 2,
   "authority": "DABBIR",
-  "runtime": "api/pilot-runtime.js",
+  "runtime": "api/dabbir-runtime.js",
   "environment": "PRODUCTION_DABBIR",
   "operational_mode": "AUTHENTICATED_WEB_RUNTIME",
   "ai": {


### PR DESCRIPTION
Safe partial legacy cleanup extracted from old PR #23 without breaking compatibility callers.

Verified before change:
- `api/pilot-runtime.js`, `api/pilot-ai.js`, and `api/pilot-whatsapp-webhook.js` are compatibility re-exports only;
- Vercel still saw `/api/pilot-runtime` and `/api/pilot-ai` traffic within the last 24h, so those routes are intentionally NOT deleted yet;
- there was no `/api/pilot-*` traffic in the last 6h, but that window is not sufficient to remove external compatibility safely.

This PR only:
- changes `api/dabbir-whatsapp-webhook.js` to import `./dabbir-runtime.js` directly;
- changes `config/runtime-registry.json` authoritative runtime from `api/pilot-runtime.js` to `api/dabbir-runtime.js`.

It intentionally preserves PILOT environment-variable fallbacks and compatibility endpoint files until their external callers are proven retired. No customer/payment/channel side effects are enabled.