### PR TITLE
Use WHATWG query parsing in DABBIR owner operations

### DIFF
--- a/api/owner-operations.js
+++ b/api/owner-operations.js
@@ -14,6 +14,16 @@ const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():
 const clean=(value,max=160)=>String(value||'').trim().slice(0,max);
 const number=value=>Number.isFinite(Number(value))?Number(value):0;
 
+function singleQueryValue(req,name){
+  try{
+    const url=new URL(String(req?.url||'/'),'https://dabbir.invalid');
+    const values=url.searchParams.getAll(name);
+    return values.length===1?values[0]:null;
+  }catch{
+    return null;
+  }
+}
+
 async function readData(response,fallback){
   const text=await response.text();
   let payload=null;
@@ -47,7 +57,7 @@ function membershipFor(memberships,businessId){
 }
 
 async function handleGet(req,res,context){
-  const requested=safeId(req.query?.business_id);
+  const requested=safeId(singleQueryValue(req,'business_id'));
   const membership=membershipFor(context.memberships,requested);
   if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
   const businessId=membership.business_id;

--- a/test/dabbir-owner-operations-query.test.mjs
+++ b/test/dabbir-owner-operations-query.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const source = await readFile(new URL('api/owner-operations.js', root), 'utf8');
+
+test('owner operations uses WHATWG query parsing instead of legacy req.query', () => {
+  assert.match(source, /new URL\(String\(req\?\.url \|\| '\/'\), 'https:\/\/dabbir\.invalid'\)/);
+  assert.match(source, /url\.searchParams\.getAll\(name\)/);
+  assert.doesNotMatch(source, /req\.query/);
+  assert.match(source, /singleQueryValue\(req,'business_id'\)/);
+});

--- a/test/dabbir-owner-operations-query.test.mjs
+++ b/test/dabbir-owner-operations-query.test.mjs
@@ -6,7 +6,7 @@ const root = new URL('../', import.meta.url);
 const source = await readFile(new URL('api/owner-operations.js', root), 'utf8');
 
 test('owner operations uses WHATWG query parsing instead of legacy req.query', () => {
-  assert.match(source, /new URL\(String\(req\?\.url \|\| '\/'\), 'https:\/\/dabbir\.invalid'\)/);
+  assert.ok(source.includes("new URL(String(req?.url||'/'),'https://dabbir.invalid')"));
   assert.match(source, /url\.searchParams\.getAll\(name\)/);
   assert.doesNotMatch(source, /req\.query/);
   assert.match(source, /singleQueryValue\(req,'business_id'\)/);


### PR DESCRIPTION
Second incremental DEP0169 cleanup after the fast-runtime experiment proved the cause in Production.

Verified evidence from the same Production deployment:
- `GET /api/dabbir-runtime-fast` no longer emitted DEP0169 after removing `req.query` and stayed 200/info.
- `GET /api/owner-operations` still emitted DEP0169 and was classified 200/error.

This PR changes only the owner-operations GET tenant selector from legacy `req.query` to fail-closed WHATWG URLSearchParams parsing. Exactly one `business_id` value is accepted; duplicates are treated as unset.

Full Customer Journey covers owner product creation, inventory updates, owner-operations GETs, order confirmation and mobile product rendering. After merge we will verify both journey success and disappearance of DEP0169 specifically from `/api/owner-operations` before migrating any further endpoint.