### PR TITLE
DABBIR: stability audit gate + clean platform capability failure

### DIFF
--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -9,7 +9,6 @@ import {
 } from './_auth-core.js';
 
 const SUPABASE_URL='https://spohjzrsymsmzsseygtw.supabase.co';
-const PLATFORM_ADMIN_CAPABILITY_VERSION='fail-closed-v3';
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const uuid=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
@@ -85,7 +84,6 @@ export default async function handler(req,res){
           allowed:serviceConfigured,
           role:context.role,
           service_configured:serviceConfigured,
-          capability_version:PLATFORM_ADMIN_CAPABILITY_VERSION,
           reason:serviceConfigured?null:'SERVER_ADMIN_NOT_CONFIGURED',
         });
       }

--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -9,6 +9,7 @@ import {
 } from './_auth-core.js';
 
 const SUPABASE_URL='https://spohjzrsymsmzsseygtw.supabase.co';
+const PLATFORM_ADMIN_CAPABILITY_VERSION='fail-closed-v2';
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const uuid=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
@@ -84,6 +85,7 @@ export default async function handler(req,res){
           allowed:serviceConfigured,
           role:context.role,
           service_configured:serviceConfigured,
+          capability_version:PLATFORM_ADMIN_CAPABILITY_VERSION,
           reason:serviceConfigured?null:'SERVER_ADMIN_NOT_CONFIGURED',
         });
       }

--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -9,7 +9,7 @@ import {
 } from './_auth-core.js';
 
 const SUPABASE_URL='https://spohjzrsymsmzsseygtw.supabase.co';
-const PLATFORM_ADMIN_CAPABILITY_VERSION='fail-closed-v2';
+const PLATFORM_ADMIN_CAPABILITY_VERSION='fail-closed-v3';
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const uuid=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 

--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -46,9 +46,11 @@ async function adminContext(req,res){
   const rows=await response.json().catch(()=>[]);
   const admin=Array.isArray(rows)?rows[0]:null;
   if(!admin?.active){json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
-  const key=serviceKey();
-  if(!key){json(res,503,{ok:false,error:'SERVER_ADMIN_NOT_CONFIGURED'});return null}
-  return {user,role:admin.role,key};
+  return {user,role:admin.role,key:serviceKey()};
+}
+
+function adminServiceUnavailable(res){
+  return json(res,503,{ok:false,error:'SERVER_ADMIN_NOT_CONFIGURED'});
 }
 
 function rpcError(error){
@@ -75,7 +77,17 @@ export default async function handler(req,res){
   try{
     if(req.method==='GET'){
       const action=String(singleQueryValue(req,'action')||'capability').trim();
-      if(action==='capability')return json(res,200,{ok:true,allowed:true,role:context.role});
+      if(action==='capability'){
+        const serviceConfigured=Boolean(context.key);
+        return json(res,200,{
+          ok:true,
+          allowed:serviceConfigured,
+          role:context.role,
+          service_configured:serviceConfigured,
+          reason:serviceConfigured?null:'SERVER_ADMIN_NOT_CONFIGURED',
+        });
+      }
+      if(!context.key)return adminServiceUnavailable(res);
       if(action==='overview'){
         const payload=await serviceRpc(context.key,'dabbir_platform_owner_overview',{p_actor_user_id:context.user.id});
         return json(res,200,{ok:true,overview:payload});
@@ -103,6 +115,7 @@ export default async function handler(req,res){
     }
 
     if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+    if(!context.key)return adminServiceUnavailable(res);
     const body=await readJsonBody(req,16384);
 
     if(body.action==='set_access'){

--- a/test/dabbir-stability-audit.test.mjs
+++ b/test/dabbir-stability-audit.test.mjs
@@ -41,7 +41,9 @@ test('tenant WhatsApp status cannot inherit a global server phone identity', () 
 });
 
 test('root routing remains pinned to the recovery-authoritative shell', async () => {
-  const vercel = await readFile(new URL('vercel.json', root), 'utf8');
-  assert.match(vercel, /\"src\": \"\^\/\$\"[\s\S]*\"dest\": \"\/api\/app-recovery\"/);
-  assert.match(vercel, /\"source\": \"\/\"[\s\S]*\"destination\": \"\/api\/app-recovery\"/);
+  const vercel = JSON.parse(await readFile(new URL('vercel.json', root), 'utf8'));
+  assert.ok(Array.isArray(vercel.routes));
+  assert.ok(Array.isArray(vercel.rewrites));
+  assert.ok(vercel.routes.some(route => route?.src === '^/$' && route?.dest === '/api/app-recovery'));
+  assert.ok(vercel.rewrites.some(rewrite => rewrite?.source === '/' && rewrite?.destination === '/api/app-recovery'));
 });

--- a/test/dabbir-stability-audit.test.mjs
+++ b/test/dabbir-stability-audit.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { access, readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const platformApi = await readFile(new URL('api/platform-customers.js', root), 'utf8');
+const shell = await readFile(new URL('api/app-recovery.js', root), 'utf8');
+const whatsappStatus = await readFile(new URL('api/dabbir-whatsapp-status.js', root), 'utf8');
+
+function injectedApiScripts(source) {
+  return [...source.matchAll(/<script src=\"(\/api\/[^\"]+)\"><\/script>/g)].map(match => match[1]);
+}
+
+test('platform capability fails closed without emitting a capability 503', () => {
+  assert.match(platformApi, /return \{user,role:admin\.role,key:serviceKey\(\)\}/);
+  assert.match(platformApi, /if\(action==='capability'\)[\s\S]*serviceConfigured=Boolean\(context\.key\)/);
+  assert.match(platformApi, /allowed:serviceConfigured/);
+  assert.match(platformApi, /service_configured:serviceConfigured/);
+  assert.match(platformApi, /reason:serviceConfigured\?null:'SERVER_ADMIN_NOT_CONFIGURED'/);
+  assert.match(platformApi, /if\(!context\.key\)return adminServiceUnavailable\(res\)/);
+  assert.doesNotMatch(platformApi, /if\(!key\)\{json\(res,503,\{ok:false,error:'SERVER_ADMIN_NOT_CONFIGURED'\}\);return null\}/);
+});
+
+test('authoritative shell injects every UI module exactly once and keeps auth stability last', async () => {
+  const scripts = injectedApiScripts(shell);
+  assert.ok(scripts.length >= 20, 'expected the authoritative UI module stack');
+  assert.equal(new Set(scripts).size, scripts.length, 'duplicate UI module injection detected');
+  assert.equal(scripts.at(-1), '/api/auth-session-stability-ui', 'auth stability must remain the final UI authority');
+
+  await Promise.all(scripts.map(async src => {
+    const relative = `${src.slice(1)}.js`;
+    await access(new URL(relative, root));
+  }));
+});
+
+test('tenant WhatsApp status cannot inherit a global server phone identity', () => {
+  assert.match(whatsappStatus, /authenticated DABBIR UI must never inherit a global\/server WhatsApp/);
+  assert.match(whatsappStatus, /businessIds\.length === 1/);
+  assert.match(whatsappStatus, /BUSINESS_CONTEXT_REQUIRED/);
+  assert.match(whatsappStatus, /TENANT_WHATSAPP_NOT_LINKED/);
+});
+
+test('root routing remains pinned to the recovery-authoritative shell', async () => {
+  const vercel = await readFile(new URL('vercel.json', root), 'utf8');
+  assert.match(vercel, /\"src\": \"\^\/\$\"[\s\S]*\"dest\": \"\/api\/app-recovery\"/);
+  assert.match(vercel, /\"source\": \"\/\"[\s\S]*\"destination\": \"\/api\/app-recovery\"/);
+});

--- a/test/dabbir-stability-audit.test.mjs
+++ b/test/dabbir-stability-audit.test.mjs
@@ -34,7 +34,7 @@ test('authoritative shell injects every UI module exactly once and keeps auth st
 });
 
 test('tenant WhatsApp status cannot inherit a global server phone identity', () => {
-  assert.match(whatsappStatus, /authenticated DABBIR UI must never inherit a global\/server WhatsApp/);
+  assert.match(whatsappStatus, /authenticated DABBIR UI must never inherit a global\/server WhatsApp/i);
   assert.match(whatsappStatus, /businessIds\.length === 1/);
   assert.match(whatsappStatus, /BUSINESS_CONTEXT_REQUIRED/);
   assert.match(whatsappStatus, /TENANT_WHATSAPP_NOT_LINKED/);


### PR DESCRIPTION
Production audit found repeated 503s from the optional platform customer-admin capability probe when the privileged service-role credential is not configured. This PR fixes that boot-time failure without weakening privileged admin operations, and adds release regression guards for the high-risk UI composition stack.

Changes:
- capability probe remains authenticated/admin-gated but returns 200 + allowed:false when privileged server admin configuration is absent
- actual privileged admin reads/writes remain fail-closed with 503 when the service credential is unavailable
- stability regression tests guard unique UI module injection, auth-session stability ordering, tenant WhatsApp identity isolation, and authoritative root routing

Verification on Vercel preview commit 4921a3113f86afcdc12ec1f3b18bf07b290a43b7: 369/369 Node tests passed, 0 failed.

No Supabase schema, payment, Meta credential, or customer-data mutation is included.