### PR TITLE
DABBIR QA: use GitHub Trusted OIDC for protected smoke

### DIFF
--- a/.github/workflows/dabbir-protected-live-smoke.yml
+++ b/.github/workflows/dabbir-protected-live-smoke.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   protected-live-smoke:
@@ -36,40 +37,65 @@ jobs:
           if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
             echo 'ready=true' >> "$GITHUB_OUTPUT"
             echo 'generated=false' >> "$GITHUB_OUTPUT"
+            echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
             echo 'AUTOMATION_BYPASS_READY_FROM_EXISTING_SECRET'
             exit 0
           fi
 
-          if [ -z "${VERCEL_TOKEN:-}" ]; then
-            echo 'ready=false' >> "$GITHUB_OUTPUT"
-            echo 'generated=false' >> "$GITHUB_OUTPUT"
-            echo 'BLOCKED_VERCEL_CREDENTIAL_NOT_CONFIGURED'
-            echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
-            echo '' >> "$GITHUB_STEP_SUMMARY"
-            echo '**State:** BLOCKED_VERCEL_CREDENTIAL_NOT_CONFIGURED' >> "$GITHUB_STEP_SUMMARY"
-            echo 'Neither an automation bypass nor a Vercel API token is available to the workflow. Production remains protected.' >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "${VERCEL_TOKEN:-}" ]; then
+            endpoint="https://api.vercel.com/v1/projects/${VERCEL_PROJECT_ID}/protection-bypass?teamId=${VERCEL_TEAM_ID}"
+            response="$(curl --fail-with-body --silent --show-error \
+              -X PATCH "$endpoint" \
+              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
+              -H 'Content-Type: application/json' \
+              --data '{"generate":{"note":"DABBIR protected live smoke temporary"}}')"
+            secret="$(printf '%s' "$response" | jq -r '.protectionBypass // empty')"
+            if [ -z "$secret" ]; then
+              echo 'ready=false' >> "$GITHUB_OUTPUT"
+              echo 'generated=false' >> "$GITHUB_OUTPUT"
+              echo 'method=none' >> "$GITHUB_OUTPUT"
+              echo 'BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'
+              exit 1
+            fi
+            echo "::add-mask::$secret"
+            echo "VERCEL_AUTOMATION_BYPASS_SECRET=$secret" >> "$GITHUB_ENV"
+            echo 'ready=true' >> "$GITHUB_OUTPUT"
+            echo 'generated=true' >> "$GITHUB_OUTPUT"
+            echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
+            echo 'AUTOMATION_BYPASS_TEMPORARILY_GENERATED'
             exit 0
           fi
 
-          endpoint="https://api.vercel.com/v1/projects/${VERCEL_PROJECT_ID}/protection-bypass?teamId=${VERCEL_TEAM_ID}"
-          response="$(curl --fail-with-body --silent --show-error \
-            -X PATCH "$endpoint" \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            -H 'Content-Type: application/json' \
-            --data '{"generate":{"note":"DABBIR protected live smoke temporary"}}')"
-          secret="$(printf '%s' "$response" | jq -r '.protectionBypass // empty')"
-          if [ -z "$secret" ]; then
-            echo 'ready=false' >> "$GITHUB_OUTPUT"
-            echo 'generated=false' >> "$GITHUB_OUTPUT"
-            echo 'BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'
-            exit 1
+          oidc_response="$(curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}")"
+          oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
+          if [ -n "$oidc_token" ]; then
+            echo "::add-mask::$oidc_token"
+            probe_body="$(mktemp)"
+            probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' \
+              -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" \
+              -H 'accept: text/html' \
+              "$PROTECTED_QA_ORIGIN/")"
+            if [ "$probe_status" = '200' ] && grep -qi 'DABBIR' "$probe_body"; then
+              echo "VERCEL_TRUSTED_OIDC_TOKEN=$oidc_token" >> "$GITHUB_ENV"
+              echo 'ready=true' >> "$GITHUB_OUTPUT"
+              echo 'generated=false' >> "$GITHUB_OUTPUT"
+              echo 'method=trusted_oidc' >> "$GITHUB_OUTPUT"
+              echo 'TRUSTED_GITHUB_OIDC_READY'
+              exit 0
+            fi
+            echo "TRUSTED_GITHUB_OIDC_REJECTED_HTTP_${probe_status}"
           fi
 
-          echo "::add-mask::$secret"
-          echo "VERCEL_AUTOMATION_BYPASS_SECRET=$secret" >> "$GITHUB_ENV"
-          echo 'ready=true' >> "$GITHUB_OUTPUT"
-          echo 'generated=true' >> "$GITHUB_OUTPUT"
-          echo 'AUTOMATION_BYPASS_TEMPORARILY_GENERATED'
+          echo 'ready=false' >> "$GITHUB_OUTPUT"
+          echo 'generated=false' >> "$GITHUB_OUTPUT"
+          echo 'method=none' >> "$GITHUB_OUTPUT"
+          echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED'
+          echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
+          echo '' >> "$GITHUB_STEP_SUMMARY"
+          echo '**State:** BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED' >> "$GITHUB_STEP_SUMMARY"
+          echo 'No existing bypass, Vercel API token, or accepted GitHub Trusted OIDC source is available. Production remains protected.' >> "$GITHUB_STEP_SUMMARY"
       - name: Install WebKit journey runner
         if: steps.bypass.outputs.ready == 'true'
         run: |
@@ -84,6 +110,7 @@ jobs:
         run: |
           if [ -f dabbir-protected-live-smoke-report.json ]; then
             echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
+            echo "**Access method:** ${{ steps.bypass.outputs.method }}" >> "$GITHUB_STEP_SUMMARY"
             echo "**Verdict:** $(jq -r '.verdict' dabbir-protected-live-smoke-report.json)" >> "$GITHUB_STEP_SUMMARY"
             echo '| Step | Status | Duration ms | Detail |' >> "$GITHUB_STEP_SUMMARY"
             echo '|---|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"

--- a/test/dabbir-protected-live-smoke-oidc.test.mjs
+++ b/test/dabbir-protected-live-smoke-oidc.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const workflow=await readFile(new URL('../.github/workflows/dabbir-protected-live-smoke.yml',import.meta.url),'utf8');
+const runner=await readFile(new URL('./dabbir-protected-live-smoke.mjs',import.meta.url),'utf8');
+
+test('protected smoke can use short-lived GitHub trusted OIDC without opening production',()=>{
+  assert.match(workflow,/id-token:\s*write/);
+  assert.match(workflow,/x-vercel-trusted-oidc-idp-token/);
+  assert.match(workflow,/VERCEL_TRUSTED_OIDC_TOKEN/);
+  assert.match(workflow,/BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED/);
+  assert.match(workflow,/steps\.bypass\.outputs\.generated == 'true'/);
+});
+
+test('smoke runner supports either documented protection access method',()=>{
+  assert.match(runner,/VERCEL_AUTOMATION_BYPASS_SECRET/);
+  assert.match(runner,/VERCEL_TRUSTED_OIDC_TOKEN/);
+  assert.match(runner,/x-vercel-protection-bypass/);
+  assert.match(runner,/x-vercel-trusted-oidc-idp-token/);
+  assert.match(runner,/VERCEL_PROTECTED_ACCESS_REQUIRED/);
+});

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -2,14 +2,16 @@ import fs from 'node:fs';
 
 const ORIGIN = String(process.env.PROTECTED_QA_ORIGIN || '').trim().replace(/\/$/, '');
 const BYPASS = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
+const TRUSTED_OIDC = String(process.env.VERCEL_TRUSTED_OIDC_TOKEN || '').trim();
 const REPORT_PATH = process.env.PROTECTED_QA_REPORT_PATH || 'dabbir-protected-live-smoke-report.json';
 
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PROTECTED_QA_ORIGIN_REQUIRED');
-if (!BYPASS) throw new Error('VERCEL_AUTOMATION_BYPASS_SECRET_REQUIRED');
+if (!BYPASS && !TRUSTED_OIDC) throw new Error('VERCEL_PROTECTED_ACCESS_REQUIRED');
 
 const report = {
   journey: 'DABBIR_PROTECTED_LIVE_IPHONE_SMOKE',
   origin: ORIGIN,
+  protection_access: BYPASS ? 'automation_bypass' : 'trusted_oidc',
   started_at: new Date().toISOString(),
   completed_at: null,
   verdict: 'RUNNING',
@@ -40,17 +42,16 @@ async function step(name, fn) {
   }
 }
 
-function bypassHeaders(extra = {}) {
-  return {
-    'x-vercel-protection-bypass': BYPASS,
-    'x-vercel-set-bypass-cookie': 'true',
-    ...extra,
-  };
+function protectionHeaders(extra = {}) {
+  const auth = BYPASS
+    ? { 'x-vercel-protection-bypass': BYPASS, 'x-vercel-set-bypass-cookie': 'true' }
+    : { 'x-vercel-trusted-oidc-idp-token': TRUSTED_OIDC };
+  return { ...auth, ...extra };
 }
 
 async function fetchProtected(path, init = {}) {
   const headers = new Headers(init.headers || {});
-  for (const [key, value] of Object.entries(bypassHeaders())) headers.set(key, value);
+  for (const [key, value] of Object.entries(protectionHeaders())) headers.set(key, value);
   return fetch(`${ORIGIN}${path}`, { redirect: 'follow', ...init, headers });
 }
 
@@ -61,14 +62,14 @@ try {
     const text = await response.text();
     assert(response.status === 200, `HOME_STATUS_${response.status}`);
     assert(/DABBIR/i.test(text), 'HOME_DABBIR_IDENTITY_MISSING');
-    return 'Protected production home returned 200 with DABBIR identity.';
+    return `Protected production home returned 200 with DABBIR identity via ${BYPASS ? 'automation bypass' : 'trusted GitHub OIDC'}.`;
   });
 
   await step('02_runtime_auth_still_fails_closed', async () => {
     const response = await fetchProtected('/api/dabbir-runtime-fast?summary=1', { headers: { accept: 'application/json' } });
     const text = await response.text();
     assert(response.status === 401, `UNAUTH_RUNTIME_EXPECTED_401_GOT_${response.status}:${text.slice(0, 200)}`);
-    return 'Vercel bypass does not bypass DABBIR authentication; unauthenticated runtime remains 401.';
+    return 'Vercel protection access does not bypass DABBIR authentication; unauthenticated runtime remains 401.';
   });
 
   await step('03_webkit_iphone_login_gate', async () => {
@@ -80,7 +81,7 @@ try {
       hasTouch: true,
       locale: 'ar-AE',
       timezoneId: 'Asia/Dubai',
-      extraHTTPHeaders: bypassHeaders(),
+      extraHTTPHeaders: protectionHeaders(),
     });
     const page = await context.newPage();
     const pageErrors = [];


### PR DESCRIPTION
Add a no-static-secret fallback for protected DABBIR QA. The smoke workflow keeps Production protection enabled and tries, in order: existing automation bypass, temporary bypass via an existing Vercel API token, then GitHub Actions Trusted OIDC. If none is accepted it remains fail-closed. The WebKit runner supports both documented Vercel protection access headers and never treats Vercel login redirects as DABBIR success.