### PR TITLE
DABBIR: gate every Vercel production build on tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/*.test.mjs"
+    "test": "node --test test/*.test.mjs",
+    "vercel-build": "npm test"
   },
   "dependencies": {
     "@vercel/oidc": "3.8.5",

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const ignore = fs.readFileSync(new URL('../vercel-ignore-if-unaffected.sh', import.meta.url), 'utf8');
+
+test('every Vercel build must execute the full DABBIR test suite', () => {
+  assert.equal(pkg.scripts?.['vercel-build'], 'npm test');
+  assert.equal(pkg.scripts?.test, 'node --test test/*.test.mjs');
+});
+
+test('runtime and package changes cannot be skipped by the Vercel ignore gate', () => {
+  assert.match(ignore, /Runtime or unknown path changed/);
+  assert.doesNotMatch(ignore, /package\.json\|/);
+  assert.doesNotMatch(ignore, /package-lock\.json\|/);
+});


### PR DESCRIPTION
## Why
`main` is still not protected at the GitHub repository level, and the current connector cannot change branch-protection settings. Until that administrative protection is enabled, Production needs an independent fail-closed safety gate.

## Change
- Adds `vercel-build: npm test` so every Vercel build runs the full DABBIR test suite.
- A failing DABBIR test now fails the Vercel build instead of allowing a broken runtime commit to become a READY Production deployment.
- Adds a regression test proving runtime/package changes cannot be skipped by the existing Vercel ignore gate.

## Scope
This is a compensating deployment control, not a claim that GitHub `main` is protected. The autonomous source-control PR remains blocked until GitHub reports `main.protected === true`.