### PR TITLE
Stabilize DABBIR production journey and screen activation

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -1,8 +1,18 @@
 name: DABBIR AI Full Customer Journey
-# Real production journey plus isolated, sequential AI and runtime capacity measurements.
+# Real production journey on push/schedule; capacity is manual-only and remains fail-closed.
 
 on:
   workflow_dispatch:
+    inputs:
+      run_capacity:
+        description: 'Run production AI/runtime capacity after a successful full journey'
+        required: false
+        default: false
+        type: boolean
+      production_capacity_ack:
+        description: 'For production capacity, enter exactly ALLOW_CAPACITY_LOAD_ON_PRODUCTION'
+        required: false
+        type: string
   push:
     branches: [main]
     paths:
@@ -36,9 +46,11 @@ permissions:
   contents: read
   id-token: write
 
+# Never cancel a trusted production journey because another qualifying commit arrived.
+# A single group also prevents two production journeys/capacity sequences from overlapping.
 concurrency:
   group: dabbir-ai-full-customer-journey
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   full-customer-journey:
@@ -84,14 +96,15 @@ jobs:
           retention-days: 14
 
   ai-capacity:
-    name: AI capacity — clean system
+    name: AI capacity — manual production gate
     needs: full-customer-journey
-    if: always()
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.full-customer-journey.result == 'success' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
       PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '300'
       RUN_RUNTIME: 'false'
       RUN_AI: 'true'
@@ -125,14 +138,15 @@ jobs:
           retention-days: 14
 
   runtime-capacity-1000:
-    name: Runtime capacity — 1000 customers
+    name: Runtime capacity — manual 1000-customer gate
     needs: ai-capacity
-    if: always()
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.ai-capacity.result == 'success' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
       PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '1000'
       RUN_RUNTIME: 'true'
       RUN_AI: 'false'

--- a/api/app.js
+++ b/api/app.js
@@ -105,16 +105,17 @@ button,a,[data-screen],[data-cid]{touch-action:manipulation}
   showScreen=function(name){
     if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';
     current=name;
+    renderCurrentFast();
+    applyFastBusinessProfile();
+    ensureConversationLoaded();
     document.querySelectorAll('.screen').forEach(s=>s.classList.toggle('active',s.id==='screen-'+name));
     document.querySelectorAll('[data-screen]').forEach(b=>b.classList.toggle('active',b.dataset.screen===name));
     const page=document.querySelector('#pageTitle');
     if(page) page.textContent=T()[name]||name;
     document.querySelector('#side')?.classList.remove('open');
-    const paint=()=>{renderCurrentFast();applyFastBusinessProfile();ensureConversationLoaded()};
-    if(typeof requestAnimationFrame==='function') requestAnimationFrame(paint); else setTimeout(paint,0);
   };
 
-  window.__dabbirInterfacePerformance='fast-v2';
+  window.__dabbirInterfacePerformance='fast-v3';
 })();
 </script>`;
 
@@ -238,6 +239,6 @@ export default function handler(req, res) {
   res.setHeader('cache-control', 'no-store');
   res.setHeader('x-dabbir-interface', 'operational-runtime-v1');
   res.setHeader('x-dabbir-chat-path', 'chat-send-fallback-v3');
-  res.setHeader('x-dabbir-performance', 'interface-fast-v2');
+  res.setHeader('x-dabbir-performance', 'interface-fast-v3');
   return res.status(200).send(html);
 }

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -20,10 +20,8 @@ test('capacity never runs automatically on push or schedule',()=>{
   const manualGate=/github\.event_name == 'workflow_dispatch'/g;
   assert.ok((workflow.match(manualGate)||[]).length>=2,'both capacity jobs must be workflow_dispatch-only');
   must(/inputs\.run_capacity == true/,'capacity requires an explicit manual boolean');
-  must(/needs\.full-customer-journey\.result == 'success'/,'AI capacity requires a successful full journey');
-  must(/needs\.ai-capacity\.result == 'success'/,'runtime capacity requires successful AI capacity');
-  mustNot(/ai-capacity:[\s\S]*?if:\s*always\(\)/,'AI capacity must not run after a failed journey');
-  mustNot(/runtime-capacity-1000:[\s\S]*?if:\s*always\(\)/,'runtime capacity must not run after a failed AI gate');
+  must(/ai-capacity:\n    name:[^\n]*\n    needs: full-customer-journey\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.full-customer-journey\.result == 'success'[^\n]*\}\}/,'AI capacity job gate must be manual-only and require a successful journey');
+  must(/runtime-capacity-1000:\n    name:[^\n]*\n    needs: ai-capacity\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.ai-capacity\.result == 'success'[^\n]*\}\}/,'runtime capacity job gate must be manual-only and require successful AI capacity');
 });
 
 test('production capacity retains exact fail-closed acknowledgement',()=>{

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here=dirname(fileURLToPath(import.meta.url));
+const workflow=readFileSync(resolve(here,'../.github/workflows/dabbir-ai-customer-journey.yml'),'utf8');
+
+function must(pattern,message){assert.match(workflow,pattern,message)}
+function mustNot(pattern,message){assert.doesNotMatch(workflow,pattern,message)}
+
+test('trusted production journeys queue instead of cancelling each other',()=>{
+  must(/group:\s*dabbir-ai-full-customer-journey/,'journeys must share one serialized production group');
+  must(/cancel-in-progress:\s*false/,'a newer push must not cancel an in-flight trusted journey');
+  mustNot(/cancel-in-progress:\s*true/,'mid-journey cancellation must not return');
+});
+
+test('capacity never runs automatically on push or schedule',()=>{
+  const manualGate=/github\.event_name == 'workflow_dispatch'/g;
+  assert.ok((workflow.match(manualGate)||[]).length>=2,'both capacity jobs must be workflow_dispatch-only');
+  must(/inputs\.run_capacity == true/,'capacity requires an explicit manual boolean');
+  must(/needs\.full-customer-journey\.result == 'success'/,'AI capacity requires a successful full journey');
+  must(/needs\.ai-capacity\.result == 'success'/,'runtime capacity requires successful AI capacity');
+  mustNot(/ai-capacity:[\s\S]*?if:\s*always\(\)/,'AI capacity must not run after a failed journey');
+  mustNot(/runtime-capacity-1000:[\s\S]*?if:\s*always\(\)/,'runtime capacity must not run after a failed AI gate');
+});
+
+test('production capacity retains exact fail-closed acknowledgement',()=>{
+  const ack='ALLOW_CAPACITY_LOAD_ON_PRODUCTION';
+  assert.ok(workflow.includes(ack),'workflow must require the exact production acknowledgement');
+  must(/PRODUCTION_CAPACITY_LOAD_ACK:\s*\$\{\{ inputs\.production_capacity_ack \}\}/,'the verified manual acknowledgement must reach the capacity safety guard');
+});

--- a/test/dabbir-screen-transition.test.mjs
+++ b/test/dabbir-screen-transition.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+const here=dirname(fileURLToPath(import.meta.url));
+const source=readFileSync(resolve(here,'../api/app.js'),'utf8');
+
+function showScreenBody(){
+  const match=source.match(/showScreen=function\(name\)\{([\s\S]*?)\n  \};/);
+  assert.ok(match,'showScreen override must exist');
+  return match[1];
+}
+
+test('screen content renders before the screen becomes active',()=>{
+  const body=showScreenBody();
+  const renderIndex=body.indexOf('renderCurrentFast();');
+  const activateIndex=body.indexOf("classList.toggle('active'");
+  assert.ok(renderIndex>=0,'showScreen must render current content');
+  assert.ok(activateIndex>=0,'showScreen must activate the target screen');
+  assert.ok(renderIndex<activateIndex,'content must render before the visible active state is published');
+});
+
+test('screen transition does not defer required content to requestAnimationFrame',()=>{
+  const body=showScreenBody();
+  assert.doesNotMatch(body,/requestAnimationFrame\s*\(/,'required screen content must not wait for a later animation frame');
+  assert.doesNotMatch(body,/setTimeout\s*\(/,'required screen content must not wait for a timer');
+});


### PR DESCRIPTION
This closes the QA reliability gaps found in the latest production journey without weakening product rules.

- Queue trusted production journeys instead of cancelling an in-flight run when a new qualifying commit arrives.
- Make AI/runtime capacity manual-only, require a successful full journey first, and preserve the exact production load acknowledgement guard.
- Render target screen content synchronously before publishing the active screen state, eliminating the mobile WebKit race and the one-frame empty-state flash.
- Add regression contracts for workflow safety and screen transition ordering.

No capacity load is enabled automatically by this PR.