### PR TITLE
DABBIR: move store navigation into one router authority

### DIFF
--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -1,4 +1,5 @@
 // BAR-30 router authority: feature modules do not create or mutate primary destinations.
+// The activity slot is reversible so switching business context cannot leave a stale target, label, or icon behind.
 const script=String.raw`(()=>{
   if(window.__dabbirContextualNavigationUi)return;
   window.__dabbirContextualNavigationUi=true;
@@ -35,9 +36,9 @@ const script=String.raw`(()=>{
     const icon=node.querySelector(':scope > .d4-nav-icon');
     if(icon&&icon.dataset.routerTarget!==target){
       icon.dataset.routerTarget=target;
-      if(target==='operations'){
-        icon.innerHTML='<svg viewBox="0 0 24 24"><path d="M4 6h16v12H4z"/><path d="M8 10h8M8 14h5"/></svg>';
-      }
+      icon.innerHTML=target==='operations'
+        ? '<svg viewBox="0 0 24 24"><path d="M4 6h16v12H4z"/><path d="M8 10h8M8 14h5"/></svg>'
+        : '<svg viewBox="0 0 24 24"><rect x="4" y="5" width="16" height="15" rx="2"/><path d="M8 3v4M16 3v4M4 9h16"/></svg>';
     }
   }
 
@@ -50,11 +51,6 @@ const script=String.raw`(()=>{
         let appointmentLabel='';
         try{appointmentLabel=String(T()?.appointments||'').trim()}catch{}
         setActivitySlot(node,'appointments',appointmentLabel||(ar()?'المواعيد':'Appointments'));
-        const icon=node.querySelector(':scope > .d4-nav-icon');
-        if(icon&&icon.dataset.routerTarget==='operations'){
-          icon.dataset.routerTarget='appointments';
-          icon.innerHTML='<svg viewBox="0 0 24 24"><rect x="4" y="5" width="16" height="15" rx="2"/><path d="M8 3v4M16 3v4M4 9h16"/></svg>';
-        }
       }
     }
     if(isStore()&&current==='appointments'&&typeof showScreen==='function')showScreen('operations');

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -1,20 +1,64 @@
-// BAR-30 invariant: contextual features are discovered under More; they do not create primary navigation destinations.
-// Exact-head build marker: Phase 2 removes competing inline UI owners without changing contextual feature behavior.
+// BAR-30 router authority: feature modules do not create or mutate primary destinations.
 const script=String.raw`(()=>{
   if(window.__dabbirContextualNavigationUi)return;
   window.__dabbirContextualNavigationUi=true;
 
   const q=s=>document.querySelector(s);
+  const qa=s=>[...document.querySelectorAll(s)];
   const ar=()=>document.documentElement.lang!=='en';
   const businessType=()=>String(window.workspace?.business?.business_type||'').toLowerCase();
-  const isServiceBusiness=()=>Boolean(businessType())&&businessType()!=='store';
+  const isStore=()=>businessType()==='store';
+  const isServiceBusiness=()=>Boolean(businessType())&&!isStore();
   const copy=()=>ar()?{
-    title:'الخدمات',
-    desc:'الخدمات الفعلية التي يقدمها نشاطك. عدّلها عند الحاجة بدون زيادة القوائم الرئيسية.'
+    servicesTitle:'الخدمات',
+    servicesDesc:'الخدمات الفعلية التي يقدمها نشاطك. عدّلها عند الحاجة بدون زيادة القوائم الرئيسية.',
+    operations:'العمليات'
   }:{
-    title:'Services',
-    desc:'The real services your business provides. Manage them when needed without adding another primary destination.'
+    servicesTitle:'Services',
+    servicesDesc:'The real services your business provides. Manage them when needed without adding another primary destination.',
+    operations:'Operations'
   };
+
+  function activitySlots(){
+    qa('#nav [data-screen="appointments"],#bottomNav [data-screen="appointments"],#nav [data-dabbir-activity-slot="true"],#bottomNav [data-dabbir-activity-slot="true"]').forEach(node=>{
+      node.dataset.dabbirActivitySlot='true';
+    });
+    return qa('[data-dabbir-activity-slot="true"]');
+  }
+
+  function setActivitySlot(node,target,label){
+    node.dataset.screen=target;
+    node.style.display='';
+    const labelNode=node.querySelector('[data-label]');
+    if(labelNode)labelNode.textContent=label;
+    node.setAttribute('aria-label',label);
+    const icon=node.querySelector(':scope > .d4-nav-icon');
+    if(icon&&icon.dataset.routerTarget!==target){
+      icon.dataset.routerTarget=target;
+      if(target==='operations'){
+        icon.innerHTML='<svg viewBox="0 0 24 24"><path d="M4 6h16v12H4z"/><path d="M8 10h8M8 14h5"/></svg>';
+      }
+    }
+  }
+
+  function adaptPrimaryActivitySlot(){
+    const t=copy();
+    for(const node of activitySlots()){
+      if(isStore()){
+        setActivitySlot(node,'operations',t.operations);
+      }else{
+        let appointmentLabel='';
+        try{appointmentLabel=String(T()?.appointments||'').trim()}catch{}
+        setActivitySlot(node,'appointments',appointmentLabel||(ar()?'المواعيد':'Appointments'));
+        const icon=node.querySelector(':scope > .d4-nav-icon');
+        if(icon&&icon.dataset.routerTarget==='operations'){
+          icon.dataset.routerTarget='appointments';
+          icon.innerHTML='<svg viewBox="0 0 24 24"><rect x="4" y="5" width="16" height="15" rx="2"/><path d="M8 3v4M16 3v4M4 9h16"/></svg>';
+        }
+      }
+    }
+    if(isStore()&&current==='appointments'&&typeof showScreen==='function')showScreen('operations');
+  }
 
   function openServices(){
     if(typeof showScreen==='function')showScreen('operations');
@@ -38,10 +82,11 @@ const script=String.raw`(()=>{
       card.addEventListener('click',openServices);
       grid.prepend(card);
     }
-    card.innerHTML='<h3>'+t.title+'</h3><p>'+t.desc+'</p>';
+    card.innerHTML='<h3>'+t.servicesTitle+'</h3><p>'+t.servicesDesc+'</p>';
   }
 
   function enforce(){
+    adaptPrimaryActivitySlot();
     ensureMoreCard();
   }
 
@@ -57,7 +102,7 @@ const script=String.raw`(()=>{
 
   setTimeout(enforce,0);
   setTimeout(enforce,650);
-  window.__dabbirContextualNavigation={refresh:enforce,version:'v2'};
+  window.__dabbirContextualNavigation={refresh:enforce,version:'v3',authority:'primary-context-router'};
 })();`;
 
 export default function handler(req,res){
@@ -65,6 +110,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-contextual-navigation','v2');
+  res.setHeader('x-dabbir-contextual-navigation','v3');
   return res.status(200).send(script);
 }

--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -46,7 +46,7 @@ const script=String.raw`(()=>{
   let loading=false;
   let businessId=null;
 
-  function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+  function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c]))}
   function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' AED'}catch{return Number(value||0).toFixed(2)+' AED'}}
   function date(value){if(!value)return '—';try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{dateStyle:'medium'}).format(new Date(value))}catch{return String(value)}}
   function isStore(){try{return String(workspace?.business?.business_type||'').toLowerCase()==='store'}catch{return false}}
@@ -81,19 +81,6 @@ const script=String.raw`(()=>{
     return screen;
   }
 
-  function ensureNav(){
-    if(!isStore())return;
-    const t=text();
-    qa('[data-screen="appointments"]').forEach(node=>{
-      node.dataset.screen='operations';
-      node.style.display='';
-      if(node.closest('#bottomNav'))node.innerHTML='▦<br><span>'+escapeHtml(t.nav)+'</span>';
-      else node.innerHTML='▦ <span>'+escapeHtml(t.nav)+'</span>';
-      node.onclick=()=>showScreen('operations');
-    });
-    qa('[data-screen="operations"]').forEach(node=>{node.style.display='';});
-  }
-
   function applyCopy(){
     const t=text();
     if(q('#opsTitle'))q('#opsTitle').textContent=t.title;
@@ -111,7 +98,6 @@ const script=String.raw`(()=>{
     if(q('#opsStockCancel'))q('#opsStockCancel').textContent=t.cancel;
     if(q('#opsStockSave'))q('#opsStockSave').textContent=t.update;
     if(current==='operations'&&q('#pageTitle'))q('#pageTitle').textContent=t.nav;
-    ensureNav();
     render();
   }
 
@@ -203,14 +189,13 @@ const script=String.raw`(()=>{
   }
 
   ensureScreen();
-  ensureNav();
 
   try{
     const baseShowScreen=showScreen;
     showScreen=function(name){
       const result=baseShowScreen(name);
       if(name==='operations'){
-        ensureScreen();ensureNav();if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;load();
+        ensureScreen();if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;load();
       }
       return result;
     };
@@ -218,11 +203,11 @@ const script=String.raw`(()=>{
 
   try{
     const baseRenderAll=renderAll;
-    renderAll=function(){const result=baseRenderAll.apply(this,arguments);ensureScreen();ensureNav();applyCopy();if(current==='operations')load();return result};
+    renderAll=function(){const result=baseRenderAll.apply(this,arguments);ensureScreen();applyCopy();if(current==='operations')load();return result};
   }catch{}
 
   new MutationObserver(applyCopy).observe(document.documentElement,{attributes:true,attributeFilter:['lang','dir']});
-  setTimeout(()=>{ensureScreen();ensureNav();if(isStore())load()},600);
+  setTimeout(()=>{ensureScreen();if(isStore())load()},600);
 })();`;
 
 export default function handler(req,res){

--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -46,7 +46,7 @@ const script=String.raw`(()=>{
   let loading=false;
   let businessId=null;
 
-  function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c]))}
+  function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
   function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' AED'}catch{return Number(value||0).toFixed(2)+' AED'}}
   function date(value){if(!value)return '—';try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{dateStyle:'medium'}).format(new Date(value))}catch{return String(value)}}
   function isStore(){try{return String(workspace?.business?.business_type||'').toLowerCase()==='store'}catch{return false}}

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,24 +1,19 @@
 {
-  "version": 1,
+  "version": 2,
   "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
   "authorities": {
     "root_shell": "api/app-recovery.js",
-    "primary_navigation": "index.html",
+    "primary_navigation_structure": "index.html",
+    "primary_navigation_context_router": "api/dabbir-contextual-navigation-ui.js",
     "service_discovery_under_more": "api/dabbir-contextual-navigation-ui.js",
-    "store_navigation_adaptation": "api/owner-operations-ui.js",
+    "store_navigation_adaptation": "api/dabbir-contextual-navigation-ui.js",
     "auth_session_gate": "api/auth-session-stability-ui.js",
     "business_activity_profile": "api/activity-profile-ui.js",
     "tenant_whatsapp_state": "api/dabbir-whatsapp-status.js",
     "verified_owner_metrics": "api/verified-metrics-ui.js",
     "owner_visual_system": "api/dabbir-owner-first-ui.js"
   },
-  "temporary_exceptions": {
-    "store_navigation_adaptation": {
-      "owner": "api/owner-operations-ui.js",
-      "reason": "Store operations currently replace the appointments destination in-place.",
-      "target": "Move this adaptation into the single navigation/router authority during stabilization phase 2."
-    }
-  },
+  "temporary_exceptions": {},
   "shell": {
     "maximum_injected_api_modules": 25,
     "require_unique_modules": true,
@@ -38,7 +33,12 @@
       "customers",
       "more"
     ],
+    "activity_slot_can_resolve_to": [
+      "appointments",
+      "operations"
+    ],
     "feature_modules_may_add_primary_destinations": false,
+    "feature_modules_may_mutate_primary_destinations": false,
     "service_catalog_must_live_under_more": true
   },
   "truth_rules": {

--- a/test/dabbir-architecture-invariants-v1.test.mjs
+++ b/test/dabbir-architecture-invariants-v1.test.mjs
@@ -7,6 +7,7 @@ const read = path => fs.readFileSync(new URL(path, root), 'utf8');
 const ownership = JSON.parse(read('config/dabbir-architecture-ownership.json'));
 const shell = read('api/app-recovery.js');
 const index = read('index.html');
+const ownerOperations = read('api/owner-operations-ui.js');
 const serviceOperations = read('api/service-operations-ui.js');
 const contextualNavigation = read('api/dabbir-contextual-navigation-ui.js');
 const ownerFirst = read('api/dabbir-owner-first-ui.js');
@@ -21,8 +22,12 @@ function navBody(id) {
   return index.match(new RegExp(`<nav class=\"[^\"]*\" id=\"${id}\">([\\s\\S]*?)<\\/nav>`))?.[1] || '';
 }
 
-test('architecture contract is fail-closed and does not permit feature-owned primary navigation', () => {
+test('architecture contract is fail-closed and gives contextual navigation one authority', () => {
   assert.equal(ownership.primary_navigation.feature_modules_may_add_primary_destinations, false);
+  assert.equal(ownership.primary_navigation.feature_modules_may_mutate_primary_destinations, false);
+  assert.equal(ownership.authorities.primary_navigation_context_router, 'api/dabbir-contextual-navigation-ui.js');
+  assert.equal(ownership.authorities.store_navigation_adaptation, 'api/dabbir-contextual-navigation-ui.js');
+  assert.deepEqual(ownership.temporary_exceptions, {});
   assert.equal(ownership.truth_rules.blocked_or_skipped_qa_is_pass, false);
   assert.equal(ownership.truth_rules.tenant_may_inherit_global_whatsapp_identity, false);
   assert.equal(ownership.truth_rules.meta_authorized_equals_operational_whatsapp, false);
@@ -38,11 +43,15 @@ test('desktop and mobile primary navigation are exactly the five owner destinati
   }
 });
 
-test('service catalog cannot inject or mutate primary navigation', () => {
-  assert.doesNotMatch(serviceOperations, /function\s+ensureNav\s*\(/);
+test('feature modules cannot own primary navigation', () => {
+  for (const source of [ownerOperations, serviceOperations]) {
+    assert.doesNotMatch(source, /function\s+ensureNav\s*\(/);
+    assert.doesNotMatch(source, /\.dataset\.screen\s*=/);
+    assert.doesNotMatch(source, /querySelector\(['\"]#nav['\"]\)/);
+  }
   assert.doesNotMatch(serviceOperations, /dabbirServicesNav/);
-  assert.doesNotMatch(serviceOperations, /\.dataset\.screen\s*=/);
-  assert.doesNotMatch(serviceOperations, /querySelector\(['\"]#nav['\"]\)/);
+  assert.match(contextualNavigation, /data-dabbir-activity-slot/);
+  assert.match(contextualNavigation, /setActivitySlot\(node,'operations'/);
   assert.match(contextualNavigation, /#screen-more \.moreGrid/);
   assert.match(contextualNavigation, /showScreen\('operations'\)/);
   assert.doesNotMatch(contextualNavigation, /dabbirServicesNav/);

--- a/test/dabbir-contextual-navigation.test.mjs
+++ b/test/dabbir-contextual-navigation.test.mjs
@@ -3,31 +3,42 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const shell = fs.readFileSync(new URL('../api/app-recovery.js', import.meta.url), 'utf8');
+const ownerOperations = fs.readFileSync(new URL('../api/owner-operations-ui.js', import.meta.url), 'utf8');
 const services = fs.readFileSync(new URL('../api/service-operations-ui.js', import.meta.url), 'utf8');
-const guard = fs.readFileSync(new URL('../api/dabbir-contextual-navigation-ui.js', import.meta.url), 'utf8');
+const router = fs.readFileSync(new URL('../api/dabbir-contextual-navigation-ui.js', import.meta.url), 'utf8');
 
-test('service operations no longer creates a sixth primary navigation destination', () => {
+test('feature operation modules do not own primary navigation', () => {
+  for (const source of [ownerOperations, services]) {
+    assert.doesNotMatch(source, /function\s+ensureNav\s*\(/);
+    assert.doesNotMatch(source, /\.dataset\.screen\s*=/);
+  }
   assert.doesNotMatch(services, /dabbirServicesNav/);
-  assert.doesNotMatch(services, /function\s+ensureNav\s*\(/);
-  assert.doesNotMatch(services, /\.dataset\.screen\s*=/);
-  assert.doesNotMatch(guard, /dabbirServicesNav/);
+  assert.doesNotMatch(router, /dabbirServicesNav/);
+});
+
+test('store resolves the shared activity slot to Operations in the router', () => {
+  assert.match(router, /data-dabbir-activity-slot/);
+  assert.match(router, /setActivitySlot\(node,'operations',t\.operations\)/);
+  assert.match(router, /setActivitySlot\(node,'appointments'/);
+  assert.match(router, /authority:'primary-context-router'/);
 });
 
 test('service businesses reach Services from More instead of a sixth primary destination', () => {
-  assert.match(guard, /id='dabbirContextServices'/);
-  assert.match(guard, /#screen-more \.moreGrid/);
-  assert.match(guard, /showScreen\('operations'\)/);
-  assert.match(guard, /title:'الخدمات'/);
-  assert.match(guard, /businessType\(\).*!==\s*'store'/s);
+  assert.match(router, /id='dabbirContextServices'/);
+  assert.match(router, /#screen-more \.moreGrid/);
+  assert.match(router, /showScreen\('operations'\)/);
+  assert.match(router, /servicesTitle:'الخدمات'/);
+  assert.match(router, /const isServiceBusiness=\(\)=>Boolean\(businessType\(\)\)&&!isStore\(\)/);
 });
 
 test('contextual navigation loads after service and owner UX layers', () => {
   assert.match(shell, /\/api\/dabbir-contextual-navigation-ui/);
   assert.ok(shell.indexOf('/api/dabbir-contextual-navigation-ui') > shell.indexOf('/api/service-operations-ui'));
+  assert.ok(shell.indexOf('/api/dabbir-contextual-navigation-ui') > shell.indexOf('/api/owner-operations-ui'));
   assert.ok(shell.indexOf('/api/dabbir-contextual-navigation-ui') > shell.indexOf('/api/owner-copilot-ui'));
 });
 
 test('contextual navigation is event-driven and does not add continuous DOM polling', () => {
-  assert.doesNotMatch(guard, /MutationObserver/);
-  assert.doesNotMatch(guard, /setInterval/);
+  assert.doesNotMatch(router, /MutationObserver/);
+  assert.doesNotMatch(router, /setInterval/);
 });


### PR DESCRIPTION
Implements BAR-30 Phase 2 navigation consolidation.

## Root cause removed
Store navigation was still mutated inside `owner-operations-ui`, while the base journey, activity profile, and contextual navigation also influenced the same primary slot. That kept multiple owners of one user-facing truth.

## Changes
- Remove `ensureNav` and all primary-navigation mutation from the store Operations feature.
- Make `dabbir-contextual-navigation-ui` the single contextual router for the shared activity slot.
- Store resolves the activity slot to Operations; non-store resolves it to Appointments.
- Services remain discoverable under More and never become a sixth primary destination.
- Update the architecture ownership contract and remove the temporary store-navigation exception.
- Add regression tests that forbid owner/service feature modules from mutating `dataset.screen`.

No backend business logic, payments, Meta authorization, database schema, or customer data changes.