### PR TITLE
DABBIR: enforce truth-safe production chat

### DIFF
--- a/api/chat-send.js
+++ b/api/chat-send.js
@@ -13,7 +13,22 @@ import { generateDABBIRAiReply } from './_ai-core.js';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId = value => UUID_RE.test(String(value || '').trim()) ? String(value).trim() : null;
 const cleanText = (value, max = 2000) => String(value || '').trim().slice(0, max);
-const number = value => Number.isFinite(Number(value)) ? Number(value) : 0;
+
+function finiteNumberOrNull(value) {
+  if (value === null || value === undefined || value === '') return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function requirePersistedRow(rows, errorCode = 'PERSISTENCE_UNVERIFIED') {
+  const row = Array.isArray(rows) ? rows[0] : null;
+  if (!row?.id) {
+    const error = new Error(errorCode);
+    error.status = 502;
+    throw error;
+  }
+  return row;
+}
 
 async function readData(response, fallback) {
   const text = await response.text();
@@ -79,18 +94,39 @@ function activeProducts(products = []) {
   return (products || []).filter(product => product.active !== false);
 }
 
-function productOperationalFact(product, inventory = []) {
-  const stock = inventoryMap(inventory).get(product?.id) || { quantity: 0, reserved: 0 };
-  const quantity = Math.max(0, number(stock.quantity));
-  const reserved = Math.max(0, number(stock.reserved));
+export function productOperationalFact(product, inventory = []) {
+  const stock = inventoryMap(inventory).get(product?.id) || null;
+  const rawPrice = finiteNumberOrNull(product?.price_aed);
+  const rawQuantity = stock ? finiteNumberOrNull(stock.quantity) : null;
+  const rawReserved = stock ? finiteNumberOrNull(stock.reserved) : null;
+  const priceVerified = rawPrice !== null && rawPrice >= 0;
+  const inventoryVerified = Boolean(
+    stock && rawQuantity !== null && rawReserved !== null && rawQuantity >= 0 && rawReserved >= 0,
+  );
+  const quantity = inventoryVerified ? rawQuantity : null;
+  const reserved = inventoryVerified ? rawReserved : null;
   return {
     id: product?.id || null,
     name: product?.name || '',
     sku: product?.sku || '',
-    price_aed: Number(number(product?.price_aed).toFixed(2)),
+    price_aed: priceVerified ? Number(rawPrice.toFixed(2)) : null,
+    price_verified: priceVerified,
     quantity,
     reserved,
-    available: Math.max(0, quantity - reserved),
+    available: inventoryVerified ? Math.max(0, quantity - reserved) : null,
+    inventory_verified: inventoryVerified,
+    inventory_updated_at: stock?.updated_at || null,
+  };
+}
+
+function operationalEvidence(products = [], inventory = []) {
+  const facts = activeProducts(products).map(product => productOperationalFact(product, inventory));
+  return {
+    source: 'DABBIR_TENANT_DATA',
+    products_seen: facts.length,
+    verified_price_products: facts.filter(fact => fact.price_verified).length,
+    verified_inventory_products: facts.filter(fact => fact.inventory_verified).length,
+    state: facts.length ? 'PARTIALLY_OR_FULLY_VERIFIED' : 'NO_PRODUCT_FACTS',
   };
 }
 
@@ -123,7 +159,7 @@ function buildContext(business, knowledge = [], products = [], inventory = [], s
       products: catalog,
       services: serviceRows,
       source: 'DABBIR live tenant data',
-      rule: 'Treat product price and available stock here as authoritative for this response. Never invent missing values.',
+      rule: 'Use product price only when price_verified=true. Use stock/availability only when inventory_verified=true. Null means unknown, never zero or unavailable. Never invent missing values.',
     },
   });
 }
@@ -149,20 +185,25 @@ function productReply({ message, language, business, products, inventory }) {
     if (!active.length) return null;
     const names = active.slice(0, 3).map(item => item.name).filter(Boolean).join('، ');
     return ar
-      ? `عندي أكثر من منتج في النظام. حدد اسم المنتج الذي تقصده${names ? `، مثل: ${names}` : ''}، وسأعطيك السعر والتوفر الموثقين.`
-      : `There is more than one product in the system. Tell me which product you mean${names ? `, for example: ${names}` : ''}, and I’ll give you its verified price and availability.`;
+      ? `عندي أكثر من منتج في النظام. حدد اسم المنتج الذي تقصده${names ? `، مثل: ${names}` : ''}، وسأعطيك فقط السعر والتوفر الموثقين.`
+      : `There is more than one product in the system. Tell me which product you mean${names ? `, for example: ${names}` : ''}, and I will give you only verified price and availability.`;
   }
 
   const fact = productOperationalFact(product, inventory);
-  const price = `${fact.price_aed.toFixed(2)} ${ar ? 'د.إ' : 'AED'}`;
-  const availabilityAr = fact.available > 0 ? `ومتوفر حاليًا، والكمية المتاحة ${fact.available}` : 'وغير متوفر حاليًا في المخزون';
-  const availabilityEn = fact.available > 0 ? `and it is currently available (${fact.available} available)` : 'and it is currently out of stock';
+  const priceAr = fact.price_verified ? `السعر ${fact.price_aed.toFixed(2)} د.إ` : 'السعر غير موثق في النظام حاليًا';
+  const priceEn = fact.price_verified ? `the price is ${fact.price_aed.toFixed(2)} AED` : 'the price is not verified in the system yet';
+  const availabilityAr = fact.inventory_verified
+    ? (fact.available > 0 ? `متوفر حاليًا، والكمية المتاحة ${fact.available}` : 'غير متوفر حاليًا حسب سجل المخزون')
+    : 'التوفر غير موثق في سجل المخزون حاليًا';
+  const availabilityEn = fact.inventory_verified
+    ? (fact.available > 0 ? `currently available (${fact.available} available)` : 'currently out of stock according to the inventory record')
+    : 'availability is not verified in the inventory record yet';
 
   if (asksPrice && asksAvailability) {
-    return ar ? `${fact.name} سعره ${price}، ${availabilityAr}.` : `${fact.name} is ${price}, ${availabilityEn}.`;
+    return ar ? `${fact.name}: ${priceAr}، و${availabilityAr}.` : `${fact.name}: ${priceEn}, and it is ${availabilityEn}.`;
   }
-  if (asksPrice) return ar ? `${fact.name} سعره الموثق في دَبِّر هو ${price}.` : `The verified price for ${fact.name} in DABBIR is ${price}.`;
-  return ar ? `${fact.name} ${availabilityAr}.` : `${fact.name} is ${availabilityEn}.`;
+  if (asksPrice) return ar ? `${fact.name}: ${priceAr}.` : `${fact.name}: ${priceEn}.`;
+  return ar ? `${fact.name}: ${availabilityAr}.` : `${fact.name}: ${availabilityEn}.`;
 }
 
 function instantGroundedReply({ message, language, intent, business, knowledge, products, inventory }) {
@@ -220,19 +261,46 @@ function failureFallbackReply({ language, intent, business }) {
 }
 
 async function persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply }) {
-  const [aiRows] = await Promise.all([
-    rest(accessToken, 'dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at', {
-      method: 'POST',
-      headers: { prefer: 'return=representation' },
-      body: JSON.stringify({ business_id: businessId, conversation_id: conversationId, sender_type: 'ai', body: reply, intent, simulated: false }),
-    }, 'AI_MESSAGE_PERSIST_FAILED'),
-    rest(accessToken, `dabbir_conversations?business_id=eq.${businessId}&id=eq.${conversationId}`, {
-      method: 'PATCH',
-      headers: { prefer: 'return=minimal' },
-      body: JSON.stringify({ state: 'waiting_customer', updated_at: new Date().toISOString() }),
-    }, 'CONVERSATION_STATE_UPDATE_FAILED'),
-  ]);
-  return aiRows?.[0] || null;
+  const aiRows = await rest(accessToken, 'dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at', {
+    method: 'POST',
+    headers: { prefer: 'return=representation' },
+    body: JSON.stringify({ business_id: businessId, conversation_id: conversationId, sender_type: 'ai', body: reply, intent, simulated: false }),
+  }, 'AI_MESSAGE_PERSIST_FAILED');
+  const aiMessage = requirePersistedRow(aiRows, 'AI_MESSAGE_PERSIST_UNVERIFIED');
+
+  await rest(accessToken, `dabbir_conversations?business_id=eq.${businessId}&id=eq.${conversationId}`, {
+    method: 'PATCH',
+    headers: { prefer: 'return=minimal' },
+    body: JSON.stringify({ state: 'waiting_customer', updated_at: new Date().toISOString() }),
+  }, 'CONVERSATION_STATE_UPDATE_FAILED');
+
+  const conversationRows = await rest(
+    accessToken,
+    `dabbir_conversations?select=id,state&business_id=eq.${businessId}&id=eq.${conversationId}&limit=1`,
+    {},
+    'CONVERSATION_STATE_VERIFY_FAILED',
+  );
+  const verifiedConversation = requirePersistedRow(conversationRows, 'CONVERSATION_STATE_UNVERIFIED');
+  if (verifiedConversation.state !== 'waiting_customer') {
+    const error = new Error('CONVERSATION_STATE_UNVERIFIED');
+    error.status = 502;
+    throw error;
+  }
+
+  return { aiMessage, verifiedConversation };
+}
+
+function truthResult(customerMessage, aiMessage, verifiedConversation) {
+  return {
+    state: 'VERIFIED',
+    source: 'SUPABASE_RETURN_REPRESENTATION_AND_READBACK',
+    verified_at: new Date().toISOString(),
+    evidence: [
+      { entity: 'customer_message', entity_id: customerMessage.id },
+      { entity: 'ai_message', entity_id: aiMessage.id },
+      { entity: 'conversation', entity_id: verifiedConversation.id, state: verifiedConversation.state },
+    ],
+  };
 }
 
 export default async function handler(req, res) {
@@ -284,23 +352,27 @@ export default async function handler(req, res) {
       headers: { prefer: 'return=representation' },
       body: JSON.stringify({ business_id: businessId, conversation_id: conversationId, sender_type: 'customer', body: message, intent, simulated: false }),
     }, 'CUSTOMER_MESSAGE_PERSIST_FAILED');
-    const customerMessage = customerRows?.[0] || null;
+    const customerMessage = requirePersistedRow(customerRows, 'CUSTOMER_MESSAGE_PERSIST_UNVERIFIED');
+    const grounding = operationalEvidence(products, inventory);
 
     const fastReply = instantGroundedReply({ message, language, intent, business, knowledge, products, inventory });
     if (fastReply) {
       const finalStarted = Date.now();
-      const aiMessage = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: fastReply });
+      const { aiMessage, verifiedConversation } = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: fastReply });
       const finalMs = Date.now() - finalStarted;
       const totalMs = Date.now() - started;
       console.info('dabbir_chat_fast_path', { intent, live_products: Array.isArray(products) ? products.length : 0, lookup_ms: lookupMs, final_ms: finalMs, total_ms: totalMs });
       return json(res, 200, {
         ok: true,
+        state: 'VERIFIED_PERSISTED',
         provider: 'dabbir-local-fastpath',
-        model: 'deterministic-v2-live-operations',
+        model: 'deterministic-v3-truth-safe',
         fast_path: true,
-        live_operations_grounded: true,
+        grounding_state: 'DETERMINISTIC_VERIFIED_OR_EXPLICITLY_UNVERIFIED',
+        grounding,
         customer_message: customerMessage,
         ai_message: aiMessage,
+        truth: truthResult(customerMessage, aiMessage, verifiedConversation),
         timing: { lookup_ms: lookupMs, ai_ms: 0, final_ms: finalMs, total_ms: totalMs },
         external_side_effects: false,
       });
@@ -319,37 +391,45 @@ export default async function handler(req, res) {
     if (!aiResult.ok) {
       const fallbackReply = failureFallbackReply({ language, intent, business });
       const finalStarted = Date.now();
-      const aiMessage = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: fallbackReply });
+      const { aiMessage, verifiedConversation } = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: fallbackReply });
       const finalMs = Date.now() - finalStarted;
       const totalMs = Date.now() - started;
       console.warn('dabbir_chat_ai_degraded', { state: aiResult.state, error: aiResult.error, model: aiResult.model, lookup_ms: lookupMs, ai_ms: aiMs, final_ms: finalMs, total_ms: totalMs });
       return json(res, 200, {
         ok: true,
+        state: 'VERIFIED_PERSISTED',
         provider: 'dabbir-local-fallback',
-        model: 'deterministic-v1',
+        model: 'deterministic-v2-truth-safe',
         degraded: true,
         upstream_ai_state: aiResult.state,
         upstream_ai_error: aiResult.error || null,
+        grounding_state: 'SAFE_FALLBACK_NO_UNVERIFIED_CLAIMS',
+        grounding,
         customer_message: customerMessage,
         ai_message: aiMessage,
+        truth: truthResult(customerMessage, aiMessage, verifiedConversation),
         timing: { lookup_ms: lookupMs, ai_ms: aiMs, final_ms: finalMs, total_ms: totalMs },
         external_side_effects: false,
       });
     }
 
     const finalStarted = Date.now();
-    const aiMessage = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: aiResult.reply });
+    const { aiMessage, verifiedConversation } = await persistAutomatedReply({ accessToken, businessId, conversationId, intent, reply: aiResult.reply });
     const finalMs = Date.now() - finalStarted;
     const totalMs = Date.now() - started;
 
     console.info('dabbir_chat_completed', { model: aiResult.model, lookup_ms: lookupMs, ai_ms: aiMs, final_ms: finalMs, total_ms: totalMs });
     return json(res, 200, {
       ok: true,
+      state: 'VERIFIED_PERSISTED',
       provider: aiResult.provider,
       model: aiResult.model,
-      live_operations_grounded: true,
+      grounding_state: aiResult.grounding_state || 'BUSINESS_CONTEXT_GROUNDED',
+      guarded: aiResult.guarded,
+      grounding,
       customer_message: customerMessage,
       ai_message: aiMessage,
+      truth: truthResult(customerMessage, aiMessage, verifiedConversation),
       timing: { lookup_ms: lookupMs, ai_ms: aiMs, final_ms: finalMs, total_ms: totalMs },
       external_side_effects: false,
     });
@@ -357,6 +437,12 @@ export default async function handler(req, res) {
     const status = Number(error?.status || 500);
     const safeStatus = [400, 401, 403, 404, 409, 413, 429, 502, 503].includes(status) ? status : 500;
     console.error('dabbir_chat_failed', { error: cleanText(error?.message || 'CHAT_SEND_FAILED', 120), status: safeStatus, total_ms: Date.now() - started });
-    return json(res, safeStatus, { ok: false, error: cleanText(error?.message || 'CHAT_SEND_FAILED', 120), detail: error?.detail || undefined });
+    return json(res, safeStatus, {
+      ok: false,
+      state: 'FAILED_OR_UNVERIFIED',
+      error: cleanText(error?.message || 'CHAT_SEND_FAILED', 120),
+      detail: error?.detail || undefined,
+      truth: { state: 'UNVERIFIED' },
+    });
   }
 }

--- a/test/dabbir-production-chat-truth.test.mjs
+++ b/test/dabbir-production-chat-truth.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { productOperationalFact, requirePersistedRow } from '../api/chat-send.js';
+
+const source = fs.readFileSync(new URL('../api/chat-send.js', import.meta.url), 'utf8');
+
+test('missing price is unknown and never silently converted to zero', () => {
+  const fact = productOperationalFact({ id: 'p1', name: 'Product', price_aed: null }, []);
+  assert.equal(fact.price_aed, null);
+  assert.equal(fact.price_verified, false);
+});
+
+test('missing inventory is unknown and never silently converted to out-of-stock', () => {
+  const fact = productOperationalFact({ id: 'p1', name: 'Product', price_aed: '12.50' }, []);
+  assert.equal(fact.inventory_verified, false);
+  assert.equal(fact.quantity, null);
+  assert.equal(fact.reserved, null);
+  assert.equal(fact.available, null);
+});
+
+test('verified numeric price and inventory produce deterministic operational fact', () => {
+  const fact = productOperationalFact(
+    { id: 'p1', name: 'Product', price_aed: '12.50' },
+    [{ product_id: 'p1', quantity: 9, reserved: 2, updated_at: '2026-08-27T12:00:00Z' }],
+  );
+  assert.equal(fact.price_verified, true);
+  assert.equal(fact.price_aed, 12.5);
+  assert.equal(fact.inventory_verified, true);
+  assert.equal(fact.available, 7);
+});
+
+test('production chat persistence helper fails closed without returned entity id', () => {
+  const row = { id: '018f5b3a-7b36-7e87-8c91-6e0438140d3f' };
+  assert.equal(requirePersistedRow([row], 'TEST_UNVERIFIED'), row);
+  assert.throws(
+    () => requirePersistedRow([], 'TEST_UNVERIFIED'),
+    error => error?.message === 'TEST_UNVERIFIED' && error?.status === 502,
+  );
+});
+
+test('chat-send verifies both messages and reads conversation state back before success', () => {
+  assert.match(source, /CUSTOMER_MESSAGE_PERSIST_UNVERIFIED/);
+  assert.match(source, /AI_MESSAGE_PERSIST_UNVERIFIED/);
+  assert.match(source, /CONVERSATION_STATE_VERIFY_FAILED/);
+  assert.match(source, /CONVERSATION_STATE_UNVERIFIED/);
+  assert.match(source, /SUPABASE_RETURN_REPRESENTATION_AND_READBACK/);
+  assert.match(source, /state:\s*'VERIFIED_PERSISTED'/);
+});
+
+test('unknown commercial data remains explicitly unknown in model context and customer replies', () => {
+  assert.match(source, /Null means unknown, never zero or unavailable/);
+  assert.match(source, /السعر غير موثق في النظام حاليًا/);
+  assert.match(source, /التوفر غير موثق في سجل المخزون حاليًا/);
+  assert.match(source, /price_verified/);
+  assert.match(source, /inventory_verified/);
+  assert.doesNotMatch(source, /\|\| \{ quantity: 0, reserved: 0 \}/);
+  assert.doesNotMatch(source, /Number\(number\(product\?\.price_aed\)/);
+});
+
+test('errors are not success-shaped when result cannot be verified', () => {
+  assert.match(source, /state:\s*'FAILED_OR_UNVERIFIED'/);
+  assert.match(source, /truth:\s*\{ state: 'UNVERIFIED' \}/);
+});


### PR DESCRIPTION
## Root cause
The production UI uses `/api/chat-send` and `/api/dabbir-runtime-fast`. The chat path could report `ok: true` without proving returned customer/AI message IDs or reading the conversation state back. It also defaulted missing inventory to zero stock and missing/invalid numeric price to `0.00 AED`, which could turn unknown business data into false verified facts.

## Fix
- Missing/invalid price stays `null` with `price_verified: false`.
- Missing/invalid inventory stays `null` with `inventory_verified: false`; it is never silently labeled out-of-stock.
- Deterministic product replies explicitly say price/availability is unverified when source data is absent.
- LLM context now instructs: use price only with `price_verified=true`, stock only with `inventory_verified=true`, and treat null as unknown.
- Customer message and AI message require concrete persisted IDs.
- Conversation state is read back and must equal `waiting_customer` before success.
- Success returns `VERIFIED_PERSISTED` plus structured evidence.
- Failure returns `FAILED_OR_UNVERIFIED`, never success-shaped uncertainty.
- Added direct regression tests for missing commercial facts and persistence truth gates.

## Safety
No payment/KYC/Meta/WhatsApp live configuration or schema changes.