### PR TITLE
DABBIR: harden customer-number lookup RPC

### DIFF
--- a/supabase/migrations/20260827190000_dabbir_customer_number_rpc_hardening_v1.sql
+++ b/supabase/migrations/20260827190000_dabbir_customer_number_rpc_hardening_v1.sql
@@ -1,0 +1,21 @@
+-- DABBIR customer-number lookup RPC hardening v1
+-- The caller already owns a self-only SELECT policy on dabbir_user_numbers, so
+-- elevated execution is unnecessary. Run under caller RLS and remove anonymous RPC access.
+
+alter table public.dabbir_user_numbers enable row level security;
+alter table public.dabbir_user_numbers force row level security;
+
+create or replace function public.dabbir_my_customer_no()
+returns text
+language sql
+stable
+security invoker
+set search_path to 'public', 'auth'
+as $function$
+  select n.customer_no
+  from public.dabbir_user_numbers n
+  where n.user_id = auth.uid();
+$function$;
+
+revoke all on function public.dabbir_my_customer_no() from public, anon;
+grant execute on function public.dabbir_my_customer_no() to authenticated, service_role;

--- a/test/dabbir-customer-number-rpc-hardening.test.mjs
+++ b/test/dabbir-customer-number-rpc-hardening.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const migration = await readFile(new URL('../supabase/migrations/20260827190000_dabbir_customer_number_rpc_hardening_v1.sql', import.meta.url), 'utf8');
+
+test('customer-number lookup runs as caller under FORCE RLS', () => {
+  assert.match(migration, /alter table public\.dabbir_user_numbers force row level security/i);
+  assert.match(migration, /create or replace function public\.dabbir_my_customer_no\(\)[\s\S]*security invoker/i);
+  assert.match(migration, /where n\.user_id = auth\.uid\(\)/i);
+});
+
+test('customer-number RPC is not callable anonymously', () => {
+  assert.match(migration, /revoke all on function public\.dabbir_my_customer_no\(\) from public, anon/i);
+  assert.match(migration, /grant execute on function public\.dabbir_my_customer_no\(\) to authenticated, service_role/i);
+  assert.doesNotMatch(migration, /^\s*grant execute[^\n]*anon/im);
+});


### PR DESCRIPTION
Removes unnecessary elevated execution from the customer-number lookup surfaced by the latest Supabase security advisor.

- Enables FORCE RLS on `dabbir_user_numbers`.
- Changes `dabbir_my_customer_no()` from SECURITY DEFINER to SECURITY INVOKER.
- Revokes PUBLIC/anon EXECUTE and grants only authenticated/service_role.
- Preserves the existing self-only RLS policy (`user_id = auth.uid()`).
- Adds regression coverage so anonymous/elevated execution cannot return.