### PR TITLE
Prevent legacy WhatsApp number from leaking into new DABBIR accounts

### DIFF
--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -60,6 +60,32 @@ function publicConfig(config) {
   };
 }
 
+export function tenantUnconfiguredStatus() {
+  return {
+    ok: true,
+    channel: 'whatsapp',
+    source: 'embedded_signup',
+    configured: false,
+    connected: false,
+    webhook_configured: false,
+    outbound_configured: false,
+    phone_number_configured: false,
+    waba_configured: false,
+    state: 'NOT_CONFIGURED',
+    meta_authorized: false,
+    meta_check_attempted: false,
+    meta_check_reason: 'TENANT_WHATSAPP_NOT_LINKED',
+    provider_status: null,
+    phone: null,
+    waba_id: null,
+    phone_number_id: null,
+    connected_at: null,
+    operational: false,
+    operational_reason: 'WHATSAPP_NOT_LINKED',
+    checked_at: new Date().toISOString(),
+  };
+}
+
 export async function verifyMetaAuthorization(config = getWhatsAppConfig()) {
   if (!config.accessToken || !config.phoneNumberId) return { attempted: false, authorized: false, reason: 'META_READ_CREDENTIALS_NOT_CONFIGURED' };
   const controller = new AbortController();
@@ -155,6 +181,7 @@ export default async function handler(req, res) {
     try {
       const tenant = await embeddedStatus(req, accessToken, businessId);
       if (tenant) return json(res, 200, tenant);
+      return json(res, 200, tenantUnconfiguredStatus());
     } catch (error) {
       return json(res, Number(error?.status || 500), { ok: false, error: error?.message || 'REQUEST_FAILED' });
     }

--- a/test/dabbir-whatsapp-status.test.mjs
+++ b/test/dabbir-whatsapp-status.test.mjs
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import { getWhatsAppConfig } from '../api/dabbir-whatsapp-status.js';
+import { getWhatsAppConfig, tenantUnconfiguredStatus } from '../api/dabbir-whatsapp-status.js';
 
 const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
@@ -53,6 +53,18 @@ test('DABBIR WhatsApp credentials take precedence when both generations exist', 
     assert.equal(config.verifyToken, 'dabbir-verify');
     assert.equal(config.appSecret, 'dabbir-secret');
   });
+});
+
+test('tenant without an Embedded Signup connection never inherits the legacy global WhatsApp number', () => {
+  const status = tenantUnconfiguredStatus();
+  assert.equal(status.source, 'embedded_signup');
+  assert.equal(status.configured, false);
+  assert.equal(status.connected, false);
+  assert.equal(status.state, 'NOT_CONFIGURED');
+  assert.equal(status.phone, null);
+  assert.equal(status.waba_id, null);
+  assert.equal(status.phone_number_id, null);
+  assert.equal(status.meta_check_reason, 'TENANT_WHATSAPP_NOT_LINKED');
 });
 
 test('WhatsApp UI reads live status instead of trusting the stale static red card', async () => {


### PR DESCRIPTION
Fix tenant WhatsApp status isolation. When a DABBIR business has no Embedded Signup connection, the tenant-specific status endpoint now returns NOT_CONFIGURED instead of falling through to the legacy global WhatsApp server configuration. This prevents a newly created account from displaying or treating the old global phone number as its own. Adds regression coverage for tenant isolation.