### PR TITLE
DABBIR QA: never report blocked browser journey as success

### DIFF
--- a/.github/workflows/dabbir-protected-live-smoke.yml
+++ b/.github/workflows/dabbir-protected-live-smoke.yml
@@ -6,6 +6,7 @@ on:
     branches: [main]
     paths:
       - 'test/dabbir-protected-live-smoke.mjs'
+      - 'test/dabbir-protected-live-smoke-oidc.test.mjs'
       - '.github/workflows/dabbir-protected-live-smoke.yml'
 
 permissions:
@@ -55,7 +56,7 @@ jobs:
               echo 'generated=false' >> "$GITHUB_OUTPUT"
               echo 'method=none' >> "$GITHUB_OUTPUT"
               echo 'BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'
-              exit 1
+              exit 2
             fi
             echo "::add-mask::$secret"
             echo "VERCEL_AUTOMATION_BYPASS_SECRET=$secret" >> "$GITHUB_ENV"
@@ -95,7 +96,8 @@ jobs:
           echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
           echo '**State:** BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED' >> "$GITHUB_STEP_SUMMARY"
-          echo 'No existing bypass, Vercel API token, or accepted GitHub Trusted OIDC source is available. Production remains protected.' >> "$GITHUB_STEP_SUMMARY"
+          echo 'No existing bypass, Vercel API token, or accepted GitHub Trusted OIDC source is available. Production remains protected and the browser journey did not run.' >> "$GITHUB_STEP_SUMMARY"
+          exit 2
       - name: Install WebKit journey runner
         if: steps.bypass.outputs.ready == 'true'
         run: |

--- a/test/dabbir-protected-live-smoke-oidc.test.mjs
+++ b/test/dabbir-protected-live-smoke-oidc.test.mjs
@@ -13,6 +13,13 @@ test('protected smoke can use short-lived GitHub trusted OIDC without opening pr
   assert.match(workflow,/steps\.bypass\.outputs\.generated == 'true'/);
 });
 
+test('blocked automation access is a real failing gate, never a green skipped journey',()=>{
+  const blocked=workflow.match(/echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED'[\s\S]{0,900}?exit 2/);
+  assert.ok(blocked,'blocked protection access must terminate the job with exit 2');
+  assert.match(workflow,/browser journey did not run/);
+  assert.match(workflow,/BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'[\s\S]{0,240}?exit 2/);
+});
+
 test('smoke runner supports either documented protection access method',()=>{
   assert.match(runner,/VERCEL_AUTOMATION_BYPASS_SECRET/);
   assert.match(runner,/VERCEL_TRUSTED_OIDC_TOKEN/);


### PR DESCRIPTION
Fixes a truthfulness gap in the protected iPhone smoke gate.

- If Vercel automation bypass generation fails, the job now exits non-zero.
- If neither bypass, Vercel token, nor accepted GitHub Trusted OIDC access exists, the job now exits non-zero instead of finishing green with all WebKit steps skipped.
- The summary explicitly states that the browser journey did not run.
- Adds regression coverage so BLOCKED cannot silently become SUCCESS again.

This does not weaken Deployment Protection and does not expose Production.