### PR TITLE
DABBIR: harden passwords without paid Auth dependency

### DIFF
--- a/api/_password-policy.js
+++ b/api/_password-policy.js
@@ -33,15 +33,16 @@ export function passwordPolicy(password, { email = '' } = {}) {
   const raw = String(password || '');
   const normalized = fold(raw);
   const compact = normalized.replace(/\s+/g, '');
+  const alphanumeric = compact.replace(/[^a-z0-9]/g, '');
   const emailLocal = fold(email).split('@')[0].replace(/[^a-z0-9]/g, '');
   const reasons = [];
 
   if (raw.length < 12) reasons.push('TOO_SHORT');
   if (raw.length > 256) reasons.push('TOO_LONG');
-  if (COMMON_PASSWORDS.has(compact)) reasons.push('COMMON_PASSWORD');
-  if (/^(.)\1{7,}$/u.test(raw)) reasons.push('REPEATED_CHARACTER');
+  if (COMMON_PASSWORDS.has(compact) || COMMON_PASSWORDS.has(alphanumeric)) reasons.push('COMMON_PASSWORD');
+  if (/(.)\1{7,}/u.test(raw)) reasons.push('REPEATED_CHARACTER');
   if (hasSimpleSequence(raw)) reasons.push('SIMPLE_SEQUENCE');
-  if (emailLocal.length >= 4 && compact.includes(emailLocal)) reasons.push('CONTAINS_EMAIL_IDENTITY');
+  if (emailLocal.length >= 4 && alphanumeric.includes(emailLocal)) reasons.push('CONTAINS_EMAIL_IDENTITY');
 
   // Long passphrases remain valid without forcing arbitrary symbol rules.
   // Shorter passwords need diversity across letters, numbers and symbols.

--- a/api/_password-policy.js
+++ b/api/_password-policy.js
@@ -1,0 +1,60 @@
+const COMMON_PASSWORDS = new Set([
+  'password','password1','password123','qwerty','qwerty123','123456','12345678','123456789',
+  '1234567890','111111','000000','abc123','letmein','welcome','admin','administrator','iloveyou',
+  'dabbir','dabbir123','dubai123','uae12345'
+]);
+
+const SIMPLE_SEQUENCES = [
+  '0123456789','9876543210','abcdefghijklmnopqrstuvwxyz','zyxwvutsrqponmlkjihgfedcba',
+  'qwertyuiop','poiuytrewq','asdfghjkl','lkjhgfdsa','zxcvbnm','mnbvcxz'
+];
+
+const fold = value => String(value || '').normalize('NFKC').toLowerCase();
+
+function characterClassCount(password) {
+  return [/[a-z]/.test(password), /[A-Z]/.test(password), /\d/.test(password), /[^A-Za-z0-9]/.test(password)]
+    .filter(Boolean).length;
+}
+
+function hasSimpleSequence(password) {
+  const value = fold(password).replace(/\s+/g, '');
+  if (value.length < 6) return false;
+  return SIMPLE_SEQUENCES.some(sequence => {
+    for (let size = 6; size <= Math.min(sequence.length, value.length); size += 1) {
+      for (let start = 0; start + size <= sequence.length; start += 1) {
+        if (value.includes(sequence.slice(start, start + size))) return true;
+      }
+    }
+    return false;
+  });
+}
+
+export function passwordPolicy(password, { email = '' } = {}) {
+  const raw = String(password || '');
+  const normalized = fold(raw);
+  const compact = normalized.replace(/\s+/g, '');
+  const emailLocal = fold(email).split('@')[0].replace(/[^a-z0-9]/g, '');
+  const reasons = [];
+
+  if (raw.length < 12) reasons.push('TOO_SHORT');
+  if (raw.length > 256) reasons.push('TOO_LONG');
+  if (COMMON_PASSWORDS.has(compact)) reasons.push('COMMON_PASSWORD');
+  if (/^(.)\1{7,}$/u.test(raw)) reasons.push('REPEATED_CHARACTER');
+  if (hasSimpleSequence(raw)) reasons.push('SIMPLE_SEQUENCE');
+  if (emailLocal.length >= 4 && compact.includes(emailLocal)) reasons.push('CONTAINS_EMAIL_IDENTITY');
+
+  // Long passphrases remain valid without forcing arbitrary symbol rules.
+  // Shorter passwords need diversity across letters, numbers and symbols.
+  if (raw.length < 20 && characterClassCount(raw) < 3) reasons.push('LOW_CHARACTER_DIVERSITY');
+
+  return {
+    valid: reasons.length === 0,
+    reasons,
+    minimum_length: 12,
+    passphrase_length: 20,
+  };
+}
+
+export function isStrongPassword(password, options) {
+  return passwordPolicy(password, options).valid;
+}

--- a/api/auth/reset-password.js
+++ b/api/auth/reset-password.js
@@ -1,4 +1,5 @@
 import { json, readJsonBody, requireSameOrigin, supabaseAuth } from '../_auth-core.js';
+import { isStrongPassword } from '../_password-policy.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
@@ -9,7 +10,7 @@ export default async function handler(req, res) {
     const accessToken = String(body.access_token || '').trim();
     const password = String(body.password || '');
 
-    if (accessToken.length < 20 || accessToken.length > 8192 || password.length < 12 || password.length > 256) {
+    if (accessToken.length < 20 || accessToken.length > 8192 || !isStrongPassword(password)) {
       return json(res, 400, { ok: false, error: 'INVALID_RESET_INPUT' });
     }
 

--- a/api/auth/signup.js
+++ b/api/auth/signup.js
@@ -1,4 +1,5 @@
 import { authCookieHeaders, json, readJsonBody, requireSameOrigin, supabaseAuth } from '../_auth-core.js';
+import { isStrongPassword } from '../_password-policy.js';
 
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 
@@ -10,7 +11,7 @@ export default async function handler(req, res) {
     const body = await readJsonBody(req);
     const email = String(body.email || '').trim().toLowerCase();
     const password = String(body.password || '');
-    if (!emailPattern.test(email) || email.length > 254 || password.length < 12 || password.length > 256) {
+    if (!emailPattern.test(email) || email.length > 254 || !isStrongPassword(password, { email })) {
       return json(res, 400, { ok: false, error: 'INVALID_SIGNUP_INPUT' });
     }
 

--- a/api/dabbir-ui-refinement.js
+++ b/api/dabbir-ui-refinement.js
@@ -3,7 +3,7 @@ const script=String.raw`(()=>{
   window.__dabbirUiRefinementLoaded=true;
 
   const style=document.createElement('style');
-  style.dataset.dabbirUiRefinement='v2';
+  style.dataset.dabbirUiRefinement='v3';
   style.textContent=[
     ':root{--dabbir-surface:#111417;--dabbir-surface-2:#171b1f;--dabbir-line:#2b3137;--dabbir-soft:#8f969f;--dabbir-accent:#d7ff5f}',
     'body{background:#080a0c!important}',
@@ -25,6 +25,9 @@ const script=String.raw`(()=>{
     'html[dir="rtl"] #screen-conversations .msgrow.customer .bubble{border-top-left-radius:15px!important;border-top-right-radius:6px!important}',
     '#screen-conversations .msgrow.ai .bubble,#screen-conversations .msgrow.human .bubble{border-top-right-radius:6px!important}',
     'html[dir="rtl"] #screen-conversations .msgrow.ai .bubble,html[dir="rtl"] #screen-conversations .msgrow.human .bubble{border-top-right-radius:15px!important;border-top-left-radius:6px!important}',
+    '.dabbirPasswordHint{display:none;margin-top:6px;color:#aab1ba;font-size:10px;line-height:1.55}',
+    '.dabbirPasswordHint.on{display:block}',
+    '.dabbirRecoveryCard .dabbirPasswordHint{display:block;margin:7px 0 2px}',
     '@media(max-width:700px){',
       'html{background:#080a0c!important}',
       'body{font-size:15px!important}',
@@ -101,6 +104,53 @@ const script=String.raw`(()=>{
     return (ar()?a:e)[s]||String(state||'').replaceAll('_',' ');
   };
 
+  function passwordHint(){
+    return ar()
+      ? '12 حرفًا على الأقل. تجنّب الكلمات الشائعة والتسلسلات واسم بريدك. العبارات الطويلة مسموحة.'
+      : 'Use 12+ characters. Avoid common passwords, sequences, and your email identity. Long passphrases are supported.';
+  }
+
+  function installPasswordGuidance(){
+    const password=document.querySelector('#authPassword');
+    const field=password?.closest('.field');
+    if(password&&field){
+      let hint=field.querySelector('[data-dabbir-password-hint="signup"]');
+      if(!hint){
+        hint=document.createElement('div');
+        hint.className='dabbirPasswordHint';
+        hint.dataset.dabbirPasswordHint='signup';
+        hint.id='dabbirSignupPasswordHint';
+        password.insertAdjacentElement('afterend',hint);
+      }
+      const signup=!!document.querySelector('#signupTab')?.classList.contains('on');
+      hint.classList.toggle('on',signup);
+      hint.textContent=passwordHint();
+      if(signup){
+        password.minLength=12;
+        password.setAttribute('aria-describedby',hint.id);
+        password.title=passwordHint();
+      }
+    }
+
+    const reset=document.querySelector('#dabbirNewPassword');
+    if(reset){
+      let hint=document.querySelector('[data-dabbir-password-hint="reset"]');
+      if(!hint){
+        hint=document.createElement('div');
+        hint.className='dabbirPasswordHint';
+        hint.dataset.dabbirPasswordHint='reset';
+        hint.id='dabbirResetPasswordHint';
+        reset.insertAdjacentElement('afterend',hint);
+      }
+      hint.textContent=passwordHint();
+      reset.setAttribute('aria-describedby',hint.id);
+      reset.title=passwordHint();
+    }
+  }
+
+  document.querySelector('#loginTab')?.addEventListener('click',()=>setTimeout(installPasswordGuidance,0));
+  document.querySelector('#signupTab')?.addEventListener('click',()=>setTimeout(installPasswordGuidance,0));
+
   function translateConversationStates(){
     document.querySelectorAll('#screen-conversations .chatContact').forEach(card=>{
       const span=card.querySelector('span');
@@ -133,7 +183,7 @@ const script=String.raw`(()=>{
     list.classList.toggle('dabbirSingleChat',count===1);
   }
 
-  function polish(){translateConversationStates();compactSingleConversation()}
+  function polish(){translateConversationStates();compactSingleConversation();installPasswordGuidance()}
   if(typeof renderChats==='function'&&!window.__dabbirUiRenderChatsWrapped){
     window.__dabbirUiRenderChatsWrapped=true;
     const base=renderChats;
@@ -148,7 +198,7 @@ const script=String.raw`(()=>{
   observer.observe(document.body,{subtree:true,childList:true});
   setTimeout(polish,0);
   setTimeout(polish,500);
-  window.__dabbirUiRefinementVersion='mobile-premium-v2';
+  window.__dabbirUiRefinementVersion='mobile-premium-v3';
 })();`;
 
 export default function handler(req,res){
@@ -157,6 +207,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-ui-refinement','mobile-premium-v2');
+  res.setHeader('x-dabbir-ui-refinement','mobile-premium-v3');
   return res.end(script);
 }

--- a/test/dabbir-password-policy.test.mjs
+++ b/test/dabbir-password-policy.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { isStrongPassword, passwordPolicy } from '../api/_password-policy.js';
+
+const root = new URL('../', import.meta.url);
+const read = async path => readFile(new URL(path, root), 'utf8');
+
+const signup = await read('api/auth/signup.js');
+const reset = await read('api/auth/reset-password.js');
+
+test('DABBIR uses one password policy for signup and password recovery', () => {
+  assert.match(signup, /_password-policy\.js/);
+  assert.match(reset, /_password-policy\.js/);
+  assert.match(signup, /isStrongPassword\(password, \{ email \}\)/);
+  assert.match(reset, /isStrongPassword\(password\)/);
+});
+
+test('password policy rejects short, common, repeated and sequential credentials', () => {
+  assert.equal(isStrongPassword('Short1!'), false);
+  assert.equal(isStrongPassword('password123!'), false);
+  assert.equal(isStrongPassword('AAAAAAAAAAAA!1'), false);
+  assert.equal(isStrongPassword('Abcdef123456!'), false);
+  assert.equal(isStrongPassword('Qwerty123456!'), false);
+});
+
+test('password policy rejects passwords containing the email identity', () => {
+  const result = passwordPolicy('Barman2026!Secure', { email: 'barman@example.com' });
+  assert.equal(result.valid, false);
+  assert.ok(result.reasons.includes('CONTAINS_EMAIL_IDENTITY'));
+});
+
+test('password policy accepts diverse credentials and long passphrases', () => {
+  assert.equal(isStrongPassword('Falcon!47River'), true);
+  assert.equal(isStrongPassword('four uncommon words stay memorable together'), true);
+});
+
+test('password policy keeps a hard maximum bound', () => {
+  assert.equal(isStrongPassword(`Aa1!${'x'.repeat(253)}`), false);
+});


### PR DESCRIPTION
Adds a shared application-layer password policy while Supabase leaked-password protection remains unavailable on the current Free plan.

- Enforces the same policy for signup and password recovery/reset.
- Keeps 12-character minimum and 256-character maximum.
- Rejects common credentials, repeated-character passwords, simple keyboard/alphabet/number sequences, and passwords containing the email identity.
- Allows long passphrases (20+ chars) without arbitrary symbol requirements; shorter passwords need character diversity.
- Adds deterministic regression tests so signup/reset cannot drift apart.

This does not claim to replace HaveIBeenPwned leaked-password screening. Native leaked-password protection remains an owner-gated Supabase Pro feature.