### PR TITLE
DABBIR: owner username + OTP sign-in

### DIFF
--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -21,6 +21,10 @@ function publicAuthError(status) {
 }
 
 export default async function handler(req, res) {
+  res.setHeader('cache-control', 'no-store, max-age=0');
+  res.setHeader('pragma', 'no-cache');
+  res.setHeader('x-dabbir-owner-auth', 'username-otp-v1');
+
   if (req.method !== 'POST') {
     return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
   }

--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -1,0 +1,116 @@
+import {
+  authCookieHeaders,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseAuth,
+} from '../_auth-core.js';
+
+const OWNER_USERNAME = 'barmanadmin';
+const OWNER_EMAIL = process.env.DABBIR_OWNER_LOGIN_EMAIL || 'barman2013@icloud.com';
+const OWNER_USER_ID = process.env.DABBIR_OWNER_USER_ID || 'f1c5e98b-4060-43cb-a09b-a67a67028800';
+const OTP_RE = /^\d{6}$/;
+
+function normalizeUsername(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function publicAuthError(status) {
+  if (status === 429) return { status: 429, error: 'OTP_RATE_LIMITED' };
+  return { status: 503, error: 'OTP_UNAVAILABLE' };
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  }
+  if (!requireSameOrigin(req)) {
+    return json(res, 403, { ok: false, error: 'ORIGIN_REQUIRED' });
+  }
+
+  try {
+    const body = await readJsonBody(req, 2048);
+    const action = String(body.action || '').trim().toLowerCase();
+    const username = normalizeUsername(body.username);
+
+    if (action === 'request') {
+      // Keep the response generic so this endpoint never becomes an account
+      // discovery oracle. Only the canonical owner username causes delivery.
+      if (username !== OWNER_USERNAME) {
+        return json(res, 200, { ok: true, otp_required: true });
+      }
+
+      const response = await supabaseAuth('/auth/v1/otp', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: OWNER_EMAIL,
+          create_user: false,
+        }),
+      });
+
+      if (!response.ok) {
+        const failure = publicAuthError(response.status);
+        return json(res, failure.status, { ok: false, error: failure.error });
+      }
+
+      return json(res, 200, { ok: true, otp_required: true });
+    }
+
+    if (action === 'verify') {
+      if (username !== OWNER_USERNAME) {
+        return json(res, 401, { ok: false, error: 'INVALID_OWNER_OTP' });
+      }
+
+      const otp = String(body.otp || '').trim();
+      if (!OTP_RE.test(otp)) {
+        return json(res, 400, { ok: false, error: 'INVALID_OTP_FORMAT' });
+      }
+
+      const response = await supabaseAuth('/auth/v1/verify', {
+        method: 'POST',
+        body: JSON.stringify({
+          email: OWNER_EMAIL,
+          token: otp,
+          type: 'email',
+        }),
+      });
+
+      if (!response.ok) {
+        return json(res, response.status === 429 ? 429 : 401, {
+          ok: false,
+          error: response.status === 429 ? 'OTP_RATE_LIMITED' : 'INVALID_OWNER_OTP',
+        });
+      }
+
+      const session = await response.json().catch(() => null);
+      if (
+        !session?.access_token ||
+        !session?.refresh_token ||
+        String(session?.user?.id || '') !== OWNER_USER_ID
+      ) {
+        return json(res, 403, { ok: false, error: 'OWNER_IDENTITY_MISMATCH' });
+      }
+
+      res.setHeader('set-cookie', authCookieHeaders(session));
+      return json(res, 200, {
+        ok: true,
+        authenticated: true,
+        username: OWNER_USERNAME,
+        expires_in: session.expires_in ?? null,
+      });
+    }
+
+    return json(res, 400, { ok: false, error: 'INVALID_OTP_ACTION' });
+  } catch (error) {
+    const code = Number(error?.code || 500);
+    return json(res, code === 400 || code === 413 ? code : 500, {
+      ok: false,
+      error:
+        error?.message === 'PAYLOAD_TOO_LARGE'
+          ? 'PAYLOAD_TOO_LARGE'
+          : error?.message === 'INVALID_JSON'
+            ? 'INVALID_JSON'
+            : 'OWNER_AUTH_UNAVAILABLE',
+    });
+  }
+}

--- a/api/owner-dashboard-gateway.js
+++ b/api/owner-dashboard-gateway.js
@@ -1,0 +1,50 @@
+import dashboard from './platform-owner-dashboard.js';
+import {
+  accessTokenFromRequest,
+  clearAuthCookieHeaders,
+  getVerifiedUser,
+  supabaseRest,
+} from './_auth-core.js';
+
+const OWNER_USER_ID = process.env.DABBIR_OWNER_USER_ID || 'f1c5e98b-4060-43cb-a09b-a67a67028800';
+
+function redirectToOwner(res, clear = false) {
+  res.statusCode = 302;
+  res.setHeader('location', '/owner');
+  res.setHeader('cache-control', 'no-store, max-age=0');
+  if (clear) res.setHeader('set-cookie', clearAuthCookieHeaders());
+  res.end('Redirecting...');
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'HEAD') {
+    res.statusCode = 405;
+    res.setHeader('allow', 'GET, HEAD');
+    return res.end('Method Not Allowed');
+  }
+
+  const accessToken = accessTokenFromRequest(req);
+  if (!accessToken) return redirectToOwner(res);
+
+  try {
+    const user = await getVerifiedUser(accessToken);
+    if (!user || String(user.id) !== OWNER_USER_ID) {
+      return redirectToOwner(res, true);
+    }
+
+    const adminResponse = await supabaseRest(
+      `dabbir_platform_admins?select=role,active&user_id=eq.${encodeURIComponent(OWNER_USER_ID)}&active=eq.true&limit=1`,
+      accessToken,
+    );
+    if (!adminResponse.ok) return redirectToOwner(res, true);
+
+    const admins = await adminResponse.json().catch(() => []);
+    if (!Array.isArray(admins) || !admins.some(row => row?.active === true && row?.role === 'platform_owner')) {
+      return redirectToOwner(res, true);
+    }
+
+    return dashboard(req, res);
+  } catch {
+    return redirectToOwner(res, true);
+  }
+}

--- a/api/owner-login.js
+++ b/api/owner-login.js
@@ -1,0 +1,75 @@
+const PAGE = String.raw`<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="theme-color" content="#08090a">
+<title>DABBIR — Owner Sign In</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#111315;--line:#2a2f34;--text:#f7f8f9;--muted:#969da6;--accent:#d7ff5f;--amber:#ffd87a;--green:#8ce6a1}*{box-sizing:border-box}html,body{margin:0;min-height:100%;background:radial-gradient(circle at 50% -15%,#20252b 0,#0c0e10 38%,var(--bg) 70%);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif}button,input{font:inherit}button,input{min-height:48px}.wrap{min-height:100vh;display:grid;place-items:center;padding:20px}.card{width:min(430px,100%);border:1px solid var(--line);background:#111315ed;border-radius:24px;padding:22px;box-shadow:0 24px 80px #0009}.brand{display:flex;align-items:center;gap:11px}.logo{width:46px;height:46px;border-radius:14px;display:grid;place-items:center;background:linear-gradient(135deg,#2e246b,#245fd6 55%,#38c8d9);border:1px solid #617dff66;font-weight:950}.brand small,.muted{color:var(--muted)}h1{font-size:23px;margin:21px 0 6px}p{font-size:11px;line-height:1.7;color:var(--muted);margin:0 0 10px}.field{margin-top:13px}.field label{display:block;color:var(--muted);font-size:10px;margin-bottom:6px}.field input{width:100%;border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:13px;padding:11px 12px}.field input[readonly]{color:#d7dde3;background:#131619}.otp input{text-align:center;direction:ltr;letter-spacing:.28em;font-size:22px;font-weight:900}.btn{width:100%;border:0;background:var(--accent);color:#10130b;border-radius:13px;padding:11px 14px;font-weight:900;cursor:pointer;margin-top:16px}.btn:disabled{opacity:.55;cursor:wait}.ghost{border:0;background:transparent;color:var(--muted);cursor:pointer;padding:8px;margin-top:5px}.ghost:disabled{opacity:.5}.msg{min-height:31px;margin-top:10px;color:var(--amber);font-size:10px;line-height:1.6}.msg.ok{color:var(--green)}.foot{display:flex;align-items:center;justify-content:space-between;margin-top:10px;border-top:1px solid #22272c;padding-top:10px}.lang{border:1px solid var(--line);background:#171a1d;color:#fff;border-radius:10px;padding:6px 10px;cursor:pointer}.hidden{display:none!important}button:focus-visible,input:focus-visible{outline:3px solid var(--accent);outline-offset:2px}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <main class="card">
+    <div class="brand"><div class="logo">D</div><div><b>DABBIR | دبّر</b><br><small>Owner Control Center</small></div></div>
+    <h1 id="title">دخول المالك</h1>
+    <p id="desc">استخدم اسم المالك. سيرسل دبّر رمز تحقق لمرة واحدة إلى وسيلة التحقق المسجلة للحساب.</p>
+    <form id="form" novalidate>
+      <div class="field">
+        <label id="usernameLabel" for="username">اسم المستخدم</label>
+        <input id="username" name="username" type="text" value="barmanadmin" autocomplete="username" autocapitalize="none" spellcheck="false" required>
+      </div>
+      <div class="field otp hidden" id="otpField">
+        <label id="otpLabel" for="otp">رمز OTP</label>
+        <input id="otp" name="otp" type="text" inputmode="numeric" autocomplete="one-time-code" maxlength="6" pattern="[0-9]{6}" aria-describedby="msg">
+      </div>
+      <button class="btn" id="submitBtn" type="submit">إرسال رمز OTP</button>
+      <button class="ghost hidden" id="resendBtn" type="button">إعادة إرسال الرمز</button>
+      <div class="msg" id="msg" role="status" aria-live="polite"></div>
+    </form>
+    <div class="foot"><span class="muted" id="secure">دخول المالك فقط · بدون كلمة مرور</span><button class="lang" id="langBtn" type="button">EN</button></div>
+  </main>
+</div>
+<script>
+(()=>{
+  const q=s=>document.querySelector(s);
+  let lang='ar', otpRequested=false;
+  const text={
+    ar:{title:'دخول المالك',desc:'استخدم اسم المالك. سيرسل دبّر رمز تحقق لمرة واحدة إلى وسيلة التحقق المسجلة للحساب.',username:'اسم المستخدم',otp:'رمز OTP',send:'إرسال رمز OTP',verify:'تحقق ودخول',resend:'إعادة إرسال الرمز',sent:'تم إرسال رمز التحقق. أدخل الرمز المكوّن من 6 أرقام.',bad:'تعذر التحقق من الرمز. تأكد منه وحاول مرة أخرى.',format:'أدخل رمزًا مكوّنًا من 6 أرقام.',rate:'تم طلب رموز كثيرة. انتظر قليلًا ثم أعد المحاولة.',unavailable:'خدمة التحقق غير متاحة الآن. حاول مرة أخرى.',secure:'دخول المالك فقط · بدون كلمة مرور'},
+    en:{title:'Owner sign in',desc:'Use the owner username. DABBIR will send a one-time verification code to the verification method registered for this account.',username:'Username',otp:'OTP code',send:'Send OTP code',verify:'Verify and sign in',resend:'Resend code',sent:'Verification code sent. Enter the 6-digit code.',bad:'The code could not be verified. Check it and try again.',format:'Enter a 6-digit code.',rate:'Too many codes were requested. Wait a moment and try again.',unavailable:'Verification is unavailable right now. Try again.',secure:'Owner access only · no password'}
+  };
+  const t=()=>text[lang];
+  const api=async(body)=>{const r=await fetch('/api/auth/owner-otp',{method:'POST',cache:'no-store',credentials:'same-origin',headers:{'content-type':'application/json'},body:JSON.stringify(body)});const p=await r.json().catch(()=>({}));return {r,p}};
+  function render(){document.documentElement.lang=lang;document.documentElement.dir=lang==='ar'?'rtl':'ltr';q('#title').textContent=t().title;q('#desc').textContent=t().desc;q('#usernameLabel').textContent=t().username;q('#otpLabel').textContent=t().otp;q('#submitBtn').textContent=otpRequested?t().verify:t().send;q('#resendBtn').textContent=t().resend;q('#secure').textContent=t().secure;q('#langBtn').textContent=lang==='ar'?'EN':'عربي'}
+  function setMessage(message,ok=false){q('#msg').textContent=message;q('#msg').classList.toggle('ok',ok)}
+  function setRequested(){otpRequested=true;q('#otpField').classList.remove('hidden');q('#resendBtn').classList.remove('hidden');q('#username').readOnly=true;q('#otp').required=true;q('#otp').focus();render();setMessage(t().sent,true)}
+  function errorMessage(p){if(p?.error==='OTP_RATE_LIMITED')return t().rate;if(p?.error==='INVALID_OTP_FORMAT')return t().format;if(p?.error==='INVALID_OWNER_OTP')return t().bad;return t().unavailable}
+  async function requestOtp(){const btn=q('#submitBtn');btn.disabled=true;setMessage('');try{const {r,p}=await api({action:'request',username:q('#username').value});if(!r.ok||!p.ok){setMessage(errorMessage(p));return false}setRequested();return true}catch{setMessage(t().unavailable);return false}finally{btn.disabled=false}}
+  async function verifyOtp(){const otp=q('#otp').value.trim();if(!/^\d{6}$/.test(otp)){setMessage(t().format);q('#otp').focus();return}const btn=q('#submitBtn');btn.disabled=true;setMessage('');try{const {r,p}=await api({action:'verify',username:q('#username').value,otp});if(!r.ok||!p.authenticated){setMessage(errorMessage(p));return}location.replace('/owner-dashboard')}catch{setMessage(t().unavailable)}finally{btn.disabled=false}}
+  q('#form').addEventListener('submit',e=>{e.preventDefault();if(otpRequested)verifyOtp();else requestOtp()});
+  q('#resendBtn').addEventListener('click',async()=>{q('#resendBtn').disabled=true;await requestOtp();q('#resendBtn').disabled=false});
+  q('#otp').addEventListener('input',e=>{e.target.value=e.target.value.replace(/\D/g,'').slice(0,6)});
+  q('#langBtn').addEventListener('click',()=>{lang=lang==='ar'?'en':'ar';render()});
+  render();
+})();
+</script>
+</body>
+</html>`;
+
+export default function handler(req,res){
+  if(req.method!=='GET'){
+    res.statusCode=405;
+    res.setHeader('allow','GET');
+    return res.end('Method Not Allowed');
+  }
+  res.statusCode=200;
+  res.setHeader('content-type','text/html; charset=utf-8');
+  res.setHeader('cache-control','no-store, max-age=0');
+  res.setHeader('x-content-type-options','nosniff');
+  res.setHeader('x-frame-options','DENY');
+  res.setHeader('referrer-policy','no-referrer');
+  res.setHeader('content-security-policy',"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; connect-src 'self'; img-src 'self' data:; frame-ancestors 'none'; base-uri 'none'; form-action 'self'");
+  res.setHeader('x-dabbir-owner-login','username-otp-v1');
+  return res.end(PAGE);
+}

--- a/test/dabbir-owner-truth-dashboard.test.mjs
+++ b/test/dabbir-owner-truth-dashboard.test.mjs
@@ -52,7 +52,8 @@ test('owner dashboard endpoint returns secure no-store HTML',()=>{
   assert.match(body,/\/api\/platform-customers\?action=overview/);
 });
 
-test('permanent owner route maps to owner dashboard endpoint',()=>{
+test('permanent owner route requires OTP gate before authenticated dashboard',()=>{
   const config=JSON.parse(read('vercel.json'));
-  assert.ok(config.routes.some(route=>route.src==='^/owner/?$'&&route.dest==='/api/platform-owner-dashboard'));
+  assert.ok(config.routes.some(route=>route.src==='^/owner/?$'&&route.dest==='/api/owner-login'));
+  assert.ok(config.routes.some(route=>route.src==='^/owner-dashboard/?$'&&route.dest==='/api/owner-dashboard-gateway'));
 });

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('owner authentication is username + OTP and fail-closed to the canonical owner UUID', async () => {
+  const source = await read('api/auth/owner-otp.js');
+  assert.match(source, /OWNER_USERNAME\s*=\s*'barmanadmin'/);
+  assert.match(source, /OWNER_USER_ID/);
+  assert.match(source, /f1c5e98b-4060-43cb-a09b-a67a67028800/);
+  assert.match(source, /requireSameOrigin\(req\)/);
+  assert.match(source, /\/auth\/v1\/otp/);
+  assert.match(source, /create_user:\s*false/);
+  assert.match(source, /\/auth\/v1\/verify/);
+  assert.match(source, /type:\s*'email'/);
+  assert.match(source, /authCookieHeaders\(session\)/);
+  assert.doesNotMatch(source, /grant_type=password/);
+});
+
+test('owner login UI never asks for email or password', async () => {
+  const source = await read('api/owner-login.js');
+  assert.match(source, /value="barmanadmin"/);
+  assert.match(source, /autocomplete="username"/);
+  assert.match(source, /autocomplete="one-time-code"/);
+  assert.match(source, /inputmode="numeric"/);
+  assert.match(source, /\/api\/auth\/owner-otp/);
+  assert.match(source, /location\.replace\('\/owner-dashboard'\)/);
+  assert.doesNotMatch(source, /type="email"/);
+  assert.doesNotMatch(source, /type="password"/);
+  assert.doesNotMatch(source, /\/api\/auth\/login/);
+});
+
+test('canonical owner routes use the OTP gate and authenticated dashboard gateway', async () => {
+  const source = await read('vercel.json');
+  const config = JSON.parse(source);
+  const ownerRoute = config.routes.find(route => route.src === '^/owner/?$');
+  const dashboardRoute = config.routes.find(route => route.src === '^/owner-dashboard/?$');
+  assert.equal(ownerRoute?.dest, '/api/owner-login');
+  assert.equal(dashboardRoute?.dest, '/api/owner-dashboard-gateway');
+});
+
+test('dashboard gateway requires exact owner identity and active platform_owner', async () => {
+  const source = await read('api/owner-dashboard-gateway.js');
+  assert.match(source, /getVerifiedUser\(accessToken\)/);
+  assert.match(source, /String\(user\.id\) !== OWNER_USER_ID/);
+  assert.match(source, /dabbir_platform_admins/);
+  assert.match(source, /active=eq\.true/);
+  assert.match(source, /row\?\.role === 'platform_owner'/);
+  assert.match(source, /clearAuthCookieHeaders/);
+});
+
+test('ordinary DABBIR customer login remains email/password and is not replaced by owner OTP', async () => {
+  const source = await read('api/auth/login.js');
+  assert.match(source, /grant_type=password/);
+  assert.match(source, /body\.email/);
+  assert.match(source, /body\.password/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -12,7 +12,11 @@
   "routes": [
     {
       "src": "^/owner/?$",
-      "dest": "/api/platform-owner-dashboard"
+      "dest": "/api/owner-login"
+    },
+    {
+      "src": "^/owner-dashboard/?$",
+      "dest": "/api/owner-dashboard-gateway"
     },
     {
       "src": "^/$",
@@ -22,7 +26,11 @@
   "rewrites": [
     {
       "source": "/owner",
-      "destination": "/api/platform-owner-dashboard"
+      "destination": "/api/owner-login"
+    },
+    {
+      "source": "/owner-dashboard",
+      "destination": "/api/owner-dashboard-gateway"
     },
     {
       "source": "/",


### PR DESCRIPTION
Replace the canonical owner sign-in path with a dedicated username + one-time-code flow without changing customer email/password auth.

- canonical owner username: `barmanadmin`
- internal delivery identity remains server-side only
- OTP request uses existing-user-only auth (`create_user: false`)
- OTP verification is bound to the exact existing owner UUID
- `/owner` now serves the OTP gate
- `/owner-dashboard` verifies the exact owner session and active `platform_owner` before rendering admin UI
- existing customer login remains unchanged
- regression tests cover routing, no email/password fields in owner UI, exact UUID binding, same-origin enforcement, and customer-login isolation