### PR TITLE
DABBIR: deduplicate Vercel test gate without weakening it

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "test": "node --test test/*.test.mjs",
-    "vercel-build": "npm test"
+    "vercel-build": "node scripts/vercel-build-gate.mjs"
   },
   "dependencies": {
     "@vercel/oidc": "3.8.5",

--- a/scripts/vercel-build-gate.mjs
+++ b/scripts/vercel-build-gate.mjs
@@ -3,7 +3,7 @@ import { existsSync, openSync, closeSync, writeFileSync, unlinkSync } from 'node
 import os from 'node:os';
 import path from 'node:path';
 
-const gateVersion = 'v2-deployment-scoped';
+const gateVersion = 'v3-final';
 const rawSha = String(process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local').trim();
 const rawDeploymentId = String(process.env.VERCEL_DEPLOYMENT_ID || `pid-${process.pid}`).trim();
 const safeSha = rawSha.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'local';

--- a/scripts/vercel-build-gate.mjs
+++ b/scripts/vercel-build-gate.mjs
@@ -1,0 +1,66 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync, openSync, closeSync, writeFileSync, unlinkSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const rawSha = String(process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local').trim();
+const safeSha = rawSha.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'local';
+const marker = path.join(os.tmpdir(), `dabbir-vercel-tests-passed-${safeSha}`);
+const lock = path.join(os.tmpdir(), `dabbir-vercel-tests-running-${safeSha}`);
+const maxWaitMs = 120000;
+const pollMs = 250;
+
+function sleep(milliseconds) {
+  const buffer = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(buffer), 0, 0, milliseconds);
+}
+
+function runTests() {
+  console.log(`[dabbir-build-gate] verifying commit ${safeSha}`);
+  const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test'], {
+    stdio: 'inherit',
+    env: process.env,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) process.exit(result.status ?? 1);
+  writeFileSync(marker, `${new Date().toISOString()}\n`, { encoding: 'utf8', mode: 0o600 });
+  console.log(`[dabbir-build-gate] verified commit ${safeSha}`);
+}
+
+if (existsSync(marker)) {
+  console.log(`[dabbir-build-gate] commit ${safeSha} already verified in this build environment; skipping duplicate test run`);
+  process.exit(0);
+}
+
+let lockFd = null;
+try {
+  lockFd = openSync(lock, 'wx', 0o600);
+} catch (error) {
+  if (error?.code !== 'EEXIST') throw error;
+}
+
+if (lockFd !== null) {
+  try {
+    runTests();
+  } finally {
+    closeSync(lockFd);
+    try { unlinkSync(lock); } catch {}
+  }
+  process.exit(0);
+}
+
+const waitStarted = Date.now();
+while (Date.now() - waitStarted < maxWaitMs) {
+  if (existsSync(marker)) {
+    console.log(`[dabbir-build-gate] commit ${safeSha} verified by another build-gate invocation`);
+    process.exit(0);
+  }
+  if (!existsSync(lock)) {
+    console.error('[dabbir-build-gate] verification lock disappeared without success evidence');
+    process.exit(1);
+  }
+  sleep(pollMs);
+}
+
+console.error('[dabbir-build-gate] timed out waiting for verified test evidence');
+process.exit(1);

--- a/scripts/vercel-build-gate.mjs
+++ b/scripts/vercel-build-gate.mjs
@@ -3,10 +3,14 @@ import { existsSync, openSync, closeSync, writeFileSync, unlinkSync } from 'node
 import os from 'node:os';
 import path from 'node:path';
 
+const gateVersion = 'v2-deployment-scoped';
 const rawSha = String(process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local').trim();
+const rawDeploymentId = String(process.env.VERCEL_DEPLOYMENT_ID || `pid-${process.pid}`).trim();
 const safeSha = rawSha.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'local';
-const marker = path.join(os.tmpdir(), `dabbir-vercel-tests-passed-${safeSha}`);
-const lock = path.join(os.tmpdir(), `dabbir-vercel-tests-running-${safeSha}`);
+const safeDeploymentId = rawDeploymentId.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 100) || `pid-${process.pid}`;
+const evidenceKey = `${safeDeploymentId}-${safeSha}`;
+const marker = path.join(os.tmpdir(), `dabbir-vercel-tests-passed-${evidenceKey}`);
+const lock = path.join(os.tmpdir(), `dabbir-vercel-tests-running-${evidenceKey}`);
 const maxWaitMs = 120000;
 const pollMs = 250;
 
@@ -16,19 +20,23 @@ function sleep(milliseconds) {
 }
 
 function runTests() {
-  console.log(`[dabbir-build-gate] verifying commit ${safeSha}`);
+  console.log(`[dabbir-build-gate:${gateVersion}] verifying deployment ${safeDeploymentId} commit ${safeSha}`);
   const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test'], {
     stdio: 'inherit',
     env: process.env,
   });
   if (result.error) throw result.error;
-  if (result.status !== 0) process.exit(result.status ?? 1);
+  if (result.status !== 0) {
+    const error = new Error(`DABBIR_TEST_GATE_FAILED_${result.status ?? 1}`);
+    error.exitCode = result.status ?? 1;
+    throw error;
+  }
   writeFileSync(marker, `${new Date().toISOString()}\n`, { encoding: 'utf8', mode: 0o600 });
-  console.log(`[dabbir-build-gate] verified commit ${safeSha}`);
+  console.log(`[dabbir-build-gate:${gateVersion}] verified deployment ${safeDeploymentId} commit ${safeSha}`);
 }
 
 if (existsSync(marker)) {
-  console.log(`[dabbir-build-gate] commit ${safeSha} already verified in this build environment; skipping duplicate test run`);
+  console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} already verified; skipping duplicate test run`);
   process.exit(0);
 }
 
@@ -40,27 +48,31 @@ try {
 }
 
 if (lockFd !== null) {
+  let exitCode = 0;
   try {
     runTests();
+  } catch (error) {
+    exitCode = Number(error?.exitCode || 1);
+    console.error(`[dabbir-build-gate:${gateVersion}] ${String(error?.message || error)}`);
   } finally {
     closeSync(lockFd);
     try { unlinkSync(lock); } catch {}
   }
-  process.exit(0);
+  process.exit(exitCode);
 }
 
 const waitStarted = Date.now();
 while (Date.now() - waitStarted < maxWaitMs) {
   if (existsSync(marker)) {
-    console.log(`[dabbir-build-gate] commit ${safeSha} verified by another build-gate invocation`);
+    console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} verified by another invocation`);
     process.exit(0);
   }
   if (!existsSync(lock)) {
-    console.error('[dabbir-build-gate] verification lock disappeared without success evidence');
+    console.error(`[dabbir-build-gate:${gateVersion}] verification lock disappeared without success evidence`);
     process.exit(1);
   }
   sleep(pollMs);
 }
 
-console.error('[dabbir-build-gate] timed out waiting for verified test evidence');
+console.error(`[dabbir-build-gate:${gateVersion}] timed out waiting for verified test evidence`);
 process.exit(1);

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -1,13 +1,35 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
 const ignore = fs.readFileSync(new URL('../vercel-ignore-if-unaffected.sh', import.meta.url), 'utf8');
+const gatePath = 'scripts/vercel-build-gate.mjs';
+const gate = fs.readFileSync(new URL(`../${gatePath}`, import.meta.url), 'utf8');
 
-test('every Vercel build must execute the full DABBIR test suite', () => {
-  assert.equal(pkg.scripts?.['vercel-build'], 'npm test');
+test('Vercel uses the fail-closed DABBIR build gate without changing the Functions deployment contract', () => {
+  assert.equal(pkg.scripts?.['vercel-build'], 'node scripts/vercel-build-gate.mjs');
   assert.equal(pkg.scripts?.test, 'node --test test/*.test.mjs');
+  const parse = spawnSync(process.execPath, ['--check', gatePath], { encoding: 'utf8' });
+  assert.equal(parse.status, 0, parse.stderr || parse.stdout);
+});
+
+test('cached build evidence is commit-scoped and written only after tests succeed', () => {
+  assert.match(gate, /VERCEL_GIT_COMMIT_SHA/);
+  assert.match(gate, /dabbir-vercel-tests-passed-/);
+  assert.match(gate, /spawnSync[\s\S]*\['test'\]/);
+  const testRun = gate.indexOf("spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test']");
+  const markerWrite = gate.indexOf('writeFileSync(marker');
+  assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the test process');
+  assert.match(gate, /if \(result\.status !== 0\) process\.exit/);
+});
+
+test('concurrent duplicate invocations fail closed without fabricating success evidence', () => {
+  assert.match(gate, /openSync\(lock, 'wx'/);
+  assert.match(gate, /verification lock disappeared without success evidence/);
+  assert.match(gate, /timed out waiting for verified test evidence/);
+  assert.match(gate, /if \(existsSync\(marker\)\)/);
 });
 
 test('runtime and package changes cannot be skipped by the Vercel ignore gate', () => {

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -15,14 +15,22 @@ test('Vercel uses the fail-closed DABBIR build gate without changing the Functio
   assert.equal(parse.status, 0, parse.stderr || parse.stdout);
 });
 
-test('cached build evidence is commit-scoped and written only after tests succeed', () => {
+test('cached build evidence is scoped to deployment plus commit and written only after tests succeed', () => {
+  assert.match(gate, /VERCEL_DEPLOYMENT_ID/);
   assert.match(gate, /VERCEL_GIT_COMMIT_SHA/);
+  assert.match(gate, /const evidenceKey = `\$\{safeDeploymentId\}-\$\{safeSha\}`/);
   assert.match(gate, /dabbir-vercel-tests-passed-/);
   assert.match(gate, /spawnSync[\s\S]*\['test'\]/);
   const testRun = gate.indexOf("spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test']");
   const markerWrite = gate.indexOf('writeFileSync(marker');
   assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the test process');
-  assert.match(gate, /if \(result\.status !== 0\) process\.exit/);
+  assert.match(gate, /DABBIR_TEST_GATE_FAILED_/);
+});
+
+test('failure cleanup cannot leave a stale success path', () => {
+  assert.match(gate, /finally \{[\s\S]*closeSync\(lockFd\)[\s\S]*unlinkSync\(lock\)/);
+  assert.match(gate, /process\.exit\(exitCode\)/);
+  assert.doesNotMatch(gate, /if \(result\.status !== 0\) process\.exit/);
 });
 
 test('concurrent duplicate invocations fail closed without fabricating success evidence', () => {


### PR DESCRIPTION
## Why
Production is now fail-closed on the full DABBIR test suite, but Vercel build logs show `vercel-build` may be invoked repeatedly in this Functions-first project. The previous `buildCommand` optimization was rejected because it broke Vercel's output-directory contract.

## Safe optimization
- Keep the proven `vercel-build` mechanism.
- Route it through `scripts/vercel-build-gate.mjs`.
- Scope success evidence to the exact commit SHA.
- Write the marker only after `npm test` exits successfully.
- Concurrent/repeated invocations wait for real success evidence; missing lock evidence or timeout fails closed.
- If Vercel build invocations share the build environment, later invocations skip duplicate full suites. If they do not, safety is unchanged and each invocation still runs the suite.

## Required evidence before merge
- GitHub DABBIR CI PASS on exact head SHA.
- Vercel Preview READY.
- Preview logs must show full tests succeed and must not introduce the `No Output Directory` failure from the rejected #88 experiment.