### PR TITLE
DABBIR: make Auth guard verify Free-plan compensation

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -8,6 +8,8 @@ on:
       - 'scripts/dabbir-production-origin-gate.mjs'
       - 'config/barman-integration-contract.json'
       - 'api/auth/**'
+      - 'api/_password-breach-check.js'
+      - 'test/dabbir-password-breach-check.test.mjs'
   workflow_dispatch:
 
 permissions:
@@ -44,7 +46,7 @@ jobs:
             echo 'source=none' >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Enforce leaked password protection
+      - name: Enforce native Supabase leaked password protection
         if: steps.credential.outputs.available == 'true'
         shell: bash
         run: |
@@ -69,8 +71,17 @@ jobs:
           if (config.password_hibp_enabled !== true) {
             throw new Error('Supabase leaked password protection remains disabled');
           }
-          console.log('Supabase leaked password protection verified.');
+          console.log('Supabase native leaked password protection verified.');
           NODE
+
+      - name: Verify DABBIR compensating leaked-password guard
+        if: steps.credential.outputs.available != 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --test test/dabbir-password-breach-check.test.mjs
+          echo 'Supabase native leaked-password protection was not modified because no Management API credential is configured.'
+          echo 'DABBIR application-layer HIBP k-anonymity guard is verified as the active compensating control.'
 
       - name: Classify canonical DABBIR production origin
         id: launch-gate
@@ -135,10 +146,3 @@ jobs:
           }
           console.log('DABBIR hosted Auth production URL configuration verified.');
           NODE
-
-      - name: Block when management credential is unavailable
-        if: steps.credential.outputs.available != 'true'
-        shell: bash
-        run: |
-          echo '::error::Supabase Management API credential is not configured; leaked-password protection cannot be remotely enforced.'
-          exit 1

--- a/test/dabbir-auth-production-guard.test.mjs
+++ b/test/dabbir-auth-production-guard.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const workflow = fs.readFileSync('.github/workflows/dabbir-auth-production.yml', 'utf8');
+
+test('auth production guard attempts native Supabase HIBP only with management credential', () => {
+  assert.match(workflow, /Enforce native Supabase leaked password protection/);
+  assert.match(workflow, /if: steps\.credential\.outputs\.available == 'true'/);
+  assert.match(workflow, /password_hibp_enabled/);
+  assert.match(workflow, /password_hibp_enabled !== true/);
+});
+
+test('missing management credential verifies the DABBIR compensating control instead of claiming native success', () => {
+  assert.match(workflow, /Verify DABBIR compensating leaked-password guard/);
+  assert.match(workflow, /if: steps\.credential\.outputs\.available != 'true'/);
+  assert.match(workflow, /node --test test\/dabbir-password-breach-check\.test\.mjs/);
+  assert.match(workflow, /native leaked-password protection was not modified/);
+  assert.match(workflow, /application-layer HIBP k-anonymity guard is verified/);
+  assert.doesNotMatch(workflow, /Block when management credential is unavailable/);
+});
+
+test('auth workflow reruns when the compensating control changes', () => {
+  assert.match(workflow, /api\/_password-breach-check\.js/);
+  assert.match(workflow, /test\/dabbir-password-breach-check\.test\.mjs/);
+  assert.match(workflow, /api\/auth\/\*\*/);
+});
+
+test('hosted Auth URL mutation remains credential-gated', () => {
+  assert.match(workflow, /Enforce hosted Supabase Auth URLs/);
+  assert.match(workflow, /steps\.credential\.outputs\.available == 'true' && steps\.launch-gate\.outputs\.ready == 'true'/);
+});


### PR DESCRIPTION
## Problem
Supabase native Leaked Password Protection is Pro+ only and the current project is on Free. The previous Auth Production Guard correctly stopped claiming remote enforcement, but then stayed permanently red even after DABBIR gained a verified application-layer HIBP guard.

## Change
- If a Supabase Management API credential exists, keep enforcing and verifying the native `password_hibp_enabled=true` control.
- If no management credential exists, explicitly state that native Supabase protection was not modified and run the DABBIR compromised-password regression suite as the active compensating control.
- Trigger the Auth guard whenever the breach guard or its regression test changes.
- Preserve credential gating for hosted Auth URL mutations.
- Add regression tests so missing credentials cannot silently become either false native success or an unverified green status.

## Truth model
A green guard without a management credential means only: the DABBIR application-layer HIBP k-anonymity protection was verified. It does **not** mean the Supabase native warning was cleared.

No plan upgrade, billing change, password mutation, or Supabase Auth setting mutation is performed by this PR.