### PR TITLE
Fail closed on missing DABBIR production origin

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
-      PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
+      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
       PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '300'
@@ -154,7 +154,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
+      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
       PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '1000'

--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -60,10 +60,18 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 18
     env:
-      PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
+      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
       JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report.json
     steps:
+      - name: Require canonical DABBIR production origin
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
+            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
+            exit 1
+          fi
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:

--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -17,10 +17,18 @@ jobs:
     timeout-minutes: 5
     env:
       PROJECT_REF: spohjzrsymsmzsseygtw
-      PRODUCTION_ORIGIN: https://pilot-taupe.vercel.app
+      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
     steps:
+      - name: Require canonical DABBIR production origin
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
+            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
+            exit 1
+          fi
       - name: Resolve management credential
         id: credential
         shell: bash

--- a/config/barman-integration-contract.json
+++ b/config/barman-integration-contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 1,
+  "version": 2,
   "producer": "DABBIR",
   "control_plane": "barman-systems/barman-control-plane",
   "target_source_repository": "barman-systems/pilot",
@@ -12,18 +12,22 @@
     "verified_import_ci_status": "PASS"
   },
   "deployment": {
-    "status": "ACTIVE_DEDICATED_VERCEL_PROJECT",
+    "status": "DEPLOYED_AUTH_PROTECTED_NO_PUBLIC_LAUNCH_DOMAIN",
     "platform": "VERCEL",
-    "project_name": "pilot",
+    "project_name": "dabbir",
     "project_id": "prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq",
     "source_repository": "barman-systems/pilot",
     "source_branch": "main",
     "root_directory": "./",
-    "verified_deployment_id": "dpl_5C2PjyZ79b5dUkBSiAWzrsRd7jx4",
+    "verified_deployment_id": "dpl_BDD7c9jHa39bQmfkJCAWyLDNruLi",
     "verified_deployment_state": "READY",
-    "verified_source_commit": "6a75246eab955a3e43a97c7ecd5f75b508b98dbe",
-    "production_domain": "pilot-taupe.vercel.app",
+    "verified_source_commit": "07c5885c0d80af93dffa63377a5dfd0248d7009a",
+    "protected_project_domain": "dabbir-nd56cm4j5v-3619s-projects.vercel.app",
+    "public_launch_domain": null,
+    "domain_access": "VERCEL_AUTH_PROTECTED",
     "production_runtime_policy": "FAIL_CLOSED_PREVIEW_ONLY",
+    "project_live": false,
+    "verified_at": "2026-08-27T07:32:53Z",
     "environment_secrets_shared_with_barman": false
   },
   "rules": {

--- a/test/ai-full-customer-journey-oidc.mjs
+++ b/test/ai-full-customer-journey-oidc.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 
-const ORIGIN = String(process.env.PRODUCTION_ORIGIN || 'https://pilot-taupe.vercel.app').replace(/\/$/, '');
+const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
 const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
 const QA_CONTROL_URL = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';

--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 
-const ORIGIN = String(process.env.PRODUCTION_ORIGIN || 'https://pilot-taupe.vercel.app').replace(/\/$/, '');
+const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
 const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
 const QA_CONTROL_URL = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';

--- a/test/ai-full-customer-journey.mjs
+++ b/test/ai-full-customer-journey.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 
-const ORIGIN = String(process.env.PRODUCTION_ORIGIN || 'https://pilot-taupe.vercel.app').replace(/\/$/, '');
+const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
 const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
 const MANAGEMENT_TOKEN = String(process.env.SUPABASE_MANAGEMENT_TOKEN || process.env.SUPABASE_ACCESS_TOKEN || '').trim();
 const PROVIDED_SERVICE_ROLE = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();

--- a/test/dabbir-ai-full-journey-oidc.mjs
+++ b/test/dabbir-ai-full-journey-oidc.mjs
@@ -1,7 +1,8 @@
 import fs from 'node:fs';
 import crypto from 'node:crypto';
 
-const ORIGIN = String(process.env.PRODUCTION_ORIGIN || 'https://pilot-taupe.vercel.app').replace(/\/$/, '');
+const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
 const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
 const BROKER = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';

--- a/test/dabbir-capacity-load.mjs
+++ b/test/dabbir-capacity-load.mjs
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import crypto from 'node:crypto';
 import { assertCapacityLoadAllowed } from './dabbir-capacity-safety.mjs';
 
-const ORIGIN=String(process.env.PRODUCTION_ORIGIN||'https://pilot-taupe.vercel.app').replace(/\/$/,'');
+const ORIGIN=String(process.env.PRODUCTION_ORIGIN||'').trim().replace(/\/$/,'');
 const CAPACITY_TARGET=String(process.env.CAPACITY_TARGET||'').trim();
 const CAPACITY_PRODUCTION_ACK=String(process.env.CAPACITY_PRODUCTION_ACK||'').trim();
 const CAPACITY_SAFETY=assertCapacityLoadAllowed({
@@ -10,6 +10,7 @@ const CAPACITY_SAFETY=assertCapacityLoadAllowed({
   declaredTarget:CAPACITY_TARGET,
   ack:CAPACITY_PRODUCTION_ACK,
 });
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
 const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'spohjzrsymsmzsseygtw').trim();
 const QA_CONTROL_URL=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE='dabbir-ai-qa';

--- a/test/dabbir-capacity-safety.mjs
+++ b/test/dabbir-capacity-safety.mjs
@@ -1,7 +1,7 @@
 export const PRODUCTION_CAPACITY_ACK = 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION';
 
 const KNOWN_PRODUCTION_HOSTS = new Set([
-  'pilot-taupe.vercel.app',
+  'dabbir-nd56cm4j5v-3619s-projects.vercel.app',
 ]);
 
 function hostname(origin) {

--- a/test/dabbir-capacity-safety.test.mjs
+++ b/test/dabbir-capacity-safety.test.mjs
@@ -8,19 +8,19 @@ import {
 
 test('known production origin is blocked without explicit acknowledgement', () => {
   assert.throws(
-    () => assertCapacityLoadAllowed({ origin: 'https://pilot-taupe.vercel.app' }),
+    () => assertCapacityLoadAllowed({ origin: 'https://dabbir-nd56cm4j5v-3619s-projects.vercel.app' }),
     /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
   );
 });
 
 test('caller cannot relabel known production as staging', () => {
   assert.equal(
-    classifyCapacityTarget('https://pilot-taupe.vercel.app', 'staging'),
+    classifyCapacityTarget('https://dabbir-nd56cm4j5v-3619s-projects.vercel.app', 'staging'),
     'production',
   );
   assert.throws(
     () => assertCapacityLoadAllowed({
-      origin: 'https://pilot-taupe.vercel.app',
+      origin: 'https://dabbir-nd56cm4j5v-3619s-projects.vercel.app',
       declaredTarget: 'staging',
     }),
     /PRODUCTION_CAPACITY_LOAD_REQUIRES_EXPLICIT_ACK/,
@@ -30,7 +30,7 @@ test('caller cannot relabel known production as staging', () => {
 test('production load is allowed only with the exact acknowledgement', () => {
   assert.deepEqual(
     assertCapacityLoadAllowed({
-      origin: 'https://pilot-taupe.vercel.app',
+      origin: 'https://dabbir-nd56cm4j5v-3619s-projects.vercel.app',
       ack: PRODUCTION_CAPACITY_ACK,
     }),
     { target: 'production', production_acknowledged: true },

--- a/test/dabbir-production-origin-truth.test.mjs
+++ b/test/dabbir-production-origin-truth.test.mjs
@@ -1,0 +1,41 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const retiredHost = ['pilot', 'taupe.vercel.app'].join('-');
+const guardedFiles = [
+  '.github/workflows/dabbir-ai-customer-journey.yml',
+  '.github/workflows/dabbir-auth-production.yml',
+  'config/barman-integration-contract.json',
+  'test/ai-full-customer-journey.mjs',
+  'test/ai-full-customer-journey-oidc.mjs',
+  'test/ai-full-customer-journey-v2.mjs',
+  'test/dabbir-ai-full-journey-oidc.mjs',
+  'test/dabbir-capacity-load.mjs',
+  'test/dabbir-capacity-safety.mjs',
+  'test/dabbir-capacity-safety.test.mjs',
+  'test/password-recovery-origin.test.mjs',
+];
+
+test('retired PILOT origin cannot return to DABBIR release controls', () => {
+  for (const path of guardedFiles) {
+    assert.doesNotMatch(fs.readFileSync(path, 'utf8'), new RegExp(retiredHost.replaceAll('.', '\\.'), 'i'), path);
+  }
+});
+
+test('release workflows require an explicit canonical DABBIR origin', () => {
+  for (const path of guardedFiles.slice(0, 2)) {
+    const source = fs.readFileSync(path, 'utf8');
+    assert.match(source, /vars\.DABBIR_PRODUCTION_ORIGIN/);
+    assert.match(source, /DABBIR_PRODUCTION_ORIGIN must be configured/);
+  }
+});
+
+test('deployment contract records the protected no-public-domain state', () => {
+  const contract = JSON.parse(fs.readFileSync('config/barman-integration-contract.json', 'utf8'));
+  assert.equal(contract.deployment.project_name, 'dabbir');
+  assert.equal(contract.deployment.project_id, 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq');
+  assert.equal(contract.deployment.public_launch_domain, null);
+  assert.equal(contract.deployment.domain_access, 'VERCEL_AUTH_PROTECTED');
+  assert.equal(contract.deployment.project_live, false);
+});

--- a/test/password-recovery-origin.test.mjs
+++ b/test/password-recovery-origin.test.mjs
@@ -42,11 +42,11 @@ test('rejects non-HTTPS public origins in production', () => {
 test('uses the first forwarded host and protocol value', () => {
   const req = {
     headers: {
-      'x-forwarded-host': 'pilot-taupe.vercel.app, internal.proxy',
+      'x-forwarded-host': 'app.dabbir.example, internal.proxy',
       'x-forwarded-proto': 'https, http',
     },
   };
 
-  assert.equal(requestPublicOrigin(req, production), 'https://pilot-taupe.vercel.app');
-  assert.equal(buildRecoveryRedirect(req, production), 'https://pilot-taupe.vercel.app/?password_recovery=1');
+  assert.equal(requestPublicOrigin(req, production), 'https://app.dabbir.example');
+  assert.equal(buildRecoveryRedirect(req, production), 'https://app.dabbir.example/?password_recovery=1');
 });


### PR DESCRIPTION
## Outcome
Removes the retired `pilot-taupe.vercel.app` deployment from release controls after the production journey proved it returns `404 DEPLOYMENT_NOT_FOUND`.

## Changes
- Requires `DABBIR_PRODUCTION_ORIGIN` as the explicit canonical public HTTPS origin in Auth and full-journey workflows.
- Removes the dead hostname fallback from all journey/capacity runners.
- Updates capacity guards to the current protected DABBIR project domain.
- Records the verified Vercel project/deployment/commit and the factual `VERCEL_AUTH_PROTECTED` / no-public-launch-domain state.
- Adds regression coverage preventing the retired hostname from returning.

## Evidence
- Failed production E2E: run `33050020905`, `HOME_INVALID_404`.
- Verified runtime deployment: `dpl_BDD7c9jHa39bQmfkJCAWyLDNruLi` at `07c5885c0d80af93dffa63377a5dfd0248d7009a`.
- Owner action still required: attach/configure a canonical public domain and set repository variable `DABBIR_PRODUCTION_ORIGIN` before release.