### PR TITLE
Run DABBIR full journey on dependency changes

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -16,6 +16,8 @@ on:
   push:
     branches: [main]
     paths:
+      - 'package.json'
+      - 'package-lock.json'
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/dabbir-capacity-load.mjs'
       - 'test/dabbir-activity-regression.test.mjs'

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -16,6 +16,11 @@ test('trusted production journeys queue instead of cancelling each other',()=>{
   mustNot(/cancel-in-progress:\s*true/,'mid-journey cancellation must not return');
 });
 
+test('runtime dependency changes trigger the production customer journey',()=>{
+  must(/- 'package\.json'/,'package.json changes must trigger the full production journey');
+  must(/- 'package-lock\.json'/,'package-lock.json changes must trigger the full production journey');
+});
+
 test('capacity never runs automatically on push or schedule',()=>{
   const manualGate=/github\.event_name == 'workflow_dispatch'/g;
   assert.ok((workflow.match(manualGate)||[]).length>=2,'both capacity jobs must be workflow_dispatch-only');


### PR DESCRIPTION
Closes a release-gate gap found after merging the npm lockfile: dependency changes (`package.json` / `package-lock.json`) affected the Vercel runtime build but did not trigger the production Full Customer Journey because they were absent from the workflow path filter.

This PR:
- adds `package.json` and `package-lock.json` to the Full Customer Journey push paths;
- adds a regression test so removing either dependency trigger will fail CI;
- does not change capacity behavior; production capacity remains manual-only and fail-closed.

After merge, the workflow-file change itself will trigger the trusted production journey against the already locked Production runtime.