### PR TITLE
Remove duplicate DABBIR customer-number registry

### DIFF
--- a/supabase/migrations/20260827144500_dabbir_customer_number_single_source_v1.sql
+++ b/supabase/migrations/20260827144500_dabbir_customer_number_single_source_v1.sql
@@ -1,0 +1,42 @@
+-- DABBIR customer number single-source cleanup.
+-- Keep public.dabbir_user_accounts + dabbir_private ledger as authoritative.
+-- Remove the parallel dabbir_user_numbers implementation only after proving exact identity parity.
+
+do $block$
+declare
+  v_mismatch_count bigint;
+begin
+  if to_regclass('public.dabbir_user_accounts') is null then
+    raise exception 'DABBIR_CUSTOMER_NUMBER_AUTHORITATIVE_REGISTRY_MISSING';
+  end if;
+
+  if to_regclass('public.dabbir_user_numbers') is null then
+    return;
+  end if;
+
+  select count(*)
+    into v_mismatch_count
+  from public.dabbir_user_accounts a
+  full join public.dabbir_user_numbers n using (user_id)
+  where a.user_id is null
+     or n.user_id is null
+     or a.customer_no is distinct from n.customer_no;
+
+  if v_mismatch_count <> 0 then
+    raise exception 'DABBIR_CUSTOMER_NUMBER_REGISTRY_MISMATCH count=%', v_mismatch_count;
+  end if;
+end;
+$block$;
+
+drop trigger if exists trg_dabbir_assign_user_number_on_membership on public.dabbir_memberships;
+
+drop function if exists public.dabbir_support_resolve_account(text);
+drop function if exists public.dabbir_resolve_customer_no(text);
+drop function if exists public.dabbir_my_customer_no();
+drop function if exists public.dabbir_assign_user_number_on_membership();
+drop function if exists public.dabbir_ensure_user_number(uuid);
+
+drop table if exists public.dabbir_user_numbers;
+
+comment on table public.dabbir_user_accounts is
+  'AUTHORITATIVE DABBIR visible account-number registry. UUID auth.users.id remains canonical; customer_no is the stable human-facing support identifier.';

--- a/test/dabbir-customer-number-single-source.test.mjs
+++ b/test/dabbir-customer-number-single-source.test.mjs
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('customer number cleanup preserves the authoritative registry and removes the duplicate', async () => {
+  const sql = await readFile(new URL('../supabase/migrations/20260827144500_dabbir_customer_number_single_source_v1.sql', import.meta.url), 'utf8');
+  assert.match(sql, /dabbir_user_accounts/);
+  assert.match(sql, /full join public\.dabbir_user_numbers/i);
+  assert.match(sql, /customer_no is distinct from n\.customer_no/i);
+  assert.match(sql, /REGISTRY_MISMATCH/);
+  assert.match(sql, /drop table if exists public\.dabbir_user_numbers/i);
+  assert.match(sql, /AUTHORITATIVE DABBIR visible account-number registry/i);
+});


### PR DESCRIPTION
Keeps the already-merged `dabbir_user_accounts` + private immutable ledger as the single authoritative DABBIR customer-number implementation.

The cleanup migration refuses to proceed unless the temporary parallel registry matches the authoritative registry exactly by `user_id` and `customer_no`, then removes the duplicate trigger/functions/table.

Database execution evidence before cleanup: 17/17 records matched. After cleanup: authoritative registry exists, duplicate registry removed, 17 numbered users, 17 ledger rows, 17 ledger matches, 0 duplicate numbers, 0 invalid formats.