### PR TITLE
Use WHATWG query parsing on DABBIR fast runtime

### DIFF
--- a/api/dabbir-runtime-fast.js
+++ b/api/dabbir-runtime-fast.js
@@ -12,6 +12,16 @@ import dabbirRuntimeHandler from './dabbir-runtime.js';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId = value => UUID_RE.test(String(value || '').trim()) ? String(value).trim() : null;
 
+function singleQueryValue(req, name) {
+  try {
+    const url = new URL(String(req?.url || '/'), 'https://dabbir.invalid');
+    const values = url.searchParams.getAll(name);
+    return values.length === 1 ? values[0] : null;
+  } catch {
+    return null;
+  }
+}
+
 function normalizeDisplayName(value = '') {
   return String(value)
     .toLowerCase()
@@ -112,7 +122,7 @@ async function handleFastGet(req, res) {
   if (!user) user = await getVerifiedUser(accessToken).catch(() => null);
   if (!user) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
-  const requestedBusinessId = safeId(req.query?.business_id);
+  const requestedBusinessId = safeId(singleQueryValue(req, 'business_id'));
   const membership = requestedBusinessId
     ? memberships.find(item => item.business_id === requestedBusinessId) || null
     : memberships[0] || null;
@@ -139,8 +149,8 @@ async function handleFastGet(req, res) {
   }
 
   const businessId = membership.business_id;
-  const requestedConversationId = safeId(req.query?.conversation_id);
-  const summaryOnly = String(req.query?.summary || '') === '1';
+  const requestedConversationId = safeId(singleQueryValue(req, 'conversation_id'));
+  const summaryOnly = singleQueryValue(req, 'summary') === '1';
 
   const businessPromise = rest(
     accessToken,

--- a/test/dabbir-auth-fastpath.test.mjs
+++ b/test/dabbir-auth-fastpath.test.mjs
@@ -56,3 +56,12 @@ test('fast runtime validates membership before trusting decoded claims and retai
   assert.match(runtimeSource, /AUTH_VERIFICATION_UNAVAILABLE/);
   assert.match(runtimeSource, /x-dabbir-runtime', 'fast-v4'/);
 });
+
+test('fast runtime parses query parameters with WHATWG URL instead of legacy req.query', () => {
+  assert.match(runtimeSource, /new URL\(String\(req\?\.url \|\| '\/'\), 'https:\/\/dabbir\.invalid'\)/);
+  assert.match(runtimeSource, /url\.searchParams\.getAll\(name\)/);
+  assert.doesNotMatch(runtimeSource, /req\.query/);
+  assert.match(runtimeSource, /singleQueryValue\(req, 'business_id'\)/);
+  assert.match(runtimeSource, /singleQueryValue\(req, 'conversation_id'\)/);
+  assert.match(runtimeSource, /singleQueryValue\(req, 'summary'\)/);
+});


### PR DESCRIPTION
Narrow observability/root-cause probe for Node 24 DEP0169 without mass-changing DABBIR endpoints.

Production logs repeatedly classify successful `GET /api/dabbir-runtime-fast` requests as error-level because a legacy `url.parse()` deprecation warning is emitted. The repo does not call `url.parse()` directly, but this hot path reads Vercel's legacy `req.query` helper.

This PR changes only `api/dabbir-runtime-fast.js` query reads to WHATWG `URL` / `URLSearchParams`, preserving fail-closed behavior by accepting exactly one value per parameter. Repeated values become invalid/unset instead of being trusted.

Regression coverage ensures:
- no `req.query` remains in the fast runtime;
- business_id, conversation_id, and summary use the new single-value parser;
- existing auth fast-path guards remain intact.

Verification plan after merge: Full Customer Journey will run automatically; then compare Production Vercel logs for `/api/dabbir-runtime-fast`. If DEP0169 disappears on that route, migrate remaining endpoints incrementally. If it remains, do not mass-migrate because the warning originates elsewhere in the Vercel runtime/wrapper.