### PR TITLE
DABBIR: collapse dead inline UI owners v2

### DIFF
--- a/api/app.js
+++ b/api/app.js
@@ -1,44 +1,10 @@
 import fs from 'node:fs';
 
 const htmlPath = new URL('../index.html', import.meta.url);
-const settingsNav = '<button class="navBtn" data-screen="settings">⚙ <span data-label="settings"></span></button>';
-const teamNav = '<a class="navBtn" data-dabbir-team-nav="true" href="/team.html" style="text-decoration:none">♟ <span data-label="team"></span></a>';
-const legacyTeamLink = '<div class="sideFoot"><a class="secondary" href="/team.html" style="display:block;text-align:center;text-decoration:none" id="teamLink"></a></div>';
-const settingsBottom = '<button data-screen="settings">⚙<br><span data-label="settings"></span></button>';
-const teamBottom = '<a data-dabbir-team-mobile="true" href="/team.html" style="border:0;background:transparent;color:#9298a1;font-size:8px;border-radius:10px;text-align:center;text-decoration:none;display:flex;flex-direction:column;align-items:center;justify-content:center">♟<br><span data-label="team"></span></a>';
-const legacyTeamLanguageWrite = "$('#teamLink').textContent=t.team;";
-const safeTeamLanguageWrite = "$('#teamLink')&&($('#teamLink').textContent=t.team);";
 
-const businessAdaptiveUi = String.raw`
-<style>
-@media(max-width:700px){.bottomNav.dabbir-store-nav{grid-template-columns:repeat(5,1fr)!important}}
-</style>
-<script>
-(()=>{
-  function applyBusinessProfile(){
-    if(!workspace?.business) return;
-    const isStore=String(workspace.business.business_type||'').toLowerCase()==='store';
-    document.body.classList.toggle('dabbir-store',isStore);
-    if(!isStore) return;
-    document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display='none'});
-    document.querySelector('#bottomNav')?.classList.add('dabbir-store-nav');
-    if(current==='appointments') showScreen('dashboard');
-    const cards=document.querySelectorAll('#dashCards .card.metric');
-    if(cards[1]){
-      const label=cards[1].querySelector('span');
-      const value=cards[1].querySelector('strong');
-      if(label) label.textContent=lang==='ar'?'المتابعات':'Follow-ups';
-      if(value) value.textContent=String((workspace.followups||[]).length);
-    }
-    const state=document.querySelector('#workspaceState');
-    if(state) state.textContent=lang==='ar'?'متجر • تشغيلي':'Store • Operational';
-  }
-  const baseRenderAll=renderAll;
-  renderAll=function(){baseRenderAll();applyBusinessProfile()};
-  setTimeout(applyBusinessProfile,0);
-})();
-</script>`;
-
+// Phase 2 stabilization: this is the remaining inline runtime/performance authority.
+// Business/activity navigation is owned by the authoritative owner journey and activity modules,
+// not by an additional legacy businessAdaptive wrapper in this response transformer.
 const interfacePerformanceUi = String.raw`
 <style>
 button,a,[data-screen],[data-cid]{touch-action:manipulation}
@@ -280,16 +246,9 @@ export default function handler(req, res) {
   if (req.method !== 'GET') return res.status(405).setHeader('allow', 'GET').end('Method Not Allowed');
 
   let html = fs.readFileSync(htmlPath, 'utf8');
-  if (!html.includes('data-dabbir-team-nav="true"') && html.includes(settingsNav)) html = html.replace(settingsNav, `${teamNav}\n    ${settingsNav}`);
-  if (!html.includes('data-dabbir-team-mobile="true"') && html.includes(settingsBottom)) {
-    html = html.replace(settingsBottom, `${teamBottom}${settingsBottom}`);
-    html = html.replace('grid-template-columns:repeat(5,1fr);bottom:0', 'grid-template-columns:repeat(6,1fr);bottom:0');
-  }
-  html = html.replace(legacyTeamLanguageWrite, safeTeamLanguageWrite);
-  html = html.replace(legacyTeamLink, '');
   html = html.replaceAll('/api/dabbir-runtime', '/api/dabbir-runtime-fast');
   html = html.replace("const {r,j}=await api('/api/dabbir-runtime-fast');if(r.status===401)", "const {r,j}=await api('/api/dabbir-runtime-fast?summary=1');if(r.status===401)");
-  html = html.replace('</body>', `${businessAdaptiveUi}\n${interfacePerformanceUi}\n${conversationPerformanceUi}\n${truthVisibilityUi}\n</body>`);
+  html = html.replace('</body>', `${interfacePerformanceUi}\n${conversationPerformanceUi}\n${truthVisibilityUi}\n</body>`);
 
   res.setHeader('content-type', 'text/html; charset=utf-8');
   res.setHeader('cache-control', 'no-store');

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -1,5 +1,5 @@
 // BAR-30 invariant: contextual features are discovered under More; they do not create primary navigation destinations.
-// Exact-head build marker: this runtime file intentionally changes only documentation so Vercel executes the full gate on the final Phase-1 branch head.
+// Exact-head build marker: Phase 2 removes competing inline UI owners without changing contextual feature behavior.
 const script=String.raw`(()=>{
   if(window.__dabbirContextualNavigationUi)return;
   window.__dabbirContextualNavigationUi=true;

--- a/test/dabbir-inline-ui-ownership-v2.test.mjs
+++ b/test/dabbir-inline-ui-ownership-v2.test.mjs
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const app=fs.readFileSync(new URL('../api/app.js',import.meta.url),'utf8');
+const index=fs.readFileSync(new URL('../index.html',import.meta.url),'utf8');
+
+test('app transformer no longer invents team or settings primary navigation',()=>{
+  assert.doesNotMatch(app,/const settingsNav\s*=/);
+  assert.doesNotMatch(app,/const settingsBottom\s*=/);
+  assert.doesNotMatch(app,/data-dabbir-team-nav/);
+  assert.doesNotMatch(app,/data-dabbir-team-mobile/);
+  assert.doesNotMatch(app,/grid-template-columns:repeat\(6,1fr\)/);
+});
+
+test('duplicate legacy businessAdaptive UI layer cannot return',()=>{
+  assert.doesNotMatch(app,/const businessAdaptiveUi\s*=/);
+  assert.doesNotMatch(app,/function applyBusinessProfile\s*\(/);
+  assert.doesNotMatch(app,/workspace\.followups\|\|\[\]\)\.length/,'bounded followup arrays must not become owner KPI truth');
+});
+
+test('app transformer only injects the three remaining inline runtime layers',()=>{
+  const injection=app.match(/html = html\.replace\('<\/body>', `\$\{([\s\S]*?)\}<\/body>`\);/)?.[1]||'';
+  assert.match(injection,/interfacePerformanceUi/);
+  assert.match(injection,/conversationPerformanceUi/);
+  assert.match(injection,/truthVisibilityUi/);
+  assert.doesNotMatch(injection,/businessAdaptiveUi/);
+});
+
+test('primary owner navigation remains authored in index instead of app string replacement',()=>{
+  const nav=index.match(/<nav class="nav" id="nav">([\s\S]*?)<\/nav>/)?.[1]||'';
+  const destinations=[...nav.matchAll(/data-screen="([^"]+)"/g)].map(match=>match[1]);
+  assert.deepEqual(destinations,['dashboard','conversations','appointments','customers','more']);
+});

--- a/test/dabbir-inline-ui-ownership-v2.test.mjs
+++ b/test/dabbir-inline-ui-ownership-v2.test.mjs
@@ -20,11 +20,10 @@ test('duplicate legacy businessAdaptive UI layer cannot return',()=>{
 });
 
 test('app transformer only injects the three remaining inline runtime layers',()=>{
-  const injection=app.match(/html = html\.replace\('<\/body>', `\$\{([\s\S]*?)\}<\/body>`\);/)?.[1]||'';
-  assert.match(injection,/interfacePerformanceUi/);
-  assert.match(injection,/conversationPerformanceUi/);
-  assert.match(injection,/truthVisibilityUi/);
-  assert.doesNotMatch(injection,/businessAdaptiveUi/);
+  assert.match(app,/html = html\.replace\('<\/body>', `\$\{interfacePerformanceUi\}/);
+  assert.match(app,/\$\{conversationPerformanceUi\}/);
+  assert.match(app,/\$\{truthVisibilityUi\}/);
+  assert.doesNotMatch(app,/`\$\{businessAdaptiveUi\}/);
 });
 
 test('primary owner navigation remains authored in index instead of app string replacement',()=>{


### PR DESCRIPTION
Implements BAR-30 Phase 2 increment 1.

## Root cause removed
`api/app.js` still contained a legacy `businessAdaptiveUi` wrapper that rewrote store navigation/dashboard state on top of the newer activity/owner layers, plus dead string-replacement logic that could inject Team/Settings primary navigation if old markup returned. Those transforms were no longer part of the five-destination owner journey but remained latent competing owners.

## Changes
- Remove dead Team/Settings navigation string injection from `api/app.js`.
- Remove the duplicate legacy `businessAdaptiveUi` wrapper.
- Remove its bounded follow-up KPI fallback.
- Preserve the existing fast runtime, conversation send path, truth badge, headers, and runtime endpoint rewrite.
- Add regression tests forbidding those legacy inline owners from returning.

## Architecture effect
This reduces inline response-time UI ownership without adding another guard or shell module. Primary navigation remains authored by the five-destination owner journey.

No payment, Meta/WhatsApp credential, database schema, customer data, or external side effect is changed.