### PR TITLE
DABBIR: make evolution control tables explicitly service-only

### DIFF
--- a/supabase/migrations/20260827185000_dabbir_evolution_service_only_policies_v1.sql
+++ b/supabase/migrations/20260827185000_dabbir_evolution_service_only_policies_v1.sql
@@ -1,0 +1,22 @@
+-- DABBIR evolution service-only policies v1
+-- These barman_control tables are operated only by service_role. Client roles have
+-- no schema USAGE and no table grants. Add explicit deny policies so the RLS
+-- contract is documented and future grant drift cannot accidentally expose rows.
+
+alter table barman_control.dabbir_evolution_objectives enable row level security;
+alter table barman_control.dabbir_evolution_objectives force row level security;
+drop policy if exists dabbir_evolution_objectives_client_deny on barman_control.dabbir_evolution_objectives;
+create policy dabbir_evolution_objectives_client_deny
+on barman_control.dabbir_evolution_objectives
+for all to anon, authenticated
+using (false)
+with check (false);
+
+alter table barman_control.dabbir_evolution_state enable row level security;
+alter table barman_control.dabbir_evolution_state force row level security;
+drop policy if exists dabbir_evolution_state_client_deny on barman_control.dabbir_evolution_state;
+create policy dabbir_evolution_state_client_deny
+on barman_control.dabbir_evolution_state
+for all to anon, authenticated
+using (false)
+with check (false);

--- a/test/dabbir-evolution-service-only-policies.test.mjs
+++ b/test/dabbir-evolution-service-only-policies.test.mjs
@@ -10,5 +10,5 @@ test('evolution control tables are explicitly denied to client roles', () => {
     assert.match(migration, new RegExp(`create policy ${table}_client_deny`, 'i'));
   }
   assert.match(migration, /for all to anon, authenticated\s+using \(false\)\s+with check \(false\)/i);
-  assert.doesNotMatch(migration, /grant\s+/i);
+  assert.doesNotMatch(migration, /^\s*grant\s+/im);
 });

--- a/test/dabbir-evolution-service-only-policies.test.mjs
+++ b/test/dabbir-evolution-service-only-policies.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migration = await readFile(new URL('../supabase/migrations/20260827185000_dabbir_evolution_service_only_policies_v1.sql', import.meta.url), 'utf8');
+
+test('evolution control tables are explicitly denied to client roles', () => {
+  for (const table of ['dabbir_evolution_objectives','dabbir_evolution_state']) {
+    assert.match(migration, new RegExp(`alter table barman_control\\.${table} force row level security`, 'i'));
+    assert.match(migration, new RegExp(`create policy ${table}_client_deny`, 'i'));
+  }
+  assert.match(migration, /for all to anon, authenticated\s+using \(false\)\s+with check \(false\)/i);
+  assert.doesNotMatch(migration, /grant\s+/i);
+});


### PR DESCRIPTION
Codifies the existing service-only contract for DABBIR autonomous evolution control tables.

- Keeps FORCE RLS on `barman_control.dabbir_evolution_objectives` and `dabbir_evolution_state`.
- Adds explicit ALL-deny policies for `anon` and `authenticated`.
- Adds no client grants; service_role remains the only operational role.
- Prevents future grant drift from accidentally exposing rows and clears ambiguous RLS-with-no-policy advisor findings.
- Adds regression coverage.