### PR TITLE
DABBIR: protected production iPhone smoke journey

### DIFF
--- a/.github/workflows/dabbir-protected-live-smoke.yml
+++ b/.github/workflows/dabbir-protected-live-smoke.yml
@@ -1,0 +1,72 @@
+name: DABBIR Protected Live Smoke
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'test/dabbir-protected-live-smoke.mjs'
+      - '.github/workflows/dabbir-protected-live-smoke.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  protected-live-smoke:
+    name: Protected production iPhone smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 12
+    env:
+      PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
+      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
+      PROTECTED_QA_REPORT_PATH: dabbir-protected-live-smoke-report.json
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+      - name: Classify automation bypass readiness
+        id: bypass
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ -z "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
+            echo 'ready=false' >> "$GITHUB_OUTPUT"
+            echo 'BLOCKED_AUTOMATION_BYPASS_NOT_CONFIGURED'
+            echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
+            echo '' >> "$GITHUB_STEP_SUMMARY"
+            echo '**State:** BLOCKED_AUTOMATION_BYPASS_NOT_CONFIGURED' >> "$GITHUB_STEP_SUMMARY"
+            echo 'Production remains protected; no credential value was exposed.' >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo 'ready=true' >> "$GITHUB_OUTPUT"
+            echo 'AUTOMATION_BYPASS_READY'
+          fi
+      - name: Install WebKit journey runner
+        if: steps.bypass.outputs.ready == 'true'
+        run: |
+          npm install --no-save playwright@1.62.1
+          npx playwright install --with-deps webkit
+      - name: Run protected production smoke
+        if: steps.bypass.outputs.ready == 'true'
+        run: node test/dabbir-protected-live-smoke.mjs
+      - name: Publish protected smoke summary
+        if: ${{ always() && steps.bypass.outputs.ready == 'true' }}
+        shell: bash
+        run: |
+          if [ -f dabbir-protected-live-smoke-report.json ]; then
+            echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
+            echo "**Verdict:** $(jq -r '.verdict' dabbir-protected-live-smoke-report.json)" >> "$GITHUB_STEP_SUMMARY"
+            echo '| Step | Status | Duration ms | Detail |' >> "$GITHUB_STEP_SUMMARY"
+            echo '|---|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
+            jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' dabbir-protected-live-smoke-report.json >> "$GITHUB_STEP_SUMMARY"
+          fi
+      - name: Upload protected smoke evidence
+        if: ${{ always() && steps.bypass.outputs.ready == 'true' }}
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-protected-live-smoke-evidence
+          path: |
+            dabbir-protected-live-smoke-report.json
+            dabbir-protected-live-smoke.png
+          if-no-files-found: warn
+          retention-days: 7

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -1,0 +1,129 @@
+import fs from 'node:fs';
+
+const ORIGIN = String(process.env.PROTECTED_QA_ORIGIN || '').trim().replace(/\/$/, '');
+const BYPASS = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
+const REPORT_PATH = process.env.PROTECTED_QA_REPORT_PATH || 'dabbir-protected-live-smoke-report.json';
+
+if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PROTECTED_QA_ORIGIN_REQUIRED');
+if (!BYPASS) throw new Error('VERCEL_AUTOMATION_BYPASS_SECRET_REQUIRED');
+
+const report = {
+  journey: 'DABBIR_PROTECTED_LIVE_IPHONE_SMOKE',
+  origin: ORIGIN,
+  started_at: new Date().toISOString(),
+  completed_at: null,
+  verdict: 'RUNNING',
+  steps: [],
+  artifacts: {},
+};
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message || 'ASSERTION_FAILED');
+}
+
+async function step(name, fn) {
+  const started = Date.now();
+  const row = { name, status: 'RUNNING', duration_ms: null, detail: null };
+  report.steps.push(row);
+  try {
+    const detail = await fn();
+    row.status = 'PASS';
+    row.duration_ms = Date.now() - started;
+    row.detail = detail || null;
+    console.log(`PASS ${name} (${row.duration_ms}ms)${detail ? ` — ${detail}` : ''}`);
+  } catch (error) {
+    row.status = 'FAIL';
+    row.duration_ms = Date.now() - started;
+    row.detail = String(error?.stack || error?.message || error).slice(0, 1200);
+    console.error(`FAIL ${name} (${row.duration_ms}ms) — ${row.detail}`);
+    throw error;
+  }
+}
+
+function bypassHeaders(extra = {}) {
+  return {
+    'x-vercel-protection-bypass': BYPASS,
+    'x-vercel-set-bypass-cookie': 'true',
+    ...extra,
+  };
+}
+
+async function fetchProtected(path, init = {}) {
+  const headers = new Headers(init.headers || {});
+  for (const [key, value] of Object.entries(bypassHeaders())) headers.set(key, value);
+  return fetch(`${ORIGIN}${path}`, { redirect: 'follow', ...init, headers });
+}
+
+let browser;
+try {
+  await step('01_protected_home_reachable', async () => {
+    const response = await fetchProtected('/', { headers: { accept: 'text/html' } });
+    const text = await response.text();
+    assert(response.status === 200, `HOME_STATUS_${response.status}`);
+    assert(/DABBIR/i.test(text), 'HOME_DABBIR_IDENTITY_MISSING');
+    return 'Protected production home returned 200 with DABBIR identity.';
+  });
+
+  await step('02_runtime_auth_still_fails_closed', async () => {
+    const response = await fetchProtected('/api/dabbir-runtime-fast?summary=1', { headers: { accept: 'application/json' } });
+    const text = await response.text();
+    assert(response.status === 401, `UNAUTH_RUNTIME_EXPECTED_401_GOT_${response.status}:${text.slice(0, 200)}`);
+    return 'Vercel bypass does not bypass DABBIR authentication; unauthenticated runtime remains 401.';
+  });
+
+  await step('03_webkit_iphone_login_gate', async () => {
+    const { webkit } = await import('playwright');
+    browser = await webkit.launch({ headless: true });
+    const context = await browser.newContext({
+      viewport: { width: 390, height: 844 },
+      isMobile: true,
+      hasTouch: true,
+      locale: 'ar-AE',
+      timezoneId: 'Asia/Dubai',
+      extraHTTPHeaders: bypassHeaders(),
+    });
+    const page = await context.newPage();
+    const pageErrors = [];
+    const consoleErrors = [];
+    page.on('pageerror', error => pageErrors.push(String(error?.message || error)));
+    page.on('console', message => {
+      if (message.type() !== 'error') return;
+      const text = message.text();
+      if (/401|AUTH_REQUIRED|Failed to load resource/i.test(text)) return;
+      consoleErrors.push(text);
+    });
+
+    const response = await page.goto(ORIGIN, { waitUntil: 'domcontentloaded', timeout: 45_000 });
+    assert(response?.status() === 200, `BROWSER_HOME_STATUS_${response?.status()}`);
+    await page.locator('#authGate:not(.hidden)').waitFor({ state: 'visible', timeout: 20_000 });
+    await page.locator('#authEmail').waitFor({ state: 'visible', timeout: 10_000 });
+    await page.locator('#authPassword').waitFor({ state: 'visible', timeout: 10_000 });
+    await page.locator('#authSubmit').waitFor({ state: 'visible', timeout: 10_000 });
+
+    const authority = await page.evaluate(() => window.__dabbirUiAuthority || null);
+    assert(authority?.version === 'owner-first-v4', `UI_AUTHORITY_INVALID_${JSON.stringify(authority)}`);
+
+    const logo = page.locator('.brand .logo').first();
+    await logo.waitFor({ state: 'visible', timeout: 10_000 });
+    const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
+    assert(String(logoBg).includes('dabbir-approved-icon'), 'APPROVED_LOGO_NOT_RENDERED');
+
+    await page.screenshot({ path: 'dabbir-protected-live-smoke.png', fullPage: true });
+    report.artifacts.screenshot = 'dabbir-protected-live-smoke.png';
+    assert(pageErrors.length === 0, `PAGE_ERRORS:${pageErrors.join(' | ')}`);
+    assert(consoleErrors.length === 0, `CONSOLE_ERRORS:${consoleErrors.slice(0, 8).join(' | ')}`);
+    await context.close();
+    return 'WebKit rendered the iPhone-size Arabic login gate, approved logo, and authoritative owner-first-v4 shell without page errors.';
+  });
+
+  report.verdict = 'PASS';
+} catch (error) {
+  report.verdict = 'FAIL';
+  report.error = String(error?.stack || error?.message || error).slice(0, 1600);
+  process.exitCode = 1;
+} finally {
+  if (browser) await browser.close().catch(() => {});
+  report.completed_at = new Date().toISOString();
+  fs.writeFileSync(REPORT_PATH, `${JSON.stringify(report, null, 2)}\n`);
+  console.log(`DABBIR_PROTECTED_LIVE_SMOKE_VERDICT=${report.verdict}`);
+}


### PR DESCRIPTION
Adds a fail-closed live QA path for the currently Vercel-protected DABBIR production alias. The workflow never disables Deployment Protection or exposes the bypass value. When `VERCEL_AUTOMATION_BYPASS_SECRET` exists, it runs WebKit at iPhone size with the documented bypass headers, verifies the protected home returns 200, verifies DABBIR auth still fails closed with 401 when unauthenticated, renders the Arabic login gate and approved owner-first-v4 shell, captures a screenshot, and records page/console errors. If the bypass secret is not configured, the workflow classifies the exact blocker instead of pretending the journey ran.