### PR TITLE
DABBIR: make auth/session an explicit state machine

### DIFF
--- a/api/_dabbir-auth-session-state-machine.js
+++ b/api/_dabbir-auth-session-state-machine.js
@@ -1,0 +1,113 @@
+// BAR-30 Phase 3: one fail-closed authority defines the owner auth/session lifecycle.
+export const AUTH_SESSION_STAGES = Object.freeze({
+  SIGNED_OUT: 'signed_out',
+  AUTHENTICATING: 'authenticating',
+  SESSION_VERIFIED: 'session_verified',
+  WORKSPACE_READY: 'workspace_ready',
+  SUSPENDED: 'suspended',
+  DEGRADED: 'degraded',
+});
+
+export const AUTH_SESSION_TRANSITIONS = Object.freeze({
+  [AUTH_SESSION_STAGES.SIGNED_OUT]: Object.freeze([
+    AUTH_SESSION_STAGES.AUTHENTICATING,
+  ]),
+  [AUTH_SESSION_STAGES.AUTHENTICATING]: Object.freeze([
+    AUTH_SESSION_STAGES.SIGNED_OUT,
+    AUTH_SESSION_STAGES.SESSION_VERIFIED,
+    AUTH_SESSION_STAGES.SUSPENDED,
+    AUTH_SESSION_STAGES.DEGRADED,
+  ]),
+  [AUTH_SESSION_STAGES.SESSION_VERIFIED]: Object.freeze([
+    AUTH_SESSION_STAGES.WORKSPACE_READY,
+    AUTH_SESSION_STAGES.SIGNED_OUT,
+    AUTH_SESSION_STAGES.SUSPENDED,
+    AUTH_SESSION_STAGES.DEGRADED,
+  ]),
+  [AUTH_SESSION_STAGES.WORKSPACE_READY]: Object.freeze([
+    AUTH_SESSION_STAGES.SIGNED_OUT,
+    AUTH_SESSION_STAGES.SUSPENDED,
+    AUTH_SESSION_STAGES.DEGRADED,
+  ]),
+  [AUTH_SESSION_STAGES.SUSPENDED]: Object.freeze([
+    AUTH_SESSION_STAGES.SIGNED_OUT,
+  ]),
+  [AUTH_SESSION_STAGES.DEGRADED]: Object.freeze([
+    AUTH_SESSION_STAGES.SIGNED_OUT,
+    AUTH_SESSION_STAGES.AUTHENTICATING,
+  ]),
+});
+
+export function isAllowedAuthSessionTransition(from, to) {
+  if (from === to) return true;
+  return AUTH_SESSION_TRANSITIONS[from]?.includes(to) === true;
+}
+
+export function deriveAuthSessionState({
+  attempting = false,
+  sessionVerified = false,
+  workspaceReady = false,
+  suspended = false,
+  verificationFailed = false,
+} = {}) {
+  if (suspended) {
+    return {
+      stage: AUTH_SESSION_STAGES.SUSPENDED,
+      authenticated: true,
+      workspace_ready: false,
+      reason: 'ACCOUNT_SUSPENDED',
+    };
+  }
+
+  if (verificationFailed) {
+    return {
+      stage: AUTH_SESSION_STAGES.DEGRADED,
+      authenticated: false,
+      workspace_ready: false,
+      reason: 'SESSION_VERIFICATION_FAILED',
+    };
+  }
+
+  if (workspaceReady && !sessionVerified) {
+    return {
+      stage: AUTH_SESSION_STAGES.DEGRADED,
+      authenticated: false,
+      workspace_ready: false,
+      reason: 'WORKSPACE_WITHOUT_VERIFIED_SESSION',
+    };
+  }
+
+  if (workspaceReady && sessionVerified) {
+    return {
+      stage: AUTH_SESSION_STAGES.WORKSPACE_READY,
+      authenticated: true,
+      workspace_ready: true,
+      reason: null,
+    };
+  }
+
+  if (sessionVerified) {
+    return {
+      stage: AUTH_SESSION_STAGES.SESSION_VERIFIED,
+      authenticated: true,
+      workspace_ready: false,
+      reason: null,
+    };
+  }
+
+  if (attempting) {
+    return {
+      stage: AUTH_SESSION_STAGES.AUTHENTICATING,
+      authenticated: false,
+      workspace_ready: false,
+      reason: null,
+    };
+  }
+
+  return {
+    stage: AUTH_SESSION_STAGES.SIGNED_OUT,
+    authenticated: false,
+    workspace_ready: false,
+    reason: null,
+  };
+}

--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -1,5 +1,6 @@
 import { AUTH_SESSION_STAGES, AUTH_SESSION_TRANSITIONS } from './_dabbir-auth-session-state-machine.js';
 
+// BAR-30 exact-head preview marker: auth/session state machine v1.
 const authSessionMachine = JSON.stringify({
   stages: AUTH_SESSION_STAGES,
   transitions: AUTH_SESSION_TRANSITIONS,

--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -1,9 +1,39 @@
+import { AUTH_SESSION_STAGES, AUTH_SESSION_TRANSITIONS } from './_dabbir-auth-session-state-machine.js';
+
+const authSessionMachine = JSON.stringify({
+  stages: AUTH_SESSION_STAGES,
+  transitions: AUTH_SESSION_TRANSITIONS,
+});
+
 const script = String.raw`(()=>{
-  if(window.__dabbirAuthSessionStabilityV1) return;
-  window.__dabbirAuthSessionStabilityV1=true;
+  if(window.__dabbirAuthSessionStabilityV2) return;
+  window.__dabbirAuthSessionStabilityV2=true;
+
+  const authMachine=${authSessionMachine};
+  let authStage=authMachine.stages.SIGNED_OUT;
+
+  function publishAuthStage(stage,reason=null){
+    authStage=stage;
+    document.body.dataset.dabbirAuthStage=stage;
+    window.__dabbirAuthSessionState={stage,reason,updated_at:new Date().toISOString()};
+  }
+
+  function setAuthStage(next,reason=null,{bootstrap=false}={}){
+    if(next===authStage){
+      publishAuthStage(next,reason);
+      return true;
+    }
+    const allowed=authMachine.transitions[authStage]||[];
+    if(!bootstrap&&!allowed.includes(next)){
+      publishAuthStage(authMachine.stages.DEGRADED,'INVALID_AUTH_TRANSITION:'+authStage+'->'+next);
+      return false;
+    }
+    publishAuthStage(next,reason);
+    return true;
+  }
 
   const style=document.createElement('style');
-  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v1';
+  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v2';
   style.textContent=[
     '.bottomNav.hidden{display:none!important}',
     '#appShell.hidden{display:none!important}',
@@ -31,6 +61,30 @@ const script = String.raw`(()=>{
 
   const baseShowGate=showGate;
   showGate=function(name){
+    if(name==='auth'){
+      if(authStage!==authMachine.stages.SUSPENDED){
+        setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_GATE_VISIBLE');
+      }
+    }else if(name==='onboarding'){
+      if(authStage!==authMachine.stages.SESSION_VERIFIED){
+        publishAuthStage(authMachine.stages.DEGRADED,'ONBOARDING_WITHOUT_VERIFIED_SESSION');
+        baseShowGate('auth');
+        const msg=document.querySelector('#authMsg');
+        if(msg) msg.textContent=localized('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
+        return;
+      }
+    }else if(name==='app'){
+      if(authStage===authMachine.stages.SESSION_VERIFIED){
+        setAuthStage(authMachine.stages.WORKSPACE_READY,'WORKSPACE_RENDERED');
+      }else if(authStage!==authMachine.stages.WORKSPACE_READY){
+        publishAuthStage(authMachine.stages.DEGRADED,'WORKSPACE_WITHOUT_VERIFIED_SESSION');
+        baseShowGate('auth');
+        const msg=document.querySelector('#authMsg');
+        if(msg) msg.textContent=localized('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
+        return;
+      }
+    }
+
     baseShowGate(name);
     document.body.dataset.dabbirGate=String(name||'');
     const bottom=document.querySelector('#bottomNav');
@@ -51,6 +105,15 @@ const script = String.raw`(()=>{
       btn.disabled=true;
       if(msg) msg.textContent='';
 
+      if(authStage===authMachine.stages.SUSPENDED){
+        setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_RETRY');
+      }
+      if(!setAuthStage(authMachine.stages.AUTHENTICATING,authMode==='login'?'LOGIN_SUBMIT':'SIGNUP_SUBMIT')){
+        if(msg) msg.textContent=localized('تعذر بدء جلسة آمنة. أعد المحاولة.','A secure session could not be started. Please try again.');
+        btn.disabled=false;
+        return;
+      }
+
       try{
         const endpoint=authMode==='login'?'/api/auth/login':'/api/auth/signup';
         const {r,j}=await api(endpoint,{
@@ -63,28 +126,32 @@ const script = String.raw`(()=>{
         });
 
         if(authMode==='signup'&&j?.verification_required){
+          setAuthStage(authMachine.stages.SIGNED_OUT,'EMAIL_VERIFICATION_REQUIRED');
           if(msg) msg.textContent=T().verification;
           return;
         }
         if(!r.ok||!j?.ok){
+          setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_REJECTED');
           if(msg) msg.textContent=T().invalid;
           return;
         }
 
-        if(authMode==='login'){
-          const state=await sessionReady();
-          if(state.suspended){
-            if(msg) msg.textContent=localized('الحساب موقوف. تواصل مع دعم دبّر.','This account is suspended. Contact DABBIR support.');
-            return;
-          }
-          if(!state.ready){
-            if(msg) msg.textContent=localized('تم قبول بيانات الدخول لكن تعذر تثبيت الجلسة. حاول مرة أخرى.','Login was accepted but the session could not be established. Please try again.');
-            return;
-          }
+        const state=await sessionReady();
+        if(state.suspended){
+          setAuthStage(authMachine.stages.SUSPENDED,'ACCOUNT_SUSPENDED');
+          if(msg) msg.textContent=localized('الحساب موقوف. تواصل مع دعم دبّر.','This account is suspended. Contact DABBIR support.');
+          return;
+        }
+        if(!state.ready){
+          setAuthStage(authMachine.stages.DEGRADED,'SESSION_VERIFICATION_FAILED');
+          if(msg) msg.textContent=localized('تم قبول البيانات لكن تعذر تثبيت الجلسة. حاول مرة أخرى.','The credentials were accepted but the session could not be established. Please try again.');
+          return;
         }
 
+        setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED');
         await boot();
       }catch{
+        setAuthStage(authMachine.stages.DEGRADED,'AUTH_REQUEST_FAILED');
         if(msg) msg.textContent=localized('تعذر الاتصال. حاول مرة أخرى.','Connection failed. Please try again.');
       }finally{
         btn.disabled=false;
@@ -94,9 +161,17 @@ const script = String.raw`(()=>{
 
   const authVisible=document.querySelector('#authGate:not(.hidden)');
   const onboardingVisible=document.querySelector('#onboardingGate:not(.hidden)');
-  document.body.dataset.dabbirGate=authVisible?'auth':onboardingVisible?'onboarding':document.querySelector('#appShell:not(.hidden)')?'app':'';
+  const appVisible=document.querySelector('#appShell:not(.hidden)');
+  if(appVisible){
+    setAuthStage(authMachine.stages.WORKSPACE_READY,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+  }else if(onboardingVisible){
+    setAuthStage(authMachine.stages.SESSION_VERIFIED,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+  }else{
+    setAuthStage(authMachine.stages.SIGNED_OUT,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+  }
+  document.body.dataset.dabbirGate=authVisible?'auth':onboardingVisible?'onboarding':appVisible?'app':'';
 
-  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v1',session_retry:true,gate_isolation:true};
+  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v2',session_retry:true,gate_isolation:true,state_machine:true};
 })();`;
 
 export default function handler(req,res){

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,5 +1,5 @@
 {
-  "version": 2,
+  "version": 3,
   "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
   "authorities": {
     "root_shell": "api/app-recovery.js",
@@ -8,6 +8,7 @@
     "service_discovery_under_more": "api/dabbir-contextual-navigation-ui.js",
     "store_navigation_adaptation": "api/dabbir-contextual-navigation-ui.js",
     "auth_session_gate": "api/auth-session-stability-ui.js",
+    "auth_session_state_machine": "api/_dabbir-auth-session-state-machine.js",
     "business_activity_profile": "api/activity-profile-ui.js",
     "tenant_whatsapp_state": "api/dabbir-whatsapp-status.js",
     "verified_owner_metrics": "api/verified-metrics-ui.js",
@@ -45,7 +46,9 @@
     "blocked_or_skipped_qa_is_pass": false,
     "tenant_may_inherit_global_whatsapp_identity": false,
     "meta_authorized_equals_operational_whatsapp": false,
-    "unverified_metrics_may_fall_back_to_bounded_lists": false
+    "unverified_metrics_may_fall_back_to_bounded_lists": false,
+    "workspace_ready_requires_verified_session": true,
+    "invalid_auth_transition_may_open_workspace": false
   },
   "change_rule": "Any change to this contract must explain the root cause, the removed competing owner, and the regression proof. Raising a limit without removing complexity is not stabilization."
 }

--- a/test/dabbir-auth-session-state-machine.test.mjs
+++ b/test/dabbir-auth-session-state-machine.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import {
+  AUTH_SESSION_STAGES,
+  deriveAuthSessionState,
+  isAllowedAuthSessionTransition,
+} from '../api/_dabbir-auth-session-state-machine.js';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+const authUi = await read('api/auth-session-stability-ui.js');
+const architecture = JSON.parse(await read('config/dabbir-architecture-ownership.json'));
+
+test('auth session state machine exposes the explicit BAR-30 lifecycle', () => {
+  assert.deepEqual(AUTH_SESSION_STAGES, {
+    SIGNED_OUT: 'signed_out',
+    AUTHENTICATING: 'authenticating',
+    SESSION_VERIFIED: 'session_verified',
+    WORKSPACE_READY: 'workspace_ready',
+    SUSPENDED: 'suspended',
+    DEGRADED: 'degraded',
+  });
+  assert.equal(isAllowedAuthSessionTransition('signed_out', 'authenticating'), true);
+  assert.equal(isAllowedAuthSessionTransition('authenticating', 'session_verified'), true);
+  assert.equal(isAllowedAuthSessionTransition('session_verified', 'workspace_ready'), true);
+  assert.equal(isAllowedAuthSessionTransition('signed_out', 'workspace_ready'), false);
+});
+
+test('workspace readiness fails closed unless the session is verified', () => {
+  assert.equal(deriveAuthSessionState({}).stage, AUTH_SESSION_STAGES.SIGNED_OUT);
+  assert.equal(deriveAuthSessionState({ attempting: true }).stage, AUTH_SESSION_STAGES.AUTHENTICATING);
+  assert.equal(deriveAuthSessionState({ sessionVerified: true }).stage, AUTH_SESSION_STAGES.SESSION_VERIFIED);
+  assert.equal(
+    deriveAuthSessionState({ sessionVerified: true, workspaceReady: true }).stage,
+    AUTH_SESSION_STAGES.WORKSPACE_READY,
+  );
+  const invalid = deriveAuthSessionState({ workspaceReady: true });
+  assert.equal(invalid.stage, AUTH_SESSION_STAGES.DEGRADED);
+  assert.equal(invalid.reason, 'WORKSPACE_WITHOUT_VERIFIED_SESSION');
+});
+
+test('suspended and failed verification are explicit non-ready states', () => {
+  const suspended = deriveAuthSessionState({ suspended: true, sessionVerified: true });
+  assert.equal(suspended.stage, AUTH_SESSION_STAGES.SUSPENDED);
+  assert.equal(suspended.workspace_ready, false);
+
+  const degraded = deriveAuthSessionState({ verificationFailed: true });
+  assert.equal(degraded.stage, AUTH_SESSION_STAGES.DEGRADED);
+  assert.equal(degraded.authenticated, false);
+});
+
+test('auth UI publishes one machine stage and cannot open app from an unverified state', () => {
+  assert.match(authUi, /dataset\.dabbirAuthStage/);
+  assert.match(authUi, /INVALID_AUTH_TRANSITION/);
+  assert.match(authUi, /WORKSPACE_WITHOUT_VERIFIED_SESSION/);
+  assert.match(authUi, /state_machine:true/);
+  assert.match(authUi, /SESSION_COOKIE_VERIFIED/);
+
+  const verifiedIndex = authUi.indexOf("setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED')");
+  const bootIndex = authUi.indexOf('await boot()');
+  assert.ok(verifiedIndex >= 0 && bootIndex > verifiedIndex);
+});
+
+test('architecture contract names the auth machine and forbids workspace promotion without verified session', () => {
+  assert.equal(
+    architecture.authorities.auth_session_state_machine,
+    'api/_dabbir-auth-session-state-machine.js',
+  );
+  assert.equal(architecture.truth_rules.workspace_ready_requires_verified_session, true);
+  assert.equal(architecture.truth_rules.invalid_auth_transition_may_open_workspace, false);
+  assert.equal(architecture.shell.final_ui_authority, '/api/auth-session-stability-ui');
+});


### PR DESCRIPTION
Implements the next BAR-30 Phase 3 increment after PR #134.

## Root cause removed
Auth/session readiness was still inferred across login response, cookie propagation, runtime boot, and gate visibility. That allowed future UI changes to treat a successful credential response or visible app shell as equivalent to a verified session.

## Changes
- Add one explicit fail-closed auth/session state machine: `signed_out → authenticating → session_verified → workspace_ready`.
- Add explicit `suspended` and `degraded` outcomes.
- Require the HttpOnly session verification step before `boot()` can promote the workspace.
- Make `auth-session-stability-ui` publish the authoritative stage and reject invalid workspace promotion.
- Register the state-machine authority and invariants in the architecture contract.
- Add deterministic regression tests for legal transitions, fail-closed workspace readiness, suspension, and verification failure.

## Safety
No payment, Meta/WhatsApp authorization, database schema, customer data, or live external side effect is changed.

BAR-30 remains open after this PR; the Release state machine and final exact-Production bilingual iPhone/desktop journey gate are still required.