### PR TITLE
DABBIR: Cash Guardian verified-evidence MVP

### DIFF
--- a/api/_cash-guardian.js
+++ b/api/_cash-guardian.js
@@ -1,0 +1,296 @@
+import { supabaseRest } from './_auth-core.js';
+
+const DAY_MS=24*60*60*1000;
+const BALANCE_MAX_AGE_MS=72*60*60*1000;
+const COVERAGE_MAX_AGE_MS=24*60*60*1000;
+const CLOCK_SKEW_MS=5*60*1000;
+
+const amount=value=>Number.isFinite(Number(value))?Math.max(0,Number(value)):0;
+const time=value=>{
+  const ms=value?Date.parse(value):NaN;
+  return Number.isFinite(ms)?ms:null;
+};
+const round=value=>Math.round((Number(value)||0)*100)/100;
+
+async function readJson(response,fallback){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=response.status;
+    error.detail=payload?.message||payload?.code||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=(token,path,fallback)=>supabaseRest(path,token).then(response=>readJson(response,fallback));
+const recordKey=row=>`${String(row?.source_system||'')}\u0000${String(row?.source_record_id||'')}`;
+
+function trace(row,openAmount=null){
+  return {
+    evidence_id:row.id,
+    evidence_type:row.evidence_type,
+    amount_aed:round(openAmount===null?amount(row.amount_aed):openAmount),
+    effective_at:row.effective_at||null,
+    due_at:row.due_at||null,
+    source_kind:row.source_kind||null,
+    source_system:row.source_system||null,
+    source_record_id:row.source_record_id||null,
+    source_event_id:row.source_event_id||null,
+    source_observed_at:row.source_observed_at||null,
+  };
+}
+
+function openItems(evidence,dueType,settledType,nowMs){
+  const settledByRecord=new Map();
+  for(const row of evidence){
+    if(row.evidence_type!==settledType)continue;
+    const effective=time(row.effective_at);
+    if(effective===null||effective>nowMs+CLOCK_SKEW_MS)continue;
+    const key=recordKey(row);
+    settledByRecord.set(key,(settledByRecord.get(key)||0)+amount(row.amount_aed));
+  }
+
+  return evidence
+    .filter(row=>row.evidence_type===dueType)
+    .map(row=>{
+      const due=time(row.due_at);
+      const effective=time(row.effective_at);
+      if(due===null||effective===null||effective>nowMs+CLOCK_SKEW_MS)return null;
+      const settled=settledByRecord.get(recordKey(row))||0;
+      const open=round(Math.max(0,amount(row.amount_aed)-settled));
+      if(open<=0)return null;
+      return {...row,open_amount_aed:open,due_ms:due};
+    })
+    .filter(Boolean);
+}
+
+function qualifyingCoverage(rows,scope,nowMs,horizonEndMs){
+  return (rows||[])
+    .filter(row=>row.scope===scope&&row.coverage_level==='complete')
+    .filter(row=>{
+      const start=time(row.coverage_start);
+      const end=time(row.coverage_end);
+      const observed=time(row.source_observed_at);
+      return start!==null&&end!==null&&observed!==null
+        && start<=nowMs
+        && end>=horizonEndMs
+        && observed<=nowMs+CLOCK_SKEW_MS
+        && nowMs-observed<=COVERAGE_MAX_AGE_MS;
+    })
+    .sort((a,b)=>(time(b.source_observed_at)||0)-(time(a.source_observed_at)||0))[0]||null;
+}
+
+export function evaluateCashGuardian({evidence=[],coverage=[],settings=null,nowMs=Date.now()}={}){
+  const rows=Array.isArray(evidence)?evidence:[];
+  const coverageRows=Array.isArray(coverage)?coverage:[];
+  const horizonDays=Math.min(30,Math.max(1,Number(settings?.horizon_days)||14));
+  const horizonEndMs=nowMs+horizonDays*DAY_MS;
+  const bufferThreshold=settings?.buffer_threshold_aed===null||settings?.buffer_threshold_aed===undefined
+    ? null
+    : round(amount(settings.buffer_threshold_aed));
+
+  const balances=rows
+    .filter(row=>row.evidence_type==='cash_balance')
+    .filter(row=>{
+      const effective=time(row.effective_at);
+      return effective!==null&&effective<=nowMs+CLOCK_SKEW_MS;
+    })
+    .sort((a,b)=>(time(b.effective_at)||0)-(time(a.effective_at)||0));
+  const latestBalance=balances[0]||null;
+  const balanceEffectiveMs=time(latestBalance?.effective_at);
+  const balanceObservedMs=time(latestBalance?.source_observed_at);
+  const balanceFresh=!!latestBalance
+    && balanceEffectiveMs!==null
+    && balanceObservedMs!==null
+    && nowMs-balanceEffectiveMs<=BALANCE_MAX_AGE_MS
+    && nowMs-balanceObservedMs<=BALANCE_MAX_AGE_MS
+    && balanceObservedMs<=nowMs+CLOCK_SKEW_MS;
+
+  const inflowCoverage=qualifyingCoverage(coverageRows,'inflows',nowMs,horizonEndMs);
+  const outflowCoverage=qualifyingCoverage(coverageRows,'outflows',nowMs,horizonEndMs);
+  const insufficiency=[];
+  if(!latestBalance)insufficiency.push('BALANCE_MISSING');
+  else if(!balanceFresh)insufficiency.push('BALANCE_STALE');
+  if(!inflowCoverage)insufficiency.push('INFLOW_COVERAGE_INCOMPLETE');
+  if(!outflowCoverage)insufficiency.push('OUTFLOW_COVERAGE_INCOMPLETE');
+
+  const receivables=openItems(rows,'receivable_due','receivable_settled',nowMs);
+  const payables=openItems(rows,'payable_due','payable_settled',nowMs);
+  const overdueReceivables=receivables.filter(row=>row.due_ms<nowMs);
+  const overduePayables=payables.filter(row=>row.due_ms<nowMs);
+  const horizonReceivables=receivables.filter(row=>row.due_ms<=horizonEndMs);
+  const horizonPayables=payables.filter(row=>row.due_ms<=horizonEndMs);
+  const receivableTotal=round(horizonReceivables.reduce((sum,row)=>sum+row.open_amount_aed,0));
+  const payableTotal=round(horizonPayables.reduce((sum,row)=>sum+row.open_amount_aed,0));
+  const overdueReceivableTotal=round(overdueReceivables.reduce((sum,row)=>sum+row.open_amount_aed,0));
+  const overduePayableTotal=round(overduePayables.reduce((sum,row)=>sum+row.open_amount_aed,0));
+  const sufficient=insufficiency.length===0;
+  const hasAnyEvidence=rows.length>0||coverageRows.length>0||!!settings;
+
+  let status='DATA_INSUFFICIENT';
+  let liquidityRange=null;
+  if(sufficient){
+    const balance=round(amount(latestBalance.amount_aed));
+    const lower=round(balance-payableTotal);
+    const upper=round(lower+receivableTotal);
+    const appliedThreshold=bufferThreshold===null?0:bufferThreshold;
+    if(upper<0)status='CRITICAL';
+    else if(lower<0)status='RISK';
+    else if(bufferThreshold!==null&&lower<appliedThreshold)status='WATCH';
+    else status='CLEAR';
+    liquidityRange={
+      horizon_days:horizonDays,
+      horizon_end:new Date(horizonEndMs).toISOString(),
+      current_balance_aed:balance,
+      committed_outflows_aed:payableTotal,
+      verified_receivables_aed:receivableTotal,
+      lower_bound_aed:lower,
+      upper_bound_aed:upper,
+      owner_buffer_threshold_aed:bufferThreshold,
+      hard_floor_aed:0,
+      meaning:'LOWER_EXCLUDES_RECEIVABLES_UPPER_ASSUMES_ALL_VERIFIED_RECEIVABLES_ARRIVE',
+    };
+  }
+
+  const autoEligibleOverdue=overdueReceivables.filter(row=>row.customer_id&&row.conversation_id).length;
+  const actions=[];
+  if(overdueReceivables.length){
+    actions.push({
+      key:'FOLLOW_UP_OVERDUE_RECEIVABLES',
+      count:overdueReceivables.length,
+      amount_aed:overdueReceivableTotal,
+      auto_internal_followup_eligible:autoEligibleOverdue,
+      owner_gate:false,
+      external_side_effects:false,
+      financial_side_effects:false,
+    });
+  }
+  if(status==='CRITICAL'||status==='RISK'||status==='WATCH'){
+    actions.push({
+      key:'OWNER_REVIEW_CASH_COMMITMENTS',
+      owner_gate:true,
+      external_side_effects:false,
+      financial_side_effects:false,
+      money_movement:false,
+    });
+  }
+  if(status==='DATA_INSUFFICIENT'&&hasAnyEvidence){
+    actions.push({
+      key:'RESTORE_FINANCIAL_DATA_COVERAGE',
+      missing:insufficiency,
+      owner_gate:false,
+      external_side_effects:false,
+      financial_side_effects:false,
+    });
+  }
+
+  return {
+    status,
+    sufficient_data:sufficient,
+    insufficiency_reasons:insufficiency,
+    generated_at:new Date(nowMs).toISOString(),
+    horizon_days:horizonDays,
+    has_any_financial_evidence:hasAnyEvidence,
+    liquidity_range:liquidityRange,
+    overdue_receivables:{count:overdueReceivables.length,amount_aed:overdueReceivableTotal,auto_internal_followup_eligible:autoEligibleOverdue},
+    overdue_payables:{count:overduePayables.length,amount_aed:overduePayableTotal},
+    coverage:{
+      inflows:inflowCoverage?{status:'COMPLETE',source_system:inflowCoverage.source_system,source_observed_at:inflowCoverage.source_observed_at,coverage_end:inflowCoverage.coverage_end}:{status:'INSUFFICIENT'},
+      outflows:outflowCoverage?{status:'COMPLETE',source_system:outflowCoverage.source_system,source_observed_at:outflowCoverage.source_observed_at,coverage_end:outflowCoverage.coverage_end}:{status:'INSUFFICIENT'},
+      balance:latestBalance?{status:balanceFresh?'FRESH':'STALE',effective_at:latestBalance.effective_at,source_system:latestBalance.source_system,source_observed_at:latestBalance.source_observed_at}:{status:'MISSING'},
+    },
+    actions,
+    traceability:{
+      balance:latestBalance?trace(latestBalance):null,
+      receivables:horizonReceivables.map(row=>trace(row,row.open_amount_aed)),
+      payables:horizonPayables.map(row=>trace(row,row.open_amount_aed)),
+      overdue_receivables:overdueReceivables.map(row=>trace(row,row.open_amount_aed)),
+    },
+    truth:{
+      orders_are_not_cash_receipts:true,
+      simulated_orders_ignored:true,
+      unverified_forecast_blocked:true,
+      money_movement_capability:false,
+      payment_execution_capability:false,
+      external_followup_sent:false,
+      range_not_point_forecast:true,
+    },
+  };
+}
+
+export async function loadCashGuardianSnapshot({token,businessId,nowMs=Date.now()}){
+  const [evidence,coverage,settingsRows]=await Promise.all([
+    rest(token,`dabbir_financial_evidence?select=id,evidence_type,amount_aed,effective_at,due_at,source_kind,source_system,source_record_id,source_event_id,source_observed_at,customer_id,conversation_id,verified_at,created_at&business_id=eq.${businessId}&order=effective_at.desc&limit=500`,'CASH_EVIDENCE_LOOKUP_FAILED'),
+    rest(token,`dabbir_financial_coverage?select=id,scope,coverage_level,coverage_start,coverage_end,source_kind,source_system,source_observed_at,verified_at,created_at&business_id=eq.${businessId}&order=source_observed_at.desc&limit=100`,'CASH_COVERAGE_LOOKUP_FAILED'),
+    rest(token,`dabbir_cash_guardian_settings?select=business_id,horizon_days,buffer_threshold_aed,updated_at&business_id=eq.${businessId}&limit=1`,'CASH_SETTINGS_LOOKUP_FAILED'),
+  ]);
+  return evaluateCashGuardian({
+    evidence:Array.isArray(evidence)?evidence:[],
+    coverage:Array.isArray(coverage)?coverage:[],
+    settings:Array.isArray(settingsRows)?settingsRows[0]||null:null,
+    nowMs,
+  });
+}
+
+export function cashGuardianActionCenterItem(snapshot){
+  if(!snapshot)return null;
+  const range=snapshot.liquidity_range;
+  if(['CRITICAL','RISK','WATCH'].includes(snapshot.status)&&range){
+    const severe=snapshot.status==='CRITICAL';
+    const amountText=`${range.lower_bound_aed.toFixed(2)}–${range.upper_bound_aed.toFixed(2)} د.إ`;
+    const amountTextEn=`AED ${range.lower_bound_aed.toFixed(2)}–${range.upper_bound_aed.toFixed(2)}`;
+    return {
+      id:'cash_guardian:liquidity_risk',
+      type:'cash_guardian',
+      priority:severe?99:88,
+      severity:severe?'critical':'warning',
+      owner_gate:true,
+      title_ar:severe?'خطر سيولة يحتاج قرارك':'السيولة قد تنخفض عن الحد الآمن',
+      title_en:severe?'Cash risk needs your decision':'Cash may fall below the safe level',
+      detail_ar:`النطاق الموثق خلال ${range.horizon_days} يومًا: ${amountText}. لا توجد حركة أموال تلقائية.`,
+      detail_en:`Verified ${range.horizon_days}-day range: ${amountTextEn}. No money movement is automatic.`,
+      target:'dashboard',
+      entity_id:null,
+      due_at:range.horizon_end,
+    };
+  }
+
+  const overdue=snapshot.overdue_receivables||{};
+  if(Number(overdue.count)>Number(overdue.auto_internal_followup_eligible)&&Number(overdue.amount_aed)>0){
+    return {
+      id:'cash_guardian:unmapped_overdue_receivables',
+      type:'cash_guardian',
+      priority:70,
+      severity:'warning',
+      owner_gate:false,
+      title_ar:'مستحقات متأخرة بلا مسار متابعة كامل',
+      title_en:'Overdue receivables need a follow-up path',
+      detail_ar:`${Number(overdue.amount_aed).toFixed(2)} د.إ متأخرة ومثبتة، وبعضها لا يملك محادثة/عميلًا مرتبطًا للمتابعة الداخلية التلقائية.`,
+      detail_en:`AED ${Number(overdue.amount_aed).toFixed(2)} is verified overdue; some items lack a linked customer/conversation for automatic internal follow-up.`,
+      target:'tasks',
+      entity_id:null,
+      due_at:null,
+    };
+  }
+
+  if(snapshot.status==='DATA_INSUFFICIENT'&&snapshot.has_any_financial_evidence){
+    return {
+      id:'cash_guardian:data_gap',
+      type:'cash_guardian',
+      priority:34,
+      severity:'info',
+      owner_gate:false,
+      title_ar:'حارس السيولة لا يملك تغطية كافية بعد',
+      title_en:'Cash Guardian needs more verified coverage',
+      detail_ar:'لن يعرض دَبِّر Forecast أو خطر سيولة غير مسند حتى تكتمل بيانات الرصيد والمستحقات والالتزامات.',
+      detail_en:'DABBIR will not claim a cash forecast or liquidity risk until balance, receivable, and commitment coverage is sufficient.',
+      target:'integrations',
+      entity_id:null,
+      due_at:null,
+    };
+  }
+  return null;
+}

--- a/api/cash-guardian.js
+++ b/api/cash-guardian.js
@@ -1,0 +1,104 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+} from './_auth-core.js';
+import { loadCashGuardianSnapshot } from './_cash-guardian.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+
+function membershipFor(memberships,businessId){
+  return (memberships||[]).find(item=>item.business_id===businessId)||null;
+}
+
+async function readData(response,fallback){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=response.status;
+    error.detail=payload?.message||payload?.code||null;
+    throw error;
+  }
+  return payload;
+}
+
+function normalizeThreshold(value){
+  if(value===null||value===undefined||value==='')return null;
+  const number=Number(value);
+  return Number.isFinite(number)&&number>=0&&number<=1000000000?Math.round(number*100)/100:undefined;
+}
+
+export default async function handler(req,res){
+  const token=accessTokenFromRequest(req);
+  const user=await getVerifiedUser(token).catch(()=>null);
+  if(!user)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+
+  let memberships;
+  try{memberships=await getBusinessMemberships(token)}
+  catch{return json(res,503,{ok:false,error:'AUTH_VERIFICATION_UNAVAILABLE'})}
+
+  if(req.method==='GET'){
+    const businessId=safeId(singleQueryValue(req,'business_id'));
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_REQUIRED'});
+    const membership=membershipFor(memberships,businessId);
+    if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+    if(membership.role!=='owner')return json(res,403,{ok:false,error:'OWNER_REQUIRED'});
+    try{
+      const snapshot=await loadCashGuardianSnapshot({token,businessId});
+      return json(res,200,{ok:true,business_id:businessId,...snapshot});
+    }catch(error){
+      const status=Number(error?.status||500);
+      return json(res,status===401?401:status===403?403:503,{ok:false,error:'CASH_GUARDIAN_LOOKUP_FAILED'});
+    }
+  }
+
+  if(req.method!=='PUT')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, PUT'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+
+  try{
+    const body=await readJsonBody(req);
+    const businessId=safeId(body.business_id);
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_REQUIRED'});
+    const membership=membershipFor(memberships,businessId);
+    if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+    if(membership.role!=='owner')return json(res,403,{ok:false,error:'OWNER_REQUIRED'});
+
+    const horizonDays=Number(body.horizon_days??14);
+    if(!Number.isInteger(horizonDays)||horizonDays<1||horizonDays>30){
+      return json(res,400,{ok:false,error:'INVALID_HORIZON'});
+    }
+    const threshold=normalizeThreshold(body.buffer_threshold_aed);
+    if(threshold===undefined)return json(res,400,{ok:false,error:'INVALID_BUFFER_THRESHOLD'});
+
+    const response=await supabaseRest('dabbir_cash_guardian_settings?on_conflict=business_id',token,{
+      method:'POST',
+      headers:{prefer:'resolution=merge-duplicates,return=representation'},
+      body:JSON.stringify({
+        business_id:businessId,
+        horizon_days:horizonDays,
+        buffer_threshold_aed:threshold,
+        updated_by:user.id,
+        updated_at:new Date().toISOString(),
+      }),
+    });
+    const rows=await readData(response,'CASH_SETTINGS_UPDATE_FAILED');
+    const row=Array.isArray(rows)?rows[0]||null:null;
+    if(!row)return json(res,502,{ok:false,error:'CASH_SETTINGS_UPDATE_UNVERIFIED'});
+
+    const snapshot=await loadCashGuardianSnapshot({token,businessId});
+    return json(res,200,{ok:true,business_id:businessId,settings:row,snapshot,verified_persisted:true});
+  }catch(error){
+    if(error?.message==='INVALID_JSON')return json(res,400,{ok:false,error:'INVALID_JSON'});
+    if(error?.message==='PAYLOAD_TOO_LARGE')return json(res,413,{ok:false,error:'PAYLOAD_TOO_LARGE'});
+    const status=Number(error?.status||500);
+    return json(res,[401,403,409].includes(status)?status:503,{ok:false,error:'CASH_SETTINGS_UPDATE_FAILED'});
+  }
+}

--- a/api/owner-action-center-away.js
+++ b/api/owner-action-center-away.js
@@ -1,5 +1,6 @@
 import ownerActionCenter from './owner-action-center.js';
 import { accessTokenFromRequest, json, supabaseRest } from './_auth-core.js';
+import { cashGuardianActionCenterItem, loadCashGuardianSnapshot } from './_cash-guardian.js';
 import { applyOwnerAwayEscalation, awayBrief, deriveOwnerAwayState } from './_owner-away-policy.js';
 
 async function readJson(response){
@@ -40,6 +41,54 @@ function capturedResponse(){
 
 function forwardHeaders(res,headers){
   for(const [name,value] of headers.entries())res.setHeader(name,value);
+}
+
+function augmentWithCashGuardian(payload,snapshot){
+  if(!payload?.ok||!Array.isArray(payload.items))return payload;
+  if(!snapshot){
+    return {
+      ...payload,
+      cash_guardian:{available:false,status:'UNAVAILABLE'},
+      truth:{...(payload.truth||{}),cash_guardian_evidence_only:true,cash_guardian_money_movement:false},
+    };
+  }
+
+  const item=cashGuardianActionCenterItem(snapshot);
+  if(!item){
+    return {
+      ...payload,
+      cash_guardian:{available:true,status:snapshot.status,sufficient_data:snapshot.sufficient_data},
+      truth:{...(payload.truth||{}),cash_guardian_evidence_only:true,cash_guardian_money_movement:false},
+    };
+  }
+
+  const items=[...payload.items,item]
+    .sort((a,b)=>(Number(b.priority)||0)-(Number(a.priority)||0)||String(a.due_at||'').localeCompare(String(b.due_at||'')))
+    .slice(0,3);
+  const previousMetrics=payload.metrics||{};
+  const cashUrgent=item.severity==='critical'?1:0;
+  const cashWarning=item.severity==='warning'?1:0;
+  const arPrefix=`حارس السيولة: ${item.title_ar}. `;
+  const enPrefix=`Cash Guardian: ${item.title_en}. `;
+
+  return {
+    ...payload,
+    status:(Number(previousMetrics.urgent)||0)+cashUrgent>0?'needs_attention':(Number(previousMetrics.warning)||0)+cashWarning>0?'watch':payload.status,
+    metrics:{
+      ...previousMetrics,
+      urgent:(Number(previousMetrics.urgent)||0)+cashUrgent,
+      warning:(Number(previousMetrics.warning)||0)+cashWarning,
+      total:(Number(previousMetrics.total)||0)+1,
+      cash_guardian_exceptions:1,
+    },
+    brief:{
+      ar:arPrefix+String(payload.brief?.ar||''),
+      en:enPrefix+String(payload.brief?.en||''),
+    },
+    items,
+    cash_guardian:{available:true,status:snapshot.status,sufficient_data:snapshot.sufficient_data},
+    truth:{...(payload.truth||{}),cash_guardian_evidence_only:true,cash_guardian_money_movement:false},
+  };
 }
 
 function applyPolicy(payload,away){
@@ -84,12 +133,19 @@ export default async function handler(req,res){
   try{payload=JSON.parse(capture.getBody()||'null')}catch{return res.end(capture.getBody())}
   if(res.statusCode!==200||!payload?.ok)return res.end(JSON.stringify(payload));
 
-  const away=await loadAwayMode(accessTokenFromRequest(req),payload.business_id);
-  const next=applyPolicy(payload,away);
+  const token=accessTokenFromRequest(req);
+  let cashSnapshot=null;
+  if(payload.role==='owner'){
+    cashSnapshot=await loadCashGuardianSnapshot({token,businessId:payload.business_id}).catch(()=>null);
+  }
+  const cashAugmented=augmentWithCashGuardian(payload,cashSnapshot);
+  const away=await loadAwayMode(token,payload.business_id);
+  const next=applyPolicy(cashAugmented,away);
   res.setHeader('content-type','application/json; charset=utf-8');
   res.setHeader('cache-control','no-store');
+  res.setHeader('x-dabbir-cash-guardian',cashSnapshot?cashSnapshot.status.toLowerCase():'unavailable');
   res.setHeader('x-dabbir-owner-away-policy',away.active?'active':'inactive');
   return res.end(JSON.stringify(next));
 }
 
-export { applyPolicy };
+export { applyPolicy, augmentWithCashGuardian };

--- a/supabase/migrations/20260827131000_dabbir_cash_guardian_v1.sql
+++ b/supabase/migrations/20260827131000_dabbir_cash_guardian_v1.sql
@@ -1,0 +1,469 @@
+-- DABBIR Cash Guardian v1
+-- Verified-evidence liquidity protection for owner-first small businesses.
+-- This migration creates no payment, transfer, withdrawal, or financial-commitment capability.
+-- Autonomous behavior is internal-only: overdue verified receivables may create a follow-up candidate.
+
+create schema if not exists dabbir_private;
+revoke all on schema dabbir_private from public, anon;
+grant usage on schema dabbir_private to authenticated, service_role;
+
+-- Composite uniqueness lets new financial evidence keep tenant-scoped foreign keys.
+create unique index if not exists dabbir_customers_business_id_id_unique
+  on public.dabbir_customers(business_id,id);
+create unique index if not exists dabbir_conversations_business_id_id_unique
+  on public.dabbir_conversations(business_id,id);
+
+create table if not exists public.dabbir_financial_evidence (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  evidence_type text not null check (evidence_type in (
+    'cash_balance',
+    'receivable_due',
+    'receivable_settled',
+    'payable_due',
+    'payable_settled'
+  )),
+  amount_aed numeric(14,2) not null check (amount_aed >= 0),
+  effective_at timestamptz not null,
+  due_at timestamptz,
+  source_kind text not null check (source_kind in ('owner_attested','integration','system')),
+  source_system text not null check (length(source_system) between 1 and 64),
+  source_record_id text not null check (length(source_record_id) between 1 and 160),
+  source_event_id text not null check (length(source_event_id) between 1 and 200),
+  source_observed_at timestamptz not null,
+  customer_id uuid,
+  conversation_id uuid,
+  verified_by uuid,
+  verified_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  constraint dabbir_financial_evidence_due_shape check (
+    (evidence_type in ('receivable_due','payable_due') and due_at is not null)
+    or (evidence_type not in ('receivable_due','payable_due'))
+  ),
+  constraint dabbir_financial_evidence_customer_fk
+    foreign key (business_id,customer_id)
+    references public.dabbir_customers(business_id,id)
+    on delete set null,
+  constraint dabbir_financial_evidence_conversation_fk
+    foreign key (business_id,conversation_id)
+    references public.dabbir_conversations(business_id,id)
+    on delete set null
+);
+
+create unique index if not exists dabbir_financial_evidence_source_event_unique
+  on public.dabbir_financial_evidence(business_id,source_system,source_event_id);
+create index if not exists dabbir_financial_evidence_business_type_due_idx
+  on public.dabbir_financial_evidence(business_id,evidence_type,due_at);
+create index if not exists dabbir_financial_evidence_business_record_idx
+  on public.dabbir_financial_evidence(business_id,source_system,source_record_id,evidence_type);
+create index if not exists dabbir_financial_evidence_business_effective_idx
+  on public.dabbir_financial_evidence(business_id,effective_at desc);
+
+alter table public.dabbir_financial_evidence enable row level security;
+alter table public.dabbir_financial_evidence force row level security;
+revoke all on public.dabbir_financial_evidence from anon;
+revoke all on public.dabbir_financial_evidence from authenticated;
+grant select, insert on public.dabbir_financial_evidence to authenticated;
+grant select, insert on public.dabbir_financial_evidence to service_role;
+
+drop policy if exists dabbir_financial_evidence_owner_select on public.dabbir_financial_evidence;
+drop policy if exists dabbir_financial_evidence_owner_attest on public.dabbir_financial_evidence;
+
+create policy dabbir_financial_evidence_owner_select
+on public.dabbir_financial_evidence
+for select to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_financial_evidence.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+);
+
+create policy dabbir_financial_evidence_owner_attest
+on public.dabbir_financial_evidence
+for insert to authenticated
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_financial_evidence.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+  and source_kind='owner_attested'
+  and created_by=(select auth.uid())
+  and verified_by=(select auth.uid())
+);
+
+create table if not exists public.dabbir_financial_coverage (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  scope text not null check (scope in ('inflows','outflows')),
+  coverage_level text not null check (coverage_level in ('complete','partial')),
+  coverage_start timestamptz not null,
+  coverage_end timestamptz not null,
+  source_kind text not null check (source_kind in ('owner_attested','integration','system')),
+  source_system text not null check (length(source_system) between 1 and 64),
+  source_observed_at timestamptz not null,
+  verified_by uuid,
+  verified_at timestamptz not null default now(),
+  metadata jsonb not null default '{}'::jsonb,
+  created_by uuid,
+  created_at timestamptz not null default now(),
+  constraint dabbir_financial_coverage_window_check check (coverage_end > coverage_start)
+);
+
+create index if not exists dabbir_financial_coverage_business_scope_idx
+  on public.dabbir_financial_coverage(business_id,scope,source_observed_at desc);
+
+alter table public.dabbir_financial_coverage enable row level security;
+alter table public.dabbir_financial_coverage force row level security;
+revoke all on public.dabbir_financial_coverage from anon;
+revoke all on public.dabbir_financial_coverage from authenticated;
+grant select, insert on public.dabbir_financial_coverage to authenticated;
+grant select, insert on public.dabbir_financial_coverage to service_role;
+
+drop policy if exists dabbir_financial_coverage_owner_select on public.dabbir_financial_coverage;
+drop policy if exists dabbir_financial_coverage_owner_attest on public.dabbir_financial_coverage;
+
+create policy dabbir_financial_coverage_owner_select
+on public.dabbir_financial_coverage
+for select to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_financial_coverage.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+);
+
+create policy dabbir_financial_coverage_owner_attest
+on public.dabbir_financial_coverage
+for insert to authenticated
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_financial_coverage.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+  and source_kind='owner_attested'
+  and created_by=(select auth.uid())
+  and verified_by=(select auth.uid())
+);
+
+create table if not exists public.dabbir_cash_guardian_settings (
+  business_id uuid primary key references public.dabbir_businesses(id) on delete cascade,
+  horizon_days smallint not null default 14 check (horizon_days between 1 and 30),
+  buffer_threshold_aed numeric(14,2) check (buffer_threshold_aed is null or buffer_threshold_aed >= 0),
+  updated_by uuid not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.dabbir_cash_guardian_settings enable row level security;
+alter table public.dabbir_cash_guardian_settings force row level security;
+revoke all on public.dabbir_cash_guardian_settings from anon;
+revoke all on public.dabbir_cash_guardian_settings from authenticated;
+grant select, insert, update on public.dabbir_cash_guardian_settings to authenticated;
+grant select, insert, update on public.dabbir_cash_guardian_settings to service_role;
+
+drop policy if exists dabbir_cash_guardian_settings_owner_select on public.dabbir_cash_guardian_settings;
+drop policy if exists dabbir_cash_guardian_settings_owner_insert on public.dabbir_cash_guardian_settings;
+drop policy if exists dabbir_cash_guardian_settings_owner_update on public.dabbir_cash_guardian_settings;
+
+create policy dabbir_cash_guardian_settings_owner_select
+on public.dabbir_cash_guardian_settings
+for select to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_cash_guardian_settings.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+);
+
+create policy dabbir_cash_guardian_settings_owner_insert
+on public.dabbir_cash_guardian_settings
+for insert to authenticated
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_cash_guardian_settings.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+  and updated_by=(select auth.uid())
+);
+
+create policy dabbir_cash_guardian_settings_owner_update
+on public.dabbir_cash_guardian_settings
+for update to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_cash_guardian_settings.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id=dabbir_cash_guardian_settings.business_id
+      and m.user_id=(select auth.uid())
+      and m.role='owner'
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+  )
+  and updated_by=(select auth.uid())
+);
+
+-- Internal-only Cash Guardian follow-up policy. It creates candidate state only.
+insert into public.dabbir_action_policies(
+  business_id,action_key,risk_class,auto_execute,
+  requires_customer_confirmation,requires_owner_approval,requires_identity_verification,
+  max_attempts,timeout_seconds,active,metadata,updated_at
+)
+select
+  b.id,
+  'cash_guardian.capture_internal_followup',
+  'LOW',
+  true,
+  false,
+  false,
+  false,
+  1,
+  5,
+  true,
+  jsonb_build_object(
+    'scope','internal_state_only',
+    'external_side_effects',false,
+    'financial_side_effects',false,
+    'money_movement',false,
+    'version','v1'
+  ),
+  now()
+from public.dabbir_businesses b
+on conflict (business_id,action_key) do nothing;
+
+create or replace function dabbir_private.seed_cash_guardian_policy()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  insert into public.dabbir_action_policies(
+    business_id,action_key,risk_class,auto_execute,
+    requires_customer_confirmation,requires_owner_approval,requires_identity_verification,
+    max_attempts,timeout_seconds,active,metadata,updated_at
+  ) values (
+    new.id,
+    'cash_guardian.capture_internal_followup',
+    'LOW',
+    true,
+    false,
+    false,
+    false,
+    1,
+    5,
+    true,
+    jsonb_build_object(
+      'scope','internal_state_only',
+      'external_side_effects',false,
+      'financial_side_effects',false,
+      'money_movement',false,
+      'version','v1'
+    ),
+    now()
+  )
+  on conflict (business_id,action_key) do nothing;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.seed_cash_guardian_policy() from public, anon, authenticated;
+
+drop trigger if exists dabbir_businesses_seed_cash_guardian_policy on public.dabbir_businesses;
+create trigger dabbir_businesses_seed_cash_guardian_policy
+after insert on public.dabbir_businesses
+for each row execute function dabbir_private.seed_cash_guardian_policy();
+
+-- One verified receivable evidence record can create at most one internal follow-up candidate.
+create unique index if not exists dabbir_followups_financial_evidence_unique
+  on public.dabbir_followups(business_id,(metadata->>'financial_evidence_id'))
+  where (metadata->>'financial_evidence_id') is not null;
+
+create or replace function dabbir_private.capture_cash_guardian_internal_followups()
+returns integer
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_candidate record;
+  v_followup_id uuid;
+  v_created integer:=0;
+begin
+  for v_candidate in
+    select
+      e.id,
+      e.business_id,
+      e.customer_id,
+      e.conversation_id,
+      c.channel_type,
+      e.amount_aed,
+      e.due_at,
+      e.source_system,
+      e.source_record_id,
+      greatest(
+        e.amount_aed - coalesce((
+          select sum(s.amount_aed)
+          from public.dabbir_financial_evidence s
+          where s.business_id=e.business_id
+            and s.evidence_type='receivable_settled'
+            and s.source_system=e.source_system
+            and s.source_record_id=e.source_record_id
+            and s.effective_at<=now()
+        ),0),
+        0
+      ) as open_amount_aed
+    from public.dabbir_financial_evidence e
+    join public.dabbir_businesses b
+      on b.id=e.business_id
+    join public.dabbir_conversations c
+      on c.id=e.conversation_id
+     and c.business_id=e.business_id
+     and c.customer_id=e.customer_id
+    join public.dabbir_action_policies p
+      on p.business_id=e.business_id
+     and p.action_key='cash_guardian.capture_internal_followup'
+    where e.evidence_type='receivable_due'
+      and e.due_at<now()
+      and e.customer_id is not null
+      and e.conversation_id is not null
+      and c.channel_type in ('web','whatsapp','instagram')
+      and coalesce(b.demo_mode,false)=false
+      and b.name not like 'DABBIR AI QA %'
+      and p.active=true
+      and p.risk_class='LOW'
+      and p.auto_execute=true
+      and p.requires_customer_confirmation=false
+      and p.requires_owner_approval=false
+      and p.requires_identity_verification=false
+      and not exists (
+        select 1 from public.dabbir_followups f
+        where f.business_id=e.business_id
+          and f.metadata->>'financial_evidence_id'=e.id::text
+      )
+  loop
+    if v_candidate.open_amount_aed<=0 then
+      continue;
+    end if;
+
+    begin
+      insert into public.dabbir_followups(
+        business_id,conversation_id,customer_id,channel_type,
+        reason,status,confidence,due_at,recommended_message,policy_state,
+        metadata,created_at,updated_at
+      ) values (
+        v_candidate.business_id,
+        v_candidate.conversation_id,
+        v_candidate.customer_id,
+        v_candidate.channel_type,
+        'cash_guardian_overdue_receivable',
+        'CANDIDATE',
+        1,
+        now(),
+        null,
+        'NOT_CHECKED',
+        jsonb_build_object(
+          'source','dabbir_cash_guardian_v1',
+          'financial_evidence_id',v_candidate.id,
+          'amount_aed',v_candidate.open_amount_aed,
+          'source_system',v_candidate.source_system,
+          'source_record_id',v_candidate.source_record_id,
+          'auto_captured',true,
+          'external_side_effects',false,
+          'financial_side_effects',false,
+          'money_movement',false
+        ),
+        now(),
+        now()
+      ) returning id into v_followup_id;
+    exception when unique_violation then
+      continue;
+    end;
+
+    insert into public.dabbir_operation_outcomes(
+      business_id,operation_key,correlation_id,operation_type,outcome,failure_class,
+      safe_eligible,autonomous,estimated_manual_seconds,source,metadata,
+      started_at,completed_at,created_at
+    ) values (
+      v_candidate.business_id,
+      'cash_guardian.capture_internal_followup:'||v_followup_id::text,
+      v_candidate.id::text,
+      'cash_guardian.capture_internal_followup',
+      'VERIFIED_SUCCESS',
+      null,
+      true,
+      true,
+      0,
+      'database_cron',
+      jsonb_build_object(
+        'followup_id',v_followup_id,
+        'financial_evidence_id',v_candidate.id,
+        'external_side_effects',false,
+        'financial_side_effects',false,
+        'money_movement',false,
+        'manual_seconds_measurement','UNMEASURED'
+      ),
+      now(),now(),now()
+    )
+    on conflict (business_id,operation_key) do nothing;
+
+    v_created:=v_created+1;
+  end loop;
+
+  return v_created;
+end;
+$$;
+revoke all on function dabbir_private.capture_cash_guardian_internal_followups() from public, anon, authenticated;
+grant execute on function dabbir_private.capture_cash_guardian_internal_followups() to service_role;
+
+comment on function dabbir_private.capture_cash_guardian_internal_followups() is
+  'Cash Guardian v1: creates internal follow-up candidates for verified overdue receivables only; no external message and no money movement.';
+
+-- Supabase Cron is already enabled on this project. Run hourly; the function is idempotent.
+select cron.schedule(
+  'dabbir-cash-guardian-followups-hourly',
+  '17 * * * *',
+  $$select dabbir_private.capture_cash_guardian_internal_followups();$$
+);

--- a/supabase/migrations/20260827131010_dabbir_cash_guardian_fk_delete_targets.sql
+++ b/supabase/migrations/20260827131010_dabbir_cash_guardian_fk_delete_targets.sql
@@ -1,0 +1,17 @@
+-- Cash Guardian financial evidence is tenant-scoped and should survive deletion of a linked
+-- customer/conversation while dropping only the optional personal/operational reference.
+-- PostgreSQL 17 supports column-targeted ON DELETE SET NULL for composite foreign keys.
+
+alter table public.dabbir_financial_evidence
+  drop constraint if exists dabbir_financial_evidence_customer_fk,
+  add constraint dabbir_financial_evidence_customer_fk
+    foreign key (business_id,customer_id)
+    references public.dabbir_customers(business_id,id)
+    on delete set null (customer_id);
+
+alter table public.dabbir_financial_evidence
+  drop constraint if exists dabbir_financial_evidence_conversation_fk,
+  add constraint dabbir_financial_evidence_conversation_fk
+    foreign key (business_id,conversation_id)
+    references public.dabbir_conversations(business_id,id)
+    on delete set null (conversation_id);

--- a/supabase/migrations/20260827131020_dabbir_cash_guardian_index_cleanup.sql
+++ b/supabase/migrations/20260827131020_dabbir_cash_guardian_index_cleanup.sql
@@ -1,0 +1,28 @@
+-- Remove redundant composite unique indexes introduced by the v1 migration because
+-- the canonical *_uq indexes already exist, then recreate the evidence foreign keys
+-- against the canonical uniqueness and add covering indexes on the referencing side.
+
+alter table public.dabbir_financial_evidence
+  drop constraint if exists dabbir_financial_evidence_customer_fk,
+  drop constraint if exists dabbir_financial_evidence_conversation_fk;
+
+drop index if exists public.dabbir_customers_business_id_id_unique;
+drop index if exists public.dabbir_conversations_business_id_id_unique;
+
+alter table public.dabbir_financial_evidence
+  add constraint dabbir_financial_evidence_customer_fk
+    foreign key (business_id,customer_id)
+    references public.dabbir_customers(business_id,id)
+    on delete set null (customer_id),
+  add constraint dabbir_financial_evidence_conversation_fk
+    foreign key (business_id,conversation_id)
+    references public.dabbir_conversations(business_id,id)
+    on delete set null (conversation_id);
+
+create index if not exists dabbir_financial_evidence_customer_fk_idx
+  on public.dabbir_financial_evidence(business_id,customer_id)
+  where customer_id is not null;
+
+create index if not exists dabbir_financial_evidence_conversation_fk_idx
+  on public.dabbir_financial_evidence(business_id,conversation_id)
+  where conversation_id is not null;

--- a/test/dabbir-cash-guardian-schema.test.mjs
+++ b/test/dabbir-cash-guardian-schema.test.mjs
@@ -1,0 +1,10 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+test('financial evidence keeps business scope when linked customer or conversation is deleted',()=>{
+  const fix=fs.readFileSync('supabase/migrations/20260827131010_dabbir_cash_guardian_fk_delete_targets.sql','utf8');
+  assert.match(fix,/foreign key \(business_id,customer_id\)[\s\S]*on delete set null \(customer_id\)/i);
+  assert.match(fix,/foreign key \(business_id,conversation_id\)[\s\S]*on delete set null \(conversation_id\)/i);
+  assert.doesNotMatch(fix,/on delete set null\s*;/i);
+});

--- a/test/dabbir-cash-guardian.test.mjs
+++ b/test/dabbir-cash-guardian.test.mjs
@@ -170,15 +170,16 @@ test('Cash Guardian augments only the top owner exceptions and preserves no-mone
 
 test('database contract is append-only for owner evidence and cron never sends or moves money',()=>{
   const migration=fs.readFileSync('supabase/migrations/20260827131000_dabbir_cash_guardian_v1.sql','utf8');
+  const executable=migration.replace(/--.*$/gm,'');
   assert.match(migration,/alter table public\.dabbir_financial_evidence force row level security/i);
   assert.match(migration,/grant select, insert on public\.dabbir_financial_evidence to authenticated/i);
-  assert.doesNotMatch(migration,/grant[^;]*(update|delete)[^;]*dabbir_financial_evidence[^;]*authenticated/i);
+  assert.doesNotMatch(executable,/grant[^;]*(update|delete)[^;]*dabbir_financial_evidence[^;]*authenticated/i);
   assert.match(migration,/source_kind='owner_attested'/);
   assert.match(migration,/cash_guardian\.capture_internal_followup/);
   assert.match(migration,/cron\.schedule\(/);
   assert.match(migration,/external_side_effects',false/);
   assert.match(migration,/money_movement',false/);
-  assert.doesNotMatch(migration,/net\.http_(post|get)|stripe|payment_intent|bank_transfer|withdraw/i);
+  assert.doesNotMatch(executable,/net\.http_(post|get)|stripe|payment_intent|bank_transfer|withdraw/i);
 });
 
 test('Cash Guardian API is owner-only and same-origin for settings mutations',()=>{

--- a/test/dabbir-cash-guardian.test.mjs
+++ b/test/dabbir-cash-guardian.test.mjs
@@ -1,0 +1,191 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateCashGuardian, cashGuardianActionCenterItem } from '../api/_cash-guardian.js';
+import { augmentWithCashGuardian } from '../api/owner-action-center-away.js';
+import { applyOwnerAwayEscalation } from '../api/_owner-away-policy.js';
+
+const nowMs=Date.parse('2026-08-27T12:00:00.000Z');
+const iso=offsetMs=>new Date(nowMs+offsetMs).toISOString();
+const day=24*60*60*1000;
+
+function coverage(){
+  return [
+    {scope:'inflows',coverage_level:'complete',coverage_start:iso(-day),coverage_end:iso(20*day),source_system:'qa-ledger',source_observed_at:iso(-60*60*1000)},
+    {scope:'outflows',coverage_level:'complete',coverage_start:iso(-day),coverage_end:iso(20*day),source_system:'qa-ledger',source_observed_at:iso(-60*60*1000)},
+  ];
+}
+
+function evidenceBase(overrides={}){
+  return {
+    id:crypto.randomUUID(),
+    evidence_type:'cash_balance',
+    amount_aed:1000,
+    effective_at:iso(-60*60*1000),
+    due_at:null,
+    source_kind:'integration',
+    source_system:'qa-ledger',
+    source_record_id:'account:1',
+    source_event_id:crypto.randomUUID(),
+    source_observed_at:iso(-60*60*1000),
+    ...overrides,
+  };
+}
+
+test('missing financial data is DATA_INSUFFICIENT and never becomes a fake forecast',()=>{
+  const snapshot=evaluateCashGuardian({nowMs});
+  assert.equal(snapshot.status,'DATA_INSUFFICIENT');
+  assert.equal(snapshot.sufficient_data,false);
+  assert.equal(snapshot.liquidity_range,null);
+  assert.deepEqual(snapshot.insufficiency_reasons,['BALANCE_MISSING','INFLOW_COVERAGE_INCOMPLETE','OUTFLOW_COVERAGE_INCOMPLETE']);
+  assert.equal(snapshot.truth.unverified_forecast_blocked,true);
+  assert.equal(snapshot.truth.range_not_point_forecast,true);
+});
+
+test('orders are not treated as cash receipts',()=>{
+  const snapshot=evaluateCashGuardian({
+    nowMs,
+    orders:[{status:'confirmed',simulated:false,total_aed:999999}],
+  });
+  assert.equal(snapshot.status,'DATA_INSUFFICIENT');
+  assert.equal(snapshot.liquidity_range,null);
+  assert.equal(snapshot.truth.orders_are_not_cash_receipts,true);
+  assert.equal(snapshot.truth.simulated_orders_ignored,true);
+});
+
+test('a fresh balance without complete inflow/outflow coverage remains insufficient',()=>{
+  const snapshot=evaluateCashGuardian({evidence:[evidenceBase()],coverage:[],nowMs});
+  assert.equal(snapshot.status,'DATA_INSUFFICIENT');
+  assert.equal(snapshot.coverage.balance.status,'FRESH');
+  assert.ok(snapshot.insufficiency_reasons.includes('INFLOW_COVERAGE_INCOMPLETE'));
+  assert.ok(snapshot.insufficiency_reasons.includes('OUTFLOW_COVERAGE_INCOMPLETE'));
+  assert.equal(snapshot.liquidity_range,null);
+});
+
+test('verified commitments and receivables create an honest liquidity range',()=>{
+  const evidence=[
+    evidenceBase({amount_aed:1000}),
+    evidenceBase({evidence_type:'payable_due',amount_aed:1200,due_at:iso(day),source_record_id:'bill:1',source_event_id:'bill:1:due'}),
+    evidenceBase({evidence_type:'receivable_due',amount_aed:500,due_at:iso(2*day),source_record_id:'invoice:1',source_event_id:'invoice:1:due'}),
+  ];
+  const snapshot=evaluateCashGuardian({evidence,coverage:coverage(),nowMs});
+  assert.equal(snapshot.status,'RISK');
+  assert.equal(snapshot.sufficient_data,true);
+  assert.deepEqual(snapshot.liquidity_range,{
+    horizon_days:14,
+    horizon_end:iso(14*day),
+    current_balance_aed:1000,
+    committed_outflows_aed:1200,
+    verified_receivables_aed:500,
+    lower_bound_aed:-200,
+    upper_bound_aed:300,
+    owner_buffer_threshold_aed:null,
+    hard_floor_aed:0,
+    meaning:'LOWER_EXCLUDES_RECEIVABLES_UPPER_ASSUMES_ALL_VERIFIED_RECEIVABLES_ARRIVE',
+  });
+  assert.equal(snapshot.traceability.payables[0].source_record_id,'bill:1');
+  assert.equal(snapshot.traceability.receivables[0].source_record_id,'invoice:1');
+});
+
+test('settlement evidence reduces the open obligation instead of double counting it',()=>{
+  const evidence=[
+    evidenceBase({amount_aed:1000}),
+    evidenceBase({evidence_type:'payable_due',amount_aed:1200,due_at:iso(day),source_record_id:'bill:2',source_event_id:'bill:2:due'}),
+    evidenceBase({evidence_type:'payable_settled',amount_aed:700,effective_at:iso(-day),source_record_id:'bill:2',source_event_id:'bill:2:payment:1'}),
+  ];
+  const snapshot=evaluateCashGuardian({evidence,coverage:coverage(),nowMs});
+  assert.equal(snapshot.status,'CLEAR');
+  assert.equal(snapshot.liquidity_range.committed_outflows_aed,500);
+  assert.equal(snapshot.liquidity_range.lower_bound_aed,500);
+  assert.equal(snapshot.traceability.payables[0].amount_aed,500);
+});
+
+test('upper bound below zero is a critical owner-gated exception',()=>{
+  const evidence=[
+    evidenceBase({amount_aed:500}),
+    evidenceBase({evidence_type:'payable_due',amount_aed:1000,due_at:iso(day),source_record_id:'bill:3',source_event_id:'bill:3:due'}),
+    evidenceBase({evidence_type:'receivable_due',amount_aed:200,due_at:iso(day),source_record_id:'invoice:3',source_event_id:'invoice:3:due'}),
+  ];
+  const snapshot=evaluateCashGuardian({evidence,coverage:coverage(),nowMs});
+  assert.equal(snapshot.status,'CRITICAL');
+  assert.equal(snapshot.liquidity_range.upper_bound_aed,-300);
+  const item=cashGuardianActionCenterItem(snapshot);
+  assert.equal(item.owner_gate,true);
+  assert.equal(item.severity,'critical');
+  const away=applyOwnerAwayEscalation([item],{active:true});
+  assert.equal(away.visible.length,1);
+  assert.equal(away.deferred.length,0);
+});
+
+test('stale balance blocks liquidity claims even when due-item coverage is complete',()=>{
+  const stale=evidenceBase({effective_at:iso(-4*day),source_observed_at:iso(-4*day)});
+  const snapshot=evaluateCashGuardian({evidence:[stale],coverage:coverage(),nowMs});
+  assert.equal(snapshot.status,'DATA_INSUFFICIENT');
+  assert.ok(snapshot.insufficiency_reasons.includes('BALANCE_STALE'));
+  assert.equal(snapshot.liquidity_range,null);
+});
+
+test('overdue verified receivable exposes only internal non-financial follow-up eligibility',()=>{
+  const evidence=[
+    evidenceBase(),
+    evidenceBase({
+      evidence_type:'receivable_due',amount_aed:250,due_at:iso(-day),source_record_id:'invoice:late',source_event_id:'invoice:late:due',
+      customer_id:'00000000-0000-4000-8000-000000000001',conversation_id:'00000000-0000-4000-8000-000000000002',
+    }),
+  ];
+  const snapshot=evaluateCashGuardian({evidence,coverage:coverage(),nowMs});
+  assert.equal(snapshot.overdue_receivables.count,1);
+  assert.equal(snapshot.overdue_receivables.amount_aed,250);
+  assert.equal(snapshot.overdue_receivables.auto_internal_followup_eligible,1);
+  const action=snapshot.actions.find(row=>row.key==='FOLLOW_UP_OVERDUE_RECEIVABLES');
+  assert.equal(action.external_side_effects,false);
+  assert.equal(action.financial_side_effects,false);
+  assert.equal(snapshot.truth.money_movement_capability,false);
+  assert.equal(snapshot.truth.payment_execution_capability,false);
+});
+
+test('Cash Guardian augments only the top owner exceptions and preserves no-money truth',()=>{
+  const payload={
+    ok:true,
+    status:'watch',
+    metrics:{urgent:0,warning:1,total:1},
+    brief:{ar:'عنصر تشغيلي.',en:'Operational item.'},
+    items:[{id:'x',type:'order',priority:50,severity:'warning',title_ar:'طلب',title_en:'Order'}],
+    truth:{source:'real'},
+  };
+  const snapshot=evaluateCashGuardian({
+    evidence:[
+      evidenceBase({amount_aed:100}),
+      evidenceBase({evidence_type:'payable_due',amount_aed:300,due_at:iso(day),source_record_id:'bill:4',source_event_id:'bill:4:due'}),
+    ],
+    coverage:coverage(),
+    nowMs,
+  });
+  const next=augmentWithCashGuardian(payload,snapshot);
+  assert.equal(next.items[0].type,'cash_guardian');
+  assert.equal(next.items[0].owner_gate,true);
+  assert.equal(next.truth.cash_guardian_money_movement,false);
+  assert.match(next.brief.ar,/حارس السيولة/);
+});
+
+test('database contract is append-only for owner evidence and cron never sends or moves money',()=>{
+  const migration=fs.readFileSync('supabase/migrations/20260827131000_dabbir_cash_guardian_v1.sql','utf8');
+  assert.match(migration,/alter table public\.dabbir_financial_evidence force row level security/i);
+  assert.match(migration,/grant select, insert on public\.dabbir_financial_evidence to authenticated/i);
+  assert.doesNotMatch(migration,/grant[^;]*(update|delete)[^;]*dabbir_financial_evidence[^;]*authenticated/i);
+  assert.match(migration,/source_kind='owner_attested'/);
+  assert.match(migration,/cash_guardian\.capture_internal_followup/);
+  assert.match(migration,/cron\.schedule\(/);
+  assert.match(migration,/external_side_effects',false/);
+  assert.match(migration,/money_movement',false/);
+  assert.doesNotMatch(migration,/net\.http_(post|get)|stripe|payment_intent|bank_transfer|withdraw/i);
+});
+
+test('Cash Guardian API is owner-only and same-origin for settings mutations',()=>{
+  const source=fs.readFileSync('api/cash-guardian.js','utf8');
+  assert.match(source,/membership\.role!=='owner'/);
+  assert.match(source,/requireSameOrigin\(req\)/);
+  assert.match(source,/buffer_threshold_aed/);
+  assert.match(source,/horizon_days/);
+  assert.doesNotMatch(source,/service_role|SUPABASE_SERVICE/i);
+});


### PR DESCRIPTION
Implements BAR-26 Cash Guardian without inventing financial truth.

- Adds append-only, owner-scoped verified financial evidence and coverage tables with forced RLS and explicit Data API grants.
- Adds owner-only Cash Guardian settings (1–30 day horizon, optional buffer threshold).
- Computes a liquidity range only when balance + inflow coverage + outflow coverage are all sufficiently fresh and complete.
- Confirmed orders are never treated as cash receipts.
- Tracks overdue receivables/payables with source/timestamp traceability.
- Adds internal-only hourly pg_cron capture of overdue receivable follow-up candidates when a verified customer/conversation link exists.
- No external message is sent by Cash Guardian and no payment/transfer/money movement capability is added.
- Integrates at most one Cash Guardian exception into the owner Action Center before Away Mode; financial owner-gated risk cannot be suppressed by Away Mode.
- Adds deterministic safety/truth tests for missing data, stale balance, settlements, range math, owner gate, and no-money-movement constraints.