### PR TITLE
Remove legacy query parsing from all DABBIR endpoints

### DIFF
--- a/api/_request-query.js
+++ b/api/_request-query.js
@@ -1,0 +1,9 @@
+export function singleQueryValue(req, name) {
+  try {
+    const url = new URL(String(req?.url || '/'), 'https://dabbir.invalid');
+    const values = url.searchParams.getAll(name);
+    return values.length === 1 ? values[0] : null;
+  } catch {
+    return null;
+  }
+}

--- a/api/activity-tasks.js
+++ b/api/activity-tasks.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import {
   accessTokenFromRequest,
   getBusinessMemberships,
@@ -45,7 +46,7 @@ export default async function handler(req,res){
   const ctx=await context(req,res);if(!ctx)return;
   try{
     if(req.method==='GET'){
-      const businessId=safeId(req.query?.business_id);
+      const businessId=safeId(singleQueryValue(req,'business_id'));
       const membership=membershipFor(ctx.memberships,businessId);
       if(!businessId||!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
       const rows=await rest(ctx.token,`dabbir_businesses?select=id,name,business_type&id=eq.${businessId}&limit=1`,'BUSINESS_LOOKUP_FAILED');

--- a/api/business-profile.js
+++ b/api/business-profile.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import {
   accessTokenFromRequest,
   getBusinessMemberships,
@@ -71,7 +72,7 @@ export default async function handler(req,res){
 
   try{
     const body=req.method==='POST'?await readJsonBody(req):null;
-    const businessId=safeId(req.method==='GET'?req.query?.business_id:body?.business_id);
+    const businessId=safeId(req.method==='GET'?singleQueryValue(req,'business_id'):body?.business_id);
     if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_ID_REQUIRED'});
     if(!membershipFor(ctx.memberships,businessId))return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
 

--- a/api/chat-customer.js
+++ b/api/chat-customer.js
@@ -28,7 +28,6 @@ function delegateRequest(req,body){
   const stream=Readable.from([Buffer.from(JSON.stringify(body),'utf8')]);
   stream.method='POST';
   stream.headers={...req.headers,'content-type':'application/json'};
-  stream.query=req.query||{};
   stream.url=req.url;
   return stream;
 }

--- a/api/dabbir-ai.js
+++ b/api/dabbir-ai.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import { generateDABBIRAiReply, getDABBIRAiConfig } from './_ai-core.js';
 
 function json(res, status, body) {
@@ -9,7 +10,7 @@ export default async function handler(req, res) {
 
   if (req.method === 'GET') {
     const config = getDABBIRAiConfig();
-    if (String(req.query?.synthetic || '') === '1') {
+    if (String(singleQueryValue(req, 'synthetic') || '') === '1') {
       const result = await generateDABBIRAiReply({
         project: 'dabbir_clinics',
         message: 'هلا، ابا موعد باجر العصر',

--- a/api/dabbir-runtime.js
+++ b/api/dabbir-runtime.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import {
   accessTokenFromRequest,
   getBusinessMemberships,
@@ -497,8 +498,8 @@ export default async function handler(req, res) {
 
   try {
     if (req.method === 'GET') {
-      const businessId = safeId(req.query?.business_id);
-      const conversationId = safeId(req.query?.conversation_id);
+      const businessId = safeId(singleQueryValue(req, 'business_id'));
+      const conversationId = safeId(singleQueryValue(req, 'conversation_id'));
       return json(res, 200, await loadWorkspace(identity, businessId, conversationId));
     }
 

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
 import { loadBusinessConnection, ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
 
@@ -31,7 +32,7 @@ export default async function handler(req, res) {
     });
   }
 
-  const businessId = String(req.query?.business_id || '').trim();
+  const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
   if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
 
   try {

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
 import {
   embeddedPlatformConfig,
@@ -149,7 +150,7 @@ export default async function handler(req, res) {
   const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
-  const businessId = String(req.query?.business_id || '').trim();
+  const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
   if (businessId) {
     try {
       const tenant = await embeddedStatus(req, accessToken, businessId);

--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import crypto from 'node:crypto';
 import { classifyClinicMessage, classifyCelebrityMessage } from './dabbir-runtime.js';
 import { attachCorrelation, correlationId, logEvent } from './_observability.js';
@@ -122,7 +123,11 @@ export default async function handler(req, res) {
   const project = normalizeProject(firstEnv('DABBIR_PROJECT', 'PILOT_PROJECT') || 'generic');
 
   if (req.method === 'GET') {
-    const result = verifyWebhookChallenge(req.query || {}, verifyToken);
+    const result = verifyWebhookChallenge({
+      'hub.mode': singleQueryValue(req, 'hub.mode'),
+      'hub.verify_token': singleQueryValue(req, 'hub.verify_token'),
+      'hub.challenge': singleQueryValue(req, 'hub.challenge'),
+    }, verifyToken);
     if (!result.ok) {
       logEvent('warn', { correlation_id: cid, component: 'whatsapp_webhook', operation: 'challenge_verification', outcome: 'FAILED', failure_class: 'AUTH' });
       return res.status(403).setHeader('x-dabbir-correlation-id', cid).send('forbidden');

--- a/api/owner-action-center.js
+++ b/api/owner-action-center.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from './_request-query.js';
 import {
   accessTokenFromRequest,
   getBusinessMemberships,
@@ -89,7 +90,7 @@ export default async function handler(req,res){
   if(!context)return;
 
   try{
-    const requested=safeId(req.query?.business_id);
+    const requested=safeId(singleQueryValue(req,'business_id'));
     const membership=membershipFor(context.memberships,requested);
     if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
     const businessId=membership.business_id;

--- a/api/team/invitations.js
+++ b/api/team/invitations.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from '../_request-query.js';
 import crypto from 'node:crypto';
 import {
   accessTokenFromRequest,
@@ -34,7 +35,7 @@ export default async function handler(req, res) {
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
   if (req.method === 'GET') {
-    const businessId = String(req.query?.business_id || '').trim();
+    const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
     if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
     const query = `dabbir_employee_invitations?business_id=eq.${encodeURIComponent(businessId)}&select=id,email,display_name,role,permissions,status,delivery_status,delivery_attempts,expires_at,accepted_at,created_at&order=created_at.desc`;
     const response = await supabaseRest(query, accessToken);

--- a/api/team/members.js
+++ b/api/team/members.js
@@ -1,3 +1,4 @@
+import { singleQueryValue } from '../_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody, readRpcJson, requireSameOrigin, rpcErrorCode, supabaseRpc } from '../_auth-core.js';
 
 const roles = new Set(['admin','manager','employee','staff','viewer','agent']);
@@ -23,7 +24,7 @@ export default async function handler(req, res) {
   if (!actor) return json(res, 401, { ok:false, error:'AUTH_REQUIRED' });
 
   if (req.method === 'GET') {
-    const businessId = String(req.query?.business_id || '').trim();
+    const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
     if (!businessId) return json(res, 400, { ok:false, error:'BUSINESS_REQUIRED' });
     const response = await supabaseRpc('dabbir_list_team', token, { p_business_id: businessId });
     const payload = await readRpcJson(response);

--- a/test/dabbir-request-query-safety.test.mjs
+++ b/test/dabbir-request-query-safety.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { singleQueryValue } from '../api/_request-query.js';
+
+const root = new URL('../', import.meta.url);
+const guardedFiles = [
+  "api/dabbir-ai.js",
+  "api/chat-customer.js",
+  "api/team/members.js",
+  "api/dabbir-whatsapp-embedded-config.js",
+  "api/team/invitations.js",
+  "api/business-profile.js",
+  "api/activity-tasks.js",
+  "api/dabbir-runtime.js",
+  "api/dabbir-whatsapp-status.js",
+  "api/dabbir-whatsapp-webhook.js",
+  "api/owner-action-center.js"
+];
+
+test('singleQueryValue uses WHATWG parsing and fails closed for duplicate or invalid values', () => {
+  assert.equal(singleQueryValue({ url: '/api/example?business_id=abc' }, 'business_id'), 'abc');
+  assert.equal(singleQueryValue({ url: '/api/example?business_id=abc&business_id=def' }, 'business_id'), null);
+  assert.equal(singleQueryValue({ url: 'http://[invalid' }, 'business_id'), null);
+  assert.equal(singleQueryValue({}, 'business_id'), null);
+});
+
+test('DABBIR runtime endpoints do not access Vercel legacy req.query', async () => {
+  for (const path of guardedFiles) {
+    const source = await readFile(new URL(path, root), 'utf8');
+    assert.doesNotMatch(source, /req\.query/, path);
+  }
+});
+
+test('WhatsApp verification reads the three Meta challenge parameters through the guarded parser', async () => {
+  const source = await readFile(new URL('api/dabbir-whatsapp-webhook.js', root), 'utf8');
+  assert.match(source, /singleQueryValue\(req, 'hub\.mode'\)/);
+  assert.match(source, /singleQueryValue\(req, 'hub\.verify_token'\)/);
+  assert.match(source, /singleQueryValue\(req, 'hub\.challenge'\)/);
+});

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -64,7 +64,8 @@ test('status endpoint prefers business-scoped Embedded Signup when business_id i
   const status = await read('api/dabbir-whatsapp-status.js');
   assert.match(status, /embeddedStatus/);
   assert.match(status, /source:\s*'embedded_signup'/);
-  assert.match(status, /req\.query\?\.business_id/);
+  assert.match(status, /singleQueryValue\(req, 'business_id'\)/);
+  assert.doesNotMatch(status, /req\.query/);
   assert.match(status, /loadBusinessConnection/);
 });
 


### PR DESCRIPTION
## Outcome
Eliminates the remaining Node 24 `DEP0169` production warnings by removing every runtime access to Vercel's legacy `req.query` parser.

## Changes
- Adds one fail-closed WHATWG query parser.
- Migrates 10 GET endpoints and the Meta webhook challenge path.
- Removes unused query copying from the customer-chat delegate.
- Rejects duplicate query parameters instead of accepting an ambiguous tenant selector.
- Adds regression tests covering every affected endpoint and WhatsApp verification fields.

## Verification
- Focused test: 3/3 passed locally.
- `node --check` passed for all changed API modules.
- Full CI and preview deployment are required before merge.

## Production evidence
Current deployment `dpl_BF8TbojKgX92ZkZDqp1S6JrzvBM9` logged 10 `DEP0169` warnings in the last hour across team, task, WhatsApp, and owner-action endpoints.