### PR TITLE
security: enforce Supabase leaked-password protection

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -12,7 +12,7 @@ permissions:
   contents: read
 
 jobs:
-  enforce-auth-production-url:
+  enforce-auth-production-security:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
@@ -21,14 +21,6 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
     steps:
-      - name: Require canonical DABBIR production origin
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
-            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
-            exit 1
-          fi
       - name: Resolve management credential
         id: credential
         shell: bash
@@ -43,6 +35,43 @@ jobs:
           else
             echo 'available=false' >> "$GITHUB_OUTPUT"
             echo 'source=none' >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Enforce leaked password protection
+        if: steps.credential.outputs.available == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          TOKEN="${SUPABASE_ACCESS_TOKEN:-${SUPABASE_MANAGEMENT_TOKEN:-}}"
+          API="https://api.supabase.com/v1/projects/${PROJECT_REF}/config/auth"
+
+          curl --silent --show-error --fail-with-body \
+            --request PATCH \
+            --header "Authorization: Bearer ${TOKEN}" \
+            --header 'Content-Type: application/json' \
+            --data '{"password_hibp_enabled":true}' \
+            "$API" >/dev/null
+
+          verified="$(curl --silent --show-error --fail-with-body \
+            --header "Authorization: Bearer ${TOKEN}" \
+            --header 'Accept: application/json' \
+            "$API")"
+
+          VERIFIED="$verified" node <<'NODE'
+          const config = JSON.parse(process.env.VERIFIED || '{}');
+          if (config.password_hibp_enabled !== true) {
+            throw new Error('Supabase leaked password protection remains disabled');
+          }
+          console.log('Supabase leaked password protection verified.');
+          NODE
+
+      - name: Require canonical DABBIR production origin
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
+            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
+            exit 1
           fi
 
       - name: Enforce hosted Supabase Auth URLs


### PR DESCRIPTION
## Why
Supabase Security Advisor reports leaked-password protection disabled.

## Change
- Enforce `password_hibp_enabled: true` through the official Management API.
- Verify the live Auth configuration after PATCH.
- Run this security control before the separate canonical-origin guard, so the missing public origin cannot prevent the security fix.

## Evidence
Supabase Management API documents `password_hibp_enabled` as an optional boolean on `PATCH /v1/projects/{ref}/config/auth`.