### PR TITLE
DABBIR: prevent production Vercel SSO resurrection

### DIFF
--- a/.github/workflows/dabbir-public-owner-link.yml
+++ b/.github/workflows/dabbir-public-owner-link.yml
@@ -3,12 +3,14 @@ name: DABBIR Public Owner Link
 on:
   push:
     branches: [main]
-    paths:
-      - '.github/workflows/dabbir-public-owner-link.yml'
   workflow_dispatch:
 
 permissions:
   contents: read
+
+concurrency:
+  group: dabbir-public-owner-link-production
+  cancel-in-progress: true
 
 jobs:
   expose-app-auth-gate:

--- a/test/dabbir-public-owner-link.test.mjs
+++ b/test/dabbir-public-owner-link.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const workflow = await readFile(new URL('../.github/workflows/dabbir-public-owner-link.yml', import.meta.url), 'utf8');
+
+test('public owner link guard runs on every main release, not only workflow-file edits', () => {
+  assert.match(workflow, /push:\s*\n\s*branches:\s*\[main\]/);
+  assert.doesNotMatch(workflow, /push:[\s\S]{0,160}?paths:/);
+});
+
+test('public owner link guard removes only Vercel SSO and preserves application auth checks', () => {
+  assert.match(workflow, /"ssoProtection":null/);
+  assert.match(workflow, /\.authenticated == false/);
+  assert.match(workflow, /\.error == "AUTH_REQUIRED"/);
+  assert.match(workflow, /dabbir-public-owner-link-production/);
+});


### PR DESCRIPTION
Closed after deeper release-contract verification during the zero-defect audit. The authoritative integration contract explicitly defines DABBIR as DEPLOYED_AUTH_PROTECTED_NO_PUBLIC_LAUNCH_DOMAIN / VERCEL_AUTH_PROTECTED / FAIL_CLOSED_PREVIEW_ONLY / project_live=false, and the production-origin gate treats that state as intentional BLOCKED_PRELAUNCH. Therefore making SSO removal run on every main push would violate the current release Source of Truth. No changes from this PR were merged.