### PR TITLE
DABBIR: architecture recurrence prevention v1

### DIFF
--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -1,4 +1,5 @@
 // BAR-30 invariant: contextual features are discovered under More; they do not create primary navigation destinations.
+// Exact-head build marker: this runtime file intentionally changes only documentation so Vercel executes the full gate on the final Phase-1 branch head.
 const script=String.raw`(()=>{
   if(window.__dabbirContextualNavigationUi)return;
   window.__dabbirContextualNavigationUi=true;

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -14,11 +14,6 @@ const script=String.raw`(()=>{
     desc:'The real services your business provides. Manage them when needed without adding another primary destination.'
   };
 
-  const style=document.createElement('style');
-  style.dataset.dabbirContextualNavigation='v1';
-  style.textContent='#dabbirServicesNav{display:none!important}';
-  document.head.append(style);
-
   function openServices(){
     if(typeof showScreen==='function')showScreen('operations');
     setTimeout(()=>window.__dabbirServiceOperations?.refresh?.(),0);
@@ -45,11 +40,6 @@ const script=String.raw`(()=>{
   }
 
   function enforce(){
-    const injected=q('#dabbirServicesNav');
-    if(injected){
-      injected.setAttribute('aria-hidden','true');
-      injected.tabIndex=-1;
-    }
     ensureMoreCard();
   }
 
@@ -65,7 +55,7 @@ const script=String.raw`(()=>{
 
   setTimeout(enforce,0);
   setTimeout(enforce,650);
-  window.__dabbirContextualNavigation={refresh:enforce,version:'v1'};
+  window.__dabbirContextualNavigation={refresh:enforce,version:'v2'};
 })();`;
 
 export default function handler(req,res){
@@ -73,6 +63,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-contextual-navigation','v1');
+  res.setHeader('x-dabbir-contextual-navigation','v2');
   return res.status(200).send(script);
 }

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -1,3 +1,4 @@
+// BAR-30 invariant: contextual features are discovered under More; they do not create primary navigation destinations.
 const script=String.raw`(()=>{
   if(window.__dabbirContextualNavigationUi)return;
   window.__dabbirContextualNavigationUi=true;

--- a/api/service-operations-ui.js
+++ b/api/service-operations-ui.js
@@ -1,5 +1,5 @@
 const css=String.raw`
-.svcHero{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px}.svcHero h1{margin:0 0 5px;font-size:25px}.svcHero p{margin:0;color:var(--muted);font-size:11px;line-height:1.7}.svcTruth{border:1px solid #314132;background:#152019;border-radius:13px;padding:10px 12px;margin-bottom:10px;color:#bfe8c7;font-size:9px}.svcMetrics{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px;margin-bottom:11px}.svcMetric{border:1px solid var(--line);background:#111315;border-radius:14px;padding:12px}.svcMetric span{display:block;color:var(--muted);font-size:9px}.svcMetric strong{display:block;font-size:22px;margin-top:5px}.svcTable{border:1px solid var(--line);border-radius:16px;overflow:hidden;background:#111315}.svcRow{display:grid;grid-template-columns:minmax(150px,1fr) .55fr .55fr auto;gap:9px;align-items:center;padding:11px;border-bottom:1px solid #24282d;font-size:10px}.svcRow:last-child{border-bottom:0}.svcRow.head{background:#15181b;color:var(--muted);font-size:9px}.svcName b{display:block;font-size:11px}.svcName small{color:var(--muted);font-size:8px}.svcStatus{display:inline-flex;border-radius:999px;padding:4px 7px;font-size:8px;font-weight:900}.svcStatus.on{background:#14331e;color:var(--green)}.svcStatus.off{background:#2b2d31;color:#aab0b7}.svcAction{border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:7px 9px;min-height:38px;font-size:9px;font-weight:800}.svcEmpty{padding:22px;text-align:center;color:var(--muted);font-size:10px}.svcNavMark{color:var(--accent)}@media(max-width:700px){.svcHero{align-items:center}.svcHero h1{font-size:20px}.svcRow{grid-template-columns:minmax(120px,1fr) .6fr auto}.svcRow .svcStateCol{display:none}}
+.svcHero{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:14px}.svcHero h1{margin:0 0 5px;font-size:25px}.svcHero p{margin:0;color:var(--muted);font-size:11px;line-height:1.7}.svcTruth{border:1px solid #314132;background:#152019;border-radius:13px;padding:10px 12px;margin-bottom:10px;color:#bfe8c7;font-size:9px}.svcMetrics{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:9px;margin-bottom:11px}.svcMetric{border:1px solid var(--line);background:#111315;border-radius:14px;padding:12px}.svcMetric span{display:block;color:var(--muted);font-size:9px}.svcMetric strong{display:block;font-size:22px;margin-top:5px}.svcTable{border:1px solid var(--line);border-radius:16px;overflow:hidden;background:#111315}.svcRow{display:grid;grid-template-columns:minmax(150px,1fr) .55fr .55fr auto;gap:9px;align-items:center;padding:11px;border-bottom:1px solid #24282d;font-size:10px}.svcRow:last-child{border-bottom:0}.svcRow.head{background:#15181b;color:var(--muted);font-size:9px}.svcName b{display:block;font-size:11px}.svcName small{color:var(--muted);font-size:8px}.svcStatus{display:inline-flex;border-radius:999px;padding:4px 7px;font-size:8px;font-weight:900}.svcStatus.on{background:#14331e;color:var(--green)}.svcStatus.off{background:#2b2d31;color:#aab0b7}.svcAction{border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:7px 9px;min-height:38px;font-size:9px;font-weight:800}.svcEmpty{padding:22px;text-align:center;color:var(--muted);font-size:10px}@media(max-width:700px){.svcHero{align-items:center}.svcHero h1{font-size:20px}.svcRow{grid-template-columns:minmax(120px,1fr) .6fr auto}.svcRow .svcStateCol{display:none}}
 `;
 
 const client=String.raw`
@@ -27,20 +27,6 @@ const client=String.raw`
 
   function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
   function notify(message){try{if(typeof toast==='function')toast(message)}catch{}}
-
-  function ensureNav(){
-    if(!isServiceBusiness())return;
-    const nav=q('#nav');
-    if(!nav||q('#dabbirServicesNav'))return;
-    const button=document.createElement('button');
-    button.id='dabbirServicesNav';
-    button.className='navBtn';
-    button.dataset.screen='operations';
-    button.innerHTML='<span class="svcNavMark">◇</span> <span id="dabbirServicesNavText"></span>';
-    button.addEventListener('click',()=>{if(typeof showScreen==='function')showScreen('operations');load(false)});
-    const integrations=nav.querySelector('[data-screen="integrations"]');
-    nav.insertBefore(button,integrations||null);
-  }
 
   function ensureScreen(){
     if(!isServiceBusiness())return null;
@@ -70,9 +56,8 @@ const client=String.raw`
 
   function applyCopy(){
     if(!isServiceBusiness())return;
-    ensureNav();ensureScreen();ensureModal();
+    ensureScreen();ensureModal();
     const t=copy();
-    if(q('#dabbirServicesNavText'))q('#dabbirServicesNavText').textContent=t.nav;
     if(q('#svcTitle'))q('#svcTitle').textContent=t.title;
     if(q('#svcDesc'))q('#svcDesc').textContent=t.desc;
     if(q('#svcTruth'))q('#svcTruth').textContent=t.truth;
@@ -173,7 +158,7 @@ const client=String.raw`
   }catch{}
 
   setTimeout(initialize,500);
-  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v2'};
+  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v3'};
 })();
 `;
 
@@ -181,6 +166,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
-  res.setHeader('x-dabbir-service-operations-ui','v2');
+  res.setHeader('x-dabbir-service-operations-ui','v3');
   return res.status(200).send(client);
 }

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,0 +1,51 @@
+{
+  "version": 1,
+  "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
+  "authorities": {
+    "root_shell": "api/app-recovery.js",
+    "primary_navigation": "index.html",
+    "service_discovery_under_more": "api/dabbir-contextual-navigation-ui.js",
+    "store_navigation_adaptation": "api/owner-operations-ui.js",
+    "auth_session_gate": "api/auth-session-stability-ui.js",
+    "business_activity_profile": "api/activity-profile-ui.js",
+    "tenant_whatsapp_state": "api/dabbir-whatsapp-status.js",
+    "verified_owner_metrics": "api/verified-metrics-ui.js",
+    "owner_visual_system": "api/dabbir-owner-first-ui.js"
+  },
+  "temporary_exceptions": {
+    "store_navigation_adaptation": {
+      "owner": "api/owner-operations-ui.js",
+      "reason": "Store operations currently replace the appointments destination in-place.",
+      "target": "Move this adaptation into the single navigation/router authority during stabilization phase 2."
+    }
+  },
+  "shell": {
+    "maximum_injected_api_modules": 25,
+    "require_unique_modules": true,
+    "final_ui_authority": "/api/auth-session-stability-ui",
+    "retired_modules_forbidden": [
+      "/api/activity-mobile-polish-ui",
+      "/api/dabbir-ui-refinement",
+      "/api/dabbir-mobile-shell-v3",
+      "/api/dabbir-logo-placement-ui"
+    ]
+  },
+  "primary_navigation": {
+    "desktop_and_mobile_destinations": [
+      "dashboard",
+      "conversations",
+      "appointments",
+      "customers",
+      "more"
+    ],
+    "feature_modules_may_add_primary_destinations": false,
+    "service_catalog_must_live_under_more": true
+  },
+  "truth_rules": {
+    "blocked_or_skipped_qa_is_pass": false,
+    "tenant_may_inherit_global_whatsapp_identity": false,
+    "meta_authorized_equals_operational_whatsapp": false,
+    "unverified_metrics_may_fall_back_to_bounded_lists": false
+  },
+  "change_rule": "Any change to this contract must explain the root cause, the removed competing owner, and the regression proof. Raising a limit without removing complexity is not stabilization."
+}

--- a/docs/DABBIR_STABILITY_CONTRACT.md
+++ b/docs/DABBIR_STABILITY_CONTRACT.md
@@ -1,0 +1,89 @@
+# DABBIR Stability Contract
+
+This contract exists because repeated defects were not isolated coding mistakes. They were symptoms of competing owners, patch-on-patch UI composition, legacy fallback leakage, and release evidence that could become detached from the exact customer journey.
+
+## Non-negotiable rule
+
+A bug is not closed when its visible symptom disappears. It is closed only when:
+
+1. the root cause is identified;
+2. the architectural failure class is named;
+3. the competing owner or unsafe fallback is removed or explicitly isolated;
+4. an invariant prevents the same class from returning;
+5. the exact production artifact passes the customer journey that exposed the failure.
+
+## Single-owner rules
+
+- Primary navigation is authored by the base owner journey, not by feature modules.
+- Service catalog access belongs under More. A service feature must never inject a sixth primary destination.
+- Store-specific navigation adaptation is a temporary exception and must migrate into the central router during phase 2.
+- Auth/session visibility is controlled by the canonical auth-session gate. CSS or feature modules must not force hidden app navigation visible.
+- Tenant WhatsApp state is tenant-scoped. Missing tenant connection data must fail closed as not configured; it must never inherit a global or legacy phone identity.
+- WhatsApp linked/authorized is not operational. Operational requires verified real inbound + verified real outbound evidence.
+- Verified metrics are authoritative. Bounded UI arrays are never a fallback for KPI truth.
+
+## Shell complexity freeze
+
+The current shell is already too layered. Stabilization therefore starts by freezing growth:
+
+- injected API UI modules are allowlisted and unique;
+- retired presentation layers cannot return;
+- a new guard/overlay module is not an acceptable default fix;
+- the module count may go down without special approval;
+- raising the module ceiling requires an explicit architecture change with a removed competing owner. Adding a patch and raising the ceiling together is prohibited.
+
+## Release truth
+
+The release state machine is:
+
+`BUILT -> EXACT_SHA_TESTED -> DEPLOYED -> PRODUCTION_JOURNEY_VERIFIED`
+
+A release cannot skip a state. A blocked or skipped browser journey is not PASS. A CI run on another SHA is not production evidence.
+
+The required production journey before launch includes:
+
+- signup / login / logout / reload;
+- business type selection and activity-specific navigation;
+- Arabic and English;
+- iPhone Safari plus desktop baseline;
+- core navigation and More destinations;
+- WhatsApp connect / disconnect / reconnect;
+- real inbound WhatsApp message;
+- persisted conversation and customer routing;
+- approved real outbound reply and delivery evidence;
+- degraded/recovery behavior when a dependency is unavailable.
+
+## Root Cause Registry format
+
+Every recurring or P0/P1 defect must record:
+
+`SYMPTOM -> ROOT_CAUSE -> FAILURE_CLASS -> OWNER -> INVARIANT -> TEST_EVIDENCE -> PRODUCTION_EVIDENCE`
+
+Examples of failure classes:
+
+- `MULTIPLE_UI_OWNERS`
+- `SESSION_RACE`
+- `LEGACY_TENANT_LEAK`
+- `FALSE_READINESS`
+- `QA_FALSE_GREEN`
+- `ARTIFACT_DRIFT`
+- `CONFIGURATION_DRIFT`
+- `UNVERIFIED_DATA_FALLBACK`
+
+## Stabilization phases
+
+### Phase 1 — Freeze and invariants
+
+Stop architecture growth, remove obvious competing navigation ownership, and turn known failure classes into failing tests.
+
+### Phase 2 — Collapse competing owners
+
+Replace stacked wrappers around `renderAll`, `showScreen`, navigation, and auth visibility with a small lifecycle/router/state registry. Remove dead compatibility transforms from `api/app.js` and reduce `app-recovery` injection count.
+
+### Phase 3 — Explicit state machines
+
+Make Auth, WhatsApp, integrations, and release readiness explicit state machines. UI must render state; it must not infer or invent it.
+
+### Phase 4 — Launch gate
+
+Only the exact production SHA that passes the full bilingual iPhone/desktop journey can be classified launch-ready.

--- a/docs/root-cause-registry.md
+++ b/docs/root-cause-registry.md
@@ -1,0 +1,16 @@
+# DABBIR Root Cause Registry
+
+| Incident class | Symptom | Root cause | Architectural class | Invariant / permanent control | Status |
+|---|---|---|---|---|---|
+| iPhone auth gate | Login returned 200 but UI stayed on auth / nav leaked into login | Session became observable after the immediate boot; late CSS forced bottom nav visible | SESSION_RACE + MULTIPLE_UI_OWNERS | Canonical auth-session verification + auth gate loaded last + hidden navigation regression test | CONTROLLED |
+| Service sixth tab | Services appeared as a sixth primary destination | Feature module injected its own navigation button | MULTIPLE_UI_OWNERS | Service module may not inject primary navigation; Services lives under More | REMOVED_IN_STABILIZATION_V1 |
+| Store operations ownership | Store operations screen disappeared / was overwritten | Service module claimed shared operations screen before business type was known | MULTIPLE_SCREEN_OWNERS | Known activity required before service screen ownership; future target is central screen registry | CONTROLLED / MIGRATION_PENDING |
+| WhatsApp legacy number | New tenant could display an old/global WhatsApp identity | Tenant status fell back to global legacy configuration | LEGACY_TENANT_LEAK | Tenant status fails closed with TENANT_WHATSAPP_NOT_LINKED / BUSINESS_CONTEXT_REQUIRED | CONTROLLED |
+| WhatsApp false readiness | Linked/authorized connection could look operational | Authorization state was treated as message-path evidence | FALSE_READINESS | OPERATIONAL requires real non-simulated inbound + outbound + verified external outcome | CONTROLLED |
+| QA false green | Protected browser journey could be skipped while workflow ended green | Blocked execution was not a failing evidence state | QA_FALSE_GREEN | Blocked/skipped journey exits non-zero and cannot count as PASS | CONTROLLED |
+| Deployment comparison drift | Test-only commit could rebuild because comparison used stale deployment SHA | Release comparison source was not the direct parent | ARTIFACT_DRIFT | Ignore gate compares triggering commit with direct parent and fails safe | CONTROLLED |
+| UI patch growth | Fixes repeatedly added guards/overlays that depended on load order | Shell had no hard complexity ceiling or ownership contract | PATCH_ON_PATCH | Explicit shell allowlist, unique modules, max module ceiling, retired-module denylist | ACTIVE |
+
+## Closure rule
+
+No row is `CLOSED` until the associated invariant is in CI and the exact Production artifact has passed the journey that originally exposed the defect. `CONTROLLED` means recurrence is guarded but broader architectural consolidation can still be pending.

--- a/test/dabbir-architecture-invariants-v1.test.mjs
+++ b/test/dabbir-architecture-invariants-v1.test.mjs
@@ -1,0 +1,105 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const read = path => fs.readFileSync(new URL(path, root), 'utf8');
+const ownership = JSON.parse(read('config/dabbir-architecture-ownership.json'));
+const shell = read('api/app-recovery.js');
+const index = read('index.html');
+const serviceOperations = read('api/service-operations-ui.js');
+const contextualNavigation = read('api/dabbir-contextual-navigation-ui.js');
+const ownerFirst = read('api/dabbir-owner-first-ui.js');
+const authStability = read('api/auth-session-stability-ui.js');
+const whatsappStatus = read('api/dabbir-whatsapp-status.js');
+
+function shellModules(source) {
+  return [...source.matchAll(/<script src=\"(\/api\/[^\"]+)\"><\/script>/g)].map(match => match[1]);
+}
+
+function navBody(id) {
+  return index.match(new RegExp(`<nav class=\"[^\"]*\" id=\"${id}\">([\\s\\S]*?)<\\/nav>`))?.[1] || '';
+}
+
+test('architecture contract is fail-closed and does not permit feature-owned primary navigation', () => {
+  assert.equal(ownership.primary_navigation.feature_modules_may_add_primary_destinations, false);
+  assert.equal(ownership.truth_rules.blocked_or_skipped_qa_is_pass, false);
+  assert.equal(ownership.truth_rules.tenant_may_inherit_global_whatsapp_identity, false);
+  assert.equal(ownership.truth_rules.meta_authorized_equals_operational_whatsapp, false);
+});
+
+test('desktop and mobile primary navigation are exactly the five owner destinations', () => {
+  const expected = ownership.primary_navigation.desktop_and_mobile_destinations;
+  assert.deepEqual(expected, ['dashboard', 'conversations', 'appointments', 'customers', 'more']);
+
+  for (const body of [navBody('nav'), navBody('bottomNav')]) {
+    const actual = [...body.matchAll(/data-screen=\"([^\"]+)\"/g)].map(match => match[1]);
+    assert.deepEqual(actual, expected);
+  }
+});
+
+test('service catalog cannot inject or mutate primary navigation', () => {
+  assert.doesNotMatch(serviceOperations, /function\s+ensureNav\s*\(/);
+  assert.doesNotMatch(serviceOperations, /dabbirServicesNav/);
+  assert.doesNotMatch(serviceOperations, /\.dataset\.screen\s*=/);
+  assert.doesNotMatch(serviceOperations, /querySelector\(['\"]#nav['\"]\)/);
+  assert.match(contextualNavigation, /#screen-more \.moreGrid/);
+  assert.match(contextualNavigation, /showScreen\('operations'\)/);
+  assert.doesNotMatch(contextualNavigation, /dabbirServicesNav/);
+});
+
+test('shell UI module growth is frozen to the explicit allowlist', () => {
+  const modules = shellModules(shell);
+  const expected = [
+    '/api/brand-ui',
+    '/api/dabbir-whatsapp-embedded-ui',
+    '/api/dabbir-whatsapp-connect-guard-ui',
+    '/api/timezone-ui',
+    '/api/auth/recovery-ui',
+    '/api/chat-human-ui',
+    '/api/translation-ui',
+    '/api/owner-operations-ui',
+    '/api/service-operations-ui',
+    '/api/activity-profile-ui',
+    '/api/owner-action-center-ui',
+    '/api/dabbir-owner-away-ui',
+    '/api/dabbir-owner-decision-memory-ui',
+    '/api/business-profile-ui',
+    '/api/dabbir-customer-number-ui',
+    '/api/dabbir-billing-ui',
+    '/api/platform-customers-ui',
+    '/api/platform-customer-support-ui',
+    '/api/platform-recovery-reconciliation-ui',
+    '/api/dabbir-owner-first-ui',
+    '/api/verified-metrics-ui',
+    '/api/customer-activation-ui',
+    '/api/owner-copilot-ui',
+    '/api/dabbir-contextual-navigation-ui',
+    '/api/auth-session-stability-ui'
+  ];
+
+  assert.deepEqual(modules, expected, 'new shell patch modules require an explicit architecture change');
+  assert.equal(new Set(modules).size, modules.length, 'duplicate shell module injection detected');
+  assert.ok(modules.length <= ownership.shell.maximum_injected_api_modules, 'shell module ceiling exceeded');
+  assert.equal(modules.at(-1), ownership.shell.final_ui_authority);
+
+  for (const retired of ownership.shell.retired_modules_forbidden) {
+    assert.equal(modules.includes(retired), false, `retired presentation layer returned: ${retired}`);
+  }
+});
+
+test('presentation authorities cannot depend on continuous polling', () => {
+  for (const [name, source] of [
+    ['owner-first', ownerFirst],
+    ['contextual-navigation', contextualNavigation],
+    ['auth-session-stability', authStability]
+  ]) {
+    assert.doesNotMatch(source, /setInterval\s*\(/, `${name} must be event/lifecycle driven`);
+  }
+});
+
+test('tenant WhatsApp truth remains fail-closed and cannot inherit global identity', () => {
+  assert.match(whatsappStatus, /TENANT_WHATSAPP_NOT_LINKED/);
+  assert.match(whatsappStatus, /BUSINESS_CONTEXT_REQUIRED/);
+  assert.match(whatsappStatus, /must never inherit a global\/server WhatsApp/i);
+});

--- a/test/dabbir-contextual-navigation.test.mjs
+++ b/test/dabbir-contextual-navigation.test.mjs
@@ -6,10 +6,11 @@ const shell = fs.readFileSync(new URL('../api/app-recovery.js', import.meta.url)
 const services = fs.readFileSync(new URL('../api/service-operations-ui.js', import.meta.url), 'utf8');
 const guard = fs.readFileSync(new URL('../api/dabbir-contextual-navigation-ui.js', import.meta.url), 'utf8');
 
-test('service operations still exists but its injected sixth primary nav is hidden', () => {
-  assert.match(services, /id='dabbirServicesNav'/);
-  assert.match(guard, /#dabbirServicesNav\{display:none!important\}/);
-  assert.match(guard, /aria-hidden/);
+test('service operations no longer creates a sixth primary navigation destination', () => {
+  assert.doesNotMatch(services, /dabbirServicesNav/);
+  assert.doesNotMatch(services, /function\s+ensureNav\s*\(/);
+  assert.doesNotMatch(services, /\.dataset\.screen\s*=/);
+  assert.doesNotMatch(guard, /dabbirServicesNav/);
 });
 
 test('service businesses reach Services from More instead of a sixth primary destination', () => {
@@ -20,13 +21,13 @@ test('service businesses reach Services from More instead of a sixth primary des
   assert.match(guard, /businessType\(\).*!==\s*'store'/s);
 });
 
-test('contextual navigation guard loads after service and owner UX layers', () => {
+test('contextual navigation loads after service and owner UX layers', () => {
   assert.match(shell, /\/api\/dabbir-contextual-navigation-ui/);
   assert.ok(shell.indexOf('/api/dabbir-contextual-navigation-ui') > shell.indexOf('/api/service-operations-ui'));
   assert.ok(shell.indexOf('/api/dabbir-contextual-navigation-ui') > shell.indexOf('/api/owner-copilot-ui'));
 });
 
-test('guard is event-driven and does not add continuous DOM polling', () => {
+test('contextual navigation is event-driven and does not add continuous DOM polling', () => {
   assert.doesNotMatch(guard, /MutationObserver/);
   assert.doesNotMatch(guard, /setInterval/);
 });

--- a/test/dabbir-operations-screen-ownership.test.mjs
+++ b/test/dabbir-operations-screen-ownership.test.mjs
@@ -18,8 +18,11 @@ test('service operations initializes after workspace render',()=>{
   assert.match(source,/renderAll=function\(\)\{const result=baseRenderAll\.apply\(this,arguments\);initialize\(\);return result\};/);
 });
 
-test('service screen ownership remains activity-gated',()=>{
+test('service screen ownership remains activity-gated without owning primary navigation',()=>{
   const ensureScreen=source.match(/function ensureScreen\(\)\{([\s\S]*?)\n  \}/)?.[1]||'';
   assert.match(ensureScreen,/if\(!isServiceBusiness\(\)\)return null;/);
-  assert.match(source,/x-dabbir-service-operations-ui','v2'/);
+  assert.doesNotMatch(source,/function\s+ensureNav\s*\(/);
+  assert.doesNotMatch(source,/dabbirServicesNav/);
+  assert.doesNotMatch(source,/\.dataset\.screen\s*=/);
+  assert.match(source,/x-dabbir-service-operations-ui','v3'/);
 });


### PR DESCRIPTION
Implements BAR-30 Phase 1: stop the recurring bug pattern instead of adding another symptom guard.

## Root cause addressed
Repeated DABBIR failures have come from competing owners of navigation/state and patch-on-patch UI composition. The most recent concrete example was the Services feature injecting a sixth primary destination and then a later guard hiding it.

## Changes
- Add an explicit architecture ownership contract and stabilization policy.
- Add a permanent root-cause registry for recurring incident classes.
- Freeze the current shell module allowlist and deny retired presentation layers from returning.
- Lock desktop/mobile primary navigation to exactly five destinations.
- Remove Services primary-navigation injection at the source.
- Keep Services accessible contextually under More instead of creating-and-hiding a sixth tab.
- Add CI invariants for tenant WhatsApp identity isolation, final auth authority, shell uniqueness/ceiling, and no continuous polling in presentation authorities.

## Important
This PR intentionally does not claim the architecture is fully clean. It creates the first hard boundary so complexity cannot continue growing while Phase 2 collapses render/navigation/session ownership into fewer authorities.

No payment, Meta credential, Supabase schema, customer data, or live WhatsApp side effect is changed.