### PR TITLE
Harden WhatsApp Embedded Signup for long mobile flows

### DIFF
--- a/api/dabbir-whatsapp-client-event.js
+++ b/api/dabbir-whatsapp-client-event.js
@@ -1,0 +1,33 @@
+import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+
+function clean(value, max = 120) {
+  return String(value || '').replace(/[\r\n\t]/g, ' ').trim().slice(0, max);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
+
+  const accessToken = accessTokenFromRequest(req);
+  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+  if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  try {
+    const body = await readJsonBody(req, 4096);
+    const event = clean(body?.event, 48);
+    const stage = clean(body?.stage, 48);
+    const error = clean(body?.error, 160);
+    const safe = {
+      event: event || 'unknown',
+      stage: stage || null,
+      error: error || null,
+      has_code: Boolean(body?.has_code),
+      has_waba: Boolean(body?.has_waba),
+      has_phone: Boolean(body?.has_phone),
+    };
+    console.info('[DABBIR_WHATSAPP_EMBEDDED_CLIENT]', JSON.stringify(safe));
+    return json(res, 200, { ok: true });
+  } catch (error) {
+    return json(res, Number(error?.code || 400), { ok: false, error: String(error?.message || 'INVALID_EVENT').slice(0, 120) });
+  }
+}

--- a/api/dabbir-whatsapp-embedded-ui.js
+++ b/api/dabbir-whatsapp-embedded-ui.js
@@ -2,6 +2,14 @@ const script = String.raw`(()=>{
   if(window.__dabbirWhatsAppEmbeddedUiLoaded) return;
   window.__dabbirWhatsAppEmbeddedUiLoaded=true;
 
+  const SESSION_TIMEOUT_MS=15*60*1000;
+  const META_MESSAGE_ORIGINS=new Set([
+    'https://www.facebook.com',
+    'https://web.facebook.com',
+    'https://m.facebook.com',
+    'https://business.facebook.com'
+  ]);
+
   const css=document.createElement('style');
   css.textContent=[
     '.dabbirWhatsAppActions{display:flex;flex-wrap:wrap;gap:8px;margin-top:10px}',
@@ -25,6 +33,18 @@ const script = String.raw`(()=>{
   function tell(text){try{if(typeof toast==='function')toast(text)}catch{}}
   function businessId(){try{return String(workspace?.business?.id||'')}catch{return ''}}
 
+  function report(event,extra={}){
+    try{
+      fetch('/api/dabbir-whatsapp-client-event',{
+        method:'POST',
+        cache:'no-store',
+        keepalive:true,
+        headers:{'content-type':'application/json','accept':'application/json'},
+        body:JSON.stringify({event,...extra})
+      }).catch(()=>{});
+    }catch{}
+  }
+
   function whatsappCard(){
     const grid=document.querySelector('#integrationGrid');
     if(!grid) return null;
@@ -32,8 +52,13 @@ const script = String.raw`(()=>{
     return [...grid.querySelectorAll('.integration')].find(card=>String(card.querySelector('h3')?.textContent||'').trim()===wanted)||null;
   }
 
+  function settleSession(value){
+    const waiters=sessionWaiters.splice(0);
+    waiters.forEach(resolve=>resolve(value));
+  }
+
   function parseMetaMessage(event){
-    if(!['https://www.facebook.com','https://web.facebook.com'].includes(String(event.origin||''))) return;
+    if(!META_MESSAGE_ORIGINS.has(String(event.origin||''))) return;
     let data=event.data;
     if(typeof data==='string'){
       try{data=JSON.parse(data)}catch{return}
@@ -45,25 +70,36 @@ const script = String.raw`(()=>{
         waba_id:String(payload.waba_id||payload.whatsapp_business_account_id||''),
         phone_number_id:String(payload.phone_number_id||''),
       };
-      const waiters=sessionWaiters.splice(0);
-      waiters.forEach(resolve=>resolve(embeddedSession));
+      report('session_finish',{stage:'meta_session',has_waba:Boolean(embeddedSession.waba_id),has_phone:Boolean(embeddedSession.phone_number_id)});
+      settleSession(embeddedSession);
     }else if(data.event==='CANCEL'){
-      const waiters=sessionWaiters.splice(0);
-      waiters.forEach(resolve=>resolve(null));
+      report('session_cancel',{stage:'meta_session'});
+      settleSession(null);
     }else if(data.event==='ERROR'){
-      const waiters=sessionWaiters.splice(0);
-      waiters.forEach(resolve=>resolve(null));
+      report('session_error',{stage:'meta_session',error:String(data?.data?.error_message||data?.data?.error||'META_EMBEDDED_SIGNUP_ERROR').slice(0,160)});
+      settleSession(null);
       tell(ar()?'تعذر إكمال ربط WhatsApp من Meta':'Meta could not complete WhatsApp setup');
     }
   }
   window.addEventListener('message',parseMetaMessage);
 
-  function waitForSession(timeoutMs=12000){
+  function waitForSession(timeoutMs=SESSION_TIMEOUT_MS){
     if(embeddedSession?.waba_id&&embeddedSession?.phone_number_id) return Promise.resolve(embeddedSession);
     return new Promise(resolve=>{
       let done=false;
-      const finish=value=>{if(done)return;done=true;clearTimeout(timer);resolve(value)};
-      const timer=setTimeout(()=>finish(null),timeoutMs);
+      let timer=null;
+      const finish=value=>{
+        if(done)return;
+        done=true;
+        if(timer)clearTimeout(timer);
+        const index=sessionWaiters.indexOf(finish);
+        if(index>=0)sessionWaiters.splice(index,1);
+        resolve(value);
+      };
+      timer=setTimeout(()=>{
+        report('session_timeout',{stage:'meta_session'});
+        finish(null);
+      },timeoutMs);
       sessionWaiters.push(finish);
     });
   }
@@ -84,13 +120,19 @@ const script = String.raw`(()=>{
         }catch(error){reject(error)}
       };
       const existing=document.querySelector('script[data-dabbir-meta-sdk]');
-      if(existing) return;
-      const script=document.createElement('script');
-      script.async=true;script.defer=true;script.crossOrigin='anonymous';
-      script.src='https://connect.facebook.net/'+encodeURIComponent(cfg.sdk_locale||'en_US')+'/sdk.js';
-      script.setAttribute('data-dabbir-meta-sdk','true');
-      script.onerror=()=>reject(new Error('META_SDK_LOAD_FAILED'));
-      document.head.appendChild(script);
+      if(existing){
+        const wait=setInterval(()=>{
+          if(window.FB){clearInterval(wait);try{window.FB.init({appId:cfg.app_id,cookie:true,xfbml:false,version:cfg.graph_version})}catch{}resolve(window.FB)}
+        },100);
+        setTimeout(()=>{clearInterval(wait);if(!window.FB)reject(new Error('META_SDK_LOAD_TIMEOUT'))},10000);
+        return;
+      }
+      const metaScript=document.createElement('script');
+      metaScript.async=true;metaScript.defer=true;metaScript.crossOrigin='anonymous';
+      metaScript.src='https://connect.facebook.net/'+encodeURIComponent(cfg.sdk_locale||'en_US')+'/sdk.js';
+      metaScript.setAttribute('data-dabbir-meta-sdk','true');
+      metaScript.onerror=()=>reject(new Error('META_SDK_LOAD_FAILED'));
+      document.head.appendChild(metaScript);
     });
     return sdkPromise;
   }
@@ -127,12 +169,14 @@ const script = String.raw`(()=>{
   }
 
   async function completeSignup(code,session){
+    report('complete_start',{stage:'server_complete',has_code:Boolean(code),has_waba:Boolean(session?.waba_id),has_phone:Boolean(session?.phone_number_id)});
     const response=await fetch('/api/dabbir-whatsapp-embedded-complete',{
       method:'POST',cache:'no-store',headers:{'content-type':'application/json','accept':'application/json'},
       body:JSON.stringify({business_id:businessId(),code,waba_id:session.waba_id,phone_number_id:session.phone_number_id})
     });
     const payload=await response.json().catch(()=>({}));
     if(!response.ok||!payload.ok) throw new Error(payload.error||'WHATSAPP_EMBEDDED_SIGNUP_FAILED');
+    report('complete_ok',{stage:'server_complete',has_waba:true,has_phone:true});
     if(typeof workspace!=='undefined'&&workspace) workspace.whatsapp={...(workspace.whatsapp||{}),...payload};
     configCache=null;
     await loadConfig(true).catch(()=>null);
@@ -140,17 +184,37 @@ const script = String.raw`(()=>{
     tell(ar()?'تم ربط WhatsApp بنجاح':'WhatsApp connected successfully');
   }
 
+  function failureText(key){
+    if(key==='META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED') return ar()?'إعداد Meta Embedded Signup الخاص بمنصة DABBIR غير مكتمل بعد':'DABBIR Meta Embedded Signup platform configuration is incomplete';
+    if(key==='META_AUTHORIZATION_CODE_MISSING') return ar()?'لم تُرجع Meta رمز التفويض. أغلق نافذة Meta وأعد المحاولة من زر ربط WhatsApp.':'Meta did not return an authorization code. Close the Meta window and retry from Connect WhatsApp.';
+    if(key==='META_EMBEDDED_SIGNUP_SESSION_MISSING') return ar()?'لم تصل بيانات حساب WhatsApp والرقم من Meta. لم يتم حفظ أي ربط ناقص.':'Meta did not return the WhatsApp account and phone data. No incomplete connection was saved.';
+    if(key==='META_SDK_LOAD_FAILED'||key==='META_SDK_LOAD_TIMEOUT') return ar()?'تعذر تحميل تسجيل الدخول من Meta. أعد المحاولة بعد تحديث الصفحة.':'Meta login could not load. Refresh the page and retry.';
+    return ar()?'تعذر ربط WhatsApp. لم يتم حفظ أي ربط غير مكتمل.':'WhatsApp could not be connected. No incomplete connection was saved.';
+  }
+
   async function connectWhatsApp(){
     if(busy) return;
     setBusy(true);
     embeddedSession=null;
+    let stage='start';
+    report('connect_start',{stage});
     try{
+      stage='platform_config';
       const cfg=await loadConfig(true);
+      report('config_loaded',{stage,has_code:false,has_waba:false,has_phone:false});
       if(!cfg?.platform_ready||!cfg.app_id||!cfg.config_id) throw new Error('META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED');
+
+      stage='sdk_load';
       const FB=await loadSdk(cfg);
+      report('sdk_ready',{stage});
+
+      stage='meta_login';
       const auth=await new Promise((resolve,reject)=>{
         try{
-          FB.login(response=>resolve(response),{
+          FB.login(response=>{
+            report('login_callback',{stage:'meta_login',has_code:Boolean(response?.authResponse?.code)});
+            resolve(response);
+          },{
             config_id:cfg.config_id,
             response_type:'code',
             override_default_response_type:true,
@@ -158,18 +222,24 @@ const script = String.raw`(()=>{
           });
         }catch(error){reject(error)}
       });
+
       const code=String(auth?.authResponse?.code||'');
       if(!code) throw new Error('META_AUTHORIZATION_CODE_MISSING');
+
+      stage='meta_session';
       const session=await waitForSession();
       if(!session?.waba_id||!session?.phone_number_id) throw new Error('META_EMBEDDED_SIGNUP_SESSION_MISSING');
+
+      stage='server_complete';
       await completeSignup(code,session);
     }catch(error){
-      const key=String(error?.message||'');
-      const text=key==='META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED'
-        ? (ar()?'إعداد Meta Embedded Signup الخاص بمنصة DABBIR غير مكتمل بعد':'DABBIR Meta Embedded Signup platform configuration is incomplete')
-        : (ar()?'تعذر ربط WhatsApp. لم يتم حفظ أي ربط غير مكتمل.':'WhatsApp could not be connected. No incomplete connection was saved.');
-      tell(text);
-    }finally{setBusy(false);renderActions()}
+      const key=String(error?.message||'WHATSAPP_EMBEDDED_SIGNUP_FAILED');
+      report('connect_error',{stage,error:key,has_waba:Boolean(embeddedSession?.waba_id),has_phone:Boolean(embeddedSession?.phone_number_id)});
+      tell(failureText(key));
+    }finally{
+      setBusy(false);
+      renderActions();
+    }
   }
 
   async function disconnectWhatsApp(){
@@ -214,11 +284,12 @@ const script = String.raw`(()=>{
     if(connected){
       const disconnect=document.createElement('button');disconnect.type='button';disconnect.className='dabbirWhatsAppDisconnect';disconnect.textContent=ar()?'فصل WhatsApp':'Disconnect WhatsApp';disconnect.onclick=disconnectWhatsApp;disconnect.disabled=busy;box.appendChild(disconnect);
     }
-    if(!cfg.platform_ready){
-      const hint=document.createElement('span');hint.className='dabbirWhatsAppHint';hint.textContent=ar()?'إعداد Meta Embedded Signup للمنصة يحتاج App ID وConfiguration ID قبل فتح نافذة الربط.':'Platform Meta Embedded Signup needs an App ID and Configuration ID before the connection window can open.';box.appendChild(hint);
-    }else{
-      const hint=document.createElement('span');hint.className='dabbirWhatsAppHint';hint.textContent=ar()?'الربط يتم داخل DABBIR عبر نافذة Meta الرسمية. لا تحتاج إلى نسخ Tokens أو IDs.':'Connection happens inside DABBIR through Meta’s official window. No tokens or IDs need to be copied.';box.appendChild(hint);
-    }
+    const hint=document.createElement('span');
+    hint.className='dabbirWhatsAppHint';
+    hint.textContent=cfg.platform_ready
+      ? (ar()?'الربط يتم داخل DABBIR عبر نافذة Meta الرسمية. اترك النافذة مفتوحة حتى تنتهي كل خطوات Meta.':'Connection happens inside DABBIR through Meta’s official window. Keep the window open until every Meta step finishes.')
+      : (ar()?'إعداد Meta Embedded Signup للمنصة يحتاج App ID وConfiguration ID قبل فتح نافذة الربط.':'Platform Meta Embedded Signup needs an App ID and Configuration ID before the connection window can open.');
+    box.appendChild(hint);
   }
 
   if(typeof renderIntegrations==='function'&&!window.__dabbirWhatsAppEmbeddedRenderWrapped){

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -31,6 +31,32 @@ test('Embedded Signup UI connects through Meta inside DABBIR without manual toke
   assert.doesNotMatch(ui, /type=["']password["']/);
 });
 
+test('Embedded Signup does not time out during a normal multi-step Meta mobile journey', async () => {
+  const ui = await read('api/dabbir-whatsapp-embedded-ui.js');
+  assert.match(ui, /SESSION_TIMEOUT_MS=15\*60\*1000/);
+  assert.doesNotMatch(ui, /waitForSession\(timeoutMs=12000\)/);
+  assert.match(ui, /https:\/\/m\.facebook\.com/);
+  assert.match(ui, /https:\/\/business\.facebook\.com/);
+});
+
+test('Embedded Signup reports safe client stages to production logs without tokens or asset IDs', async () => {
+  const ui = await read('api/dabbir-whatsapp-embedded-ui.js');
+  const events = await read('api/dabbir-whatsapp-client-event.js');
+  assert.match(ui, /\/api\/dabbir-whatsapp-client-event/);
+  assert.match(ui, /connect_start/);
+  assert.match(ui, /login_callback/);
+  assert.match(ui, /session_finish/);
+  assert.match(ui, /complete_start/);
+  assert.match(ui, /connect_error/);
+  assert.match(events, /DABBIR_WHATSAPP_EMBEDDED_CLIENT/);
+  assert.match(events, /has_code/);
+  assert.match(events, /has_waba/);
+  assert.match(events, /has_phone/);
+  assert.doesNotMatch(events, /access_token/);
+  assert.doesNotMatch(events, /phone_number_id/);
+  assert.doesNotMatch(events, /waba_id/);
+});
+
 test('Embedded completion exchanges authorization code server-side and never returns access token', async () => {
   const endpoint = await read('api/dabbir-whatsapp-embedded-complete.js');
   assert.match(endpoint, /exchangeEmbeddedCode/);


### PR DESCRIPTION
Fix the next blocking failure in DABBIR WhatsApp Embedded Signup. The UI was waiting only 12 seconds for the WA_EMBEDDED_SIGNUP session payload, which is too short for the real multi-step Meta mobile flow and can abort before FINISH arrives. Extend the session window to 15 minutes, support additional legitimate Meta mobile/business postMessage origins, make SDK reuse resilient, surface stage-specific user errors, and add safe server-side client-stage telemetry (booleans only; no tokens, WABA IDs, or phone IDs) so future failures can be diagnosed from production logs instead of screenshots. Adds regression coverage.