### PR TITLE
DABBIR: make Vercel test gate single-run

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test test/*.test.mjs",
-    "vercel-build": "npm test"
+    "test": "node --test test/*.test.mjs"
   },
   "dependencies": {
     "@vercel/oidc": "3.8.5",

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -3,15 +3,18 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 const ignore = fs.readFileSync(new URL('../vercel-ignore-if-unaffected.sh', import.meta.url), 'utf8');
 
-test('every Vercel build must execute the full DABBIR test suite', () => {
-  assert.equal(pkg.scripts?.['vercel-build'], 'npm test');
+test('every Vercel build executes the full DABBIR test suite at deployment level', () => {
+  assert.equal(vercel.buildCommand, 'npm test');
   assert.equal(pkg.scripts?.test, 'node --test test/*.test.mjs');
+  assert.equal(pkg.scripts?.['vercel-build'], undefined);
 });
 
-test('runtime and package changes cannot be skipped by the Vercel ignore gate', () => {
+test('runtime, Vercel config and package changes cannot be skipped by the Vercel ignore gate', () => {
   assert.match(ignore, /Runtime or unknown path changed/);
   assert.doesNotMatch(ignore, /package\.json\|/);
   assert.doesNotMatch(ignore, /package-lock\.json\|/);
+  assert.doesNotMatch(ignore, /vercel\.json\|/);
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
+  "buildCommand": "npm test",
   "functions": {
     "api/app.js": {
       "includeFiles": "index.html"

--- a/vercel.json
+++ b/vercel.json
@@ -30,6 +30,7 @@
         { "key": "X-Frame-Options", "value": "DENY" },
         { "key": "Referrer-Policy", "value": "no-referrer" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=(), payment=()" },
+        { "key": "X-DABBIR-Build-Gate", "value": "tests-v1" },
         { "key": "Content-Security-Policy", "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; form-action 'self'; img-src 'self' data: https://*.facebook.com https://*.fbcdn.net; font-src 'self' data:; connect-src 'self' https://graph.facebook.com https://www.facebook.com https://web.facebook.com; frame-src https://www.facebook.com https://web.facebook.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' https://connect.facebook.net" }
       ]
     }


### PR DESCRIPTION
## Final verification result — NOT MERGED

The deployment-level `buildCommand: npm test` experiment was rejected after real Vercel verification.

### Evidence
- Final combined preview commit `7cbdc39f233d8d0e3c89b23a8107e9b004037fbf` ran the complete DABBIR suite successfully: 261 passed, 0 failed.
- Vercel then failed the deployment with: `No Output Directory named "public" found after the Build completed`.
- This DABBIR project is Functions-first and the top-level `buildCommand` changes Vercel's expected output contract in a way that is not compatible with the current deployment shape.

### Decision
Close without merge. Keep the already-merged fail-closed `vercel-build: npm test` gate on Production. Reliability takes priority over reducing repeated test invocation.

### Follow-up
Any build-speed optimization must preserve the existing Functions deployment contract and prove READY in a real Vercel preview before merge.