### PR TITLE
DABBIR: surface verified data provenance in owner UI

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -115,7 +115,7 @@ button,a,[data-screen],[data-cid]{touch-action:manipulation}
     document.querySelector('#side')?.classList.remove('open');
   };
 
-  window.__dabbirInterfacePerformance='fast-v3';
+  window.__dabbirInterfacePerformance='fast-v4-truth';
 })();
 </script>`;
 
@@ -177,6 +177,7 @@ const conversationPerformanceUi = String.raw`
       });
 
       workspace.messages=(workspace.messages||[]).filter(m=>m.id!==tempId&&m.id!==typingId);
+      workspace.last_action_truth=j.truth||{state:'UNVERIFIED'};
 
       if(j.customer_message) workspace.messages.push(j.customer_message);
       else if(!j.customer_message_persisted) workspace.messages.push({id:tempId,conversation_id:selectedConversationId,sender_type:'customer',body:text,intent:'UNVERIFIED',simulated:false,created_at:now});
@@ -185,6 +186,7 @@ const conversationPerformanceUi = String.raw`
         localConversationState('action_required');
         renderMessages();
         if(current==='dashboard') renderDashboard();
+        if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
         toast(lang==='ar'?(j.customer_message_persisted?'تم حفظ رسالتك، وتعذر رد AI مؤقتًا':'تعذر إرسال الرسالة'):(j.customer_message_persisted?'Message saved; AI reply is temporarily unavailable':'Message could not be sent'));
         return;
       }
@@ -197,9 +199,12 @@ const conversationPerformanceUi = String.raw`
       renderMessages();
       if(current==='dashboard') renderDashboard();
       if(current==='analytics') renderAnalytics();
+      if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
     }catch{
+      workspace.last_action_truth={state:'UNVERIFIED'};
       workspace.messages=(workspace.messages||[]).filter(m=>m.id!==typingId);
       renderMessages();
+      if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
       toast(lang==='ar'?'تعذر الاتصال؛ حاول مرة أخرى':'Connection failed; try again');
     }finally{
       dabbirSending=false;
@@ -220,6 +225,57 @@ const conversationPerformanceUi = String.raw`
 })();
 </script>`;
 
+const truthVisibilityUi = String.raw`
+<style>
+.dabbirTruthBadge{display:inline-flex;align-items:center;gap:6px;margin-inline-start:8px;padding:4px 8px;border:1px solid rgba(255,255,255,.10);border-radius:999px;background:rgba(255,255,255,.04);font-size:10px;font-weight:700;letter-spacing:.01em;color:#bfc5cf;vertical-align:middle;white-space:nowrap}
+.dabbirTruthBadge[data-state="verified"]{color:#bfe7cf;border-color:rgba(137,214,170,.22);background:rgba(137,214,170,.07)}
+.dabbirTruthBadge[data-state="unverified"]{color:#f0cf9a;border-color:rgba(240,207,154,.20);background:rgba(240,207,154,.06)}
+.dabbirTruthBadge .dot{width:6px;height:6px;border-radius:50%;background:currentColor;box-shadow:0 0 10px currentColor}
+@media(max-width:700px){.dabbirTruthBadge{font-size:9px;padding:3px 7px;margin-inline-start:5px}}
+</style>
+<script>
+(()=>{
+  function exactTime(value){
+    if(!value) return '';
+    try{return new Intl.DateTimeFormat(lang==='ar'?'ar-AE':'en-AE',{hour:'2-digit',minute:'2-digit',second:'2-digit'}).format(new Date(value))}catch{return ''}
+  }
+
+  function renderTruth(){
+    const anchor=document.querySelector('#workspaceState');
+    if(!anchor) return;
+    let badge=document.querySelector('#dabbirTruthBadge');
+    if(!badge){
+      badge=document.createElement('span');
+      badge.id='dabbirTruthBadge';
+      badge.className='dabbirTruthBadge';
+      badge.innerHTML='<span class="dot"></span><span class="label"></span>';
+      anchor.insertAdjacentElement('afterend',badge);
+    }
+    const data=workspace?.data_truth;
+    const action=workspace?.last_action_truth;
+    const verified=data?.state==='VERIFIED_TENANT_READ';
+    const actionUnverified=action&&action.state!=='VERIFIED';
+    const state=actionUnverified?'unverified':(verified?'verified':'unverified');
+    badge.dataset.state=state;
+    const label=badge.querySelector('.label');
+    if(label){
+      if(actionUnverified) label.textContent=lang==='ar'?'آخر إجراء يحتاج تحقق':'Last action needs verification';
+      else if(verified) label.textContent=lang==='ar'?'بيانات موثقة':'Verified data';
+      else label.textContent=lang==='ar'?'حالة البيانات غير مؤكدة':'Data status unverified';
+    }
+    const readAt=exactTime(data?.read_at);
+    badge.title=verified
+      ? (lang==='ar'?`المصدر: بيانات النشاط المعزولة • آخر قراءة ${readAt||'الآن'}`:`Source: isolated tenant data • last read ${readAt||'now'}`)
+      : (lang==='ar'?'لا يوجد دليل قراءة موثقة لهذه الحالة':'No verified read evidence is available for this state');
+  }
+
+  const baseRenderAllTruth=renderAll;
+  renderAll=function(){baseRenderAllTruth();renderTruth()};
+  window.__dabbirRenderTruth=renderTruth;
+  setTimeout(renderTruth,0);
+})();
+</script>`;
+
 export default function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).setHeader('allow', 'GET').end('Method Not Allowed');
 
@@ -233,12 +289,12 @@ export default function handler(req, res) {
   html = html.replace(legacyTeamLink, '');
   html = html.replaceAll('/api/dabbir-runtime', '/api/dabbir-runtime-fast');
   html = html.replace("const {r,j}=await api('/api/dabbir-runtime-fast');if(r.status===401)", "const {r,j}=await api('/api/dabbir-runtime-fast?summary=1');if(r.status===401)");
-  html = html.replace('</body>', `${businessAdaptiveUi}\n${interfacePerformanceUi}\n${conversationPerformanceUi}\n</body>`);
+  html = html.replace('</body>', `${businessAdaptiveUi}\n${interfacePerformanceUi}\n${conversationPerformanceUi}\n${truthVisibilityUi}\n</body>`);
 
   res.setHeader('content-type', 'text/html; charset=utf-8');
   res.setHeader('cache-control', 'no-store');
-  res.setHeader('x-dabbir-interface', 'operational-runtime-v1');
-  res.setHeader('x-dabbir-chat-path', 'chat-send-fallback-v3');
-  res.setHeader('x-dabbir-performance', 'interface-fast-v3');
+  res.setHeader('x-dabbir-interface', 'operational-runtime-v2-truth');
+  res.setHeader('x-dabbir-chat-path', 'chat-send-truth-v4');
+  res.setHeader('x-dabbir-performance', 'interface-fast-v4-truth');
   return res.status(200).send(html);
 }

--- a/api/app.js
+++ b/api/app.js
@@ -265,7 +265,7 @@ const truthVisibilityUi = String.raw`
     }
     const readAt=exactTime(data?.read_at);
     badge.title=verified
-      ? (lang==='ar'?`المصدر: بيانات النشاط المعزولة • آخر قراءة ${readAt||'الآن'}`:`Source: isolated tenant data • last read ${readAt||'now'}`)
+      ? (lang==='ar'?'المصدر: بيانات النشاط المعزولة • آخر قراءة '+(readAt||'الآن'):'Source: isolated tenant data • last read '+(readAt||'now'))
       : (lang==='ar'?'لا يوجد دليل قراءة موثقة لهذه الحالة':'No verified read evidence is available for this state');
   }
 

--- a/api/dabbir-runtime-fast.js
+++ b/api/dabbir-runtime-fast.js
@@ -97,14 +97,30 @@ async function loadMessages(accessToken, businessId, conversationId) {
   );
 }
 
+function buildDataTruth({ business, conversations, customers, appointments, handoffs, followups, messages, duration, summaryOnly }) {
+  return {
+    state: 'VERIFIED_TENANT_READ',
+    source: 'SUPABASE_RLS_TENANT_DATA',
+    read_at: new Date().toISOString(),
+    business_updated_at: business?.updated_at || null,
+    runtime_ms: duration,
+    summary_only: summaryOnly,
+    counts: {
+      conversations: Array.isArray(conversations) ? conversations.length : 0,
+      customers: Array.isArray(customers) ? customers.length : 0,
+      appointments: Array.isArray(appointments) ? appointments.length : 0,
+      handoffs: Array.isArray(handoffs) ? handoffs.length : 0,
+      followups: Array.isArray(followups) ? followups.length : 0,
+      loaded_messages: Array.isArray(messages) ? messages.length : 0,
+    },
+  };
+}
+
 async function handleFastGet(req, res) {
   const started = Date.now();
   const accessToken = accessTokenFromRequest(req);
   if (!accessToken) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
-  // The membership read goes through Supabase Data API, which validates the
-  // same JWT before applying RLS. Reuse that successful validation instead of
-  // sending every hot-path request through /auth/v1/user as well.
   let memberships;
   try {
     memberships = await getBusinessMemberships(accessToken);
@@ -117,8 +133,6 @@ async function handleFastGet(req, res) {
   }
 
   let user = userClaimsFromValidatedAccessToken(accessToken);
-  // Compatibility fallback for an unexpected/legacy token shape. Normal
-  // Supabase Auth access tokens stay on the local claims path above.
   if (!user) user = await getVerifiedUser(accessToken).catch(() => null);
   if (!user) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
@@ -137,6 +151,12 @@ async function handleFastGet(req, res) {
       needs_onboarding: memberships.length === 0,
       memberships,
       operational_mode: 'AUTHENTICATED_WEB_RUNTIME',
+      truth_mode: 'AUTH_VERIFIED_NO_TENANT',
+      data_truth: {
+        state: 'NO_TENANT_SELECTED',
+        source: 'SUPABASE_AUTH_AND_MEMBERSHIP',
+        read_at: new Date().toISOString(),
+      },
       whatsapp: { state: 'NOT_OPERATIONAL', blocker: 'META_AUTHORIZATION_NOT_COMPLETED' },
       ai: {
         provider: aiConfig.provider,
@@ -226,14 +246,17 @@ async function handleFastGet(req, res) {
   }
 
   const duration = Date.now() - started;
+  const dataTruth = buildDataTruth({ business, conversations, customers, appointments, handoffs, followups, messages, duration, summaryOnly });
   res.setHeader('server-timing', `dabbir;dur=${duration}`);
-  res.setHeader('x-dabbir-runtime', 'fast-v4');
+  res.setHeader('x-dabbir-runtime', 'fast-v5-truth');
   return json(res, 200, {
     ok: true,
     authenticated: true,
     user,
     needs_onboarding: false,
     operational_mode: 'AUTHENTICATED_WEB_RUNTIME',
+    truth_mode: 'VERIFIED_TENANT_READS',
+    data_truth: dataTruth,
     membership,
     memberships,
     business,
@@ -266,8 +289,10 @@ export default async function handler(req, res) {
       const safeStatus = [400, 401, 403, 404, 409, 413, 429, 502, 503].includes(status) ? status : 500;
       return json(res, safeStatus, {
         ok: false,
+        state: 'FAILED_OR_UNVERIFIED',
         error: String(error?.message || 'FAST_RUNTIME_FAILED').slice(0, 120),
         detail: error?.detail || undefined,
+        truth: { state: 'UNVERIFIED' },
       });
     }
   }

--- a/test/dabbir-auth-fastpath.test.mjs
+++ b/test/dabbir-auth-fastpath.test.mjs
@@ -54,7 +54,7 @@ test('fast runtime validates membership before trusting decoded claims and retai
   assert.ok(claimsRead > membershipLookup, 'claims may only be trusted after Supabase Data API accepts the token');
   assert.ok(fallback > claimsRead, 'legacy/unexpected token shapes must retain server verification fallback');
   assert.match(runtimeSource, /AUTH_VERIFICATION_UNAVAILABLE/);
-  assert.match(runtimeSource, /x-dabbir-runtime', 'fast-v4'/);
+  assert.match(runtimeSource, /x-dabbir-runtime', 'fast-v5-truth'/);
 });
 
 test('fast runtime parses query parameters with WHATWG URL instead of legacy req.query', () => {

--- a/test/dabbir-truth-visibility.test.mjs
+++ b/test/dabbir-truth-visibility.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const appPath = 'api/app.js';
+const runtimePath = 'api/dabbir-runtime-fast.js';
+const app = fs.readFileSync(appPath, 'utf8');
+const runtime = fs.readFileSync(runtimePath, 'utf8');
+
+test('truth visibility files parse', () => {
+  for (const path of [appPath, runtimePath]) {
+    const result = spawnSync(process.execPath, ['--check', path], { encoding: 'utf8' });
+    assert.equal(result.status, 0, `${path}: ${result.stderr || result.stdout}`);
+  }
+});
+
+test('fast runtime exposes verified tenant read provenance and exact read timestamp', () => {
+  assert.match(runtime, /truth_mode:\s*'VERIFIED_TENANT_READS'/);
+  assert.match(runtime, /state:\s*'VERIFIED_TENANT_READ'/);
+  assert.match(runtime, /source:\s*'SUPABASE_RLS_TENANT_DATA'/);
+  assert.match(runtime, /read_at:\s*new Date\(\)\.toISOString\(\)/);
+  assert.match(runtime, /business_updated_at/);
+  assert.match(runtime, /counts:/);
+  assert.match(runtime, /x-dabbir-runtime', 'fast-v5-truth'/);
+});
+
+test('fast runtime failures are explicit unverified states', () => {
+  assert.match(runtime, /state:\s*'FAILED_OR_UNVERIFIED'/);
+  assert.match(runtime, /truth:\s*\{ state: 'UNVERIFIED' \}/);
+});
+
+test('owner interface renders a compact verified-data badge', () => {
+  assert.match(app, /dabbirTruthBadge/);
+  assert.match(app, /بيانات موثقة/);
+  assert.match(app, /Verified data/);
+  assert.match(app, /SUPABASE_RLS_TENANT_DATA|بيانات النشاط المعزولة/);
+  assert.match(app, /workspace\?\.data_truth/);
+});
+
+test('owner interface surfaces unverified action state instead of hiding it', () => {
+  assert.match(app, /workspace\.last_action_truth=j\.truth\|\|\{state:'UNVERIFIED'\}/);
+  assert.match(app, /آخر إجراء يحتاج تحقق/);
+  assert.match(app, /Last action needs verification/);
+  assert.match(app, /action\.state!=='VERIFIED'/);
+});


### PR DESCRIPTION
## Goal
Make DABBIR visibly professional and precise: the owner should know whether dashboard data is a verified tenant read and whether the last action was actually verified.

## Changes
- Fast runtime returns `truth_mode: VERIFIED_TENANT_READS` and structured `data_truth` evidence.
- Evidence includes source, exact read timestamp, business update timestamp, runtime duration, and collection counts.
- Fast runtime failures return `FAILED_OR_UNVERIFIED` with explicit unverified truth.
- Owner UI adds a compact bilingual trust badge beside workspace state.
- Badge shows `بيانات موثقة / Verified data` for verified tenant reads.
- If the latest chat action lacks verified evidence, badge changes to `آخر إجراء يحتاج تحقق / Last action needs verification`.
- Exact data-read time is available in the badge details.
- Added parse/regression tests for runtime and injected UI.

## Safety
No payment, KYC, Meta/WhatsApp, schema, or authorization policy changes.