### PR TITLE
BAR-16: explicit deny policy for source-control ledger

### DIFF
--- a/supabase/migrations/20260827162300_dabbir_source_control_runs_explicit_deny_v1.sql
+++ b/supabase/migrations/20260827162300_dabbir_source_control_runs_explicit_deny_v1.sql
@@ -1,0 +1,19 @@
+-- BAR-16 explicit client deny for internal source-control run ledger.
+-- The table is service-only already; this policy makes the fail-closed intent explicit
+-- and removes ambiguity from the Supabase RLS advisor without granting client access.
+
+alter table barman_control.dabbir_source_control_runs enable row level security;
+alter table barman_control.dabbir_source_control_runs force row level security;
+revoke all on barman_control.dabbir_source_control_runs from anon, authenticated;
+
+drop policy if exists dabbir_source_control_runs_client_deny on barman_control.dabbir_source_control_runs;
+create policy dabbir_source_control_runs_client_deny
+on barman_control.dabbir_source_control_runs
+as restrictive
+for all
+to anon, authenticated
+using (false)
+with check (false);
+
+comment on policy dabbir_source_control_runs_client_deny on barman_control.dabbir_source_control_runs is
+'BAR-16: explicit deny-all for client roles. Internal service-role operations remain server-side.';


### PR DESCRIPTION
Follow-up hardening after BAR-16 merge. The internal `barman_control.dabbir_source_control_runs` table already has FORCE RLS and no anon/authenticated grants; this PR adds an explicit restrictive deny-all policy for client roles so the fail-closed intent is visible to Supabase Security Advisor without changing service-role access.