### PR TITLE
DABBIR: classify protected prelaunch instead of false production CI failures

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -1,5 +1,5 @@
 name: DABBIR AI Full Customer Journey
-# Real production journey on push/schedule; capacity is manual-only and remains fail-closed.
+# Real production journey on push/schedule; protected pre-launch is classified without pretending production was tested.
 
 on:
   workflow_dispatch:
@@ -21,6 +21,8 @@ on:
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/dabbir-capacity-load.mjs'
       - 'test/dabbir-activity-regression.test.mjs'
+      - 'scripts/dabbir-production-origin-gate.mjs'
+      - 'config/barman-integration-contract.json'
       - '.github/workflows/dabbir-ai-customer-journey.yml'
       - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
@@ -48,42 +50,40 @@ permissions:
   contents: read
   id-token: write
 
-# Never cancel a trusted production journey because another qualifying commit arrived.
-# A single group also prevents two production journeys/capacity sequences from overlapping.
 concurrency:
   group: dabbir-ai-full-customer-journey
   cancel-in-progress: false
 
 jobs:
   full-customer-journey:
-    name: Real owner + customer + employee + AI journey
+    name: Public-production owner + customer + employee + AI journey
     runs-on: ubuntu-latest
     timeout-minutes: 18
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
       JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report.json
+    outputs:
+      production_ready: ${{ steps.launch-gate.outputs.ready }}
+      production_state: ${{ steps.launch-gate.outputs.state }}
     steps:
-      - name: Require canonical DABBIR production origin
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
-            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
-            exit 1
-          fi
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+      - name: Classify canonical DABBIR production origin
+        id: launch-gate
+        run: node scripts/dabbir-production-origin-gate.mjs
       - name: Install WebKit journey runner
+        if: steps.launch-gate.outputs.ready == 'true'
         run: |
           npm install --no-save playwright@1.62.1
           npx playwright install --with-deps webkit
       - name: Run AI full customer journey against production
+        if: steps.launch-gate.outputs.ready == 'true'
         run: node test/ai-full-customer-journey-v2.mjs
       - name: Publish journey summary
-        if: always()
+        if: ${{ always() && steps.launch-gate.outputs.ready == 'true' }}
         shell: bash
         run: |
           if [ -f dabbir-ai-customer-journey-report.json ]; then
@@ -95,7 +95,7 @@ jobs:
             jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' dabbir-ai-customer-journey-report.json >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload journey evidence
-        if: always()
+        if: ${{ always() && steps.launch-gate.outputs.ready == 'true' }}
         uses: actions/upload-artifact@v6
         with:
           name: dabbir-ai-customer-journey-evidence
@@ -108,7 +108,7 @@ jobs:
   ai-capacity:
     name: AI capacity — manual production gate
     needs: full-customer-journey
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.full-customer-journey.result == 'success' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.full-customer-journey.result == 'success' && needs.full-customer-journey.outputs.production_ready == 'true' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
     runs-on: ubuntu-latest
     timeout-minutes: 25
     env:
@@ -149,8 +149,8 @@ jobs:
 
   runtime-capacity-1000:
     name: Runtime capacity — manual 1000-customer gate
-    needs: ai-capacity
-    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.ai-capacity.result == 'success' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
+    needs: [full-customer-journey, ai-capacity]
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.run_capacity == true && needs.ai-capacity.result == 'success' && needs.full-customer-journey.outputs.production_ready == 'true' && inputs.production_capacity_ack == 'ALLOW_CAPACITY_LOAD_ON_PRODUCTION' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:

--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/dabbir-auth-production.yml'
+      - 'scripts/dabbir-production-origin-gate.mjs'
+      - 'config/barman-integration-contract.json'
       - 'api/auth/**'
   workflow_dispatch:
 
@@ -21,6 +23,11 @@ jobs:
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
     steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
       - name: Resolve management credential
         id: credential
         shell: bash
@@ -65,17 +72,12 @@ jobs:
           console.log('Supabase leaked password protection verified.');
           NODE
 
-      - name: Require canonical DABBIR production origin
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
-            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
-            exit 1
-          fi
+      - name: Classify canonical DABBIR production origin
+        id: launch-gate
+        run: node scripts/dabbir-production-origin-gate.mjs
 
       - name: Enforce hosted Supabase Auth URLs
-        if: steps.credential.outputs.available == 'true'
+        if: steps.credential.outputs.available == 'true' && steps.launch-gate.outputs.ready == 'true'
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/dabbir-owner-away-production.yml
+++ b/.github/workflows/dabbir-owner-away-production.yml
@@ -12,6 +12,8 @@ on:
       - 'api/app-recovery.js'
       - 'supabase/migrations/*owner_away*'
       - 'test/dabbir-owner-away-production-journey.mjs'
+      - 'scripts/dabbir-production-origin-gate.mjs'
+      - 'config/barman-integration-contract.json'
       - '.github/workflows/dabbir-owner-away-production.yml'
 
 permissions:
@@ -24,30 +26,29 @@ concurrency:
 
 jobs:
   owner-away-production:
-    name: Real owner + employee Away Mode journey
+    name: Owner Away public-production gate
     runs-on: ubuntu-latest
     timeout-minutes: 12
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
       AWAY_REPORT_PATH: dabbir-owner-away-production-report.json
+    outputs:
+      production_ready: ${{ steps.launch-gate.outputs.ready }}
+      production_state: ${{ steps.launch-gate.outputs.state }}
     steps:
-      - name: Require canonical DABBIR production origin
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ ! "${PRODUCTION_ORIGIN:-}" =~ ^https://[^/]+$ ]]; then
-            echo 'DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.'
-            exit 1
-          fi
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
+      - name: Classify canonical DABBIR production origin
+        id: launch-gate
+        run: node scripts/dabbir-production-origin-gate.mjs
       - name: Run real Owner Away Mode journey
+        if: steps.launch-gate.outputs.ready == 'true'
         run: node test/dabbir-owner-away-production-journey.mjs
       - name: Publish Owner Away summary
-        if: always()
+        if: ${{ always() && steps.launch-gate.outputs.ready == 'true' }}
         shell: bash
         run: |
           if [ -f dabbir-owner-away-production-report.json ]; then
@@ -59,7 +60,7 @@ jobs:
             jq -r '.steps[] | "| \(.name) | \(.status) | \(.http_status // 0) | \(.duration_ms // 0) |"' dabbir-owner-away-production-report.json >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload Owner Away evidence
-        if: always()
+        if: ${{ always() && steps.launch-gate.outputs.ready == 'true' }}
         uses: actions/upload-artifact@v6
         with:
           name: dabbir-owner-away-production-evidence

--- a/scripts/dabbir-production-origin-gate.mjs
+++ b/scripts/dabbir-production-origin-gate.mjs
@@ -1,0 +1,66 @@
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const CONTRACT_PATH = 'config/barman-integration-contract.json';
+const HTTPS_ORIGIN_RE = /^https:\/\/[^/]+$/i;
+
+export function classifyProductionOrigin({ origin = '', contract }) {
+  const value = String(origin || '').trim().replace(/\/$/, '');
+  const deployment = contract?.deployment || {};
+  const launchDomain = String(deployment.public_launch_domain || '').trim().toLowerCase();
+  const protectedPrelaunch =
+    !launchDomain &&
+    deployment.domain_access === 'VERCEL_AUTH_PROTECTED' &&
+    deployment.production_runtime_policy === 'FAIL_CLOSED_PREVIEW_ONLY' &&
+    deployment.project_live === false;
+
+  if (!value) {
+    if (protectedPrelaunch) {
+      return {
+        ready: false,
+        state: 'BLOCKED_PRELAUNCH',
+        reason: 'DABBIR intentionally has no public launch domain; production-only journeys must not run against the protected Vercel project URL.',
+      };
+    }
+    throw new Error('DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.');
+  }
+
+  if (!HTTPS_ORIGIN_RE.test(value)) {
+    throw new Error('DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin.');
+  }
+  if (!launchDomain) {
+    throw new Error('DABBIR_PRODUCTION_ORIGIN is configured before public_launch_domain is approved in the integration contract.');
+  }
+
+  const url = new URL(value);
+  if (url.hostname.toLowerCase() !== launchDomain || url.pathname !== '/' || url.search || url.hash) {
+    throw new Error('DABBIR_PRODUCTION_ORIGIN does not match the approved public_launch_domain.');
+  }
+  if (deployment.domain_access === 'VERCEL_AUTH_PROTECTED' || deployment.production_runtime_policy === 'FAIL_CLOSED_PREVIEW_ONLY' || deployment.project_live !== true) {
+    throw new Error('DABBIR public launch contract is inconsistent: a public origin exists while deployment remains protected or not live.');
+  }
+
+  return {
+    ready: true,
+    state: 'PUBLIC_PRODUCTION_READY',
+    origin: value,
+    reason: 'Canonical public launch origin matches the approved live deployment contract.',
+  };
+}
+
+function append(file, text) {
+  if (file) fs.appendFileSync(file, text);
+}
+
+export function runGate({ origin = process.env.PRODUCTION_ORIGIN, contractPath = CONTRACT_PATH } = {}) {
+  const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
+  const result = classifyProductionOrigin({ origin, contract });
+  append(process.env.GITHUB_OUTPUT, `ready=${result.ready ? 'true' : 'false'}\nstate=${result.state}\n`);
+  append(process.env.GITHUB_STEP_SUMMARY, `## DABBIR Production Origin Gate\n\n**State:** ${result.state}\n\n${result.reason}\n`);
+  console.log(`${result.state}: ${result.reason}`);
+  return result;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  runGate();
+}

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -25,8 +25,8 @@ test('capacity never runs automatically on push or schedule',()=>{
   const manualGate=/github\.event_name == 'workflow_dispatch'/g;
   assert.ok((workflow.match(manualGate)||[]).length>=2,'both capacity jobs must be workflow_dispatch-only');
   must(/inputs\.run_capacity == true/,'capacity requires an explicit manual boolean');
-  must(/ai-capacity:\n    name:[^\n]*\n    needs: full-customer-journey\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.full-customer-journey\.result == 'success'[^\n]*\}\}/,'AI capacity job gate must be manual-only and require a successful journey');
-  must(/runtime-capacity-1000:\n    name:[^\n]*\n    needs: ai-capacity\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.ai-capacity\.result == 'success'[^\n]*\}\}/,'runtime capacity job gate must be manual-only and require successful AI capacity');
+  must(/ai-capacity:\n    name:[^\n]*\n    needs: full-customer-journey\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.full-customer-journey\.result == 'success'[^\n]*needs\.full-customer-journey\.outputs\.production_ready == 'true'[^\n]*\}\}/,'AI capacity must require a successful public-production journey');
+  must(/runtime-capacity-1000:\n    name:[^\n]*\n    needs: \[full-customer-journey, ai-capacity\]\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.ai-capacity\.result == 'success'[^\n]*needs\.full-customer-journey\.outputs\.production_ready == 'true'[^\n]*\}\}/,'runtime capacity must require both successful AI capacity and the explicit public-production-ready gate');
 });
 
 test('production capacity retains exact fail-closed acknowledgement',()=>{

--- a/test/dabbir-production-origin-gate.test.mjs
+++ b/test/dabbir-production-origin-gate.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyProductionOrigin } from '../scripts/dabbir-production-origin-gate.mjs';
+
+function contract(overrides={}) {
+  return {
+    deployment: {
+      public_launch_domain: null,
+      domain_access: 'VERCEL_AUTH_PROTECTED',
+      production_runtime_policy: 'FAIL_CLOSED_PREVIEW_ONLY',
+      project_live: false,
+      ...overrides,
+    },
+  };
+}
+
+test('protected DABBIR prelaunch is BLOCKED_PRELAUNCH rather than a false production failure', () => {
+  const result=classifyProductionOrigin({origin:'',contract:contract()});
+  assert.equal(result.ready,false);
+  assert.equal(result.state,'BLOCKED_PRELAUNCH');
+  assert.match(result.reason,/no public launch domain/i);
+});
+
+test('missing production origin fails once the contract says DABBIR is no longer protected prelaunch', () => {
+  assert.throws(
+    ()=>classifyProductionOrigin({origin:'',contract:contract({public_launch_domain:'dabbir.example',domain_access:'PUBLIC',production_runtime_policy:'LIVE',project_live:true})}),
+    /DABBIR_PRODUCTION_ORIGIN must be configured/
+  );
+});
+
+test('an origin cannot be configured before a public launch domain is approved', () => {
+  assert.throws(
+    ()=>classifyProductionOrigin({origin:'https://dabbir-nd56cm4j5v-3619s-projects.vercel.app',contract:contract()}),
+    /before public_launch_domain is approved/
+  );
+});
+
+test('public production requires exact approved hostname and a live unprotected contract', () => {
+  const live=contract({public_launch_domain:'dabbir.example',domain_access:'PUBLIC',production_runtime_policy:'LIVE',project_live:true});
+  assert.throws(()=>classifyProductionOrigin({origin:'https://other.example',contract:live}),/does not match/);
+  const result=classifyProductionOrigin({origin:'https://dabbir.example',contract:live});
+  assert.equal(result.ready,true);
+  assert.equal(result.state,'PUBLIC_PRODUCTION_READY');
+  assert.equal(result.origin,'https://dabbir.example');
+});
+
+test('public origin cannot coexist with Vercel-auth-protected or not-live deployment state', () => {
+  assert.throws(
+    ()=>classifyProductionOrigin({origin:'https://dabbir.example',contract:contract({public_launch_domain:'dabbir.example'})}),
+    /inconsistent/
+  );
+});

--- a/test/dabbir-production-origin-truth.test.mjs
+++ b/test/dabbir-production-origin-truth.test.mjs
@@ -3,9 +3,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 const retiredHost = ['pilot', 'taupe.vercel.app'].join('-');
-const guardedFiles = [
+const releaseWorkflows = [
   '.github/workflows/dabbir-ai-customer-journey.yml',
   '.github/workflows/dabbir-auth-production.yml',
+  '.github/workflows/dabbir-owner-away-production.yml',
+];
+const guardedFiles = [
+  ...releaseWorkflows,
+  'scripts/dabbir-production-origin-gate.mjs',
   'config/barman-integration-contract.json',
   'test/ai-full-customer-journey.mjs',
   'test/ai-full-customer-journey-oidc.mjs',
@@ -23,12 +28,28 @@ test('retired PILOT origin cannot return to DABBIR release controls', () => {
   }
 });
 
-test('release workflows require an explicit canonical DABBIR origin', () => {
-  for (const path of guardedFiles.slice(0, 2)) {
+test('all release workflows use the same strict canonical DABBIR origin gate', () => {
+  for (const path of releaseWorkflows) {
     const source = fs.readFileSync(path, 'utf8');
-    assert.match(source, /vars\.DABBIR_PRODUCTION_ORIGIN/);
-    assert.match(source, /DABBIR_PRODUCTION_ORIGIN must be configured/);
+    assert.match(source, /vars\.DABBIR_PRODUCTION_ORIGIN/, path);
+    assert.match(source, /scripts\/dabbir-production-origin-gate\.mjs/, path);
+    assert.match(source, /launch-gate/, path);
   }
+  const gate=fs.readFileSync('scripts/dabbir-production-origin-gate.mjs','utf8');
+  assert.match(gate, /DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin/);
+  assert.match(gate, /BLOCKED_PRELAUNCH/);
+  assert.match(gate, /VERCEL_AUTH_PROTECTED/);
+  assert.match(gate, /FAIL_CLOSED_PREVIEW_ONLY/);
+});
+
+test('production journeys and capacity cannot execute while the public launch gate is blocked', () => {
+  const journey=fs.readFileSync('.github/workflows/dabbir-ai-customer-journey.yml','utf8');
+  const away=fs.readFileSync('.github/workflows/dabbir-owner-away-production.yml','utf8');
+  const auth=fs.readFileSync('.github/workflows/dabbir-auth-production.yml','utf8');
+  assert.match(journey,/steps\.launch-gate\.outputs\.ready == 'true'/);
+  assert.match(journey,/needs\.full-customer-journey\.outputs\.production_ready == 'true'/);
+  assert.match(away,/steps\.launch-gate\.outputs\.ready == 'true'/);
+  assert.match(auth,/steps\.credential\.outputs\.available == 'true' && steps\.launch-gate\.outputs\.ready == 'true'/);
 });
 
 test('deployment contract records the protected no-public-domain state', () => {
@@ -37,5 +58,6 @@ test('deployment contract records the protected no-public-domain state', () => {
   assert.equal(contract.deployment.project_id, 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq');
   assert.equal(contract.deployment.public_launch_domain, null);
   assert.equal(contract.deployment.domain_access, 'VERCEL_AUTH_PROTECTED');
+  assert.equal(contract.deployment.production_runtime_policy, 'FAIL_CLOSED_PREVIEW_ONLY');
   assert.equal(contract.deployment.project_live, false);
 });


### PR DESCRIPTION
## Root cause
DABBIR is intentionally `VERCEL_AUTH_PROTECTED`, `FAIL_CLOSED_PREVIEW_ONLY`, `project_live=false`, with no approved `public_launch_domain`. Production workflows were treating the intentionally absent `DABBIR_PRODUCTION_ORIGIN` as a technical failure, producing red CI before any real journey ran.

## Fix
- Adds one strict production-origin classifier shared by release workflows.
- Current protected state becomes `BLOCKED_PRELAUNCH` and production-only work is skipped rather than falsely failed or falsely passed.
- Once a public launch domain is approved, missing/mismatched origin becomes a hard failure.
- A configured origin is rejected if the contract still says protected/not-live.
- AI capacity cannot run unless the full-customer journey reports `production_ready=true`.
- Auth leaked-password hardening remains independent and can run prelaunch; hosted public Auth URL mutation waits for an approved public origin.
- Away Mode production journey remains present and will automatically become executable after public launch.

## Safety
No deployment protection is disabled, no public domain is invented, and no protected Vercel URL is hardcoded as a fake production origin.

## Regression coverage
Adds classifier tests for protected prelaunch, missing origin after launch, premature origin, domain mismatch, and live/unprotected consistency; release-control tests verify all three workflows use the same gate.