### PR TITLE
DABBIR: make WhatsApp readiness an explicit state machine

### DIFF
--- a/api/_dabbir-whatsapp-state-machine.js
+++ b/api/_dabbir-whatsapp-state-machine.js
@@ -1,3 +1,4 @@
+// BAR-30 Phase 3: one fail-closed authority interprets WhatsApp operational evidence.
 export const WHATSAPP_OPERATIONAL_STAGES = Object.freeze({
   NOT_CONFIGURED: 'NOT_CONFIGURED',
   AUTHORIZATION_INVALID: 'AUTHORIZATION_INVALID',

--- a/api/_dabbir-whatsapp-state-machine.js
+++ b/api/_dabbir-whatsapp-state-machine.js
@@ -1,0 +1,102 @@
+export const WHATSAPP_OPERATIONAL_STAGES = Object.freeze({
+  NOT_CONFIGURED: 'NOT_CONFIGURED',
+  AUTHORIZATION_INVALID: 'AUTHORIZATION_INVALID',
+  META_AUTHORIZED: 'META_AUTHORIZED',
+  INBOUND_VERIFIED: 'INBOUND_VERIFIED',
+  OUTBOUND_VERIFIED: 'OUTBOUND_VERIFIED',
+  OPERATIONAL: 'OPERATIONAL',
+  DEGRADED: 'DEGRADED',
+});
+
+function booleanEvidence(evidence = {}) {
+  return {
+    available: evidence?.available === true,
+    real_whatsapp_conversation: evidence?.real_whatsapp_conversation === true,
+    real_inbound_message: evidence?.real_inbound_message === true,
+    real_outbound_reply: evidence?.real_outbound_reply === true,
+    verified_external_result: evidence?.verified_external_result === true,
+  };
+}
+
+export function deriveWhatsAppOperationalState({
+  hasConnection = true,
+  authorized = false,
+  evidence = {},
+  verificationFailed = false,
+} = {}) {
+  if (!hasConnection) {
+    return {
+      state: 'NOT_CONFIGURED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.NOT_CONFIGURED,
+      operational: false,
+      reason: 'WHATSAPP_NOT_LINKED',
+    };
+  }
+
+  if (verificationFailed) {
+    return {
+      state: 'CONNECTED_VERIFICATION_FAILED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.DEGRADED,
+      operational: false,
+      reason: 'META_AUTHORIZATION_NOT_VERIFIED',
+    };
+  }
+
+  if (!authorized) {
+    return {
+      state: 'AUTHORIZATION_INVALID',
+      stage: WHATSAPP_OPERATIONAL_STAGES.AUTHORIZATION_INVALID,
+      operational: false,
+      reason: 'META_AUTHORIZATION_NOT_VERIFIED',
+    };
+  }
+
+  const proof = booleanEvidence(evidence);
+  if (!proof.available) {
+    return {
+      state: 'META_AUTHORIZED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.DEGRADED,
+      operational: false,
+      reason: 'OPERATIONAL_EVIDENCE_UNAVAILABLE',
+    };
+  }
+  if (!proof.real_whatsapp_conversation) {
+    return {
+      state: 'META_AUTHORIZED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.META_AUTHORIZED,
+      operational: false,
+      reason: 'REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED',
+    };
+  }
+  if (!proof.real_inbound_message) {
+    return {
+      state: 'META_AUTHORIZED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.META_AUTHORIZED,
+      operational: false,
+      reason: 'REAL_WHATSAPP_INBOUND_NOT_VERIFIED',
+    };
+  }
+  if (!proof.real_outbound_reply) {
+    return {
+      state: 'META_AUTHORIZED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.INBOUND_VERIFIED,
+      operational: false,
+      reason: 'REAL_WHATSAPP_REPLY_NOT_RECORDED',
+    };
+  }
+  if (!proof.verified_external_result) {
+    return {
+      state: 'META_AUTHORIZED',
+      stage: WHATSAPP_OPERATIONAL_STAGES.OUTBOUND_VERIFIED,
+      operational: false,
+      reason: 'EXTERNAL_REPLY_RESULT_NOT_VERIFIED',
+    };
+  }
+
+  return {
+    state: 'OPERATIONAL',
+    stage: WHATSAPP_OPERATIONAL_STAGES.OPERATIONAL,
+    operational: true,
+    reason: null,
+  };
+}

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,5 +1,6 @@
 import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRest } from './_auth-core.js';
+import { deriveWhatsAppOperationalState } from './_dabbir-whatsapp-state-machine.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
@@ -118,17 +119,8 @@ export async function loadOperationalEvidence(accessToken, businessId) {
   }
 }
 
-function operationalReason(authorized, evidence) {
-  if (!authorized) return 'META_AUTHORIZATION_NOT_VERIFIED';
-  if (!evidence?.available) return 'OPERATIONAL_EVIDENCE_UNAVAILABLE';
-  if (!evidence.real_whatsapp_conversation) return 'REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED';
-  if (!evidence.real_inbound_message) return 'REAL_WHATSAPP_INBOUND_NOT_VERIFIED';
-  if (!evidence.real_outbound_reply) return 'REAL_WHATSAPP_REPLY_NOT_RECORDED';
-  if (!evidence.verified_external_result) return 'EXTERNAL_REPLY_RESULT_NOT_VERIFIED';
-  return null;
-}
-
 export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') {
+  const machine = deriveWhatsAppOperationalState({ hasConnection: false });
   return {
     ok: true,
     channel: 'whatsapp',
@@ -139,7 +131,8 @@ export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') 
     outbound_configured: false,
     phone_number_configured: false,
     waba_configured: false,
-    state: 'NOT_CONFIGURED',
+    state: machine.state,
+    operational_stage: machine.stage,
     meta_authorized: false,
     meta_check_attempted: false,
     meta_check_reason: reason,
@@ -148,8 +141,8 @@ export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') 
     waba_id: null,
     phone_number_id: null,
     connected_at: null,
-    operational: false,
-    operational_reason: 'WHATSAPP_NOT_LINKED',
+    operational: machine.operational,
+    operational_reason: machine.reason,
     operational_evidence: emptyOperationalEvidence(true),
     checked_at: new Date().toISOString(),
   };
@@ -189,8 +182,11 @@ async function embeddedStatus(req, accessToken, businessId) {
       verifyStoredConnection(platform, row),
       loadOperationalEvidence(accessToken, businessId),
     ]);
-    const reason = operationalReason(Boolean(verified.authorized), evidence);
-    const operational = reason === null;
+    const machine = deriveWhatsAppOperationalState({
+      hasConnection: true,
+      authorized: Boolean(verified.authorized),
+      evidence,
+    });
     return {
       ok: true,
       channel: 'whatsapp',
@@ -201,7 +197,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       outbound_configured: Boolean(verified.authorized),
       phone_number_configured: true,
       waba_configured: true,
-      state: operational ? 'OPERATIONAL' : verified.authorized ? 'META_AUTHORIZED' : 'AUTHORIZATION_INVALID',
+      state: machine.state,
+      operational_stage: machine.stage,
       meta_authorized: Boolean(verified.authorized),
       meta_check_attempted: true,
       meta_check_reason: verified.authorized ? null : 'META_AUTHORIZATION_CHECK_FAILED',
@@ -213,12 +210,19 @@ async function embeddedStatus(req, accessToken, businessId) {
       waba_id: row.waba_id,
       phone_number_id: row.phone_number_id,
       connected_at: row.connected_at,
-      operational,
-      operational_reason: reason,
+      operational: machine.operational,
+      operational_reason: machine.reason,
       operational_evidence: evidence,
       checked_at: new Date().toISOString(),
     };
   } catch (error) {
+    const evidence = emptyOperationalEvidence(false);
+    const machine = deriveWhatsAppOperationalState({
+      hasConnection: true,
+      authorized: false,
+      evidence,
+      verificationFailed: true,
+    });
     return {
       ok: true,
       channel: 'whatsapp',
@@ -229,7 +233,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       outbound_configured: true,
       phone_number_configured: true,
       waba_configured: true,
-      state: 'CONNECTED_VERIFICATION_FAILED',
+      state: machine.state,
+      operational_stage: machine.stage,
       meta_authorized: false,
       meta_check_attempted: true,
       meta_check_reason: String(error?.message || 'META_AUTHORIZATION_CHECK_UNAVAILABLE').slice(0, 200),
@@ -238,9 +243,9 @@ async function embeddedStatus(req, accessToken, businessId) {
       waba_id: row.waba_id,
       phone_number_id: row.phone_number_id,
       connected_at: row.connected_at,
-      operational: false,
-      operational_reason: 'META_AUTHORIZATION_NOT_VERIFIED',
-      operational_evidence: emptyOperationalEvidence(false),
+      operational: machine.operational,
+      operational_reason: machine.reason,
+      operational_evidence: evidence,
       checked_at: new Date().toISOString(),
     };
   }

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -4,8 +4,10 @@ import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 const statusPath='api/dabbir-whatsapp-status.js';
+const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
 const status=fs.readFileSync(statusPath,'utf8');
+const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
 
 test('WhatsApp operational evidence is tenant-scoped and excludes simulation',()=>{
@@ -19,14 +21,20 @@ test('WhatsApp operational evidence is tenant-scoped and excludes simulation',()
   assert.match(status,/business_id=eq\.\$\{encodedBusinessId\}/);
 });
 
-test('WhatsApp becomes operational only after inbound, outbound and verified external result',()=>{
-  assert.match(status,/REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED/);
-  assert.match(status,/REAL_WHATSAPP_INBOUND_NOT_VERIFIED/);
-  assert.match(status,/REAL_WHATSAPP_REPLY_NOT_RECORDED/);
-  assert.match(status,/EXTERNAL_REPLY_RESULT_NOT_VERIFIED/);
-  assert.match(status,/const operational = reason === null/);
-  assert.match(status,/state: operational \? 'OPERATIONAL'/);
+test('WhatsApp becomes operational only through the explicit evidence state machine',()=>{
+  assert.match(status,/deriveWhatsAppOperationalState/);
+  assert.match(status,/operational_stage: machine\.stage/);
+  assert.match(status,/operational: machine\.operational/);
+  assert.match(status,/operational_reason: machine\.reason/);
   assert.match(status,/operational_evidence: evidence/);
+  assert.match(machine,/REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED/);
+  assert.match(machine,/REAL_WHATSAPP_INBOUND_NOT_VERIFIED/);
+  assert.match(machine,/REAL_WHATSAPP_REPLY_NOT_RECORDED/);
+  assert.match(machine,/EXTERNAL_REPLY_RESULT_NOT_VERIFIED/);
+  assert.match(machine,/stage: WHATSAPP_OPERATIONAL_STAGES\.INBOUND_VERIFIED/);
+  assert.match(machine,/stage: WHATSAPP_OPERATIONAL_STAGES\.OUTBOUND_VERIFIED/);
+  assert.match(machine,/state: 'OPERATIONAL'/);
+  assert.match(machine,/operational: true/);
 });
 
 test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
@@ -44,7 +52,7 @@ test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
 });
 
 test('operational truth files parse as Node modules',()=>{
-  for(const path of [statusPath,activationPath]){
+  for(const path of [statusPath,machinePath,activationPath]){
     const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
     assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
   }

--- a/test/dabbir-whatsapp-state-machine.test.mjs
+++ b/test/dabbir-whatsapp-state-machine.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { deriveWhatsAppOperationalState } from '../api/_dabbir-whatsapp-state-machine.js';
+
+const evidence=(overrides={})=>({
+  available:true,
+  real_whatsapp_conversation:true,
+  real_inbound_message:true,
+  real_outbound_reply:true,
+  verified_external_result:true,
+  ...overrides,
+});
+
+test('WhatsApp fails closed when no tenant connection exists',()=>{
+  assert.deepEqual(deriveWhatsAppOperationalState({hasConnection:false}),{
+    state:'NOT_CONFIGURED',stage:'NOT_CONFIGURED',operational:false,reason:'WHATSAPP_NOT_LINKED'
+  });
+});
+
+test('Meta authorization alone never becomes operational',()=>{
+  const state=deriveWhatsAppOperationalState({authorized:true,evidence:evidence({real_whatsapp_conversation:false,real_inbound_message:false,real_outbound_reply:false,verified_external_result:false})});
+  assert.equal(state.state,'META_AUTHORIZED');
+  assert.equal(state.stage,'META_AUTHORIZED');
+  assert.equal(state.operational,false);
+  assert.equal(state.reason,'REAL_WHATSAPP_CONVERSATION_NOT_VERIFIED');
+});
+
+test('verified inbound advances only to INBOUND_VERIFIED',()=>{
+  const state=deriveWhatsAppOperationalState({authorized:true,evidence:evidence({real_outbound_reply:false,verified_external_result:false})});
+  assert.equal(state.state,'META_AUTHORIZED');
+  assert.equal(state.stage,'INBOUND_VERIFIED');
+  assert.equal(state.operational,false);
+  assert.equal(state.reason,'REAL_WHATSAPP_REPLY_NOT_RECORDED');
+});
+
+test('recorded outbound without provider proof advances only to OUTBOUND_VERIFIED',()=>{
+  const state=deriveWhatsAppOperationalState({authorized:true,evidence:evidence({verified_external_result:false})});
+  assert.equal(state.state,'META_AUTHORIZED');
+  assert.equal(state.stage,'OUTBOUND_VERIFIED');
+  assert.equal(state.operational,false);
+  assert.equal(state.reason,'EXTERNAL_REPLY_RESULT_NOT_VERIFIED');
+});
+
+test('only the full evidence chain can become OPERATIONAL',()=>{
+  const state=deriveWhatsAppOperationalState({authorized:true,evidence:evidence()});
+  assert.deepEqual(state,{state:'OPERATIONAL',stage:'OPERATIONAL',operational:true,reason:null});
+});
+
+test('unavailable evidence and verification failure are explicitly degraded',()=>{
+  const unavailable=deriveWhatsAppOperationalState({authorized:true,evidence:{available:false}});
+  assert.equal(unavailable.stage,'DEGRADED');
+  assert.equal(unavailable.operational,false);
+  assert.equal(unavailable.reason,'OPERATIONAL_EVIDENCE_UNAVAILABLE');
+
+  const failed=deriveWhatsAppOperationalState({authorized:true,verificationFailed:true});
+  assert.equal(failed.state,'CONNECTED_VERIFICATION_FAILED');
+  assert.equal(failed.stage,'DEGRADED');
+  assert.equal(failed.operational,false);
+});


### PR DESCRIPTION
Implements BAR-30 Phase 3 increment 1.

## Root cause removed
WhatsApp readiness was derived inline in the status endpoint from several booleans/reasons. That made it easy for a future UI or integration change to collapse `META_AUTHORIZED` into `OPERATIONAL` again.

## Changes
- Add one pure WhatsApp operational state machine.
- Preserve backward-compatible top-level `state` values while adding explicit `operational_stage`.
- Progression is fail-closed: NOT_CONFIGURED → META_AUTHORIZED → INBOUND_VERIFIED → OUTBOUND_VERIFIED → OPERATIONAL, with DEGRADED for unavailable/failed verification evidence.
- OPERATIONAL still requires real non-demo WhatsApp conversation + real inbound + real outbound + verified external result.
- Route `dabbir-whatsapp-status` through the machine instead of ad-hoc readiness conditionals.
- Add deterministic transition tests and update operational-truth regression coverage.

## Safety
No Meta authorization, webhook registration, token, payment, database schema, or customer data is changed. This only centralizes interpretation of already existing evidence.