### PR TITLE
DABBIR: remove unused direct DELETE grants

### DIFF
--- a/supabase/migrations/20260827184000_dabbir_unused_delete_grants_v1.sql
+++ b/supabase/migrations/20260827184000_dabbir_unused_delete_grants_v1.sql
@@ -1,0 +1,6 @@
+-- DABBIR unused direct DELETE grants v1
+-- Neither table has an authenticated DELETE policy and no runtime path performs a
+-- direct delete. Remove the redundant grants so ACLs match the actual contract.
+
+revoke delete on table public.dabbir_businesses from authenticated;
+revoke delete on table public.dabbir_conversations from authenticated;

--- a/test/dabbir-unused-delete-grants.test.mjs
+++ b/test/dabbir-unused-delete-grants.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migration = await readFile(new URL('../supabase/migrations/20260827184000_dabbir_unused_delete_grants_v1.sql', import.meta.url), 'utf8');
+
+test('unused direct DELETE grants remain revoked', () => {
+  assert.match(migration, /revoke delete on table public\.dabbir_businesses from authenticated/i);
+  assert.match(migration, /revoke delete on table public\.dabbir_conversations from authenticated/i);
+  assert.doesNotMatch(migration, /grant delete/i);
+});


### PR DESCRIPTION
Removes the last authenticated write grants that have no corresponding RLS DELETE policy and no runtime consumer.

- Revokes direct DELETE on `dabbir_businesses`.
- Revokes direct DELETE on `dabbir_conversations`.
- Adds regression coverage to keep those grants closed.