### PR TITLE
DABBIR: pin public Meta identifiers in app code

### DIFF
--- a/api/_dabbir-meta-public-config.js
+++ b/api/_dabbir-meta-public-config.js
@@ -1,0 +1,15 @@
+export const DABBIR_META_APP_ID = '1876008666699823';
+export const DABBIR_WHATSAPP_EMBEDDED_CONFIG_ID = '1984552462260787';
+
+export function applyDabbirMetaPublicIdentifiers(platform = {}) {
+  const appId = String(platform.appId || DABBIR_META_APP_ID).trim();
+  const configId = String(platform.configId || DABBIR_WHATSAPP_EMBEDDED_CONFIG_ID).trim();
+  return {
+    ...platform,
+    appId,
+    configId,
+    appIdSource: platform.appId ? platform.appIdSource : 'dabbir_platform_registry',
+    configIdSource: platform.configId ? 'environment' : 'dabbir_platform_registry',
+    ready: Boolean(appId && platform.appSecret && configId && platform.encryptionSecret),
+  };
+}

--- a/api/dabbir-whatsapp-embedded-complete.js
+++ b/api/dabbir-whatsapp-embedded-complete.js
@@ -1,4 +1,5 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
 import {
   exchangeEmbeddedCode,
   ownerContext,
@@ -64,7 +65,7 @@ export default async function handler(req, res) {
     if (!wabaId) return json(res, 400, { ok: false, error: 'META_EMBEDDED_SIGNUP_WABA_REQUIRED' });
 
     const owner = await ownerContext(req, businessId);
-    const platform = await resolveEmbeddedPlatformConfig();
+    const platform = applyDabbirMetaPublicIdentifiers(await resolveEmbeddedPlatformConfig());
     if (!platform.ready) return json(res, 503, { ok: false, error: 'META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED' });
 
     const exchanged = await exchangeEmbeddedCode(platform, code);

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,5 +1,6 @@
 import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
+import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
 import { loadBusinessConnection, ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
 
 function readiness(platform) {
@@ -10,13 +11,14 @@ function readiness(platform) {
     encryption_configured: Boolean(platform.encryptionSecret),
     existing_whatsapp_token_available: Boolean(platform.legacyAccessTokenAvailable),
     app_id_source: platform.appIdSource || null,
+    config_id_source: platform.configIdSource || null,
   };
 }
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
 
-  const platform = await resolveEmbeddedPlatformConfig();
+  const platform = applyDabbirMetaPublicIdentifiers(await resolveEmbeddedPlatformConfig());
   const accessToken = accessTokenFromRequest(req);
   const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
   const platformReadiness = readiness(platform);

--- a/test/dabbir-whatsapp-public-meta-ids.test.mjs
+++ b/test/dabbir-whatsapp-public-meta-ids.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+test('DABBIR keeps non-secret Meta App and Embedded Signup IDs in one public registry', async () => {
+  const registry = await read('api/_dabbir-meta-public-config.js');
+  assert.match(registry, /1876008666699823/);
+  assert.match(registry, /1984552462260787/);
+  assert.match(registry, /dabbir_platform_registry/);
+  assert.doesNotMatch(registry, /APP_SECRET|access_token|Bearer\s/i);
+});
+
+test('Embedded Signup config and completion both apply the DABBIR public Meta registry', async () => {
+  const config = await read('api/dabbir-whatsapp-embedded-config.js');
+  const complete = await read('api/dabbir-whatsapp-embedded-complete.js');
+  for (const source of [config, complete]) {
+    assert.match(source, /applyDabbirMetaPublicIdentifiers/);
+    assert.match(source, /await resolveEmbeddedPlatformConfig\(\)/);
+  }
+  assert.match(config, /app_secret_configured/);
+  assert.match(config, /config_id_source/);
+  assert.match(complete, /if \(!platform\.ready\)/);
+});


### PR DESCRIPTION
Remove a fragile deployment dependency from WhatsApp Embedded Signup.

- Register DABBIR Meta App ID and WhatsApp Embedded Signup Configuration ID as public, non-secret platform identifiers in source.
- Apply the same registry to browser config and server-side authorization-code completion.
- Keep App Secret and integration encryption server-only and fail closed when absent.
- Add regression coverage to prevent the public IDs from drifting or being mistaken for secrets.

This intentionally does not fabricate or expose the Meta App Secret. Production remains blocked on that one server-side secret until it is restored.