### PR TITLE
DABBIR: remove direct team write surface

### DIFF
--- a/db/dabbir_business_onboarding_v12.sql
+++ b/db/dabbir_business_onboarding_v12.sql
@@ -30,7 +30,7 @@ begin
     raise exception 'UNSUPPORTED_BUSINESS_TYPE';
   end if;
 
-  v_slug := 'pilot-' || substr(replace(v_id::text,'-',''),1,16);
+  v_slug := 'dabbir-' || substr(replace(v_id::text,'-',''),1,16);
 
   insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode)
   values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),false);

--- a/supabase/migrations/20260827181500_dabbir_team_direct_write_hardening_v1.sql
+++ b/supabase/migrations/20260827181500_dabbir_team_direct_write_hardening_v1.sql
@@ -1,0 +1,17 @@
+-- DABBIR team direct-write hardening v1
+-- Keep first-owner bootstrap working, but force all later team mutations through guarded RPCs.
+
+-- First-owner bootstrap uses SECURITY INVOKER dabbir_create_business and therefore
+-- still requires authenticated INSERT on dabbir_memberships. Direct UPDATE is not
+-- required by the runtime; role/status/permission changes go through guarded RPCs.
+revoke update on table public.dabbir_memberships from authenticated;
+drop policy if exists dabbir_memberships_team_update on public.dabbir_memberships;
+
+-- Invitation creation/acceptance/revocation is implemented by SECURITY DEFINER RPCs.
+-- Authenticated clients only need tenant-scoped read access to list invitations.
+revoke insert, update, delete, truncate, references, trigger
+on table public.dabbir_employee_invitations from authenticated;
+
+-- Preserve the minimal intended client grants explicitly.
+grant select, insert on table public.dabbir_memberships to authenticated;
+grant select on table public.dabbir_employee_invitations to authenticated;

--- a/supabase/migrations/20260827182000_dabbir_business_slug_source_alignment_v1.sql
+++ b/supabase/migrations/20260827182000_dabbir_business_slug_source_alignment_v1.sql
@@ -1,0 +1,39 @@
+-- DABBIR business slug source alignment v1
+-- Production already creates dabbir-* slugs; codify that behavior in migrations so
+-- a future replay cannot resurrect the retired PILOT prefix.
+
+create or replace function public.dabbir_create_business(
+  p_name text,
+  p_business_type text,
+  p_locale text default 'ar-AE'::text
+)
+returns table(business_id uuid, business_slug text)
+language plpgsql
+security invoker
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_user uuid := auth.uid();
+  v_id uuid := gen_random_uuid();
+  v_slug text;
+begin
+  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+  if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
+  if p_business_type not in ('store','clinic','creator','salon','real_estate','services','other') then
+    raise exception 'UNSUPPORTED_BUSINESS_TYPE';
+  end if;
+
+  v_slug := 'dabbir-' || substr(replace(v_id::text,'-',''),1,16);
+
+  insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode)
+  values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),false);
+
+  insert into public.dabbir_memberships(business_id,user_id,role,status,accepted_at)
+  values(v_id,v_user,'owner','active',now());
+
+  return query select v_id,v_slug;
+end;
+$function$;
+
+revoke all on function public.dabbir_create_business(text,text,text) from public, anon;
+grant execute on function public.dabbir_create_business(text,text,text) to authenticated, service_role;

--- a/test/dabbir-team-direct-write-hardening.test.mjs
+++ b/test/dabbir-team-direct-write-hardening.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migration = await readFile(new URL('../supabase/migrations/20260827181500_dabbir_team_direct_write_hardening_v1.sql', import.meta.url), 'utf8');
+const invitationsApi = await readFile(new URL('../api/team/invitations.js', import.meta.url), 'utf8');
+const membersApi = await readFile(new URL('../api/team/members.js', import.meta.url), 'utf8');
+const onboarding = await readFile(new URL('../db/dabbir_business_onboarding_v12.sql', import.meta.url), 'utf8');
+
+test('team tables expose only the direct grants required by the runtime', () => {
+  assert.match(migration, /revoke update on table public\.dabbir_memberships from authenticated/i);
+  assert.match(migration, /drop policy if exists dabbir_memberships_team_update/i);
+  assert.match(migration, /grant select, insert on table public\.dabbir_memberships to authenticated/i);
+  assert.match(migration, /revoke insert, update, delete, truncate, references, trigger\s+on table public\.dabbir_employee_invitations from authenticated/i);
+  assert.match(migration, /grant select on table public\.dabbir_employee_invitations to authenticated/i);
+});
+
+test('team mutations stay behind guarded RPCs', () => {
+  assert.match(invitationsApi, /supabaseRpc\('dabbir_create_employee_invitation'/);
+  assert.doesNotMatch(invitationsApi, /supabaseRest\([^\n]*dabbir_employee_invitations[^\n]*method:\s*['"](?:POST|PATCH|DELETE)['"]/i);
+  assert.match(membersApi, /dabbir_update_employee_access|dabbir_set_employee_status/);
+});
+
+test('first-owner bootstrap still has the membership insert grant it requires', () => {
+  assert.match(onboarding, /security invoker/i);
+  assert.match(onboarding, /insert into public\.dabbir_memberships/i);
+  assert.match(migration, /grant select, insert on table public\.dabbir_memberships to authenticated/i);
+});

--- a/test/dabbir-team-direct-write-hardening.test.mjs
+++ b/test/dabbir-team-direct-write-hardening.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
 const migration = await readFile(new URL('../supabase/migrations/20260827181500_dabbir_team_direct_write_hardening_v1.sql', import.meta.url), 'utf8');
+const slugMigration = await readFile(new URL('../supabase/migrations/20260827182000_dabbir_business_slug_source_alignment_v1.sql', import.meta.url), 'utf8');
 const invitationsApi = await readFile(new URL('../api/team/invitations.js', import.meta.url), 'utf8');
 const membersApi = await readFile(new URL('../api/team/members.js', import.meta.url), 'utf8');
 const onboarding = await readFile(new URL('../db/dabbir_business_onboarding_v12.sql', import.meta.url), 'utf8');
@@ -25,4 +26,11 @@ test('first-owner bootstrap still has the membership insert grant it requires', 
   assert.match(onboarding, /security invoker/i);
   assert.match(onboarding, /insert into public\.dabbir_memberships/i);
   assert.match(migration, /grant select, insert on table public\.dabbir_memberships to authenticated/i);
+});
+
+test('new business slugs can never resurrect the retired PILOT prefix', () => {
+  assert.match(onboarding, /v_slug\s*:=\s*'dabbir-'/i);
+  assert.doesNotMatch(onboarding, /v_slug\s*:=\s*'pilot-'/i);
+  assert.match(slugMigration, /v_slug\s*:=\s*'dabbir-'/i);
+  assert.doesNotMatch(slugMigration, /v_slug\s*:=\s*'pilot-'/i);
 });


### PR DESCRIPTION
Defense-in-depth follow-up after live privilege-escalation probes.

- Keeps authenticated INSERT on `dabbir_memberships` because first-owner bootstrap is SECURITY INVOKER and requires it.
- Removes authenticated direct UPDATE on memberships and drops the direct team-update RLS policy.
- Removes authenticated INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER on employee invitations; keeps SELECT only.
- Leaves team mutations exclusively behind the already tested guarded RPCs.
- Adds regression coverage so onboarding remains functional while direct team writes stay closed.