### PR TITLE
DABBIR: enforce least-privilege RLS grants

### DIFF
--- a/supabase/migrations/20260827180100_dabbir_rls_grant_hardening_v1.sql
+++ b/supabase/migrations/20260827180100_dabbir_rls_grant_hardening_v1.sql
@@ -1,0 +1,21 @@
+-- DABBIR least-privilege hardening for client-facing operational tables.
+-- Keep application-required access only; remove inherited/default privileges that bypass intent.
+
+alter table public.dabbir_tasks enable row level security;
+alter table public.dabbir_tasks force row level security;
+alter table public.dabbir_whatsapp_connections enable row level security;
+alter table public.dabbir_whatsapp_connections force row level security;
+
+revoke all on table public.dabbir_tasks from public, anon, authenticated;
+grant select, update on table public.dabbir_tasks to authenticated;
+
+revoke all on table public.dabbir_whatsapp_connections from public, anon, authenticated;
+grant select, insert, update, delete on table public.dabbir_whatsapp_connections to authenticated;
+
+-- Task status mutation is authenticated-only and still executes as the caller,
+-- so RLS + the function's manage_business guard both remain authoritative.
+revoke execute on function public.dabbir_set_task_status(uuid, uuid, text) from public, anon;
+grant execute on function public.dabbir_set_task_status(uuid, uuid, text) to authenticated;
+
+-- Trigger functions do not need direct Data API execution grants.
+revoke execute on function public.dabbir_validate_procedure_run_transition() from public, anon, authenticated;

--- a/test/dabbir-rls-grant-hardening.test.mjs
+++ b/test/dabbir-rls-grant-hardening.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migration = await readFile(new URL('../supabase/migrations/20260827180100_dabbir_rls_grant_hardening_v1.sql', import.meta.url), 'utf8');
+
+test('DABBIR tasks and WhatsApp connection tables use FORCE RLS', () => {
+  assert.match(migration, /alter table public\.dabbir_tasks force row level security/i);
+  assert.match(migration, /alter table public\.dabbir_whatsapp_connections force row level security/i);
+});
+
+test('anonymous access is fully revoked and authenticated grants are least privilege', () => {
+  assert.match(migration, /revoke all on table public\.dabbir_tasks from public, anon, authenticated/i);
+  assert.match(migration, /grant select, update on table public\.dabbir_tasks to authenticated/i);
+  assert.match(migration, /revoke all on table public\.dabbir_whatsapp_connections from public, anon, authenticated/i);
+  assert.match(migration, /grant select, insert, update, delete on table public\.dabbir_whatsapp_connections to authenticated/i);
+  assert.doesNotMatch(migration, /grant .*truncate/i);
+  assert.doesNotMatch(migration, /grant .*trigger/i);
+  assert.doesNotMatch(migration, /grant .*references/i);
+});
+
+test('public task RPC is authenticated-only and trigger function is not directly executable by clients', () => {
+  assert.match(migration, /revoke execute on function public\.dabbir_set_task_status\(uuid, uuid, text\) from public, anon/i);
+  assert.match(migration, /grant execute on function public\.dabbir_set_task_status\(uuid, uuid, text\) to authenticated/i);
+  assert.match(migration, /revoke execute on function public\.dabbir_validate_procedure_run_transition\(\) from public, anon, authenticated/i);
+});


### PR DESCRIPTION
Hardens the remaining DABBIR client-facing tables found by the direct database audit.

- Enables FORCE RLS on `dabbir_tasks` and `dabbir_whatsapp_connections`.
- Removes all `anon` access.
- Reduces authenticated task privileges to SELECT + UPDATE only (the current task status RPC is SECURITY INVOKER and still needs UPDATE).
- Reduces WhatsApp connection privileges to SELECT/INSERT/UPDATE/DELETE only, matching Embedded Signup storage/removal behavior.
- Removes client TRUNCATE/TRIGGER/REFERENCES privileges.
- Removes PUBLIC/anon execution from the task RPC while preserving authenticated execution.
- Removes direct client execution from the procedure transition trigger function.
- Adds deterministic grant-contract tests.