### PR TITLE
DABBIR: add static syntax and dependency CI gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           package-manager-cache: false
       - name: Install locked dependencies
         run: npm ci --no-audit --no-fund
+      - name: Check JavaScript syntax
+        run: npm run check:syntax
+      - name: Audit production dependencies
+        run: npm run audit:prod
       - name: Run DABBIR tests
         run: npm test
       - name: Reject committed secrets

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test test/*.test.mjs",
+    "check:syntax": "git ls-files '*.js' '*.mjs' | xargs -r -n1 node --check",
+    "audit:prod": "npm audit --omit=dev --audit-level=high",
     "vercel-build": "node scripts/vercel-build-gate.mjs"
   },
   "dependencies": {

--- a/test/ci-static-gates.test.mjs
+++ b/test/ci-static-gates.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const pkg = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const ci = await readFile(new URL('.github/workflows/ci.yml', root), 'utf8');
+
+test('CI exposes a repository-wide JavaScript syntax gate', () => {
+  assert.match(String(pkg.scripts?.['check:syntax'] || ''), /node --check/);
+  assert.match(String(pkg.scripts?.['check:syntax'] || ''), /git ls-files/);
+  assert.match(ci, /npm run check:syntax/);
+});
+
+test('CI audits production dependency vulnerabilities at high severity', () => {
+  assert.equal(pkg.scripts?.['audit:prod'], 'npm audit --omit=dev --audit-level=high');
+  assert.match(ci, /npm run audit:prod/);
+});
+
+test('static gates run before the main DABBIR test suite', () => {
+  const syntax = ci.indexOf('npm run check:syntax');
+  const audit = ci.indexOf('npm run audit:prod');
+  const tests = ci.indexOf('npm test');
+  assert.ok(syntax >= 0 && audit >= 0 && tests >= 0);
+  assert.ok(syntax < tests && audit < tests);
+});


### PR DESCRIPTION
Zero-defect audit hardening for a CI coverage gap. DABBIR CI previously ran tests and a committed-secret scan but had no independent repository-wide JavaScript syntax gate or production dependency vulnerability gate.

This adds:
- `npm run check:syntax` across tracked JS/MJS via `node --check`.
- `npm audit --omit=dev --audit-level=high` for production dependencies.
- CI ordering before the main test suite.
- Regression tests preventing either gate from silently disappearing.

No runtime behavior, database schema, secrets, or production data are changed.