### PR TITLE
DABBIR: one-time Vault bridge for protected iPhone QA v2

### DIFF
--- a/.github/workflows/dabbir-protected-live-smoke.yml
+++ b/.github/workflows/dabbir-protected-live-smoke.yml
@@ -7,7 +7,10 @@ on:
     paths:
       - 'test/dabbir-protected-live-smoke.mjs'
       - 'test/dabbir-protected-live-smoke-oidc.test.mjs'
+      - 'test/dabbir-protected-browser-bridge.test.mjs'
       - '.github/workflows/dabbir-protected-live-smoke.yml'
+      - 'supabase/functions/barman-browser-runner/**'
+      - 'supabase/migrations/20260828013400_dabbir_protected_qa_share_vault.sql'
 
 permissions:
   contents: read
@@ -25,6 +28,7 @@ jobs:
       VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       VERCEL_TEAM_ID: team_pwfKq8jHuyW1XFVSZirAJiId
       PROTECTED_QA_REPORT_PATH: dabbir-protected-live-smoke-report.json
+      PROTECTED_QA_BRIDGE_REPORT_PATH: dabbir-protected-browser-bridge-report.json
     steps:
       - uses: actions/checkout@v7
       - uses: actions/setup-node@v7
@@ -39,6 +43,7 @@ jobs:
             echo 'ready=true' >> "$GITHUB_OUTPUT"
             echo 'generated=false' >> "$GITHUB_OUTPUT"
             echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
+            echo 'bridge_required=false' >> "$GITHUB_OUTPUT"
             echo 'AUTOMATION_BYPASS_READY_FROM_EXISTING_SECRET'
             exit 0
           fi
@@ -55,6 +60,7 @@ jobs:
               echo 'ready=false' >> "$GITHUB_OUTPUT"
               echo 'generated=false' >> "$GITHUB_OUTPUT"
               echo 'method=none' >> "$GITHUB_OUTPUT"
+              echo 'bridge_required=false' >> "$GITHUB_OUTPUT"
               echo 'BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'
               exit 2
             fi
@@ -63,6 +69,7 @@ jobs:
             echo 'ready=true' >> "$GITHUB_OUTPUT"
             echo 'generated=true' >> "$GITHUB_OUTPUT"
             echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
+            echo 'bridge_required=false' >> "$GITHUB_OUTPUT"
             echo 'AUTOMATION_BYPASS_TEMPORARILY_GENERATED'
             exit 0
           fi
@@ -83,6 +90,7 @@ jobs:
               echo 'ready=true' >> "$GITHUB_OUTPUT"
               echo 'generated=false' >> "$GITHUB_OUTPUT"
               echo 'method=trusted_oidc' >> "$GITHUB_OUTPUT"
+              echo 'bridge_required=false' >> "$GITHUB_OUTPUT"
               echo 'TRUSTED_GITHUB_OIDC_READY'
               exit 0
             fi
@@ -91,13 +99,43 @@ jobs:
 
           echo 'ready=false' >> "$GITHUB_OUTPUT"
           echo 'generated=false' >> "$GITHUB_OUTPUT"
-          echo 'method=none' >> "$GITHUB_OUTPUT"
-          echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED'
+          echo 'method=one_time_vault_browser_bridge' >> "$GITHUB_OUTPUT"
+          echo 'bridge_required=true' >> "$GITHUB_OUTPUT"
+          echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED_FALLING_BACK_TO_ONE_TIME_BROWSER_BRIDGE'
+      - name: Run one-time protected browser bridge
+        if: steps.bypass.outputs.bridge_required == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          oidc_url="${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=dabbir-protected-browser-qa"
+          oidc_response="$(curl --fail-with-body --silent --show-error \
+            -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+            "$oidc_url")"
+          oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
+          if [ -z "$oidc_token" ]; then
+            echo 'BLOCKED_GITHUB_OIDC_TOKEN_UNAVAILABLE'
+            exit 2
+          fi
+          echo "::add-mask::$oidc_token"
+          bridge_status="$(curl --silent --show-error \
+            --output "$PROTECTED_QA_BRIDGE_REPORT_PATH" \
+            --write-out '%{http_code}' \
+            -X POST 'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/barman-browser-runner' \
+            -H "Authorization: Bearer ${oidc_token}" \
+            -H 'Content-Type: application/json' \
+            --data '{"action":"dabbir_protected_browser_smoke"}')"
           echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo '**State:** BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED' >> "$GITHUB_STEP_SUMMARY"
-          echo 'No existing bypass, Vercel API token, or accepted GitHub Trusted OIDC source is available. Production remains protected and the browser journey did not run.' >> "$GITHUB_STEP_SUMMARY"
-          exit 2
+          echo '**Access method:** one_time_vault_browser_bridge' >> "$GITHUB_STEP_SUMMARY"
+          echo "**Bridge HTTP:** ${bridge_status}" >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f "$PROTECTED_QA_BRIDGE_REPORT_PATH" ]; then
+            echo '**Verdict:** FAIL — bridge report missing' >> "$GITHUB_STEP_SUMMARY"
+            exit 2
+          fi
+          verdict="$(jq -r 'if .ok == true and .pass == true then "PASS" else "FAIL" end' "$PROTECTED_QA_BRIDGE_REPORT_PATH")"
+          echo "**Verdict:** ${verdict}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Final host:** $(jq -r '.final_host // "—"' "$PROTECTED_QA_BRIDGE_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Browser HTTP:** $(jq -r '.browser_http_status // 0' "$PROTECTED_QA_BRIDGE_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
+          jq -e '.ok == true and .pass == true' "$PROTECTED_QA_BRIDGE_REPORT_PATH" >/dev/null || exit 2
       - name: Install WebKit journey runner
         if: steps.bypass.outputs.ready == 'true'
         run: |
@@ -119,13 +157,14 @@ jobs:
             jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' dabbir-protected-live-smoke-report.json >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Upload protected smoke evidence
-        if: ${{ always() && steps.bypass.outputs.ready == 'true' }}
+        if: ${{ always() && (steps.bypass.outputs.ready == 'true' || steps.bypass.outputs.bridge_required == 'true') }}
         uses: actions/upload-artifact@v6
         with:
           name: dabbir-protected-live-smoke-evidence
           path: |
             dabbir-protected-live-smoke-report.json
             dabbir-protected-live-smoke.png
+            dabbir-protected-browser-bridge-report.json
           if-no-files-found: warn
           retention-days: 7
       - name: Revoke temporary automation bypass

--- a/supabase/functions/barman-browser-runner/index.ts
+++ b/supabase/functions/barman-browser-runner/index.ts
@@ -3,33 +3,145 @@ import { createClient } from "jsr:@supabase/supabase-js@2.112.2";
 
 const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,{auth:{persistSession:false}});
 const BROWSER='https://barman-browser-worker.vercel.app/api/qa';
+const PROTECTED_ACTION='dabbir_protected_browser_smoke';
+const ALLOWED_HOST='dabbir-nd56cm4j5v-3619s-projects.vercel.app';
+const SAFE_TARGET=`https://${ALLOWED_HOST}/`;
+const GH_ISSUER='https://token.actions.githubusercontent.com';
+const GH_REPOSITORY='barman-systems/pilot';
+const GH_REF='refs/heads/main';
+const GH_WORKFLOW_REF='barman-systems/pilot/.github/workflows/dabbir-protected-live-smoke.yml@refs/heads/main';
+const GH_AUDIENCE='dabbir-protected-browser-qa';
+const GH_EVENTS=new Set(['push','workflow_dispatch']);
+
+function b64urlDecode(value:string){
+  const padded=value.replaceAll('-','+').replaceAll('_','/')+'='.repeat((4-value.length%4)%4);
+  const binary=atob(padded);
+  return Uint8Array.from(binary,c=>c.charCodeAt(0));
+}
+function decodeJsonPart(value:string){return JSON.parse(new TextDecoder().decode(b64urlDecode(value)))}
+
+async function verifyGitHubOidc(req:Request){
+  const authHeader=req.headers.get('authorization')||'';
+  if(!authHeader.startsWith('Bearer '))throw new Error('OIDC_REQUIRED');
+  const token=authHeader.slice(7).trim(),parts=token.split('.');
+  if(parts.length!==3)throw new Error('OIDC_FORMAT_INVALID');
+  const header=decodeJsonPart(parts[0]),payload=decodeJsonPart(parts[1]);
+  if(header?.alg!=='RS256'||!header?.kid)throw new Error('OIDC_ALG_INVALID');
+  const jwksResponse=await fetch('https://token.actions.githubusercontent.com/.well-known/jwks',{headers:{accept:'application/json'},signal:AbortSignal.timeout(10000)});
+  if(!jwksResponse.ok)throw new Error('OIDC_JWKS_UNAVAILABLE');
+  const jwks=await jwksResponse.json(),jwk=(jwks?.keys||[]).find((key:any)=>key.kid===header.kid&&key.kty==='RSA');
+  if(!jwk)throw new Error('OIDC_KEY_NOT_FOUND');
+  const key=await crypto.subtle.importKey('jwk',jwk,{name:'RSASSA-PKCS1-v1_5',hash:'SHA-256'},false,['verify']);
+  const valid=await crypto.subtle.verify('RSASSA-PKCS1-v1_5',key,b64urlDecode(parts[2]),new TextEncoder().encode(`${parts[0]}.${parts[1]}`));
+  if(!valid)throw new Error('OIDC_SIGNATURE_INVALID');
+  const now=Math.floor(Date.now()/1000);
+  if(payload.iss!==GH_ISSUER)throw new Error('OIDC_ISSUER_DENIED');
+  const audiences=Array.isArray(payload.aud)?payload.aud:[payload.aud];
+  if(!audiences.includes(GH_AUDIENCE))throw new Error('OIDC_AUDIENCE_DENIED');
+  if(Number(payload.exp||0)<=now||Number(payload.nbf||0)>now+30)throw new Error('OIDC_TIME_INVALID');
+  if(payload.repository!==GH_REPOSITORY)throw new Error('OIDC_REPOSITORY_DENIED');
+  if(payload.ref!==GH_REF)throw new Error('OIDC_REF_DENIED');
+  if(payload.workflow_ref!==GH_WORKFLOW_REF)throw new Error('OIDC_WORKFLOW_DENIED');
+  if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
+  return payload;
+}
+
+function validateShare(value:unknown){
+  const raw=String(value||'').trim();
+  if(raw.length<32||raw.length>3000)throw new Error('SHARE_URL_INVALID');
+  const url=new URL(raw);
+  if(url.protocol!=='https:'||url.hostname!==ALLOWED_HOST||url.pathname!=='/')throw new Error('SHARE_URL_TARGET_DENIED');
+  if(!url.searchParams.get('_vercel_share'))throw new Error('SHARE_TOKEN_MISSING');
+  return url;
+}
+function redactString(value:unknown){return String(value??'').replace(/([?&]_vercel_share=)[^&\s"']+/gi,'$1[REDACTED]').slice(0,1000)}
+function safeArray(value:unknown,limit=20){
+  if(!Array.isArray(value))return [];
+  return value.slice(0,limit).map((item:any)=>{
+    if(item&&typeof item==='object'){
+      const out:any={};
+      for(const [key,val] of Object.entries(item)){
+        if(['value','url','target','final_url'].includes(key))continue;
+        out[key]=typeof val==='string'?redactString(val):val;
+      }
+      return out;
+    }
+    return redactString(item);
+  });
+}
+
+async function callBrowser(payload:any){
+  let result:any={};let status=0;
+  try{
+    const r=await fetch(BROWSER,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(payload),signal:AbortSignal.timeout(65000)});
+    status=r.status;
+    result=await r.json().catch(()=>({ok:false,pass:false,error:'INVALID_JSON_RESPONSE'}));
+  }catch(error){result={ok:false,pass:false,error:String(error)}}
+  return {status,result};
+}
+
+async function protectedSmoke(req:Request){
+  const claims=await verifyGitHubOidc(req);
+  const {data:share,error:shareError}=await db.rpc('dabbir_qa_consume_protected_share');
+  if(shareError||!share)return Response.json({ok:false,pass:false,error:'PROTECTED_SHARE_UNAVAILABLE'},{status:409,headers:{'cache-control':'no-store'}});
+  let target:URL;
+  try{target=validateShare(share)}catch(error){return Response.json({ok:false,pass:false,error:redactString(error instanceof Error?error.message:error)},{status:400,headers:{'cache-control':'no-store'}})}
+
+  const actions=[
+    {type:'wait',selector:'#authGate:not(.hidden)',timeout_ms:15000},
+    {type:'assert_count',selector:'#authEmail',min:1,max:1},
+    {type:'assert_count',selector:'#authPassword',min:1,max:1},
+    {type:'assert_count',selector:'#authSubmit',min:1,max:1},
+    {type:'assert_count',selector:'.brand .logo',min:1},
+    {type:'assert_text',selector:'body',includes:'DABBIR'},
+  ];
+  const {status,result}=await callBrowser({url:target.href,mode:'owner_simulation',device:'iphone',deploymentId:null,artifactHash:null,baseline:null,actions});
+  let finalHost='';try{finalHost=new URL(String(result?.final_url||'')).hostname}catch{}
+  const targetReached=finalHost===ALLOWED_HOST;
+  const pass=status===200&&result?.ok===true&&result?.pass===true&&targetReached;
+  const safe:any={
+    worker_status:status,
+    target_reached:targetReached,
+    final_host:finalHost||null,
+    browser_http_status:Number(result?.http_status||0),
+    title:redactString(result?.title||''),
+    page:result?.page||null,
+    actions:safeArray(result?.actions,30),
+    network:result?.network||null,
+    console_errors:safeArray(result?.console_errors),
+    page_errors:safeArray(result?.page_errors),
+    phase_errors:safeArray(result?.phase_errors),
+    phase_warnings:safeArray(result?.phase_warnings),
+    latency_ms:Number(result?.latency_ms||0),
+  };
+  const {data:runId,error:recordError}=await db.rpc('barman_record_browser_executor_run',{
+    p_target_url:SAFE_TARGET,p_mode:'protected_owner_smoke',p_devices:['iphone'],p_deployment_id:null,p_artifact_hash:null,p_pass:pass,p_result:{source:'GITHUB_OIDC_ONE_TIME_VERCEL_SHARE_BROWSER_BRIDGE',github_run_id:claims?.run_id||null,...safe}
+  });
+  if(recordError)return Response.json({ok:false,pass:false,error:'QA_EVIDENCE_RECORD_FAILED'},{status:500,headers:{'cache-control':'no-store'}});
+  return Response.json({ok:true,pass,source:'GITHUB_OIDC_ONE_TIME_VERCEL_SHARE_BROWSER_BRIDGE',run_id:runId,...safe},{headers:{'cache-control':'no-store'}});
+}
 
 Deno.serve(async(req:Request)=>{
   if(req.method!=='POST')return new Response('method not allowed',{status:405});
+  const body=await req.json().catch(()=>({}));
+  if(String(body?.action||'')===PROTECTED_ACTION){
+    try{return await protectedSmoke(req)}catch(error){
+      const message=redactString(error instanceof Error?error.message:error);
+      const status=message.startsWith('OIDC_')?401:502;
+      return Response.json({ok:false,pass:false,error:message},{status,headers:{'cache-control':'no-store'}});
+    }
+  }
+
   const supplied=req.headers.get('x-barman-worker-secret')||'';
   if(!supplied)return new Response('unauthorized',{status:401});
   const {data:valid}=await db.rpc('barman_validate_worker_secret',{p_secret:supplied});
   if(valid!==true)return new Response('unauthorized',{status:401});
 
-  const body=await req.json().catch(()=>({}));
   const {url,mode='smoke',device='desktop',deploymentId=null,artifactHash=null,baseline=null,actions=[]}=body;
   if(!url)return Response.json({ok:false,error:'url_required'},{status:400});
   if(!Array.isArray(actions))return Response.json({ok:false,error:'actions_must_be_array'},{status:400});
 
-  let result:any={};
-  let status=0;
-  try{
-    const r=await fetch(BROWSER,{
-      method:'POST',
-      headers:{'content-type':'application/json'},
-      body:JSON.stringify({url,mode,device,deploymentId,artifactHash,baseline,actions:actions.slice(0,30)})
-    });
-    status=r.status;
-    result=await r.json().catch(()=>({ok:false,pass:false,error:'INVALID_JSON_RESPONSE'}));
-  }catch(e){
-    result={ok:false,pass:false,error:String(e)};
-  }
-
+  const {status,result}=await callBrowser({url,mode,device,deploymentId,artifactHash,baseline,actions:actions.slice(0,30)});
   const pass=status===200&&result?.ok===true&&result?.pass===true;
   const {data:runId,error}=await db.rpc('barman_record_browser_executor_run',{
     p_target_url:url,

--- a/supabase/migrations/20260828013400_dabbir_protected_qa_share_vault.sql
+++ b/supabase/migrations/20260828013400_dabbir_protected_qa_share_vault.sql
@@ -1,0 +1,36 @@
+create or replace function public.dabbir_qa_consume_protected_share()
+returns text
+language plpgsql
+security definer
+set search_path = pg_catalog, public, vault
+as $$
+declare
+  v_id uuid;
+  v_secret text;
+  v_created_at timestamptz;
+begin
+  select id, decrypted_secret, created_at
+    into v_id, v_secret, v_created_at
+  from vault.decrypted_secrets
+  where name = 'dabbir_protected_qa_once'
+  order by created_at desc
+  limit 1;
+
+  if v_id is null or coalesce(v_secret, '') = '' then
+    raise exception 'DABBIR_PROTECTED_QA_SHARE_NOT_FOUND';
+  end if;
+
+  if v_created_at < now() - interval '2 hours' then
+    delete from vault.secrets where id = v_id;
+    raise exception 'DABBIR_PROTECTED_QA_SHARE_EXPIRED';
+  end if;
+
+  delete from vault.secrets where id = v_id;
+  return v_secret;
+end;
+$$;
+
+revoke all on function public.dabbir_qa_consume_protected_share() from public;
+revoke all on function public.dabbir_qa_consume_protected_share() from anon;
+revoke all on function public.dabbir_qa_consume_protected_share() from authenticated;
+grant execute on function public.dabbir_qa_consume_protected_share() to service_role;

--- a/test/dabbir-protected-browser-bridge.test.mjs
+++ b/test/dabbir-protected-browser-bridge.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const runner=await readFile(new URL('../supabase/functions/barman-browser-runner/index.ts',import.meta.url),'utf8');
+const migration=await readFile(new URL('../supabase/migrations/20260828013400_dabbir_protected_qa_share_vault.sql',import.meta.url),'utf8');
+const workflow=await readFile(new URL('../.github/workflows/dabbir-protected-live-smoke.yml',import.meta.url),'utf8');
+
+test('protected browser bridge is GitHub OIDC bound to the exact main workflow',()=>{
+  assert.match(runner,/GH_AUDIENCE='dabbir-protected-browser-qa'/);
+  assert.match(runner,/GH_REPOSITORY='barman-systems\/pilot'/);
+  assert.match(runner,/GH_REF='refs\/heads\/main'/);
+  assert.match(runner,/dabbir-protected-live-smoke\.yml@refs\/heads\/main/);
+  assert.match(runner,/crypto\.subtle\.verify/);
+  assert.match(runner,/OIDC_SIGNATURE_INVALID/);
+});
+
+test('one-time Vercel share is restricted, consumed server-side, redacted and recorded against safe canonical target',()=>{
+  assert.match(runner,/dabbir_qa_consume_protected_share/);
+  assert.match(runner,/ALLOWED_HOST='dabbir-nd56cm4j5v-3619s-projects\.vercel\.app'/);
+  assert.match(runner,/SAFE_TARGET=`https:\/\/\$\{ALLOWED_HOST\}\//);
+  assert.match(runner,/_vercel_share/);
+  assert.match(runner,/SHARE_URL_TARGET_DENIED/);
+  assert.match(runner,/GITHUB_OIDC_ONE_TIME_VERCEL_SHARE_BROWSER_BRIDGE/);
+  assert.match(runner,/p_target_url:SAFE_TARGET/);
+  assert.match(runner,/\['value','url','target','final_url'\]/);
+});
+
+test('existing worker-secret browser runner path remains enforced for ordinary calls',()=>{
+  assert.match(runner,/x-barman-worker-secret/);
+  assert.match(runner,/barman_validate_worker_secret/);
+  assert.match(runner,/actions:actions\.slice\(0,30\)/);
+  assert.match(runner,/String\(body\?\.action\|\|''\)===PROTECTED_ACTION/);
+});
+
+test('Vault consumer is service-role only, expiring and destructive-on-read',()=>{
+  assert.match(migration,/security definer/i);
+  assert.match(migration,/v_created_at < now\(\) - interval '2 hours'/i);
+  assert.match(migration,/delete from vault\.secrets where id = v_id/i);
+  assert.match(migration,/revoke all on function public\.dabbir_qa_consume_protected_share\(\) from anon/i);
+  assert.match(migration,/revoke all on function public\.dabbir_qa_consume_protected_share\(\) from authenticated/i);
+  assert.match(migration,/grant execute on function public\.dabbir_qa_consume_protected_share\(\) to service_role/i);
+});
+
+test('protected smoke falls back to the existing OIDC browser runner without committing access secrets',()=>{
+  assert.match(workflow,/bridge_required=true/);
+  assert.match(workflow,/audience=dabbir-protected-browser-qa/);
+  assert.match(workflow,/functions\/v1\/barman-browser-runner/);
+  assert.match(workflow,/one_time_vault_browser_bridge/);
+  assert.match(workflow,/jq -e '\.ok == true and \.pass == true'/);
+  assert.doesNotMatch(workflow,/_vercel_share=[A-Za-z0-9]/);
+});

--- a/test/dabbir-protected-live-smoke-oidc.test.mjs
+++ b/test/dabbir-protected-live-smoke-oidc.test.mjs
@@ -13,14 +13,15 @@ test('protected smoke can use short-lived GitHub trusted OIDC without opening pr
   assert.match(workflow,/steps\.bypass\.outputs\.generated == 'true'/);
 });
 
-test('blocked automation access is a real failing gate, never a green skipped journey',()=>{
-  const blocked=workflow.match(/echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED'[\s\S]{0,900}?exit 2/);
-  assert.ok(blocked,'blocked protection access must terminate the job with exit 2');
-  assert.match(workflow,/browser journey did not run/);
-  assert.match(workflow,/BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'[\s\S]{0,240}?exit 2/);
+test('blocked direct Vercel access falls back to a real browser gate and can never become a green skip',()=>{
+  assert.match(workflow,/BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED_FALLING_BACK_TO_ONE_TIME_BROWSER_BRIDGE/);
+  assert.match(workflow,/bridge_required=true/);
+  assert.match(workflow,/Run one-time protected browser bridge/);
+  assert.match(workflow,/jq -e '\.ok == true and \.pass == true'[\s\S]{0,120}?exit 2/);
+  assert.match(workflow,/BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'[\s\S]{0,260}?exit 2/);
 });
 
-test('smoke runner supports either documented protection access method',()=>{
+test('smoke runner supports either documented direct Vercel protection access method',()=>{
   assert.match(runner,/VERCEL_AUTOMATION_BYPASS_SECRET/);
   assert.match(runner,/VERCEL_TRUSTED_OIDC_TOKEN/);
   assert.match(runner,/x-vercel-protection-bypass/);


### PR DESCRIPTION
Closed as stale/non-mergeable and not safe to revive under the current DABBIR release architecture.

The branch is 25 commits behind current authoritative `main`. The underlying problem is still real: Vercel Production is protected by SSO and the current GitHub protected-browser workflow can remain blocked when no automation bypass/accepted Trusted OIDC path exists.

However this v2 fallback is not fully autonomous: it consumes a one-time `_vercel_share` URL from Supabase Vault but does not itself create and store that share. Reintroducing it would therefore add a privileged SECURITY DEFINER/Vault bridge while retaining hidden manual dependency.

Do not merge this branch. A replacement, if needed, must be rebuilt from current `main` with an end-to-end source for the temporary access credential or a native Vercel automation-access mechanism, and must pass the current exact-SHA/release/security gates.