### PR TITLE
DABBIR: revoke anonymous recovery helper execution

### DIFF
--- a/supabase/migrations/20260828043800_dabbir_recovery_anon_execute_hardening_v1.sql
+++ b/supabase/migrations/20260828043800_dabbir_recovery_anon_execute_hardening_v1.sql
@@ -1,0 +1,16 @@
+-- DABBIR least-privilege hardening.
+-- recovery_is_active() is required by authenticated DML trigger WHEN clauses,
+-- but anonymous clients have no DABBIR table DML grants and do not need direct
+-- EXECUTE on this private SECURITY DEFINER helper.
+revoke execute on function dabbir_private.recovery_is_active() from anon;
+
+do $$
+begin
+  if has_function_privilege('anon', 'dabbir_private.recovery_is_active()', 'EXECUTE') then
+    raise exception 'DABBIR_RECOVERY_ANON_EXECUTE_STILL_GRANTED';
+  end if;
+  if not has_function_privilege('authenticated', 'dabbir_private.recovery_is_active()', 'EXECUTE') then
+    raise exception 'DABBIR_RECOVERY_AUTHENTICATED_EXECUTE_REQUIRED';
+  end if;
+end
+$$;

--- a/test/dabbir-recovery-anon-execute.test.mjs
+++ b/test/dabbir-recovery-anon-execute.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const hardening = await readFile(new URL('supabase/migrations/20260828043800_dabbir_recovery_anon_execute_hardening_v1.sql', root), 'utf8');
+const source = await readFile(new URL('supabase/migrations/20260827134844_dabbir_customer_recovery_vault_trigger_hardening_v1.sql', root), 'utf8');
+
+test('private recovery context helper is no longer executable by anonymous clients', () => {
+  assert.match(hardening, /revoke execute on function dabbir_private\.recovery_is_active\(\) from anon/i);
+  assert.match(hardening, /has_function_privilege\('anon',[\s\S]*recovery_is_active\(\)[\s\S]*'EXECUTE'\)/i);
+});
+
+test('authenticated execution remains available because application DML trigger guards require it', () => {
+  assert.match(hardening, /has_function_privilege\('authenticated',[\s\S]*recovery_is_active\(\)[\s\S]*'EXECUTE'\)/i);
+  assert.match(source, /for each row when \(not dabbir_private\.recovery_is_active\(\)\)/i);
+});


### PR DESCRIPTION
Least-privilege hardening found during the zero-defect SECURITY DEFINER audit.

`dabbir_private.recovery_is_active()` is required by authenticated DML trigger WHEN clauses, so authenticated execution must remain. Anonymous clients have no DABBIR table DML grants and do not need direct EXECUTE on this private SECURITY DEFINER helper.

This migration revokes only `anon`, asserts that anonymous execution is gone, asserts authenticated execution remains, and adds a regression test. No production data mutation.