### PR TITLE
Add private DABBIR support account lookup

### DIFF
--- a/supabase/migrations/20260827145000_dabbir_support_account_lookup_v1.sql
+++ b/supabase/migrations/20260827145000_dabbir_support_account_lookup_v1.sql
@@ -1,0 +1,68 @@
+-- Service-only exact DABBIR account resolver for support/recovery workflows.
+-- Human-facing lookup may use DAB number, verified Auth email, or Auth phone.
+-- UUID remains canonical and no lookup capability is granted to client roles.
+
+create or replace function dabbir_private.resolve_account_lookup(p_query text)
+returns table (
+  customer_no text,
+  user_id uuid,
+  business_id uuid,
+  business_name text,
+  membership_role text,
+  membership_status text,
+  matched_on text
+)
+language sql
+stable
+security definer
+set search_path = pg_catalog, public, auth
+as $function$
+  with q as (
+    select
+      nullif(trim(p_query), '') as raw_value,
+      upper(nullif(trim(p_query), '')) as number_value,
+      lower(nullif(trim(p_query), '')) as email_value,
+      regexp_replace(coalesce(p_query, ''), '[^0-9+]', '', 'g') as phone_value
+  ), matched_users as (
+    select
+      a.customer_no,
+      a.user_id,
+      case
+        when a.customer_no = q.number_value then 'customer_no'
+        when lower(u.email) = q.email_value then 'email'
+        when q.phone_value <> ''
+          and regexp_replace(coalesce(u.phone, ''), '[^0-9+]', '', 'g') = q.phone_value then 'phone'
+        else null
+      end as matched_on
+    from public.dabbir_user_accounts a
+    join auth.users u on u.id = a.user_id
+    cross join q
+    where q.raw_value is not null
+      and (
+        a.customer_no = q.number_value
+        or lower(u.email) = q.email_value
+        or (
+          q.phone_value <> ''
+          and regexp_replace(coalesce(u.phone, ''), '[^0-9+]', '', 'g') = q.phone_value
+        )
+      )
+  )
+  select
+    mu.customer_no,
+    mu.user_id,
+    m.business_id,
+    b.name as business_name,
+    m.role::text as membership_role,
+    m.status::text as membership_status,
+    mu.matched_on
+  from matched_users mu
+  left join public.dabbir_memberships m on m.user_id = mu.user_id
+  left join public.dabbir_businesses b on b.id = m.business_id
+  order by mu.customer_no, m.created_at nulls last;
+$function$;
+
+revoke all on function dabbir_private.resolve_account_lookup(text) from public, anon, authenticated;
+grant execute on function dabbir_private.resolve_account_lookup(text) to service_role;
+
+comment on function dabbir_private.resolve_account_lookup(text) is
+  'Service-only exact account lookup by DAB customer number, Auth email, or Auth phone. Returns canonical UUID and DABBIR memberships for support/recovery.';

--- a/test/dabbir-support-account-lookup.test.mjs
+++ b/test/dabbir-support-account-lookup.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('support lookup resolves exact DAB/email/phone and stays service-only', async () => {
+  const sql = await readFile(new URL('../supabase/migrations/20260827145000_dabbir_support_account_lookup_v1.sql', import.meta.url), 'utf8');
+  assert.match(sql, /dabbir_private\.resolve_account_lookup/);
+  assert.match(sql, /customer_no/);
+  assert.match(sql, /lower\(u\.email\)/i);
+  assert.match(sql, /regexp_replace\(coalesce\(u\.phone/i);
+  assert.match(sql, /matched_on/);
+  assert.match(sql, /revoke all on function dabbir_private\.resolve_account_lookup\(text\) from public, anon, authenticated/i);
+  assert.match(sql, /grant execute on function dabbir_private\.resolve_account_lookup\(text\) to service_role/i);
+});


### PR DESCRIPTION
Adds a service-role-only exact DABBIR account resolver for support/recovery workflows. It accepts the visible DAB customer number, Auth email, or Auth phone and returns the canonical UUID plus DABBIR membership/business context. No client role receives execute permission.

Live DB verification: exact DAB lookup returns one account; exact email lookup returns the same account. No current DABBIR Auth user has a stored phone value, so the phone path is structurally covered and remains unavailable to exercise against live data until one exists.