### PR TITLE
DABBIR: close BAR-16 privacy and recovery gaps

### DIFF
--- a/api/_observability.js
+++ b/api/_observability.js
@@ -5,6 +5,13 @@ const FAILURE_CLASSES = new Set([
   'POLICY','USER_INPUT','EXTERNAL_PROVIDER','SECURITY','UNKNOWN',
 ]);
 
+const REDACTED='[REDACTED]';
+const SENSITIVE_KEY=/(^|_)(authorization|cookie|set_cookie|access_token|refresh_token|id_token|token|secret|password|passwd|api_key|app_secret|phone|phone_number|mobile|email|message|message_body|body|raw_body|raw_payload)($|_)/i;
+const EMAIL=/\b[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}\b/gi;
+const BEARER=/\bBearer\s+[A-Za-z0-9._~+\/-]+=*/gi;
+const JWT=/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g;
+const PHONE=/(^|[^A-Za-z0-9])((?:\+\d[\d ()-]{7,}\d)|(?:\d{9,15}))(?=$|[^A-Za-z0-9])/g;
+
 export function correlationId(req) {
   const incoming = String(req?.headers?.['x-correlation-id'] || req?.headers?.['x-request-id'] || '').trim();
   if (/^[A-Za-z0-9._:-]{8,120}$/.test(incoming)) return incoming;
@@ -29,13 +36,40 @@ export function classifyFailure(error, fallback = 'UNKNOWN') {
   return FAILURE_CLASSES.has(fallback) ? fallback : 'UNKNOWN';
 }
 
+function redactString(value){
+  return String(value)
+    .replace(BEARER,REDACTED)
+    .replace(JWT,REDACTED)
+    .replace(EMAIL,REDACTED)
+    .replace(PHONE,(full,prefix)=>`${prefix}${REDACTED}`);
+}
+
+export function redactLogValue(value,key='',depth=0){
+  if(SENSITIVE_KEY.test(String(key)))return REDACTED;
+  if(depth>8)return '[TRUNCATED_DEPTH]';
+  if(value==null||typeof value==='boolean'||typeof value==='number')return value;
+  if(typeof value==='string')return redactString(value).slice(0,2000);
+  if(Array.isArray(value))return value.slice(0,50).map(item=>redactLogValue(item,'',depth+1));
+  if(typeof value==='object'){
+    const safe={};
+    for(const [childKey,childValue] of Object.entries(value).slice(0,100)){
+      safe[childKey]=redactLogValue(childValue,childKey,depth+1);
+    }
+    return safe;
+  }
+  return redactString(value);
+}
+
+export function redactLogEvent(event={}){
+  return redactLogValue(event,'',0);
+}
+
 export function logEvent(level, event) {
-  const safe = {
+  const safe = redactLogEvent({
     ts: new Date().toISOString(),
     product: 'DABBIR',
     ...event,
-  };
-  // Never log message bodies, access tokens, refresh tokens, secrets, phone numbers or emails here.
+  });
   const line = JSON.stringify(safe);
   if (level === 'error') console.error(line);
   else if (level === 'warn') console.warn(line);
@@ -53,4 +87,4 @@ export function operationalResult({ correlation_id, operation, outcome, failure_
   };
 }
 
-export { FAILURE_CLASSES };
+export { FAILURE_CLASSES, REDACTED };

--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -48,12 +48,23 @@ export function embeddedPlatformConfig() {
   );
   const graphVersion = firstEnv('DABBIR_META_GRAPH_VERSION', 'PILOT_META_GRAPH_VERSION', 'META_GRAPH_VERSION') || 'v23.0';
   const encryptionSecret = firstEnv('DABBIR_INTEGRATION_ENCRYPTION_KEY') || appSecret;
+  const encryptionKeyVersion = firstEnv('DABBIR_INTEGRATION_ENCRYPTION_KEY_VERSION') || 'whatsapp_v1';
+  const previousEncryptionSecret = firstEnv('DABBIR_INTEGRATION_ENCRYPTION_KEY_PREVIOUS');
+  const previousEncryptionKeyVersion = firstEnv('DABBIR_INTEGRATION_ENCRYPTION_KEY_PREVIOUS_VERSION');
   return {
     appId,
     appSecret,
     configId,
     graphVersion,
     encryptionSecret,
+    encryptionKeyVersion,
+    previousEncryptionSecret,
+    previousEncryptionKeyVersion,
+    rotationReady: Boolean(
+      previousEncryptionSecret
+      && previousEncryptionKeyVersion
+      && previousEncryptionKeyVersion !== encryptionKeyVersion
+    ),
     appIdSource: appId ? 'environment' : null,
     legacyAccessTokenAvailable: Boolean(legacyWhatsAppAccessToken()),
     ready: Boolean(appId && appSecret && configId && encryptionSecret),
@@ -114,33 +125,46 @@ export async function ownerContext(req, businessId) {
   return { accessToken, user, membership };
 }
 
-function keyFor(config, businessId) {
-  if (!config.encryptionSecret) throw new Error('INTEGRATION_ENCRYPTION_NOT_CONFIGURED');
+function keySecretForVersion(config, keyVersion) {
+  const currentVersion = String(config.encryptionKeyVersion || 'whatsapp_v1');
+  const requestedVersion = String(keyVersion || currentVersion);
+  if (requestedVersion === currentVersion && config.encryptionSecret) return config.encryptionSecret;
+  if (
+    requestedVersion === String(config.previousEncryptionKeyVersion || '')
+    && config.previousEncryptionSecret
+  ) return config.previousEncryptionSecret;
+  throw new Error('INTEGRATION_ENCRYPTION_KEY_VERSION_UNAVAILABLE');
+}
+
+function keyFor(config, businessId, keyVersion = config.encryptionKeyVersion) {
+  const secret = keySecretForVersion(config, keyVersion);
   return crypto.createHash('sha256')
     .update('dabbir-whatsapp-embedded-v1\0')
     .update(String(businessId))
     .update('\0')
-    .update(config.encryptionSecret)
+    .update(secret)
     .digest();
 }
 
 export function sealAccessToken(token, config, businessId) {
+  const keyVersion = String(config.encryptionKeyVersion || 'whatsapp_v1');
   const iv = crypto.randomBytes(12);
-  const cipher = crypto.createCipheriv('aes-256-gcm', keyFor(config, businessId), iv);
+  const cipher = crypto.createCipheriv('aes-256-gcm', keyFor(config, businessId, keyVersion), iv);
   const ciphertext = Buffer.concat([cipher.update(String(token), 'utf8'), cipher.final()]);
   const tag = cipher.getAuthTag();
   return {
     access_token_ciphertext: ciphertext.toString('base64url'),
     access_token_iv: iv.toString('base64url'),
     access_token_tag: tag.toString('base64url'),
-    token_key_version: 'whatsapp_v1',
+    token_key_version: keyVersion,
   };
 }
 
 export function openAccessToken(row, config, businessId) {
+  const keyVersion = String(row.token_key_version || 'whatsapp_v1');
   const decipher = crypto.createDecipheriv(
     'aes-256-gcm',
-    keyFor(config, businessId),
+    keyFor(config, businessId, keyVersion),
     Buffer.from(String(row.access_token_iv || ''), 'base64url'),
   );
   decipher.setAuthTag(Buffer.from(String(row.access_token_tag || ''), 'base64url'));
@@ -149,6 +173,29 @@ export function openAccessToken(row, config, businessId) {
     decipher.final(),
   ]);
   return plaintext.toString('utf8');
+}
+
+export function tokenNeedsRotation(row, config) {
+  return String(row?.token_key_version || 'whatsapp_v1') !== String(config?.encryptionKeyVersion || 'whatsapp_v1');
+}
+
+export async function rotateStoredConnectionEncryption(accessToken, row, config, token = null) {
+  if (!row || !tokenNeedsRotation(row, config)) return { rotated: false, row };
+  const plaintext = token == null ? openAccessToken(row, config, row.business_id) : String(token);
+  const sealed = sealAccessToken(plaintext, config, row.business_id);
+  const response = await supabaseRest(
+    `dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(row.business_id))}`,
+    accessToken,
+    {
+      method: 'PATCH',
+      headers: { prefer: 'return=representation' },
+      body: JSON.stringify(sealed),
+    },
+  );
+  const payload = await response.json().catch(() => []);
+  if (!response.ok) throw Object.assign(new Error('INTEGRATION_KEY_ROTATION_STORE_FAILED'), { status: 502 });
+  const updated = Array.isArray(payload) ? payload[0] || { ...row, ...sealed } : { ...row, ...sealed };
+  return { rotated: true, row: updated };
 }
 
 async function graphFetch(config, path, { method = 'GET', token, query, body } = {}) {
@@ -248,7 +295,14 @@ export async function loadBusinessConnection(accessToken, businessId) {
   const response = await supabaseRest(path, accessToken);
   if (!response.ok) return null;
   const rows = await response.json().catch(() => []);
-  return Array.isArray(rows) ? rows[0] || null : null;
+  let row = Array.isArray(rows) ? rows[0] || null : null;
+  if (!row) return null;
+  const config = embeddedPlatformConfig();
+  if (tokenNeedsRotation(row, config) && config.rotationReady) {
+    const rotation = await rotateStoredConnectionEncryption(accessToken, row, config);
+    row = rotation.row || row;
+  }
+  return row;
 }
 
 export async function upsertBusinessConnection(accessToken, row) {

--- a/api/privacy/execute.js
+++ b/api/privacy/execute.js
@@ -1,0 +1,81 @@
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  readRpcJson,
+  requireSameOrigin,
+  supabaseRest,
+  supabaseRpc,
+} from '../_auth-core.js';
+import { attachCorrelation, correlationId, logEvent } from '../_observability.js';
+
+const UUID=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const KNOWN_ERRORS=[
+  'AUTH_REQUIRED','OWNER_REQUIRED','PRIVACY_REQUEST_NOT_FOUND','CUSTOMER_PRIVACY_REQUEST_REQUIRED',
+  'CUSTOMER_TARGET_ALREADY_REMOVED','PRIVACY_REQUEST_NOT_EXECUTABLE','CUSTOMER_NOT_FOUND',
+  'CUSTOMER_EXPORT_TOO_LARGE','LEGAL_HOLD_ACTIVE','EXPLICIT_DELETE_CONFIRMATION_REQUIRED',
+  'CUSTOMER_DELETE_NOT_VERIFIED',
+];
+
+function reply(res,status,body,cid){
+  attachCorrelation(res,cid);
+  return json(res,status,{...body,correlation_id:cid});
+}
+
+function errorCode(payload){
+  const raw=String(payload?.message||payload?.error||'').toUpperCase();
+  return KNOWN_ERRORS.find(code=>raw.includes(code))||'PRIVACY_EXECUTION_FAILED';
+}
+
+async function readRequest(token,requestId){
+  const response=await supabaseRest(
+    `dabbir_privacy_requests?select=id,business_id,customer_id,request_type,status&id=eq.${encodeURIComponent(requestId)}&limit=1`,
+    token,
+  );
+  if(!response.ok)return null;
+  const rows=await response.json().catch(()=>[]);
+  return Array.isArray(rows)?rows[0]||null:null;
+}
+
+export default async function handler(req,res){
+  const cid=correlationId(req);
+  attachCorrelation(res,cid);
+  if(req.method!=='POST')return reply(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},cid);
+  if(!requireSameOrigin(req))return reply(res,403,{ok:false,error:'ORIGIN_REQUIRED'},cid);
+
+  try{
+    const token=accessTokenFromRequest(req);
+    const user=token?await getVerifiedUser(token).catch(()=>null):null;
+    if(!user)return reply(res,401,{ok:false,error:'AUTH_REQUIRED'},cid);
+    const body=await readJsonBody(req,8192);
+    const requestId=String(body.request_id||'').trim();
+    if(!UUID.test(requestId))return reply(res,400,{ok:false,error:'PRIVACY_REQUEST_REQUIRED'},cid);
+
+    const request=await readRequest(token,requestId);
+    if(!request)return reply(res,404,{ok:false,error:'PRIVACY_REQUEST_NOT_FOUND'},cid);
+    const memberships=await getBusinessMemberships(token).catch(()=>[]);
+    const membership=memberships.find(item=>item.business_id===request.business_id&&item.status==='active');
+    if(!membership||membership.role!=='owner')return reply(res,403,{ok:false,error:'OWNER_REQUIRED'},cid);
+
+    const confirmation=body.confirmation==null?null:String(body.confirmation).slice(0,120);
+    const rpc=await supabaseRpc('dabbir_execute_customer_privacy_request',token,{
+      p_request_id:requestId,
+      p_confirmation:confirmation,
+    });
+    const payload=await readRpcJson(rpc);
+    if(!rpc.ok){
+      const code=errorCode(payload);
+      const status=code==='OWNER_REQUIRED'?403:code==='LEGAL_HOLD_ACTIVE'||code==='PRIVACY_REQUEST_NOT_EXECUTABLE'?409:code==='PRIVACY_REQUEST_NOT_FOUND'||code==='CUSTOMER_NOT_FOUND'?404:400;
+      logEvent('warn',{correlation_id:cid,component:'privacy',operation:'execute_customer_request',outcome:'BLOCKED',failure_class:'POLICY',request_type:request.request_type,error_code:code});
+      return reply(res,status,{ok:false,error:code},cid);
+    }
+
+    logEvent('info',{correlation_id:cid,component:'privacy',operation:'execute_customer_request',outcome:'VERIFIED_SUCCESS',request_type:request.request_type,persisted_request_state:true});
+    return reply(res,200,{ok:true,result:payload},cid);
+  }catch(error){
+    const status=error?.message==='PAYLOAD_TOO_LARGE'?413:error?.message==='INVALID_JSON'?400:503;
+    return reply(res,status,{ok:false,error:status===413?'PAYLOAD_TOO_LARGE':status===400?'INVALID_JSON':'PRIVACY_EXECUTION_UNAVAILABLE'},cid);
+  }
+}

--- a/docs/security/bar-16-threat-model.md
+++ b/docs/security/bar-16-threat-model.md
@@ -1,0 +1,142 @@
+# BAR-16 — DABBIR Privacy & Tenant Isolation Threat Model
+
+## Scope
+
+This model covers DABBIR customer data isolation, privacy export/delete execution, integration secrets, observability, and customer-scoped recovery.
+
+## Protected assets
+
+- Business and customer records.
+- Customer identities, conversations, messages, appointments, memory and consent records.
+- Payment/accounting evidence that must not be erased merely because customer-identifying data is removed.
+- WhatsApp/Meta integration access tokens and integration encryption keys.
+- Privacy request and audit records.
+- Recovery journals, snapshots and restore cases.
+
+## Trust boundaries
+
+1. Browser/app -> DABBIR API.
+2. DABBIR API -> Supabase Data API/RPC.
+3. Tenant A -> Tenant B data boundary.
+4. Authenticated user -> owner/admin-only operations.
+5. DABBIR runtime -> Meta/WhatsApp provider.
+6. Application logs -> operators/observability systems.
+7. Production tables -> private recovery vault.
+
+## Threats and enforced controls
+
+### Cross-tenant read/write
+
+Threat: a valid signed-in user attempts to read or mutate another business's rows.
+
+Controls:
+- Tenant tables use RLS and FORCE RLS where applicable.
+- Membership checks bind business_id to auth.uid().
+- Privacy execution re-checks active owner membership inside the SECURITY DEFINER function rather than trusting request parameters.
+- Negative QA executes RPCs as the authenticated role and verifies non-owner denial.
+
+### Privilege escalation through RPC
+
+Threat: an authenticated caller invokes a privileged SECURITY DEFINER function directly.
+
+Controls:
+- Public privacy RPC is SECURITY INVOKER.
+- Anonymous execution is revoked.
+- The private executor independently checks auth.uid(), request type, business membership and owner role.
+- Sensitive operations fail closed on unknown states.
+
+### Silent or accidental deletion
+
+Threat: customer data is erased because of a UI bug, replay, forged request, or implicit automation.
+
+Controls:
+- Privacy intake and execution are separate operations.
+- Customer deletion requires exact confirmation `DELETE_CUSTOMER:<uuid>`.
+- LEGAL_HOLD blocks deletion.
+- Request row is locked during execution.
+- Deletion verifies exactly one root customer row was removed.
+- No external financial side effect is executed.
+
+### Destruction of accounting evidence
+
+Threat: privacy deletion removes records required for finance, reconciliation, disputes or legal obligations.
+
+Controls:
+- Orders, offers, payments and financial evidence are dissociated from the customer identity instead of blindly deleted.
+- Stripe customer references are removed from the retained payment row.
+- Financial-evidence metadata is replaced with a privacy-redacted marker.
+
+### Privacy export creating a second PII store
+
+Threat: an export request persists another plaintext copy of customer data.
+
+Controls:
+- Export body is returned inline only.
+- Persisted request evidence contains SHA-256, byte count and completion metadata, not the export body.
+- Maximum inline export size is bounded.
+
+### Sensitive data in logs
+
+Threat: tokens, email addresses, phone numbers or message bodies are accidentally logged by a caller.
+
+Controls:
+- `logEvent` performs recursive mandatory redaction centrally.
+- Sensitive keys are redacted regardless of caller intent.
+- Embedded Bearer/JWT/email/phone values are redacted from otherwise safe strings.
+- Object depth, array size and string length are bounded.
+
+### Integration token disclosure or key compromise
+
+Threat: encrypted WhatsApp tokens become readable because a key leaks, or routine key rotation makes existing ciphertext unavailable.
+
+Controls:
+- Tokens are encrypted with AES-256-GCM and a tenant-derived key.
+- Ciphertext, IV and authentication tag are stored separately from key material.
+- Key material remains in runtime secret configuration, not the database.
+- `token_key_version` identifies the encryption version.
+- DABBIR supports a current key/version and exactly one previous key/version during rotation.
+- When an old-version connection is loaded, DABBIR re-encrypts it with the current key automatically.
+- If the required version is not available, decryption fails closed.
+
+## Integration key rotation policy
+
+Routine rotation target: every 90 days. Immediate rotation is required after suspected exposure, privileged-operator offboarding, secret-store compromise, or accidental secret disclosure.
+
+Safe sequence:
+
+1. Generate a new high-entropy `DABBIR_INTEGRATION_ENCRYPTION_KEY` and increment `DABBIR_INTEGRATION_ENCRYPTION_KEY_VERSION`.
+2. Move the old key/version to `DABBIR_INTEGRATION_ENCRYPTION_KEY_PREVIOUS` and `DABBIR_INTEGRATION_ENCRYPTION_KEY_PREVIOUS_VERSION`.
+3. Deploy the application before removing the previous key.
+4. Existing connections are lazily rewrapped to the current version on authenticated connection load; newly linked connections use the current version immediately.
+5. Verify no stored `dabbir_whatsapp_connections.token_key_version` remains on the previous version.
+6. Remove the previous key/version from runtime configuration and redeploy.
+7. If compromise is suspected, revoke/replace provider tokens as well; encryption-key rotation alone does not revoke a Meta token.
+
+Never rotate by replacing the current key while omitting the previous key/version if old ciphertext still exists.
+
+## Recovery failure and corruption
+
+Threat: operator error or privacy execution deletes customer-scoped data that must be restored, but the recovery journal omits the root customer row.
+
+Controls:
+- Recovery journal and restore evidence are private and append-only.
+- Journal events are hashed and health-checked.
+- `dabbir_customers.id` is explicitly registered as a customer scope key.
+- Customer-scoped recovery therefore includes both root customer and child rows.
+- BAR-16 live transactional QA mutates an existing customer row, opens a recovery case to the pre-change time, applies recovery, verifies the original value, and rolls the entire QA transaction back.
+
+## Residual risks
+
+- Supabase leaked-password protection is an Auth configuration control and must be enabled separately when the account plan/settings allow it.
+- Provider-token revocation still depends on the external provider.
+- Legal retention requirements vary by business and jurisdiction; LEGAL_HOLD and retention policy must remain authoritative over deletion.
+- Business-wide export/delete is outside this BAR-16 customer-data executor and requires its own explicitly reviewed workflow.
+
+## Release gate
+
+BAR-16 may be marked complete only when:
+- CI and committed-secret scanning pass on the exact PR head.
+- Security Advisor has no new BAR-16 RLS/RPC finding.
+- Customer export/delete negative and positive paths pass transactionally on production schema with rollback.
+- Recovery root-row test passes transactionally with rollback.
+- Production deployment matches the merged commit and has no new runtime errors.

--- a/supabase/migrations/20260827162000_dabbir_customer_privacy_executor_v1.sql
+++ b/supabase/migrations/20260827162000_dabbir_customer_privacy_executor_v1.sql
@@ -1,0 +1,176 @@
+-- DABBIR BAR-16 customer privacy executor v1
+-- Customer export is returned inline and only a hash is persisted.
+-- Customer deletion is an explicit owner-only second step, blocks on LEGAL_HOLD,
+-- erases customer-scoped personal content, and dissociates retained financial records.
+
+alter table public.dabbir_privacy_requests
+  add column if not exists target_ref_hash text,
+  add column if not exists execution_summary jsonb not null default '{}'::jsonb;
+
+alter table public.dabbir_privacy_requests
+  drop constraint if exists dabbir_privacy_requests_target_ref_hash_check;
+alter table public.dabbir_privacy_requests
+  add constraint dabbir_privacy_requests_target_ref_hash_check
+  check (target_ref_hash is null or target_ref_hash ~ '^[0-9a-f]{64}$');
+
+alter table public.dabbir_privacy_requests
+  drop constraint if exists dabbir_privacy_requests_execution_summary_check;
+alter table public.dabbir_privacy_requests
+  add constraint dabbir_privacy_requests_execution_summary_check
+  check (jsonb_typeof(execution_summary)='object' and octet_length(execution_summary::text)<=16384);
+
+alter table public.dabbir_privacy_requests
+  drop constraint if exists dabbir_privacy_requests_scope_check;
+alter table public.dabbir_privacy_requests
+  add constraint dabbir_privacy_requests_scope_check check (
+    (request_type in ('BUSINESS_EXPORT','BUSINESS_DELETE') and customer_id is null)
+    or
+    (request_type in ('CUSTOMER_EXPORT','CUSTOMER_DELETE') and (
+      customer_id is not null
+      or (
+        customer_id is null
+        and target_ref_hash is not null
+        and status in ('PROCESSING','COMPLETED','REJECTED','FAILED','CANCELLED')
+      )
+    ))
+  );
+
+create or replace function dabbir_private.dabbir_customer_export_payload(
+  p_business_id uuid,
+  p_customer_id uuid
+)
+returns jsonb
+language plpgsql
+stable
+security definer
+set search_path=''
+as $$
+declare
+  v_payload jsonb;
+begin
+  if not exists (
+    select 1 from public.dabbir_customers c
+    where c.business_id=p_business_id and c.id=p_customer_id
+  ) then
+    raise exception 'CUSTOMER_NOT_FOUND';
+  end if;
+
+  select jsonb_build_object(
+    'schema_version','dabbir_customer_export_v1',
+    'exported_at',now(),
+    'business_id',p_business_id,
+    'customer_id',p_customer_id,
+    'customer',(select to_jsonb(c) from public.dabbir_customers c where c.business_id=p_business_id and c.id=p_customer_id),
+    'identities',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_customer_identities x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'management',coalesce((select jsonb_agg(to_jsonb(x)) from public.dabbir_customer_management x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'memory',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_customer_memory x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'conversations',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_conversations x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'messages',coalesce((select jsonb_agg(to_jsonb(m) order by m.created_at) from public.dabbir_messages m where m.business_id=p_business_id and exists(select 1 from public.dabbir_conversations c where c.id=m.conversation_id and c.business_id=p_business_id and c.customer_id=p_customer_id)),'[]'::jsonb),
+    'appointments',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_appointments x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'handoffs',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_handoffs x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'followups',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_followups x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'consents',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_customer_consents x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'orders',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_orders x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'offers',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_offers x where x.payer_customer_id=p_customer_id and (x.creator_business_id=p_business_id or x.advertiser_business_id=p_business_id)),'[]'::jsonb),
+    'payments',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_payments x where x.payer_customer_id=p_customer_id and (x.recipient_business_id=p_business_id or x.payer_business_id=p_business_id)),'[]'::jsonb),
+    'financial_evidence',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_financial_evidence x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb),
+    'customer_evidence',coalesce((select jsonb_agg(to_jsonb(x) order by x.created_at) from public.dabbir_customer_evidence x where x.business_id=p_business_id and x.customer_id=p_customer_id),'[]'::jsonb)
+  ) into v_payload;
+
+  if octet_length(v_payload::text)>5242880 then raise exception 'CUSTOMER_EXPORT_TOO_LARGE'; end if;
+  return v_payload;
+end;
+$$;
+revoke all on function dabbir_private.dabbir_customer_export_payload(uuid,uuid) from public,anon,authenticated;
+
+create or replace function dabbir_private.dabbir_execute_customer_privacy_request(
+  p_request_id uuid,
+  p_confirmation text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_user uuid := auth.uid();
+  v_req public.dabbir_privacy_requests%rowtype;
+  v_export jsonb;
+  v_hash text;
+  v_confirmation_expected text;
+  v_summary jsonb;
+  v_conversation_ids uuid[] := '{}'::uuid[];
+  v_count bigint;
+begin
+  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+  select * into v_req from public.dabbir_privacy_requests r where r.id=p_request_id for update;
+  if not found then raise exception 'PRIVACY_REQUEST_NOT_FOUND'; end if;
+  if v_req.request_type not in ('CUSTOMER_EXPORT','CUSTOMER_DELETE') then raise exception 'CUSTOMER_PRIVACY_REQUEST_REQUIRED'; end if;
+  if v_req.customer_id is null then raise exception 'CUSTOMER_TARGET_ALREADY_REMOVED'; end if;
+  if not exists(select 1 from public.dabbir_memberships m where m.business_id=v_req.business_id and m.user_id=v_user and m.status='active' and m.role='owner') then raise exception 'OWNER_REQUIRED'; end if;
+  if v_req.status not in ('REQUESTED','REVIEW_REQUIRED','APPROVED','FAILED') then raise exception 'PRIVACY_REQUEST_NOT_EXECUTABLE'; end if;
+
+  if v_req.request_type='CUSTOMER_EXPORT' then
+    v_export:=dabbir_private.dabbir_customer_export_payload(v_req.business_id,v_req.customer_id);
+    v_hash:=encode(extensions.digest(convert_to(v_export::text,'UTF8'),'sha256'),'hex');
+    v_summary:=jsonb_build_object('mode','INLINE_EXPORT','sha256',v_hash,'bytes',octet_length(v_export::text),'customer_id_present',true);
+    update public.dabbir_privacy_requests set status='COMPLETED',completed_at=now(),result_ref='sha256:'||v_hash,execution_summary=v_summary where id=v_req.id;
+    insert into public.dabbir_privacy_audit(business_id,actor_user_id,action,target_type,target_id,privacy_request_id,correlation_id,metadata)
+    values(v_req.business_id,v_user,'customer_export_completed','customer',v_req.customer_id::text,v_req.id,v_req.correlation_id,jsonb_build_object('sha256',v_hash,'bytes',octet_length(v_export::text),'persisted_export_body',false));
+    return jsonb_build_object('ok',true,'request_id',v_req.id,'request_type',v_req.request_type,'sha256',v_hash,'export',v_export);
+  end if;
+
+  if exists(select 1 from public.dabbir_retention_policies rp where rp.business_id=v_req.business_id and rp.policy_state='LEGAL_HOLD' and rp.data_category in ('CUSTOMER_PROFILE','CUSTOMER_IDENTITY','CONVERSATION','MESSAGE','APPOINTMENT')) then raise exception 'LEGAL_HOLD_ACTIVE'; end if;
+  v_confirmation_expected:='DELETE_CUSTOMER:'||v_req.customer_id::text;
+  if coalesce(p_confirmation,'')<>v_confirmation_expected then raise exception 'EXPLICIT_DELETE_CONFIRMATION_REQUIRED'; end if;
+
+  v_hash:=encode(extensions.digest(convert_to(v_req.business_id::text||':'||v_req.customer_id::text,'UTF8'),'sha256'),'hex');
+  select coalesce(array_agg(c.id),'{}'::uuid[]) into v_conversation_ids from public.dabbir_conversations c where c.business_id=v_req.business_id and c.customer_id=v_req.customer_id;
+  v_summary:=jsonb_build_object('mode','ERASE_PERSONAL_DATA_DISSOCIATE_FINANCIAL','target_ref_hash',v_hash,'conversation_count',cardinality(v_conversation_ids),'financial_records_retained',true);
+
+  update public.dabbir_privacy_requests set status='CANCELLED',customer_id=null,target_ref_hash=v_hash,execution_summary=execution_summary||jsonb_build_object('cancelled_due_to_customer_deletion',true) where business_id=v_req.business_id and customer_id=v_req.customer_id and id<>v_req.id;
+  update public.dabbir_privacy_requests set status='PROCESSING',customer_id=null,target_ref_hash=v_hash,execution_summary=v_summary where id=v_req.id;
+
+  delete from public.dabbir_customer_evidence where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_handoffs where business_id=v_req.business_id and (customer_id=v_req.customer_id or conversation_id=any(v_conversation_ids));
+  delete from public.dabbir_followups where business_id=v_req.business_id and (customer_id=v_req.customer_id or conversation_id=any(v_conversation_ids));
+  delete from public.dabbir_message_batches where business_id=v_req.business_id and (customer_id=v_req.customer_id or conversation_id=any(v_conversation_ids));
+  delete from public.dabbir_messages where business_id=v_req.business_id and conversation_id=any(v_conversation_ids);
+  delete from public.dabbir_conversations where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_appointments where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_customer_identities where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_customer_management where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_customer_memory where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_customer_consents where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_verification_challenges where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  delete from public.dabbir_event_inbox where business_id=v_req.business_id and customer_id=v_req.customer_id;
+
+  update public.dabbir_orders set customer_id=null where business_id=v_req.business_id and customer_id=v_req.customer_id;
+  update public.dabbir_offers set payer_customer_id=null where payer_customer_id=v_req.customer_id and (creator_business_id=v_req.business_id or advertiser_business_id=v_req.business_id);
+  update public.dabbir_payments set payer_customer_id=null,stripe_customer_id=null where payer_customer_id=v_req.customer_id and (recipient_business_id=v_req.business_id or payer_business_id=v_req.business_id);
+  update public.dabbir_financial_evidence set customer_id=null,conversation_id=null,metadata=jsonb_build_object('privacy_redacted',true,'redacted_at',now()) where business_id=v_req.business_id and customer_id=v_req.customer_id;
+
+  delete from public.dabbir_customers where business_id=v_req.business_id and id=v_req.customer_id;
+  get diagnostics v_count = row_count;
+  if v_count<>1 then raise exception 'CUSTOMER_DELETE_NOT_VERIFIED'; end if;
+
+  update public.dabbir_privacy_requests set status='COMPLETED',completed_at=now(),result_ref='erased:'||v_hash,execution_summary=v_summary where id=v_req.id;
+  insert into public.dabbir_privacy_audit(business_id,actor_user_id,action,target_type,target_id,privacy_request_id,correlation_id,metadata)
+  values(v_req.business_id,v_user,'customer_delete_completed','customer_hash',v_hash,v_req.id,v_req.correlation_id,jsonb_build_object('financial_records_retained',true,'external_money_side_effects',false,'target_ref_hash',v_hash));
+
+  return jsonb_build_object('ok',true,'request_id',v_req.id,'request_type',v_req.request_type,'deleted',true,'target_ref_hash',v_hash,'financial_records_retained',true);
+end;
+$$;
+
+revoke all on function dabbir_private.dabbir_execute_customer_privacy_request(uuid,text) from public,anon;
+grant execute on function dabbir_private.dabbir_execute_customer_privacy_request(uuid,text) to authenticated;
+
+create or replace function public.dabbir_execute_customer_privacy_request(p_request_id uuid,p_confirmation text default null)
+returns jsonb language sql volatile security invoker set search_path='' as $$
+  select dabbir_private.dabbir_execute_customer_privacy_request(p_request_id,p_confirmation);
+$$;
+revoke all on function public.dabbir_execute_customer_privacy_request(uuid,text) from public,anon;
+grant execute on function public.dabbir_execute_customer_privacy_request(uuid,text) to authenticated;
+
+comment on function public.dabbir_execute_customer_privacy_request(uuid,text) is
+'Owner-only BAR-16 executor. CUSTOMER_EXPORT returns data inline without persisting the body. CUSTOMER_DELETE requires DELETE_CUSTOMER:<uuid> confirmation and fails under LEGAL_HOLD.';

--- a/supabase/migrations/20260827162100_dabbir_recovery_customer_root_scope_fix_v2.sql
+++ b/supabase/migrations/20260827162100_dabbir_recovery_customer_root_scope_fix_v2.sql
@@ -1,0 +1,136 @@
+-- DABBIR BAR-16 recovery hardening v2
+-- Treat dabbir_customers.id as the customer scope key. Without this, customer-scoped
+-- recovery can restore child rows but misses the root customer row itself.
+
+create or replace function dabbir_private.recovery_refresh_registry()
+returns integer
+language plpgsql
+security definer
+set search_path=pg_catalog,public,dabbir_private,pg_temp
+as $function$
+declare
+  r record;
+  v_rel regclass;
+  v_pk text[];
+  v_business text[];
+  v_users text[];
+  v_customers text[];
+  v_journal boolean;
+  v_rank integer;
+  v_count integer := 0;
+begin
+  for r in
+    select c.relname as table_name
+    from pg_class c
+    join pg_namespace n on n.oid=c.relnamespace
+    where n.nspname='public'
+      and c.relkind='r'
+      and c.relname like 'dabbir\_%' escape '\'
+  loop
+    v_rel := to_regclass(format('public.%I', r.table_name));
+
+    select array_agg(a.attname order by ord.n)
+      into v_pk
+    from pg_index i
+    join lateral unnest(i.indkey) with ordinality ord(attnum,n) on true
+    join pg_attribute a on a.attrelid=i.indrelid and a.attnum=ord.attnum
+    where i.indrelid=v_rel and i.indisprimary;
+
+    if v_pk is null or cardinality(v_pk)=0 then continue; end if;
+
+    if r.table_name='dabbir_businesses' then
+      v_business := array['id'];
+    elsif r.table_name='dabbir_offers' then
+      v_business := array['creator_business_id','advertiser_business_id'];
+    elsif r.table_name='dabbir_payments' then
+      v_business := array['recipient_business_id','payer_business_id'];
+    elsif exists (
+      select 1 from pg_attribute
+      where attrelid=v_rel and attname='business_id' and attnum>0 and not attisdropped
+    ) then
+      v_business := array['business_id'];
+    else
+      continue;
+    end if;
+
+    select coalesce(array_agg(x.col order by x.ord), '{}'::text[])
+      into v_users
+    from (
+      select u.col, u.ord
+      from unnest(array['user_id','owner_id','payer_user_id','created_by_user_id','sender_user_id','actor_user_id','assigned_user_id']) with ordinality u(col,ord)
+      where exists (
+        select 1 from pg_attribute a
+        where a.attrelid=v_rel and a.attname=u.col and a.attnum>0 and not a.attisdropped
+      )
+    ) x;
+
+    if r.table_name='dabbir_customers' then
+      v_customers := array['id'];
+    else
+      select coalesce(array_agg(x.col order by x.ord), '{}'::text[])
+        into v_customers
+      from (
+        select u.col, u.ord
+        from unnest(array['customer_id','payer_customer_id']) with ordinality u(col,ord)
+        where exists (
+          select 1 from pg_attribute a
+          where a.attrelid=v_rel and a.attname=u.col and a.attnum>0 and not a.attisdropped
+        )
+      ) x;
+    end if;
+
+    v_journal := not (
+      r.table_name ~ '(audit|event|evidence|log|demo|quality)'
+      or r.table_name in ('dabbir_event_inbox','dabbir_message_batch_items')
+    );
+
+    v_rank := case
+      when r.table_name='dabbir_businesses' then 10
+      when r.table_name in ('dabbir_memberships','dabbir_creator_profiles') then 20
+      when r.table_name in ('dabbir_customers','dabbir_payment_accounts') then 30
+      when r.table_name in ('dabbir_conversations','dabbir_orders','dabbir_appointments','dabbir_tasks','dabbir_whatsapp_connections') then 40
+      when r.table_name='dabbir_offers' then 50
+      when r.table_name='dabbir_payments' then 60
+      when r.table_name='dabbir_messages' then 70
+      else 45
+    end;
+
+    insert into dabbir_private.recovery_supported_tables(
+      table_name,pk_columns,business_columns,user_columns,customer_columns,
+      journal_enabled,snapshot_enabled,restore_rank,updated_at
+    )
+    values(r.table_name,v_pk,v_business,v_users,v_customers,v_journal,true,v_rank,now())
+    on conflict (table_name) do update set
+      pk_columns=excluded.pk_columns,
+      business_columns=excluded.business_columns,
+      user_columns=excluded.user_columns,
+      customer_columns=excluded.customer_columns,
+      journal_enabled=excluded.journal_enabled,
+      snapshot_enabled=excluded.snapshot_enabled,
+      restore_rank=excluded.restore_rank,
+      updated_at=now();
+
+    if v_journal then
+      execute format('drop trigger if exists dabbir_recovery_capture on public.%I', r.table_name);
+      execute format(
+        'create trigger dabbir_recovery_capture after insert or update or delete on public.%I for each row execute function dabbir_private.recovery_capture_change()',
+        r.table_name
+      );
+    else
+      execute format('drop trigger if exists dabbir_recovery_capture on public.%I', r.table_name);
+    end if;
+
+    v_count := v_count + 1;
+  end loop;
+
+  return v_count;
+end;
+$function$;
+
+revoke all on function dabbir_private.recovery_refresh_registry() from public,anon,authenticated;
+grant execute on function dabbir_private.recovery_refresh_registry() to service_role;
+
+select dabbir_private.recovery_refresh_registry();
+
+comment on function dabbir_private.recovery_refresh_registry() is
+'BAR-16 recovery registry. dabbir_customers.id is a customer scope key so customer-scoped recovery includes the root customer row.';

--- a/supabase/migrations/20260827162200_dabbir_privacy_retained_record_scrub_v2.sql
+++ b/supabase/migrations/20260827162200_dabbir_privacy_retained_record_scrub_v2.sql
@@ -1,0 +1,47 @@
+-- DABBIR BAR-16 retained-record privacy scrub v2
+-- Operational audit/procedure rows may need to survive customer deletion, but their
+-- payload must not retain customer content after the customer identity is erased.
+
+create or replace function dabbir_private.dabbir_scrub_retained_customer_records()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_conversation_ids uuid[] := '{}'::uuid[];
+begin
+  select coalesce(array_agg(c.id),'{}'::uuid[])
+    into v_conversation_ids
+  from public.dabbir_conversations c
+  where c.business_id=old.business_id and c.customer_id=old.id;
+
+  update public.dabbir_procedure_runs
+     set customer_id=null,
+         conversation_id=null,
+         input=jsonb_build_object('privacy_redacted',true),
+         output=jsonb_build_object('privacy_redacted',true),
+         external_reference=null,
+         last_error_detail=null
+   where business_id=old.business_id
+     and (customer_id=old.id or conversation_id=any(v_conversation_ids));
+
+  update public.dabbir_quality_events
+     set conversation_id=null,
+         context=jsonb_build_object('privacy_redacted',true)
+   where business_id=old.business_id
+     and conversation_id=any(v_conversation_ids);
+
+  return old;
+end;
+$$;
+
+revoke all on function dabbir_private.dabbir_scrub_retained_customer_records() from public,anon,authenticated;
+
+drop trigger if exists dabbir_privacy_scrub_retained_customer_records on public.dabbir_customers;
+create trigger dabbir_privacy_scrub_retained_customer_records
+before delete on public.dabbir_customers
+for each row execute function dabbir_private.dabbir_scrub_retained_customer_records();
+
+comment on function dabbir_private.dabbir_scrub_retained_customer_records() is
+'BAR-16 retained operational records are dissociated and payload-redacted before customer deletion; financial records are handled separately and are not deleted.';

--- a/test/dabbir-bar16-privacy-recovery-contract.test.mjs
+++ b/test/dabbir-bar16-privacy-recovery-contract.test.mjs
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root=new URL('../',import.meta.url);
+const read=path=>readFile(new URL(path,root),'utf8');
+
+const privacyMigration=await read('supabase/migrations/20260827162000_dabbir_customer_privacy_executor_v1.sql');
+const recoveryMigration=await read('supabase/migrations/20260827162100_dabbir_recovery_customer_root_scope_fix_v2.sql');
+const api=await read('api/privacy/execute.js');
+const threatModel=await read('docs/security/bar-16-threat-model.md');
+
+test('customer privacy delete is explicit owner-only and legal-hold aware',()=>{
+  assert.match(privacyMigration,/m\.role='owner'/i);
+  assert.match(privacyMigration,/LEGAL_HOLD_ACTIVE/i);
+  assert.match(privacyMigration,/DELETE_CUSTOMER:/i);
+  assert.match(privacyMigration,/EXPLICIT_DELETE_CONFIRMATION_REQUIRED/i);
+  assert.match(privacyMigration,/CUSTOMER_DELETE_NOT_VERIFIED/i);
+  assert.match(privacyMigration,/financial_records_retained/i);
+  assert.match(privacyMigration,/stripe_customer_id=null/i);
+});
+
+test('customer export does not persist a second plaintext export body',()=>{
+  assert.match(privacyMigration,/INLINE_EXPORT/i);
+  assert.match(privacyMigration,/persisted_export_body',false/i);
+  assert.match(privacyMigration,/result_ref='sha256:'/i);
+  assert.doesNotMatch(privacyMigration,/set\s+result_ref\s*=\s*v_export/i);
+});
+
+test('privacy execution API uses authenticated cookie flow and same-origin writes',()=>{
+  assert.match(api,/accessTokenFromRequest/);
+  assert.match(api,/getVerifiedUser/);
+  assert.match(api,/requireSameOrigin\(req\)/);
+  assert.match(api,/membership\.role!=='owner'/);
+  assert.match(api,/dabbir_execute_customer_privacy_request/);
+  assert.doesNotMatch(api,/service[_-]?role/i);
+});
+
+test('customer-scoped recovery always includes the root customer row',()=>{
+  assert.match(recoveryMigration,/if r\.table_name='dabbir_customers' then[\s\S]*v_customers := array\['id'\]/i);
+  assert.match(recoveryMigration,/select dabbir_private\.recovery_refresh_registry\(\)/i);
+  assert.match(recoveryMigration,/customer-scoped recovery includes the root customer row/i);
+});
+
+test('BAR-16 threat model locks the release gates and rotation policy',()=>{
+  for(const required of [
+    'Cross-tenant read/write',
+    'Silent or accidental deletion',
+    'Sensitive data in logs',
+    'Integration key rotation policy',
+    'Recovery failure and corruption',
+    'Production deployment matches the merged commit',
+  ]) assert.match(threatModel,new RegExp(required.replace(/[.*+?^${}()|[\]\\]/g,'\\$&'),'i'));
+});

--- a/test/dabbir-integration-key-rotation.test.mjs
+++ b/test/dabbir-integration-key-rotation.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  openAccessToken,
+  sealAccessToken,
+  tokenNeedsRotation,
+} from '../api/_whatsapp-embedded-core.js';
+
+const businessId='13863744-4655-440f-bf9a-12b2e0e40e94';
+
+test('stored WhatsApp tokens can move from previous key version to current without plaintext persistence',()=>{
+  const oldConfig={
+    encryptionSecret:'old-secret-material-for-test-only',
+    encryptionKeyVersion:'whatsapp_v1',
+    previousEncryptionSecret:'',
+    previousEncryptionKeyVersion:'',
+  };
+  const oldRow={business_id:businessId,...sealAccessToken('meta-token-value',oldConfig,businessId)};
+  assert.equal(oldRow.token_key_version,'whatsapp_v1');
+  assert.equal(openAccessToken(oldRow,oldConfig,businessId),'meta-token-value');
+
+  const rotatingConfig={
+    encryptionSecret:'new-secret-material-for-test-only',
+    encryptionKeyVersion:'whatsapp_v2',
+    previousEncryptionSecret:'old-secret-material-for-test-only',
+    previousEncryptionKeyVersion:'whatsapp_v1',
+    rotationReady:true,
+  };
+  assert.equal(tokenNeedsRotation(oldRow,rotatingConfig),true);
+  assert.equal(openAccessToken(oldRow,rotatingConfig,businessId),'meta-token-value');
+
+  const currentRow={business_id:businessId,...sealAccessToken('meta-token-value',rotatingConfig,businessId)};
+  assert.equal(currentRow.token_key_version,'whatsapp_v2');
+  assert.equal(tokenNeedsRotation(currentRow,rotatingConfig),false);
+  assert.equal(openAccessToken(currentRow,rotatingConfig,businessId),'meta-token-value');
+  assert.notEqual(currentRow.access_token_ciphertext,oldRow.access_token_ciphertext);
+});
+
+test('old ciphertext fails closed when its previous key version is unavailable',()=>{
+  const oldConfig={encryptionSecret:'old-key',encryptionKeyVersion:'whatsapp_v1'};
+  const oldRow={business_id:businessId,...sealAccessToken('secret',oldConfig,businessId)};
+  const currentOnly={encryptionSecret:'new-key',encryptionKeyVersion:'whatsapp_v2'};
+  assert.throws(
+    ()=>openAccessToken(oldRow,currentOnly,businessId),
+    /INTEGRATION_ENCRYPTION_KEY_VERSION_UNAVAILABLE/,
+  );
+});

--- a/test/dabbir-observability-redaction.test.mjs
+++ b/test/dabbir-observability-redaction.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { redactLogEvent, REDACTED } from '../api/_observability.js';
+
+test('observability redacts sensitive keys recursively',()=>{
+  const event=redactLogEvent({
+    operation:'privacy_export',
+    access_token:'secret-token',
+    nested:{refresh_token:'refresh-me',email:'owner@example.com',phone_number:'+971501234567',message_body:'hello'},
+    business_id:'13863744-4655-440f-bf9a-12b2e0e40e94',
+  });
+  assert.equal(event.access_token,REDACTED);
+  assert.equal(event.nested.refresh_token,REDACTED);
+  assert.equal(event.nested.email,REDACTED);
+  assert.equal(event.nested.phone_number,REDACTED);
+  assert.equal(event.nested.message_body,REDACTED);
+  assert.equal(event.business_id,'13863744-4655-440f-bf9a-12b2e0e40e94');
+});
+
+test('observability redacts secrets embedded in otherwise safe strings',()=>{
+  const event=redactLogEvent({
+    detail:'contact owner@example.com or +971501234567 using Bearer abc.def.ghi',
+    failure:'JWT eyJabcdefghijk.abcdefghijk.abcdefghijk was rejected',
+  });
+  assert.doesNotMatch(event.detail,/owner@example\.com|971501234567|Bearer abc/);
+  assert.doesNotMatch(event.failure,/eyJabcdefghijk/);
+  assert.match(event.detail,/\[REDACTED\]/);
+});
+
+test('observability bounds nested payload size and depth',()=>{
+  const tooDeep={};let node=tooDeep;
+  for(let i=0;i<12;i++){node.next={};node=node.next}
+  const event=redactLogEvent({items:Array.from({length:80},(_,i)=>i),tooDeep,long:'x'.repeat(4000)});
+  assert.equal(event.items.length,50);
+  assert.equal(event.long.length,2000);
+  assert.match(JSON.stringify(event.tooDeep),/TRUNCATED_DEPTH/);
+});

--- a/test/dabbir-privacy-executor.test.mjs
+++ b/test/dabbir-privacy-executor.test.mjs
@@ -28,7 +28,7 @@ test('customer export is inline and only hash metadata is persisted',()=>{
   assert.match(executor,/INLINE_EXPORT/);
   assert.match(executor,/persisted_export_body',false/);
   assert.match(executor,/result_ref='sha256:'/);
-  assert.doesNotMatch(executor,/insert\s+into\s+[^;]*(export_blob|export_body|export_payload)/i);
+  assert.doesNotMatch(executor,/insert\s+into\s+(?:public\.)?[a-z0-9_]*(?:export_blob|export_body|export_payload)[a-z0-9_]*/i);
 });
 
 test('financial records are retained but identity links are removed',()=>{

--- a/test/dabbir-privacy-executor.test.mjs
+++ b/test/dabbir-privacy-executor.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root=new URL('../',import.meta.url);
+const read=path=>readFile(new URL(path,root),'utf8');
+const api=await read('api/privacy/execute.js');
+const executor=await read('supabase/migrations/20260827162000_dabbir_customer_privacy_executor_v1.sql');
+const recovery=await read('supabase/migrations/20260827162100_dabbir_recovery_customer_root_scope_fix_v2.sql');
+const retained=await read('supabase/migrations/20260827162200_dabbir_privacy_retained_record_scrub_v2.sql');
+
+test('privacy execution API is authenticated owner-gated and same-origin',()=>{
+  assert.match(api,/requireSameOrigin\(req\)/);
+  assert.match(api,/getVerifiedUser/);
+  assert.match(api,/membership\.role!=='owner'/);
+  assert.match(api,/dabbir_execute_customer_privacy_request/);
+  assert.doesNotMatch(api,/SUPABASE_SERVICE_ROLE_KEY|service[_-]?role/i);
+});
+
+test('customer delete is explicit and blocks legal hold',()=>{
+  assert.match(executor,/LEGAL_HOLD_ACTIVE/);
+  assert.match(executor,/DELETE_CUSTOMER:/);
+  assert.match(executor,/EXPLICIT_DELETE_CONFIRMATION_REQUIRED/);
+  assert.match(executor,/CUSTOMER_DELETE_NOT_VERIFIED/);
+});
+
+test('customer export is inline and only hash metadata is persisted',()=>{
+  assert.match(executor,/INLINE_EXPORT/);
+  assert.match(executor,/persisted_export_body',false/);
+  assert.match(executor,/result_ref='sha256:'/);
+  assert.doesNotMatch(executor,/insert\s+into\s+[^;]*(export_blob|export_body|export_payload)/i);
+});
+
+test('financial records are retained but identity links are removed',()=>{
+  assert.match(executor,/update public\.dabbir_orders set customer_id=null/i);
+  assert.match(executor,/update public\.dabbir_payments set payer_customer_id=null,stripe_customer_id=null/i);
+  assert.match(executor,/update public\.dabbir_financial_evidence[\s\S]*customer_id=null,conversation_id=null/i);
+  assert.doesNotMatch(executor,/delete from public\.dabbir_(orders|payments|financial_evidence)/i);
+});
+
+test('retained operational records are payload-redacted before customer deletion',()=>{
+  assert.match(retained,/before delete on public\.dabbir_customers/i);
+  assert.match(retained,/update public\.dabbir_procedure_runs[\s\S]*input=jsonb_build_object\('privacy_redacted',true\)[\s\S]*output=jsonb_build_object\('privacy_redacted',true\)/i);
+  assert.match(retained,/update public\.dabbir_quality_events[\s\S]*context=jsonb_build_object\('privacy_redacted',true\)/i);
+  assert.match(retained,/revoke all on function dabbir_private\.dabbir_scrub_retained_customer_records\(\) from public,anon,authenticated/i);
+});
+
+test('customer-scoped recovery includes the root customer row',()=>{
+  assert.match(recovery,/if r\.table_name='dabbir_customers' then\s*v_customers := array\['id'\]/i);
+  assert.match(recovery,/select dabbir_private\.recovery_refresh_registry\(\)/i);
+});


### PR DESCRIPTION
Implements the remaining BAR-16 security/privacy closure work.

Changes include:
- mandatory observability redaction for secrets, tokens, email, phone and message bodies;
- owner-gated privacy request execution with explicit delete confirmation and legal-hold blocking;
- customer export path that does not persist a new PII copy;
- customer delete semantics that preserve required financial records by unlinking customer identity rather than blindly deleting accounting evidence;
- Recovery Vault customer-root scoping fix so `dabbir_customers.id` is included in customer-scoped recovery;
- regression coverage for redaction/privacy/recovery contracts.

Safety gate: no database DDL from this branch will be applied until CI passes on the exact PR head. Live QA will run transactionally with rollback before merge.