### PR TITLE
DABBIR: explicitly deny client access to payment events

### DIFF
--- a/supabase/migrations/20260827174100_dabbir_payment_events_explicit_deny_rls_v1.sql
+++ b/supabase/migrations/20260827174100_dabbir_payment_events_explicit_deny_rls_v1.sql
@@ -1,0 +1,15 @@
+-- DABBIR payment webhook event ledger is internal-only.
+-- Keep Data API client roles explicitly denied while service_role retains its existing grant.
+
+alter table public.dabbir_payment_events enable row level security;
+alter table public.dabbir_payment_events force row level security;
+
+revoke all on public.dabbir_payment_events from anon, authenticated;
+
+drop policy if exists dabbir_payment_events_explicit_deny_all on public.dabbir_payment_events;
+create policy dabbir_payment_events_explicit_deny_all
+on public.dabbir_payment_events
+for all
+to anon, authenticated
+using (false)
+with check (false);


### PR DESCRIPTION
Hardens the internal Stripe webhook event ledger without widening access.

- Keeps RLS + FORCE RLS on `dabbir_payment_events`.
- Keeps all `anon` / `authenticated` table privileges revoked.
- Adds an explicit deny-all RLS policy for client roles so the access model is documented and Supabase no longer reports RLS-with-no-policy.
- Leaves `service_role` access unchanged for trusted webhook processing.