### PR TITLE
DABBIR: make WhatsApp readiness evidence-based

### DIFF
--- a/api/customer-activation-ui.js
+++ b/api/customer-activation-ui.js
@@ -13,7 +13,7 @@ const script=String.raw`(()=>{
   const CACHE_MS=30000;
 
   const style=document.createElement('style');
-  style.dataset.dabbirCustomerActivation='v2';
+  style.dataset.dabbirCustomerActivation='v3';
   style.textContent=[
     '.dabbirActivation{margin:0 0 14px;border:1px solid #334061;background:linear-gradient(145deg,#12182b 0%,#101526 54%,#111827 100%);border-radius:22px;padding:16px;box-shadow:0 18px 55px #0005}',
     '.daHead{display:flex;align-items:flex-start;justify-content:space-between;gap:14px}.daHead h2{margin:0;font-size:16px;line-height:1.35}.daHead p{margin:5px 0 0;color:#a9b4c8;font-size:10px;line-height:1.65}',
@@ -34,10 +34,10 @@ const script=String.raw`(()=>{
 
   function copy(){return ar()?{
     title:'جهّز دَبِّر ليعمل عنك',readyTitle:'دَبِّر جاهز للعمل',desc:'دقيقة واحدة هنا تختصر عليك البحث داخل الإعدادات. نعرض فقط ما تم التحقق منه فعليًا.',readyDesc:'الأساسيات التشغيلية جاهزة. راقب ما أنجزه دَبِّر وما يحتاج قرارك فقط.',score:'الجاهزية',next:'الخطوة الأفضل الآن',proof:'دليل القيمة',intentTitle:'ماذا تريد من دَبِّر الآن؟',
-    profile:'معلومات النشاط',channel:'واتساب',ai:'ذكاء دَبِّر',profileTodo:'أكمل معلومات نشاطك',profileBody:'أضف الساعات وبيانات التواصل والسياسات الأساسية حتى يرد دَبِّر بمعلومات صحيحة.',profileAction:'إكمال المعلومات',channelTodo:'اربط واتساب',channelBody:'اربط رقم WhatsApp Business من داخل دَبِّر حتى تنتقل من التجربة الداخلية إلى قناة العميل الحقيقية.',channelAction:'ربط واتساب',aiTodo:'تحقق من جاهزية الذكاء',aiBody:'دَبِّر يحتاج AI تشغيليًا قبل أن يعتمد عليه في الردود والمتابعة.',aiAction:'فتح الحالة',testTodo:'جرّب أول محادثة',testBody:'أرسل محادثة اختبار حقيقية داخل دَبِّر وشاهد الرد والحفظ قبل الاعتماد اليومي.',testAction:'فتح المحادثات',priorities:'راجع أولويات اليوم',customers:'عملاء',chats:'محادثات',aiReplies:'ردود AI',unverified:'—',loading:'دَبِّر يتحقق من التجهيز الفعلي…',complete:'مكتمل',reply:'الرد على العملاء',follow:'المتابعات',customerRecords:'العملاء',settings:'معلومات النشاط',appointments:'المواعيد',operations:'الطلبات والمخزون',viewings:'المعاينات',schedule:'الجدول'
+    profile:'معلومات النشاط',channel:'واتساب',ai:'ذكاء دَبِّر',profileTodo:'أكمل معلومات نشاطك',profileBody:'أضف الساعات وبيانات التواصل والسياسات الأساسية حتى يرد دَبِّر بمعلومات صحيحة.',profileAction:'إكمال المعلومات',channelTodo:'اربط واتساب',channelBody:'اربط رقم WhatsApp Business من داخل دَبِّر حتى تنتقل من التجربة الداخلية إلى قناة العميل الحقيقية.',channelAction:'ربط واتساب',channelVerifyTodo:'تحقق من تشغيل واتساب',channelVerifyBody:'الرقم مرتبط بـ Meta، لكن دَبِّر لن يعتبره جاهزًا حتى يستقبل رسالة WhatsApp حقيقية ويسجل ردًا حقيقيًا بنتيجة خارجية موثقة.',channelVerifyAction:'اختبار واتساب',aiTodo:'تحقق من جاهزية الذكاء',aiBody:'دَبِّر يحتاج AI تشغيليًا قبل أن يعتمد عليه في الردود والمتابعة.',aiAction:'فتح الحالة',testTodo:'جرّب أول محادثة',testBody:'أرسل محادثة اختبار حقيقية داخل دَبِّر وشاهد الرد والحفظ قبل الاعتماد اليومي.',testAction:'فتح المحادثات',priorities:'راجع أولويات اليوم',customers:'عملاء',chats:'محادثات',aiReplies:'ردود AI',unverified:'—',loading:'دَبِّر يتحقق من التجهيز الفعلي…',complete:'مكتمل',reply:'الرد على العملاء',follow:'المتابعات',customerRecords:'العملاء',settings:'معلومات النشاط',appointments:'المواعيد',operations:'الطلبات والمخزون',viewings:'المعاينات',schedule:'الجدول'
   }:{
     title:'Get DABBIR working for you',readyTitle:'DABBIR is ready to operate',desc:'One minute here saves hunting through settings. Only verified setup state is shown.',readyDesc:'Core operations are ready. Focus on what DABBIR completed and what actually needs your decision.',score:'Readiness',next:'Best next step',proof:'Proof of value',intentTitle:'What do you want DABBIR to do now?',
-    profile:'Business info',channel:'WhatsApp',ai:'DABBIR AI',profileTodo:'Complete business information',profileBody:'Add hours, contact details and key policies so DABBIR can answer accurately.',profileAction:'Complete info',channelTodo:'Connect WhatsApp',channelBody:'Connect your WhatsApp Business number inside DABBIR to move from internal testing to the real customer channel.',channelAction:'Connect WhatsApp',aiTodo:'Verify AI readiness',aiBody:'DABBIR needs operational AI before replies and follow-ups can be trusted.',aiAction:'Open status',testTodo:'Try the first conversation',testBody:'Run a real in-app conversation and verify the reply and persistence before daily use.',testAction:'Open conversations',priorities:'Review today’s priorities',customers:'Customers',chats:'Conversations',aiReplies:'AI replies',unverified:'—',loading:'DABBIR is checking verified setup…',complete:'Complete',reply:'Reply to customers',follow:'Follow-ups',customerRecords:'Customers',settings:'Business info',appointments:'Appointments',operations:'Orders & inventory',viewings:'Viewings',schedule:'Schedule'
+    profile:'Business info',channel:'WhatsApp',ai:'DABBIR AI',profileTodo:'Complete business information',profileBody:'Add hours, contact details and key policies so DABBIR can answer accurately.',profileAction:'Complete info',channelTodo:'Connect WhatsApp',channelBody:'Connect your WhatsApp Business number inside DABBIR to move from internal testing to the real customer channel.',channelAction:'Connect WhatsApp',channelVerifyTodo:'Verify WhatsApp operation',channelVerifyBody:'The number is linked to Meta, but DABBIR will not mark it ready until a real WhatsApp inbound and a real externally verified reply are recorded.',channelVerifyAction:'Test WhatsApp',aiTodo:'Verify AI readiness',aiBody:'DABBIR needs operational AI before replies and follow-ups can be trusted.',aiAction:'Open status',testTodo:'Try the first conversation',testBody:'Run a real in-app conversation and verify the reply and persistence before daily use.',testAction:'Open conversations',priorities:'Review today’s priorities',customers:'Customers',chats:'Conversations',aiReplies:'AI replies',unverified:'—',loading:'DABBIR is checking verified setup…',complete:'Complete',reply:'Reply to customers',follow:'Follow-ups',customerRecords:'Customers',settings:'Business info',appointments:'Appointments',operations:'Orders & inventory',viewings:'Viewings',schedule:'Schedule'
   }}
 
   function profileReady(){
@@ -47,9 +47,14 @@ const script=String.raw`(()=>{
     return core&&contact;
   }
 
+  function whatsappLinked(){
+    const w=whatsapp||workspace?.whatsapp||{};
+    return Boolean(w.connected||w.meta_authorized||['META_AUTHORIZED','OPERATIONAL'].includes(String(w.state||'')));
+  }
+
   function whatsappReady(){
     const w=whatsapp||workspace?.whatsapp||{};
-    return Boolean(w.operational||w.connected||w.meta_authorized||['META_AUTHORIZED','WEBHOOK_LINKED','CONFIGURED_READY_FOR_VERIFICATION','OUTBOUND_CONFIGURED','OPERATIONAL'].includes(String(w.state||'')));
+    return w.operational===true&&String(w.state||'')==='OPERATIONAL';
   }
 
   function aiReady(){return Boolean(workspace?.ai?.configured)}
@@ -77,7 +82,8 @@ const script=String.raw`(()=>{
   function nextStep(){
     const t=copy();
     if(!profileReady())return {title:t.profileTodo,body:t.profileBody,action:t.profileAction,screen:'settings'};
-    if(!whatsappReady())return {title:t.channelTodo,body:t.channelBody,action:t.channelAction,screen:'integrations'};
+    if(!whatsappLinked())return {title:t.channelTodo,body:t.channelBody,action:t.channelAction,screen:'integrations'};
+    if(!whatsappReady())return {title:t.channelVerifyTodo,body:t.channelVerifyBody,action:t.channelVerifyAction,screen:'integrations'};
     if(!aiReady())return {title:t.aiTodo,body:t.aiBody,action:t.aiAction,screen:'integrations'};
     const chats=exactMetric('active_chats');
     if(chats===0)return {title:t.testTodo,body:t.testBody,action:t.testAction,screen:'conversations'};
@@ -149,7 +155,7 @@ const script=String.raw`(()=>{
     setLanguage=function(next){const result=base(next);setTimeout(render,0);return result};
   }
   setTimeout(()=>{render();load(false)},500);
-  window.__dabbirCustomerActivation={version:'customer-activation-v2',refresh:()=>load(true)};
+  window.__dabbirCustomerActivation={version:'customer-activation-v3',refresh:()=>load(true)};
 })();`;
 
 export default function handler(req,res){
@@ -158,6 +164,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-customer-activation','v2');
+  res.setHeader('x-dabbir-customer-activation','v3');
   return res.end(script);
 }

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,5 +1,5 @@
 import { singleQueryValue } from './_request-query.js';
-import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json } from './_auth-core.js';
+import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRest } from './_auth-core.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
@@ -60,6 +60,74 @@ function publicConfig(config) {
   };
 }
 
+function emptyOperationalEvidence(available = true) {
+  return {
+    available,
+    real_whatsapp_conversation: false,
+    real_inbound_message: false,
+    real_outbound_reply: false,
+    verified_external_result: false,
+  };
+}
+
+async function rowsOrNull(response) {
+  if (!response?.ok) return null;
+  const rows = await response.json().catch(() => null);
+  return Array.isArray(rows) ? rows : null;
+}
+
+export async function loadOperationalEvidence(accessToken, businessId) {
+  try {
+    const encodedBusinessId = encodeURIComponent(String(businessId));
+    const conversationResponse = await supabaseRest(
+      `dabbir_conversations?select=id&business_id=eq.${encodedBusinessId}&channel_type=eq.whatsapp&demo_mode=eq.false&order=created_at.desc&limit=100`,
+      accessToken,
+    );
+    const conversations = await rowsOrNull(conversationResponse);
+    if (conversations === null) return emptyOperationalEvidence(false);
+    const conversationIds = conversations.map(row => String(row?.id || '')).filter(Boolean);
+    if (!conversationIds.length) return emptyOperationalEvidence(true);
+
+    const conversationFilter = `in.(${conversationIds.join(',')})`;
+    const [messageResponse, outcomeResponse] = await Promise.all([
+      supabaseRest(
+        `dabbir_messages?select=sender_type,simulated&business_id=eq.${encodedBusinessId}&conversation_id=${conversationFilter}&simulated=eq.false&limit=200`,
+        accessToken,
+      ),
+      supabaseRest(
+        `dabbir_conversation_outcomes?select=verified_external_result&business_id=eq.${encodedBusinessId}&conversation_id=${conversationFilter}&verified_external_result=eq.true&limit=1`,
+        accessToken,
+      ),
+    ]);
+    const messages = await rowsOrNull(messageResponse);
+    const outcomes = await rowsOrNull(outcomeResponse);
+    if (messages === null || outcomes === null) return emptyOperationalEvidence(false);
+
+    const inbound = messages.some(row => row?.simulated === false && String(row?.sender_type || '') === 'customer');
+    const outbound = messages.some(row => row?.simulated === false && ['ai', 'human'].includes(String(row?.sender_type || '')));
+    const verifiedExternal = outcomes.some(row => row?.verified_external_result === true);
+    return {
+      available: true,
+      real_whatsapp_conversation: true,
+      real_inbound_message: inbound,
+      real_outbound_reply: outbound,
+      verified_external_result: verifiedExternal,
+    };
+  } catch {
+    return emptyOperationalEvidence(false);
+  }
+}
+
+function operationalReason(authorized, evidence) {
+  if (!authorized) return 'META_AUTHORIZATION_NOT_VERIFIED';
+  if (!evidence?.available) return 'OPERATIONAL_EVIDENCE_UNAVAILABLE';
+  if (!evidence.real_whatsapp_conversation) return 'REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED';
+  if (!evidence.real_inbound_message) return 'REAL_WHATSAPP_INBOUND_NOT_VERIFIED';
+  if (!evidence.real_outbound_reply) return 'REAL_WHATSAPP_REPLY_NOT_RECORDED';
+  if (!evidence.verified_external_result) return 'EXTERNAL_REPLY_RESULT_NOT_VERIFIED';
+  return null;
+}
+
 export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') {
   return {
     ok: true,
@@ -82,6 +150,7 @@ export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') 
     connected_at: null,
     operational: false,
     operational_reason: 'WHATSAPP_NOT_LINKED',
+    operational_evidence: emptyOperationalEvidence(true),
     checked_at: new Date().toISOString(),
   };
 }
@@ -116,7 +185,12 @@ async function embeddedStatus(req, accessToken, businessId) {
   if (!row) return null;
   const platform = embeddedPlatformConfig();
   try {
-    const verified = await verifyStoredConnection(platform, row);
+    const [verified, evidence] = await Promise.all([
+      verifyStoredConnection(platform, row),
+      loadOperationalEvidence(accessToken, businessId),
+    ]);
+    const reason = operationalReason(Boolean(verified.authorized), evidence);
+    const operational = reason === null;
     return {
       ok: true,
       channel: 'whatsapp',
@@ -127,7 +201,7 @@ async function embeddedStatus(req, accessToken, businessId) {
       outbound_configured: Boolean(verified.authorized),
       phone_number_configured: true,
       waba_configured: true,
-      state: verified.authorized ? 'META_AUTHORIZED' : 'AUTHORIZATION_INVALID',
+      state: operational ? 'OPERATIONAL' : verified.authorized ? 'META_AUTHORIZED' : 'AUTHORIZATION_INVALID',
       meta_authorized: Boolean(verified.authorized),
       meta_check_attempted: true,
       meta_check_reason: verified.authorized ? null : 'META_AUTHORIZATION_CHECK_FAILED',
@@ -139,8 +213,9 @@ async function embeddedStatus(req, accessToken, businessId) {
       waba_id: row.waba_id,
       phone_number_id: row.phone_number_id,
       connected_at: row.connected_at,
-      operational: false,
-      operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+      operational,
+      operational_reason: reason,
+      operational_evidence: evidence,
       checked_at: new Date().toISOString(),
     };
   } catch (error) {
@@ -164,7 +239,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       phone_number_id: row.phone_number_id,
       connected_at: row.connected_at,
       operational: false,
-      operational_reason: 'LIVE_MESSAGE_PATH_NOT_YET_VERIFIED',
+      operational_reason: 'META_AUTHORIZATION_NOT_VERIFIED',
+      operational_evidence: emptyOperationalEvidence(false),
       checked_at: new Date().toISOString(),
     };
   }

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const statusPath='api/dabbir-whatsapp-status.js';
+const activationPath='api/customer-activation-ui.js';
+const status=fs.readFileSync(statusPath,'utf8');
+const activation=fs.readFileSync(activationPath,'utf8');
+
+test('WhatsApp operational evidence is tenant-scoped and excludes simulation',()=>{
+  assert.match(status,/dabbir_conversations\?select=id/);
+  assert.match(status,/channel_type=eq\.whatsapp/);
+  assert.match(status,/demo_mode=eq\.false/);
+  assert.match(status,/dabbir_messages\?select=sender_type,simulated/);
+  assert.match(status,/simulated=eq\.false/);
+  assert.match(status,/dabbir_conversation_outcomes\?select=verified_external_result/);
+  assert.match(status,/verified_external_result=eq\.true/);
+  assert.match(status,/business_id=eq\.\$\{encodedBusinessId\}/);
+});
+
+test('WhatsApp becomes operational only after inbound, outbound and verified external result',()=>{
+  assert.match(status,/REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED/);
+  assert.match(status,/REAL_WHATSAPP_INBOUND_NOT_VERIFIED/);
+  assert.match(status,/REAL_WHATSAPP_REPLY_NOT_RECORDED/);
+  assert.match(status,/EXTERNAL_REPLY_RESULT_NOT_VERIFIED/);
+  assert.match(status,/const operational = reason === null/);
+  assert.match(status,/state: operational \? 'OPERATIONAL'/);
+  assert.match(status,/operational_evidence: evidence/);
+});
+
+test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
+  assert.match(activation,/function whatsappLinked\(\)/);
+  assert.match(activation,/function whatsappReady\(\)/);
+  const readyStart=activation.indexOf('function whatsappReady()');
+  const readyEnd=activation.indexOf('function aiReady()',readyStart);
+  const readyBody=activation.slice(readyStart,readyEnd);
+  assert.match(readyBody,/w\.operational===true/);
+  assert.match(readyBody,/state\|\|''\)===\s*'OPERATIONAL'/);
+  assert.doesNotMatch(readyBody,/w\.connected/);
+  assert.doesNotMatch(readyBody,/w\.meta_authorized/);
+  assert.match(activation,/if\(!whatsappLinked\(\)\).*channelTodo/);
+  assert.match(activation,/if\(!whatsappReady\(\)\).*channelVerifyTodo/);
+});
+
+test('operational truth files parse as Node modules',()=>{
+  for(const path of [statusPath,activationPath]){
+    const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
+    assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
+  }
+});


### PR DESCRIPTION
Fixes a truth-gate flaw where Customer Activation could mark WhatsApp ready from `connected` / `meta_authorized` even though the real message path was still unverified.

Changes:
- derive tenant WhatsApp `OPERATIONAL` only from the same business's RLS-protected evidence
- require a non-demo WhatsApp conversation
- require a non-simulated inbound customer message
- require a non-simulated AI/human outbound reply
- require `verified_external_result=true` on a WhatsApp conversation outcome
- keep `META_AUTHORIZED` as a distinct linked-but-not-operational state
- return explicit `operational_reason` and boolean `operational_evidence`
- Customer Activation v3 separates “Connect WhatsApp” from “Verify WhatsApp operation” and counts WhatsApp readiness only when `operational=true` + state `OPERATIONAL`
- add regression tests that forbid the old permissive readiness logic

Safety:
- no service-role usage added
- evidence reads execute under the authenticated owner's normal RLS permissions
- no database migration or data mutation
- no Meta/WhatsApp provider state is changed
- no Stripe code touched
- no live message is fabricated