### PR TITLE
DABBIR: complete live WhatsApp message path v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,10 @@ jobs:
           package-manager-cache: false
       - name: Install locked dependencies
         run: npm ci --no-audit --no-fund
+      - name: Check JavaScript syntax
+        run: npm run check:syntax
+      - name: Audit production dependencies
+        run: npm run audit:prod
       - name: Run DABBIR tests
         run: npm test
       - name: Reject committed secrets

--- a/api/_whatsapp-live-core.js
+++ b/api/_whatsapp-live-core.js
@@ -1,0 +1,238 @@
+import { openAccessToken, embeddedPlatformConfig } from './_whatsapp-embedded-core.js';
+import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
+
+const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
+
+function clean(value, max = 4000) {
+  return String(value || '').trim().slice(0, max);
+}
+
+function serviceKey() {
+  return clean(process.env.SUPABASE_SERVICE_ROLE_KEY, 4096);
+}
+
+export function whatsappLiveServerCapability() {
+  return {
+    service_data_access: Boolean(serviceKey()),
+    meta_app_secret: Boolean(clean(process.env.DABBIR_WHATSAPP_APP_SECRET || process.env.PILOT_WHATSAPP_APP_SECRET, 4096)),
+  };
+}
+
+async function readResponse(response, fallback) {
+  const text = await response.text();
+  let payload = null;
+  try { payload = text ? JSON.parse(text) : null; } catch { payload = null; }
+  if (!response.ok) {
+    const detail = clean(payload?.message || payload?.error_description || payload?.error || payload?.code || '', 300);
+    const error = new Error(detail || fallback);
+    error.status = Number(response.status || 500);
+    error.code = detail || fallback;
+    throw error;
+  }
+  return payload;
+}
+
+export async function serviceRpc(name, params = {}) {
+  const key = serviceKey();
+  if (!key) {
+    const error = new Error('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED');
+    error.status = 503;
+    error.code = 'WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED';
+    throw error;
+  }
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`, {
+    method: 'POST',
+    cache: 'no-store',
+    headers: {
+      apikey: key,
+      authorization: `Bearer ${key}`,
+      'content-type': 'application/json',
+      accept: 'application/json',
+    },
+    body: JSON.stringify(params),
+  });
+  return readResponse(response, 'WHATSAPP_SERVER_RPC_FAILED');
+}
+
+function oneRow(payload) {
+  return Array.isArray(payload) ? payload[0] || null : payload || null;
+}
+
+function occurredAt(timestamp) {
+  const seconds = Number(timestamp);
+  if (!Number.isFinite(seconds) || seconds <= 0) return new Date().toISOString();
+  const date = new Date(seconds * 1000);
+  return Number.isFinite(date.getTime()) ? date.toISOString() : new Date().toISOString();
+}
+
+export async function persistSignedInbound(event) {
+  if (!event?.messageId || !event?.phoneNumberId || !event?.from || !clean(event?.text)) {
+    const error = new Error('WHATSAPP_INBOUND_EVENT_INCOMPLETE');
+    error.status = 400;
+    throw error;
+  }
+  const row = oneRow(await serviceRpc('dabbir_whatsapp_persist_inbound', {
+    p_phone_number_id: clean(event.phoneNumberId, 160),
+    p_provider_message_id: clean(event.messageId, 320),
+    p_sender_handle: clean(event.from, 160),
+    p_display_name: clean(event.contactName, 120) || null,
+    p_body: clean(event.text, 4000),
+    p_intent: clean(event.classification, 120) || null,
+    p_occurred_at: occurredAt(event.timestamp),
+  }));
+  if (!row?.conversation_id || !row?.message_id) {
+    const error = new Error('WHATSAPP_INBOUND_PERSISTENCE_UNVERIFIED');
+    error.status = 502;
+    throw error;
+  }
+  return {
+    persisted: true,
+    duplicate: row.duplicate === true,
+    conversationId: row.conversation_id,
+    messageId: row.message_id,
+  };
+}
+
+export async function reserveOutboundReply({ businessId, conversationId, senderUserId, idempotencyKey, payloadHash, body }) {
+  const row = oneRow(await serviceRpc('dabbir_whatsapp_reserve_outbound', {
+    p_business_id: String(businessId),
+    p_conversation_id: String(conversationId),
+    p_sender_user_id: String(senderUserId),
+    p_idempotency_key: clean(idempotencyKey, 160),
+    p_payload_hash: clean(payloadHash, 64).toLowerCase(),
+    p_body: clean(body, 4000),
+  }));
+  if (!row?.reservation_id || !row?.connection_id || !row?.recipient_handle) {
+    const error = new Error('WHATSAPP_OUTBOUND_RESERVATION_UNVERIFIED');
+    error.status = 502;
+    throw error;
+  }
+  return {
+    reservationId: row.reservation_id,
+    shouldSend: row.should_send === true,
+    state: clean(row.reservation_state, 40),
+    connectionId: row.connection_id,
+    phoneNumberId: clean(row.phone_number_id, 160),
+    recipient: clean(row.recipient_handle, 160),
+    providerMessageId: clean(row.provider_message_id, 320) || null,
+    messageId: row.message_id || null,
+  };
+}
+
+export async function finalizeOutboundReply({ reservationId, providerMessageId }) {
+  const row = oneRow(await serviceRpc('dabbir_whatsapp_finalize_outbound', {
+    p_reservation_id: String(reservationId),
+    p_provider_message_id: clean(providerMessageId, 320),
+  }));
+  if (!row?.message_id || !row?.event_id) {
+    const error = new Error('WHATSAPP_OUTBOUND_FINALIZE_UNVERIFIED');
+    error.status = 502;
+    throw error;
+  }
+  return {
+    messageId: row.message_id,
+    eventId: row.event_id,
+    state: clean(row.reservation_state, 40),
+    duplicate: row.duplicate === true,
+  };
+}
+
+export async function markOutboundResult(reservationId, state, errorCode) {
+  return serviceRpc('dabbir_whatsapp_mark_outbound_result', {
+    p_reservation_id: String(reservationId),
+    p_state: clean(state, 20).toUpperCase(),
+    p_error_code: clean(errorCode, 160) || null,
+  }).catch(() => null);
+}
+
+export async function applySignedStatus(event) {
+  if (!event?.messageId || !event?.phoneNumberId || !event?.status) {
+    const error = new Error('WHATSAPP_STATUS_EVENT_INCOMPLETE');
+    error.status = 400;
+    throw error;
+  }
+  const row = oneRow(await serviceRpc('dabbir_whatsapp_apply_status', {
+    p_phone_number_id: clean(event.phoneNumberId, 160),
+    p_provider_message_id: clean(event.messageId, 320),
+    p_status: clean(event.status, 40).toLowerCase(),
+    p_occurred_at: occurredAt(event.timestamp),
+  }));
+  return {
+    matched: row?.matched === true,
+    providerVerified: row?.provider_verified === true,
+    state: clean(row?.reservation_state, 40) || null,
+  };
+}
+
+export async function sendMetaText({ connection, businessId, recipient, body }) {
+  const capability = whatsappLiveServerCapability();
+  if (!capability.service_data_access) {
+    const error = new Error('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED');
+    error.status = 503;
+    throw error;
+  }
+  const platform = applyDabbirMetaPublicIdentifiers(embeddedPlatformConfig());
+  if (!platform.appSecret || !platform.encryptionSecret) {
+    const error = new Error('WHATSAPP_PLATFORM_SECRET_NOT_CONFIGURED');
+    error.status = 503;
+    throw error;
+  }
+  const token = openAccessToken(connection, platform, businessId);
+  const phoneNumberId = clean(connection?.phone_number_id, 160);
+  if (!token || !phoneNumberId || !clean(recipient, 160) || !clean(body, 4000)) {
+    const error = new Error('WHATSAPP_OUTBOUND_CONTEXT_INCOMPLETE');
+    error.status = 409;
+    throw error;
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+  try {
+    const response = await fetch(`https://graph.facebook.com/${encodeURIComponent(platform.graphVersion)}/${encodeURIComponent(phoneNumberId)}/messages`, {
+      method: 'POST',
+      cache: 'no-store',
+      signal: controller.signal,
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body: JSON.stringify({
+        messaging_product: 'whatsapp',
+        recipient_type: 'individual',
+        to: clean(recipient, 160),
+        type: 'text',
+        text: { preview_url: false, body: clean(body, 4000) },
+      }),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      const error = new Error('META_WHATSAPP_SEND_FAILED');
+      error.status = response.status >= 500 ? 502 : 409;
+      error.providerStatus = response.status;
+      error.providerCode = payload?.error?.code || null;
+      error.ambiguous = response.status >= 500;
+      error.definitive = response.status >= 400 && response.status < 500;
+      throw error;
+    }
+    const providerMessageId = clean(payload?.messages?.[0]?.id, 320);
+    if (!providerMessageId) {
+      const error = new Error('META_WHATSAPP_SEND_ACCEPTED_WITHOUT_ID');
+      error.status = 502;
+      error.ambiguous = true;
+      throw error;
+    }
+    return { providerMessageId, providerStatus: response.status };
+  } catch (error) {
+    if (error?.name === 'AbortError') {
+      const timeoutError = new Error('META_WHATSAPP_SEND_TIMEOUT_AMBIGUOUS');
+      timeoutError.status = 502;
+      timeoutError.ambiguous = true;
+      throw timeoutError;
+    }
+    if (error instanceof TypeError && error?.ambiguous !== false) error.ambiguous = true;
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}

--- a/api/app.js
+++ b/api/app.js
@@ -96,6 +96,7 @@ const conversationPerformanceUi = String.raw`
 <script>
 (()=>{
   let dabbirSending=false;
+  const WA_KEY_RE=/^[A-Za-z0-9:_-]{16,160}$/;
 
   function renderFastMessages(){
     renderMessages();
@@ -110,21 +111,114 @@ const conversationPerformanceUi = String.raw`
     });
   }
 
+  function selectedConversation(){
+    return (workspace?.conversations||[]).find(c=>c.id===selectedConversationId)||null;
+  }
+
   function localConversationState(state){
-    const conversation=(workspace?.conversations||[]).find(c=>c.id===selectedConversationId);
+    const conversation=selectedConversation();
     if(conversation) conversation.state=state;
   }
 
-  async function fastSendMessage(){
-    const input=document.querySelector('#composer');
-    const btn=document.querySelector('#sendBtn');
-    const text=(input?.value||'').trim();
-    if(!input||!btn||!text||!selectedConversationId||dabbirSending) return;
+  function whatsappStorageKey(conversation){
+    return 'dabbir-wa-pending:'+String(workspace?.business?.id||'')+':'+String(conversation?.id||'');
+  }
 
-    dabbirSending=true;
-    btn.disabled=true;
-    input.value='';
+  async function whatsappPayloadHash(conversation,text){
+    const source=String(workspace.business.id)+'\u0000'+String(conversation.id)+'\u0000'+String(text);
+    if(!globalThis.crypto?.subtle) throw new Error('CRYPTO_UNAVAILABLE');
+    const digest=await crypto.subtle.digest('SHA-256',new TextEncoder().encode(source));
+    return [...new Uint8Array(digest)].map(byte=>byte.toString(16).padStart(2,'0')).join('');
+  }
 
+  function newWhatsAppIdempotencyKey(){
+    if(globalThis.crypto?.randomUUID) return 'wa_'+crypto.randomUUID();
+    const bytes=new Uint8Array(24);
+    if(!globalThis.crypto?.getRandomValues) throw new Error('CRYPTO_UNAVAILABLE');
+    crypto.getRandomValues(bytes);
+    return 'wa_'+[...bytes].map(byte=>byte.toString(16).padStart(2,'0')).join('');
+  }
+
+  function readPendingWhatsApp(conversation){
+    try{return JSON.parse(localStorage.getItem(whatsappStorageKey(conversation))||'null')}catch{return null}
+  }
+
+  function writePendingWhatsApp(conversation,pending){
+    try{localStorage.setItem(whatsappStorageKey(conversation),JSON.stringify(pending))}catch{}
+  }
+
+  function clearPendingWhatsApp(conversation){
+    try{localStorage.removeItem(whatsappStorageKey(conversation))}catch{}
+  }
+
+  async function whatsappOperation(conversation,text){
+    const payloadHash=await whatsappPayloadHash(conversation,text);
+    const pending=readPendingWhatsApp(conversation);
+    if(pending&&pending.payload_hash===payloadHash&&WA_KEY_RE.test(String(pending.idempotency_key||''))){
+      return {idempotency_key:pending.idempotency_key,payload_hash:payloadHash,reused:true};
+    }
+    const operation={idempotency_key:newWhatsAppIdempotencyKey(),payload_hash:payloadHash,reused:false};
+    writePendingWhatsApp(conversation,operation);
+    return operation;
+  }
+
+  async function sendApprovedWhatsAppReply({text,conversation}){
+    let operation;
+    try{operation=await whatsappOperation(conversation,text)}catch{
+      toast(lang==='ar'?'تعذر إنشاء معرف إرسال آمن؛ لم يتم الإرسال':'Could not create a safe send identifier; nothing was sent');
+      return;
+    }
+
+    try{
+      const {r,j={}}=await api('/api/dabbir-whatsapp-reply',{
+        method:'POST',
+        body:JSON.stringify({
+          business_id:workspace.business.id,
+          conversation_id:conversation.id,
+          message:text,
+          idempotency_key:operation.idempotency_key
+        })
+      });
+      workspace.last_action_truth=j.truth||{state:'UNVERIFIED'};
+
+      if(!r.ok||!j.ok){
+        localConversationState('action_required');
+        const needsReconciliation=j.automatic_resend_blocked===true&&(j.state==='AMBIGUOUS'||j.state==='SENDING'||j.state==='AMBIGUOUS_NO_AUTOMATIC_RESEND'||j.external_side_effects_possible===true);
+        if(j.retry_requires_new_operation===true||(!needsReconciliation&&j.state==='FAILED')) clearPendingWhatsApp(conversation);
+        if(needsReconciliation){
+          toast(lang==='ar'?'حالة الإرسال تحتاج تحقق؛ دبّر لن يعيد الإرسال تلقائيًا':'Send status needs verification; DABBIR will not resend automatically');
+        }else{
+          toast(lang==='ar'?'لم يتم تأكيد إرسال رد واتساب':'WhatsApp reply was not confirmed');
+        }
+        if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
+        return;
+      }
+
+      clearPendingWhatsApp(conversation);
+      if(j.message){
+        workspace.messages=(workspace.messages||[]).filter(m=>m.id!==j.message.id);
+        workspace.messages.push(j.message);
+      }
+      localConversationState('waiting_customer');
+      workspace.messages_loaded=true;
+      translations.clear();
+      translationMode=false;
+      renderMessages();
+      if(current==='dashboard') renderDashboard();
+      if(current==='analytics') renderAnalytics();
+      if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
+      toast(j.provider_status_verified===true
+        ? (lang==='ar'?'تم التحقق من تسليم رد واتساب':'WhatsApp reply delivery verified')
+        : (lang==='ar'?'قبلت Meta الرد؛ بانتظار تأكيد التسليم':'Meta accepted the reply; awaiting delivery confirmation'));
+    }catch{
+      workspace.last_action_truth={state:'UNVERIFIED'};
+      localConversationState('action_required');
+      if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
+      toast(lang==='ar'?'الاتصال انقطع؛ لن يعيد دبّر الإرسال تلقائيًا حتى نتحقق':'Connection dropped; DABBIR will not resend until the attempt is verified');
+    }
+  }
+
+  async function sendWebConversation({text}){
     const stamp=Date.now();
     const tempId='dabbir-local-'+stamp;
     const typingId='dabbir-typing-'+stamp;
@@ -172,6 +266,26 @@ const conversationPerformanceUi = String.raw`
       renderMessages();
       if(typeof window.__dabbirRenderTruth==='function') window.__dabbirRenderTruth();
       toast(lang==='ar'?'تعذر الاتصال؛ حاول مرة أخرى':'Connection failed; try again');
+    }
+  }
+
+  async function fastSendMessage(){
+    const input=document.querySelector('#composer');
+    const btn=document.querySelector('#sendBtn');
+    const text=(input?.value||'').trim();
+    const conversation=selectedConversation();
+    if(!input||!btn||!text||!selectedConversationId||!conversation||dabbirSending) return;
+
+    dabbirSending=true;
+    btn.disabled=true;
+    input.value='';
+
+    try{
+      if(String(conversation.channel_type||'').toLowerCase()==='whatsapp'){
+        await sendApprovedWhatsAppReply({text,conversation});
+      }else{
+        await sendWebConversation({text});
+      }
     }finally{
       dabbirSending=false;
       btn.disabled=false;
@@ -253,7 +367,7 @@ export default function handler(req, res) {
   res.setHeader('content-type', 'text/html; charset=utf-8');
   res.setHeader('cache-control', 'no-store');
   res.setHeader('x-dabbir-interface', 'operational-runtime-v2-truth');
-  res.setHeader('x-dabbir-chat-path', 'chat-send-truth-v4');
+  res.setHeader('x-dabbir-chat-path', 'chat-send-truth-v4-whatsapp-reserve-v2');
   res.setHeader('x-dabbir-performance', 'interface-fast-v4-truth');
   return res.status(200).send(html);
 }

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -1,0 +1,190 @@
+import crypto from 'node:crypto';
+import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
+import { loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+import {
+  finalizeOutboundReply,
+  markOutboundResult,
+  reserveOutboundReply,
+  sendMetaText,
+} from './_whatsapp-live-core.js';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const IDEMPOTENCY_RE = /^[A-Za-z0-9:_-]{16,160}$/;
+const safeId = value => UUID_RE.test(String(value || '').trim()) ? String(value).trim() : null;
+const cleanText = (value, max = 4000) => String(value || '').trim().slice(0, max);
+
+function payloadHash(businessId, conversationId, message) {
+  return crypto.createHash('sha256')
+    .update(String(businessId)).update('\0')
+    .update(String(conversationId)).update('\0')
+    .update(String(message))
+    .digest('hex');
+}
+
+async function readRows(response, fallback) {
+  const payload = await response.json().catch(() => []);
+  if (!response.ok) throw Object.assign(new Error(fallback), { status: response.status });
+  return Array.isArray(payload) ? payload : [];
+}
+
+async function readPersistedMessage(token, businessId, messageId) {
+  if (!messageId) return null;
+  const rows = await readRows(await supabaseRest(
+    `dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at,sender_user_id&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(messageId)}&limit=1`,
+    token,
+  ), 'WHATSAPP_REPLY_READBACK_FAILED');
+  const message = rows[0] || null;
+  return message?.id && message.sender_type === 'human' && message.simulated === false ? message : null;
+}
+
+function replayResponse(res, reservation, message) {
+  const externallyVerified = ['DELIVERED', 'READ'].includes(reservation.state);
+  return json(res, 200, {
+    ok: true,
+    state: reservation.state,
+    channel: 'whatsapp',
+    replayed: true,
+    provider_accepted: true,
+    provider_status_verified: externallyVerified,
+    message,
+    truth: {
+      state: externallyVerified ? 'VERIFIED_EXTERNAL_DELIVERY' : 'VERIFIED_PERSISTED_PROVIDER_ACCEPTED',
+      source: 'DABBIR_OUTBOUND_RESERVATION',
+      verified_at: new Date().toISOString(),
+    },
+    external_side_effects: false,
+    secrets_exposed: false,
+  });
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
+  if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
+
+  let reservation = null;
+  let providerAccepted = false;
+  try {
+    const body = await readJsonBody(req, 16 * 1024);
+    const businessId = safeId(body?.business_id);
+    const conversationId = safeId(body?.conversation_id);
+    const message = cleanText(body?.message, 4000);
+    const idempotencyKey = cleanText(body?.idempotency_key, 160);
+    if (!businessId || !conversationId || !message || !IDEMPOTENCY_RE.test(idempotencyKey)) {
+      return json(res, 400, { ok: false, error: 'WHATSAPP_REPLY_INPUT_REQUIRED' });
+    }
+
+    const owner = await ownerContext(req, businessId);
+    const connection = await loadBusinessConnection(owner.accessToken, businessId);
+    if (!connection || connection.status !== 'connected') return json(res, 409, { ok: false, error: 'WHATSAPP_TENANT_NOT_LINKED' });
+
+    reservation = await reserveOutboundReply({
+      businessId,
+      conversationId,
+      senderUserId: owner.user.id,
+      idempotencyKey,
+      payloadHash: payloadHash(businessId, conversationId, message),
+      body: message,
+    });
+
+    if (!reservation.shouldSend) {
+      if (['PROVIDER_ACCEPTED', 'SENT', 'DELIVERED', 'READ'].includes(reservation.state) && reservation.messageId) {
+        const persisted = await readPersistedMessage(owner.accessToken, businessId, reservation.messageId);
+        if (!persisted) return json(res, 502, { ok: false, state: 'LOCAL_READBACK_UNVERIFIED', error: 'WHATSAPP_REPLY_READBACK_UNVERIFIED' });
+        return replayResponse(res, reservation, persisted);
+      }
+      if (['SENDING', 'AMBIGUOUS'].includes(reservation.state)) {
+        return json(res, 409, {
+          ok: false,
+          state: reservation.state,
+          error: 'WHATSAPP_REPLY_REQUIRES_RECONCILIATION',
+          retry_safe_with_same_key: true,
+          automatic_resend_blocked: true,
+          external_side_effects_possible: true,
+        });
+      }
+      return json(res, 409, {
+        ok: false,
+        state: reservation.state || 'FAILED',
+        error: 'WHATSAPP_REPLY_PREVIOUS_ATTEMPT_FAILED',
+        retry_requires_new_operation: true,
+        automatic_resend_blocked: true,
+      });
+    }
+
+    if (String(connection.id) !== String(reservation.connectionId)
+      || String(connection.phone_number_id) !== String(reservation.phoneNumberId)) {
+      await markOutboundResult(reservation.reservationId, 'FAILED', 'WHATSAPP_CONNECTION_CHANGED_AFTER_RESERVATION');
+      return json(res, 409, { ok: false, state: 'FAILED', error: 'WHATSAPP_CONNECTION_CHANGED_AFTER_RESERVATION' });
+    }
+
+    let sent;
+    try {
+      sent = await sendMetaText({ connection, businessId, recipient: reservation.recipient, body: message });
+      providerAccepted = true;
+    } catch (error) {
+      await markOutboundResult(
+        reservation.reservationId,
+        error?.ambiguous === true ? 'AMBIGUOUS' : 'FAILED',
+        cleanText(error?.message || 'META_WHATSAPP_SEND_FAILED', 160),
+      );
+      throw error;
+    }
+
+    let finalized;
+    try {
+      finalized = await finalizeOutboundReply({
+        reservationId: reservation.reservationId,
+        providerMessageId: sent.providerMessageId,
+      });
+    } catch (error) {
+      await markOutboundResult(reservation.reservationId, 'AMBIGUOUS', 'LOCAL_FINALIZE_FAILED_AFTER_PROVIDER_ACCEPT');
+      error.providerAccepted = true;
+      error.ambiguous = true;
+      throw error;
+    }
+
+    const persisted = await readPersistedMessage(owner.accessToken, businessId, finalized.messageId);
+    if (!persisted) {
+      return json(res, 502, {
+        ok: false,
+        state: 'PROVIDER_ACCEPTED_LOCAL_READBACK_UNVERIFIED',
+        error: 'WHATSAPP_REPLY_READBACK_UNVERIFIED',
+        provider_accepted: true,
+        automatic_resend_blocked: true,
+        external_side_effects: true,
+      });
+    }
+
+    return json(res, 200, {
+      ok: true,
+      state: 'PROVIDER_ACCEPTED',
+      channel: 'whatsapp',
+      replayed: false,
+      provider_accepted: true,
+      provider_status_verified: false,
+      message: persisted,
+      truth: {
+        state: 'VERIFIED_PERSISTED_PROVIDER_ACCEPTED',
+        source: 'RESERVATION_META_SEND_FINALIZE_READBACK',
+        verified_at: new Date().toISOString(),
+      },
+      automatic_resend_blocked: true,
+      external_side_effects: true,
+      secrets_exposed: false,
+    });
+  } catch (error) {
+    const status = Number(error?.status || 500);
+    const safeStatus = [400, 401, 403, 404, 409, 413, 429, 502, 503].includes(status) ? status : 500;
+    const ambiguous = error?.ambiguous === true || error?.providerAccepted === true || (providerAccepted && reservation?.reservationId);
+    return json(res, safeStatus, {
+      ok: false,
+      state: ambiguous ? 'AMBIGUOUS_NO_AUTOMATIC_RESEND' : 'FAILED',
+      error: cleanText(error?.message || 'WHATSAPP_REPLY_FAILED', 160),
+      provider_status: error?.providerStatus || null,
+      provider_code: error?.providerCode || null,
+      automatic_resend_blocked: Boolean(reservation?.reservationId),
+      external_side_effects_possible: ambiguous,
+      truth: { state: 'UNVERIFIED' },
+    });
+  }
+}

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,7 +1,7 @@
 import { singleQueryValue } from './_request-query.js';
-import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRpc } from './_auth-core.js';
+import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json } from './_auth-core.js';
 import { deriveWhatsAppOperationalState } from './_dabbir-whatsapp-state-machine.js';
-import { whatsappLiveServerCapability } from './_whatsapp-live-core.js';
+import { serviceRpc, whatsappLiveServerCapability } from './_whatsapp-live-core.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
@@ -55,17 +55,10 @@ function emptyOperationalEvidence(available = true) {
   };
 }
 
-async function rowsOrNull(response) {
-  if (!response?.ok) return null;
-  const rows = await response.json().catch(() => null);
-  return Array.isArray(rows) ? rows : null;
-}
-
-export async function loadOperationalEvidence(accessToken, businessId) {
+export async function loadOperationalEvidence(businessId) {
   try {
-    const response = await supabaseRpc('dabbir_whatsapp_operational_evidence', accessToken, { p_business_id: businessId });
-    const rows = await rowsOrNull(response);
-    const row = rows?.[0];
+    const rows = await serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: businessId });
+    const row = Array.isArray(rows) ? rows[0] : rows;
     if (!row) return emptyOperationalEvidence(false);
     return {
       available: row.available === true,
@@ -141,7 +134,7 @@ async function embeddedStatus(req, accessToken, businessId) {
   try {
     const [verified, evidence] = await Promise.all([
       verifyStoredConnection(platform, row),
-      loadOperationalEvidence(accessToken, businessId),
+      loadOperationalEvidence(businessId),
     ]);
     const machine = deriveWhatsAppOperationalState({
       hasConnection: true,

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,6 +1,7 @@
 import { singleQueryValue } from './_request-query.js';
-import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRest } from './_auth-core.js';
+import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRpc } from './_auth-core.js';
 import { deriveWhatsAppOperationalState } from './_dabbir-whatsapp-state-machine.js';
+import { whatsappLiveServerCapability } from './_whatsapp-live-core.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
@@ -44,23 +45,6 @@ export function getWhatsAppConfig() {
   return { verifyToken, appSecret, accessToken, phoneNumberId, wabaId, graphVersion, webhookConfigured, outboundConfigured, configured };
 }
 
-function publicConfig(config) {
-  let state = 'NOT_CONFIGURED';
-  if (config.webhookConfigured && config.outboundConfigured) state = 'CONFIGURED_READY_FOR_VERIFICATION';
-  else if (config.webhookConfigured) state = 'WEBHOOK_LINKED';
-  else if (config.outboundConfigured) state = 'OUTBOUND_CONFIGURED';
-  else if (config.configured) state = 'PARTIALLY_CONFIGURED';
-  return {
-    configured: config.configured,
-    connected: config.webhookConfigured || config.outboundConfigured,
-    webhook_configured: config.webhookConfigured,
-    outbound_configured: config.outboundConfigured,
-    phone_number_configured: Boolean(config.phoneNumberId),
-    waba_configured: Boolean(config.wabaId),
-    state,
-  };
-}
-
 function emptyOperationalEvidence(available = true) {
   return {
     available,
@@ -79,40 +63,16 @@ async function rowsOrNull(response) {
 
 export async function loadOperationalEvidence(accessToken, businessId) {
   try {
-    const encodedBusinessId = encodeURIComponent(String(businessId));
-    const conversationResponse = await supabaseRest(
-      `dabbir_conversations?select=id&business_id=eq.${encodedBusinessId}&channel_type=eq.whatsapp&demo_mode=eq.false&order=created_at.desc&limit=100`,
-      accessToken,
-    );
-    const conversations = await rowsOrNull(conversationResponse);
-    if (conversations === null) return emptyOperationalEvidence(false);
-    const conversationIds = conversations.map(row => String(row?.id || '')).filter(Boolean);
-    if (!conversationIds.length) return emptyOperationalEvidence(true);
-
-    const conversationFilter = `in.(${conversationIds.join(',')})`;
-    const [messageResponse, outcomeResponse] = await Promise.all([
-      supabaseRest(
-        `dabbir_messages?select=sender_type,simulated&business_id=eq.${encodedBusinessId}&conversation_id=${conversationFilter}&simulated=eq.false&limit=200`,
-        accessToken,
-      ),
-      supabaseRest(
-        `dabbir_conversation_outcomes?select=verified_external_result&business_id=eq.${encodedBusinessId}&conversation_id=${conversationFilter}&verified_external_result=eq.true&limit=1`,
-        accessToken,
-      ),
-    ]);
-    const messages = await rowsOrNull(messageResponse);
-    const outcomes = await rowsOrNull(outcomeResponse);
-    if (messages === null || outcomes === null) return emptyOperationalEvidence(false);
-
-    const inbound = messages.some(row => row?.simulated === false && String(row?.sender_type || '') === 'customer');
-    const outbound = messages.some(row => row?.simulated === false && ['ai', 'human'].includes(String(row?.sender_type || '')));
-    const verifiedExternal = outcomes.some(row => row?.verified_external_result === true);
+    const response = await supabaseRpc('dabbir_whatsapp_operational_evidence', accessToken, { p_business_id: businessId });
+    const rows = await rowsOrNull(response);
+    const row = rows?.[0];
+    if (!row) return emptyOperationalEvidence(false);
     return {
-      available: true,
-      real_whatsapp_conversation: true,
-      real_inbound_message: inbound,
-      real_outbound_reply: outbound,
-      verified_external_result: verifiedExternal,
+      available: row.available === true,
+      real_whatsapp_conversation: row.real_whatsapp_conversation === true,
+      real_inbound_message: row.real_inbound_message === true,
+      real_outbound_reply: row.real_outbound_reply === true,
+      verified_external_result: row.verified_external_result === true,
     };
   } catch {
     return emptyOperationalEvidence(false);
@@ -131,6 +91,7 @@ export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') 
     outbound_configured: false,
     phone_number_configured: false,
     waba_configured: false,
+    server_runtime_configured: whatsappLiveServerCapability().service_data_access,
     state: machine.state,
     operational_stage: machine.stage,
     meta_authorized: false,
@@ -197,6 +158,7 @@ async function embeddedStatus(req, accessToken, businessId) {
       outbound_configured: Boolean(verified.authorized),
       phone_number_configured: true,
       waba_configured: true,
+      server_runtime_configured: whatsappLiveServerCapability().service_data_access,
       state: machine.state,
       operational_stage: machine.stage,
       meta_authorized: Boolean(verified.authorized),
@@ -233,6 +195,7 @@ async function embeddedStatus(req, accessToken, businessId) {
       outbound_configured: false,
       phone_number_configured: true,
       waba_configured: true,
+      server_runtime_configured: whatsappLiveServerCapability().service_data_access,
       state: machine.state,
       operational_stage: machine.stage,
       meta_authorized: false,
@@ -271,12 +234,6 @@ export default async function handler(req, res) {
     }
   }
 
-  // The authenticated DABBIR UI must never inherit a global/server WhatsApp
-  // identity. When the caller omitted business_id, resolve the tenant only if
-  // there is exactly one active membership; otherwise fail closed with a
-  // tenant-unconfigured payload. This keeps old platform credentials usable for
-  // webhook infrastructure without ever presenting that legacy number as the
-  // current customer's WhatsApp number.
   try {
     const memberships = await getBusinessMemberships(accessToken);
     const businessIds = [...new Set((Array.isArray(memberships) ? memberships : [])

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -234,6 +234,9 @@ export default async function handler(req, res) {
     }
   }
 
+  // The authenticated DABBIR UI must never inherit a global/server WhatsApp
+  // identity. Platform-level credentials remain webhook/runtime infrastructure
+  // only; tenant display state always resolves from the tenant connection row.
   try {
     const memberships = await getBusinessMemberships(accessToken);
     const businessIds = [...new Set((Array.isArray(memberships) ? memberships : [])

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -1,7 +1,7 @@
 import { singleQueryValue } from './_request-query.js';
-import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json } from './_auth-core.js';
+import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json, supabaseRpc } from './_auth-core.js';
 import { deriveWhatsAppOperationalState } from './_dabbir-whatsapp-state-machine.js';
-import { serviceRpc, whatsappLiveServerCapability } from './_whatsapp-live-core.js';
+import { whatsappLiveServerCapability } from './_whatsapp-live-core.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
@@ -55,10 +55,17 @@ function emptyOperationalEvidence(available = true) {
   };
 }
 
-export async function loadOperationalEvidence(businessId) {
+async function rowsOrNull(response) {
+  if (!response?.ok) return null;
+  const rows = await response.json().catch(() => null);
+  return Array.isArray(rows) ? rows : null;
+}
+
+export async function loadOperationalEvidence(accessToken, businessId) {
   try {
-    const rows = await serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: businessId });
-    const row = Array.isArray(rows) ? rows[0] : rows;
+    const response = await supabaseRpc('dabbir_whatsapp_operational_evidence', accessToken, { p_business_id: businessId });
+    const rows = await rowsOrNull(response);
+    const row = rows?.[0];
     if (!row) return emptyOperationalEvidence(false);
     return {
       available: row.available === true,
@@ -134,7 +141,7 @@ async function embeddedStatus(req, accessToken, businessId) {
   try {
     const [verified, evidence] = await Promise.all([
       verifyStoredConnection(platform, row),
-      loadOperationalEvidence(businessId),
+      loadOperationalEvidence(accessToken, businessId),
     ]);
     const machine = deriveWhatsAppOperationalState({
       hasConnection: true,

--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -2,6 +2,7 @@ import { singleQueryValue } from './_request-query.js';
 import crypto from 'node:crypto';
 import { classifyClinicMessage, classifyCelebrityMessage } from './dabbir-runtime.js';
 import { attachCorrelation, correlationId, logEvent } from './_observability.js';
+import { applySignedStatus, persistSignedInbound } from './_whatsapp-live-core.js';
 
 export const config = {
   api: {
@@ -88,12 +89,32 @@ export function extractWhatsAppEvents(payload = {}) {
       const value = change.value || {};
       const phoneNumberId = value.metadata?.phone_number_id || null;
       const displayPhoneNumber = value.metadata?.display_phone_number || null;
+      const contactNames = new Map((Array.isArray(value.contacts) ? value.contacts : [])
+        .map(contact => [String(contact?.wa_id || ''), String(contact?.profile?.name || '').slice(0, 120)]));
       for (const message of value.messages || []) {
         const text = message.text?.body || message.button?.text || message.interactive?.button_reply?.title || message.interactive?.list_reply?.title || '';
-        events.push({ type: 'message', messageId: message.id || null, from: message.from || null, timestamp: message.timestamp || null, messageType: message.type || null, text: String(text || '').slice(0, 4000), phoneNumberId, displayPhoneNumber });
+        events.push({
+          type: 'message',
+          messageId: message.id || null,
+          from: message.from || null,
+          contactName: contactNames.get(String(message.from || '')) || null,
+          timestamp: message.timestamp || null,
+          messageType: message.type || null,
+          text: String(text || '').slice(0, 4000),
+          phoneNumberId,
+          displayPhoneNumber,
+        });
       }
       for (const status of value.statuses || []) {
-        events.push({ type: 'status', messageId: status.id || null, recipientId: status.recipient_id || null, status: status.status || null, timestamp: status.timestamp || null, phoneNumberId, displayPhoneNumber });
+        events.push({
+          type: 'status',
+          messageId: status.id || null,
+          recipientId: status.recipient_id || null,
+          status: status.status || null,
+          timestamp: status.timestamp || null,
+          phoneNumberId,
+          displayPhoneNumber,
+        });
       }
     }
   }
@@ -113,11 +134,13 @@ export function classifyDABBIREvent(event, project = 'generic') {
   return { classification: 'GENERAL_INQUIRY', workflow: ['CLASSIFY', 'CUSTOMER', 'CONVERSATION', 'TASK'] };
 }
 
+function unlinkedTenant(error) {
+  return String(error?.code || error?.message || '').includes('WHATSAPP_TENANT_CONNECTION_NOT_FOUND');
+}
+
 export default async function handler(req, res) {
   const cid = correlationId(req);
   attachCorrelation(res, cid);
-  // Keep the credentials the owner already provisioned under PILOT working after the DABBIR rename.
-  // DABBIR-prefixed values win when both generations are present.
   const verifyToken = firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN');
   const appSecret = firstEnv('DABBIR_WHATSAPP_APP_SECRET', 'PILOT_WHATSAPP_APP_SECRET');
   const project = normalizeProject(firstEnv('DABBIR_PROJECT', 'PILOT_PROJECT') || 'generic');
@@ -155,19 +178,77 @@ export default async function handler(req, res) {
   const messageCount = routed.filter(e => e.type === 'message').length;
   const statusCount = routed.filter(e => e.type === 'status').length;
   const classifications = [...new Set(routed.map(e => e.classification).filter(Boolean))].slice(0, 20);
+  let persistedMessages = 0;
+  let duplicateMessages = 0;
+  let matchedStatuses = 0;
+  let providerVerifiedStatuses = 0;
+  let unlinkedMessages = 0;
 
-  // Never log or echo message text, sender/recipient IDs, phone numbers, message IDs, or raw payloads.
+  try {
+    for (const event of routed) {
+      if (event.type === 'message') {
+        try {
+          const result = await persistSignedInbound(event);
+          if (result.persisted) persistedMessages += 1;
+          if (result.duplicate) duplicateMessages += 1;
+        } catch (error) {
+          if (unlinkedTenant(error)) {
+            unlinkedMessages += 1;
+            continue;
+          }
+          throw error;
+        }
+      } else if (event.type === 'status') {
+        const result = await applySignedStatus(event);
+        if (result.matched) matchedStatuses += 1;
+        if (result.providerVerified) providerVerifiedStatuses += 1;
+      }
+    }
+  } catch (error) {
+    const missingService = String(error?.code || error?.message || '').includes('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED');
+    const status = missingService ? 503 : Number(error?.status || 502);
+    logEvent('error', {
+      correlation_id: cid,
+      component: 'whatsapp_webhook',
+      operation: 'signed_event_persistence',
+      outcome: 'FAILED',
+      failure_class: missingService ? 'CONFIGURATION' : 'DATABASE',
+      event_count: routed.length,
+      message_count: messageCount,
+      status_count: statusCount,
+    });
+    return json(res, status, {
+      ok: false,
+      service: 'dabbir-whatsapp-webhook',
+      state: missingService ? 'SERVER_PERSISTENCE_NOT_CONFIGURED' : 'SIGNED_EVENT_PERSISTENCE_FAILED',
+      signature_verified: true,
+      persisted: false,
+      outbound_messages_sent: false,
+      retryable: true,
+      correlation_id: cid,
+    }, cid);
+  }
+
+  const persistenceVerified = messageCount === 0 || persistedMessages === messageCount - unlinkedMessages;
+  const state = unlinkedMessages > 0 && persistedMessages === 0
+    ? 'TENANT_NOT_LINKED'
+    : (persistedMessages > 0 || matchedStatuses > 0 ? 'LIVE_EVENT_PERSISTED' : 'SIGNED_EVENT_NO_ACTION');
+
   logEvent('info', {
     correlation_id: cid,
     component: 'whatsapp_webhook',
-    operation: 'signed_inbound_normalization',
-    outcome: 'PARTIAL',
+    operation: 'signed_event_persistence',
+    outcome: persistenceVerified ? 'VERIFIED_SUCCESS' : 'PARTIAL',
     project,
     event_count: routed.length,
     message_count: messageCount,
     status_count: statusCount,
     classifications,
-    persisted: false,
+    persisted_messages: persistedMessages,
+    duplicate_messages: duplicateMessages,
+    matched_statuses: matchedStatuses,
+    provider_verified_statuses: providerVerifiedStatuses,
+    unlinked_messages: unlinkedMessages,
     outbound_messages_sent: false,
   });
 
@@ -175,13 +256,18 @@ export default async function handler(req, res) {
     ok: true,
     service: 'dabbir-whatsapp-webhook',
     project,
-    state: 'CONFIGURED_NOT_OPERATIONAL',
+    state,
     signature_verified: true,
     event_count: routed.length,
     message_count: messageCount,
     status_count: statusCount,
     classifications,
-    persisted: false,
+    persisted: persistedMessages > 0,
+    persistence_verified: persistenceVerified,
+    duplicate_messages: duplicateMessages,
+    matched_statuses: matchedStatuses,
+    provider_verified_statuses: providerVerifiedStatuses,
+    tenant_unlinked_events: unlinkedMessages,
     outbound_messages_sent: false,
     external_side_effects: false,
     correlation_id: cid,

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "type": "module",
   "scripts": {
     "test": "node --test test/*.test.mjs",
+    "check:syntax": "git ls-files '*.js' '*.mjs' | xargs -r -n1 node --check",
+    "audit:prod": "npm audit --omit=dev --audit-level=high",
     "vercel-build": "node scripts/vercel-build-gate.mjs"
   },
   "dependencies": {

--- a/supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql
+++ b/supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql
@@ -1,0 +1,492 @@
+-- BAR-13 v2: real WhatsApp inbound persistence + reserve/send/finalize outbound semantics.
+-- This migration is intentionally later than the 04:29 active-membership root fix
+-- and 04:37 recovery hardening migrations. No raw webhook payload or access token
+-- is stored in the evidence tables.
+
+create unique index if not exists dabbir_customers_business_channel_handle_uq
+  on public.dabbir_customers(business_id, channel_handle)
+  where channel_handle is not null;
+
+create unique index if not exists dabbir_messages_business_id_id_uq
+  on public.dabbir_messages(business_id, id);
+
+create table if not exists public.dabbir_whatsapp_event_ledger (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  connection_id uuid not null references public.dabbir_whatsapp_connections(id) on delete cascade,
+  event_key text not null,
+  direction text not null check (direction in ('inbound','outbound','status')),
+  event_type text not null check (event_type in ('message','status')),
+  provider_message_id text,
+  conversation_id uuid,
+  message_id uuid,
+  provider_status text,
+  provider_verified boolean not null default false,
+  occurred_at timestamptz not null default now(),
+  verified_at timestamptz,
+  evidence jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint dabbir_whatsapp_event_key_nonempty check (length(trim(event_key)) between 3 and 320),
+  constraint dabbir_whatsapp_provider_message_id_bounded check (provider_message_id is null or length(provider_message_id) between 3 and 320),
+  constraint dabbir_whatsapp_event_business_key_uq unique (business_id, event_key),
+  constraint dabbir_whatsapp_event_business_conversation_fk foreign key (business_id, conversation_id)
+    references public.dabbir_conversations(business_id, id) on delete cascade,
+  constraint dabbir_whatsapp_event_business_message_fk foreign key (business_id, message_id)
+    references public.dabbir_messages(business_id, id) on delete cascade
+);
+
+create index if not exists dabbir_whatsapp_event_business_time_idx
+  on public.dabbir_whatsapp_event_ledger(business_id, occurred_at desc);
+create index if not exists dabbir_whatsapp_event_provider_message_idx
+  on public.dabbir_whatsapp_event_ledger(business_id, provider_message_id)
+  where provider_message_id is not null;
+
+create table if not exists public.dabbir_whatsapp_outbound_reservations (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  connection_id uuid not null references public.dabbir_whatsapp_connections(id) on delete cascade,
+  conversation_id uuid not null,
+  sender_user_id uuid not null references auth.users(id) on delete restrict,
+  idempotency_key text not null,
+  payload_hash text not null,
+  recipient_handle text not null,
+  body text not null,
+  state text not null default 'SENDING' check (state in ('SENDING','PROVIDER_ACCEPTED','SENT','DELIVERED','READ','FAILED','AMBIGUOUS')),
+  provider_message_id text,
+  message_id uuid,
+  provider_status text,
+  provider_verified boolean not null default false,
+  external_attempt_started_at timestamptz not null default now(),
+  finalized_at timestamptz,
+  verified_at timestamptz,
+  error_code text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint dabbir_whatsapp_outbound_idempotency_key_check check (length(trim(idempotency_key)) between 16 and 160),
+  constraint dabbir_whatsapp_outbound_payload_hash_check check (payload_hash ~ '^[0-9a-f]{64}$'),
+  constraint dabbir_whatsapp_outbound_recipient_check check (length(trim(recipient_handle)) between 5 and 160),
+  constraint dabbir_whatsapp_outbound_body_check check (length(trim(body)) between 1 and 4000),
+  constraint dabbir_whatsapp_outbound_provider_message_check check (provider_message_id is null or length(provider_message_id) between 3 and 320),
+  constraint dabbir_whatsapp_outbound_business_idempotency_uq unique (business_id, idempotency_key),
+  constraint dabbir_whatsapp_outbound_business_conversation_fk foreign key (business_id, conversation_id)
+    references public.dabbir_conversations(business_id, id) on delete cascade,
+  constraint dabbir_whatsapp_outbound_business_message_fk foreign key (business_id, message_id)
+    references public.dabbir_messages(business_id, id) on delete cascade
+);
+
+create unique index if not exists dabbir_whatsapp_outbound_provider_message_uq
+  on public.dabbir_whatsapp_outbound_reservations(business_id, provider_message_id)
+  where provider_message_id is not null;
+create index if not exists dabbir_whatsapp_outbound_conversation_idx
+  on public.dabbir_whatsapp_outbound_reservations(business_id, conversation_id, created_at desc);
+
+alter table public.dabbir_whatsapp_event_ledger enable row level security;
+alter table public.dabbir_whatsapp_event_ledger force row level security;
+alter table public.dabbir_whatsapp_outbound_reservations enable row level security;
+alter table public.dabbir_whatsapp_outbound_reservations force row level security;
+revoke all on public.dabbir_whatsapp_event_ledger from public, anon, authenticated;
+revoke all on public.dabbir_whatsapp_outbound_reservations from public, anon, authenticated;
+grant select, insert, update on public.dabbir_whatsapp_event_ledger to service_role;
+grant select, insert, update on public.dabbir_whatsapp_outbound_reservations to service_role;
+
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,
+  p_provider_message_id text,
+  p_sender_handle text,
+  p_display_name text,
+  p_body text,
+  p_intent text,
+  p_occurred_at timestamptz default now()
+)
+returns table(
+  business_id uuid,
+  connection_id uuid,
+  customer_id uuid,
+  conversation_id uuid,
+  message_id uuid,
+  duplicate boolean
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id) > 320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(trim(p_sender_handle),'') is null or length(p_sender_handle) > 160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body) > 4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and c.status='connected'
+  limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key := 'inbound:' || trim(p_provider_message_id);
+  perform pg_advisory_xact_lock(hashtextextended(v_connection.business_id::text || ':' || v_event_key, 0));
+
+  select * into v_existing
+  from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key
+  limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  v_name := left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,trim(p_sender_handle),'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set
+    display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb) || jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id
+  from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id
+    and c.customer_id=v_customer_id
+    and c.channel_type='whatsapp'
+    and c.demo_mode=false
+    and c.state<>'closed'
+  order by c.updated_at desc
+  limit 1
+  for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations
+    set state=case when state='waiting_customer' then 'ai_active' else state end,
+        updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true)
+  );
+
+  update public.dabbir_whatsapp_connections
+  set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;
+
+create or replace function public.dabbir_whatsapp_reserve_outbound(
+  p_business_id uuid,
+  p_conversation_id uuid,
+  p_sender_user_id uuid,
+  p_idempotency_key text,
+  p_payload_hash text,
+  p_body text
+)
+returns table(
+  reservation_id uuid,
+  should_send boolean,
+  reservation_state text,
+  connection_id uuid,
+  phone_number_id text,
+  recipient_handle text,
+  provider_message_id text,
+  message_id uuid
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_conversation public.dabbir_conversations%rowtype;
+  v_existing public.dabbir_whatsapp_outbound_reservations%rowtype;
+  v_recipient text;
+  v_key text:=trim(coalesce(p_idempotency_key,''));
+  v_hash text:=lower(trim(coalesce(p_payload_hash,'')));
+begin
+  if p_business_id is null or p_conversation_id is null or p_sender_user_id is null then raise exception 'WHATSAPP_OUTBOUND_CONTEXT_REQUIRED'; end if;
+  if length(v_key) not between 16 and 160 then raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REQUIRED'; end if;
+  if v_hash !~ '^[0-9a-f]{64}$' then raise exception 'WHATSAPP_PAYLOAD_HASH_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  if exists(select 1 from public.account_access_state s where s.user_id=p_sender_user_id and s.status='suspended') then
+    raise exception 'WHATSAPP_REPLY_ACCOUNT_SUSPENDED';
+  end if;
+  if not exists(
+    select 1 from auth.users u
+    where u.id=p_sender_user_id
+      and u.deleted_at is null
+      and (u.banned_until is null or u.banned_until<=now())
+  ) then raise exception 'WHATSAPP_REPLY_USER_INACTIVE'; end if;
+  if not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id
+      and m.user_id=p_sender_user_id
+      and m.status='active'
+      and m.suspended_at is null
+      and m.removed_at is null
+      and m.role in ('owner','admin')
+  ) then raise exception 'WHATSAPP_REPLY_APPROVER_REQUIRED'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.business_id=p_business_id and c.status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  select * into v_conversation from public.dabbir_conversations c
+  where c.business_id=p_business_id and c.id=p_conversation_id and c.channel_type='whatsapp' and c.demo_mode=false
+  limit 1;
+  if not found or v_conversation.customer_id is null then raise exception 'WHATSAPP_CONVERSATION_NOT_FOUND'; end if;
+
+  select nullif(trim(c.channel_handle),'') into v_recipient
+  from public.dabbir_customers c
+  where c.business_id=p_business_id and c.id=v_conversation.customer_id
+  limit 1;
+  if v_recipient is null then raise exception 'WHATSAPP_CUSTOMER_HANDLE_REQUIRED'; end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_business_id::text || ':wa-out:' || v_key,0));
+  select * into v_existing from public.dabbir_whatsapp_outbound_reservations r
+  where r.business_id=p_business_id and r.idempotency_key=v_key
+  limit 1;
+  if found then
+    if v_existing.conversation_id<>p_conversation_id
+      or v_existing.sender_user_id<>p_sender_user_id
+      or v_existing.payload_hash<>v_hash then
+      raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REUSED_DIFFERENT_REQUEST';
+    end if;
+    return query select v_existing.id,false,v_existing.state,v_existing.connection_id,
+      v_connection.phone_number_id,v_existing.recipient_handle,v_existing.provider_message_id,v_existing.message_id;
+    return;
+  end if;
+
+  insert into public.dabbir_whatsapp_outbound_reservations(
+    business_id,connection_id,conversation_id,sender_user_id,idempotency_key,payload_hash,
+    recipient_handle,body,state,external_attempt_started_at
+  ) values (
+    p_business_id,v_connection.id,p_conversation_id,p_sender_user_id,v_key,v_hash,
+    v_recipient,left(trim(p_body),4000),'SENDING',now()
+  ) returning * into v_existing;
+
+  return query select v_existing.id,true,v_existing.state,v_existing.connection_id,
+    v_connection.phone_number_id,v_existing.recipient_handle,null::text,null::uuid;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) to service_role;
+
+create or replace function public.dabbir_whatsapp_finalize_outbound(
+  p_reservation_id uuid,
+  p_provider_message_id text
+)
+returns table(message_id uuid,event_id uuid,reservation_state text,duplicate boolean)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_res public.dabbir_whatsapp_outbound_reservations%rowtype;
+  v_message_id uuid;
+  v_event_id uuid;
+  v_provider_id text:=trim(coalesce(p_provider_message_id,''));
+begin
+  if p_reservation_id is null or length(v_provider_id) not between 3 and 320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  select * into v_res from public.dabbir_whatsapp_outbound_reservations where id=p_reservation_id for update;
+  if not found then raise exception 'WHATSAPP_OUTBOUND_RESERVATION_NOT_FOUND'; end if;
+
+  if v_res.state<>'SENDING' then
+    if v_res.provider_message_id=v_provider_id and v_res.message_id is not null then
+      return query select v_res.message_id,
+        (select e.id from public.dabbir_whatsapp_event_ledger e where e.business_id=v_res.business_id and e.event_key='outbound:'||v_provider_id limit 1),
+        v_res.state,true;
+      return;
+    end if;
+    raise exception 'WHATSAPP_OUTBOUND_RESERVATION_NOT_FINALIZABLE';
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated,sender_user_id)
+  values(v_res.business_id,v_res.conversation_id,'human',v_res.body,null,false,v_res.sender_user_id)
+  returning id into v_message_id;
+
+  update public.dabbir_conversations
+  set state='waiting_customer',updated_at=now()
+  where business_id=v_res.business_id and id=v_res.conversation_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,evidence
+  ) values (
+    v_res.business_id,v_res.connection_id,'outbound:'||v_provider_id,'outbound','message',v_provider_id,
+    v_res.conversation_id,v_message_id,'accepted',false,now(),
+    jsonb_build_object('source','meta_messages_api','provider_accepted',true,'reservation_id',v_res.id)
+  ) returning id into v_event_id;
+
+  update public.dabbir_whatsapp_outbound_reservations
+  set state='PROVIDER_ACCEPTED',provider_message_id=v_provider_id,message_id=v_message_id,
+      provider_status='accepted',finalized_at=now(),error_code=null,updated_at=now()
+  where id=v_res.id;
+
+  return query select v_message_id,v_event_id,'PROVIDER_ACCEPTED'::text,false;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_finalize_outbound(uuid,text) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_finalize_outbound(uuid,text) to service_role;
+
+create or replace function public.dabbir_whatsapp_mark_outbound_result(
+  p_reservation_id uuid,
+  p_state text,
+  p_error_code text default null
+)
+returns boolean
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare v_state text:=upper(trim(coalesce(p_state,'')));
+begin
+  if v_state not in ('FAILED','AMBIGUOUS') then raise exception 'WHATSAPP_OUTBOUND_TERMINAL_STATE_INVALID'; end if;
+  update public.dabbir_whatsapp_outbound_reservations
+  set state=v_state,error_code=left(nullif(trim(coalesce(p_error_code,'')),''),160),updated_at=now()
+  where id=p_reservation_id and state='SENDING';
+  return found;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) to service_role;
+
+create or replace function public.dabbir_whatsapp_apply_status(
+  p_phone_number_id text,
+  p_provider_message_id text,
+  p_status text,
+  p_occurred_at timestamptz default now()
+)
+returns table(matched boolean,provider_verified boolean,conversation_id uuid,message_id uuid,reservation_state text)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_res public.dabbir_whatsapp_outbound_reservations%rowtype;
+  v_status text:=lower(trim(coalesce(p_status,'')));
+  v_verified boolean;
+  v_next_state text;
+  v_status_key text;
+begin
+  if nullif(trim(p_phone_number_id),'') is null or nullif(trim(p_provider_message_id),'') is null then raise exception 'WHATSAPP_STATUS_CONTEXT_REQUIRED'; end if;
+  if v_status not in ('sent','delivered','read','failed','deleted') then raise exception 'WHATSAPP_STATUS_INVALID'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id) and c.status='connected' limit 1;
+  if not found then return query select false,false,null::uuid,null::uuid,null::text; return; end if;
+
+  select * into v_res from public.dabbir_whatsapp_outbound_reservations r
+  where r.business_id=v_connection.business_id and r.provider_message_id=trim(p_provider_message_id)
+  for update;
+  if not found then return query select false,false,null::uuid,null::uuid,null::text; return; end if;
+
+  v_verified:=v_status in ('delivered','read');
+  v_next_state:=case v_status when 'sent' then 'SENT' when 'delivered' then 'DELIVERED' when 'read' then 'READ' else 'FAILED' end;
+
+  update public.dabbir_whatsapp_outbound_reservations
+  set state=case
+        when state='READ' then 'READ'
+        when state='DELIVERED' and v_next_state='SENT' then 'DELIVERED'
+        when state in ('DELIVERED','READ') and v_next_state='FAILED' then state
+        else v_next_state end,
+      provider_status=v_status,
+      provider_verified=provider_verified or v_verified,
+      verified_at=case when v_verified then coalesce(verified_at,now()) else verified_at end,
+      error_code=case when v_next_state='FAILED' then 'META_OUTBOUND_'||upper(v_status) else null end,
+      updated_at=now()
+  where id=v_res.id
+  returning state into v_next_state;
+
+  update public.dabbir_whatsapp_event_ledger
+  set provider_status=v_status,
+      provider_verified=provider_verified or v_verified,
+      verified_at=case when v_verified then coalesce(verified_at,now()) else verified_at end,
+      updated_at=now(),
+      evidence=coalesce(evidence,'{}'::jsonb)||jsonb_build_object('status_source','meta_signed_webhook')
+  where business_id=v_res.business_id and event_key='outbound:'||trim(p_provider_message_id);
+
+  v_status_key:='status:'||trim(p_provider_message_id)||':'||v_status||':'||extract(epoch from coalesce(p_occurred_at,now()))::bigint::text;
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_res.business_id,v_res.connection_id,v_status_key,'status','status',trim(p_provider_message_id),
+    v_res.conversation_id,v_res.message_id,v_status,v_verified,coalesce(p_occurred_at,now()),
+    case when v_verified then now() else null end,jsonb_build_object('source','meta_signed_webhook','reservation_id',v_res.id)
+  ) on conflict (business_id,event_key) do nothing;
+
+  update public.dabbir_whatsapp_connections
+  set last_verified_at=case when v_verified then now() else last_verified_at end,
+      last_provider_status=200,
+      last_error=case when v_next_state='FAILED' then 'META_OUTBOUND_'||upper(v_status) else null end,
+      updated_at=now()
+  where id=v_connection.id;
+
+  return query select true,v_verified,v_res.conversation_id,v_res.message_id,v_next_state;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) to service_role;
+
+create or replace function public.dabbir_whatsapp_operational_evidence(p_business_id uuid)
+returns table(
+  available boolean,
+  real_whatsapp_conversation boolean,
+  real_inbound_message boolean,
+  real_outbound_reply boolean,
+  verified_external_result boolean
+)
+language plpgsql
+stable
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+begin
+  if (select auth.uid()) is null then raise exception 'AUTH_REQUIRED'; end if;
+  if not dabbir_private.has_permission(p_business_id,'view_integrations') then raise exception 'INTEGRATION_VIEW_REQUIRED'; end if;
+
+  return query
+  select true,
+    exists(select 1 from public.dabbir_conversations c where c.business_id=p_business_id and c.channel_type='whatsapp' and c.demo_mode=false),
+    exists(select 1 from public.dabbir_whatsapp_event_ledger e where e.business_id=p_business_id and e.direction='inbound' and e.event_type='message' and e.message_id is not null),
+    exists(select 1 from public.dabbir_whatsapp_outbound_reservations r where r.business_id=p_business_id and r.message_id is not null and r.provider_message_id is not null and r.state in ('PROVIDER_ACCEPTED','SENT','DELIVERED','READ')),
+    exists(select 1 from public.dabbir_whatsapp_outbound_reservations r where r.business_id=p_business_id and r.provider_verified=true and r.state in ('DELIVERED','READ'));
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon;
+grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to authenticated;

--- a/supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql
+++ b/supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql
@@ -1,0 +1,121 @@
+-- DABBIR WhatsApp inbound race hardening.
+-- Two different provider message IDs from the same brand-new sender may arrive
+-- concurrently. Event-key locking alone serializes duplicates of one message,
+-- but not two distinct messages. Serialize tenant+sender conversation ownership
+-- before customer/conversation upsert so one active WhatsApp conversation wins.
+
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,
+  p_provider_message_id text,
+  p_sender_handle text,
+  p_display_name text,
+  p_body text,
+  p_intent text,
+  p_occurred_at timestamptz default now()
+)
+returns table(
+  business_id uuid,
+  connection_id uuid,
+  customer_id uuid,
+  conversation_id uuid,
+  message_id uuid,
+  duplicate boolean
+)
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+  v_sender text:=trim(coalesce(p_sender_handle,''));
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id) > 320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(v_sender,'') is null or length(v_sender) > 160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body) > 4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and c.status='connected'
+  limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key := 'inbound:' || trim(p_provider_message_id);
+  perform pg_advisory_xact_lock(hashtextextended(v_connection.business_id::text || ':' || v_event_key, 0));
+
+  select * into v_existing
+  from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key
+  limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  -- Root-cause guard: distinct inbound messages from the same tenant/sender must
+  -- not race the customer/conversation discovery and create parallel threads.
+  perform pg_advisory_xact_lock(hashtextextended(v_connection.business_id::text || ':wa-sender:' || v_sender, 0));
+
+  v_name := left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,v_sender,'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set
+    display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb) || jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id
+  from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id
+    and c.customer_id=v_customer_id
+    and c.channel_type='whatsapp'
+    and c.demo_mode=false
+    and c.state<>'closed'
+  order by c.updated_at desc
+  limit 1
+  for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations
+    set state=case when state='waiting_customer' then 'ai_active' else state end,
+        updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true)
+  );
+
+  update public.dabbir_whatsapp_connections
+  set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;

--- a/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
+++ b/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
@@ -1,0 +1,27 @@
+-- DABBIR WhatsApp RPC privilege hardening.
+-- Live WhatsApp mutation/evidence RPCs are server-only and called with the
+-- Supabase service role from DABBIR server functions. They do not need to run
+-- with the function owner's privileges. Keep them in the exposed RPC schema for
+-- PostgREST service access, but make execution SECURITY INVOKER and service-role
+-- only. This removes an unnecessary SECURITY DEFINER privilege boundary.
+
+alter function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) security invoker;
+alter function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) security invoker;
+alter function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) security invoker;
+alter function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) security invoker;
+alter function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) security invoker;
+alter function public.dabbir_whatsapp_operational_evidence(uuid) security invoker;
+
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon,authenticated;
+
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;
+grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) to service_role;
+grant execute on function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) to service_role;
+grant execute on function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) to service_role;
+grant execute on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) to service_role;
+grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to service_role;

--- a/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
+++ b/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
@@ -1,8 +1,7 @@
 -- DABBIR WhatsApp RPC privilege hardening aligned to BAR-13 v2.
--- Server-side mutation RPCs are invoked only with the Supabase service role and
--- therefore do not need function-owner privilege. The authenticated evidence
--- RPC remains SECURITY DEFINER because it performs its own fail-closed
--- has_permission(view_integrations) check and must read the service-only ledger.
+-- Every live WhatsApp RPC is server-only and invoked with the Supabase service
+-- role from DABBIR server functions. No live ledger/reservation function needs
+-- function-owner privilege or direct authenticated-client EXECUTE.
 
 alter function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) security invoker;
 alter function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) security invoker;
@@ -10,19 +9,56 @@ alter function public.dabbir_whatsapp_finalize_outbound(uuid,text) security invo
 alter function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) security invoker;
 alter function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) security invoker;
 
+-- Evidence moved behind the authenticated DABBIR server endpoint. Because this
+-- RPC is service-role only, authorization is enforced before this call by
+-- ownerContext()/tenant resolution and the function itself needs no auth.uid()
+-- based SECURITY DEFINER bypass.
+create or replace function public.dabbir_whatsapp_operational_evidence(p_business_id uuid)
+returns table(
+  available boolean,
+  real_whatsapp_conversation boolean,
+  real_inbound_message boolean,
+  real_outbound_reply boolean,
+  verified_external_result boolean
+)
+language sql
+stable
+security invoker
+set search_path = pg_catalog, public
+as $$
+  select true,
+    exists(
+      select 1 from public.dabbir_conversations c
+      where c.business_id=p_business_id and c.channel_type='whatsapp' and c.demo_mode=false
+    ),
+    exists(
+      select 1 from public.dabbir_whatsapp_event_ledger e
+      where e.business_id=p_business_id and e.direction='inbound'
+        and e.event_type='message' and e.message_id is not null
+    ),
+    exists(
+      select 1 from public.dabbir_whatsapp_outbound_reservations r
+      where r.business_id=p_business_id and r.message_id is not null
+        and r.provider_message_id is not null
+        and r.state in ('PROVIDER_ACCEPTED','SENT','DELIVERED','READ')
+    ),
+    exists(
+      select 1 from public.dabbir_whatsapp_outbound_reservations r
+      where r.business_id=p_business_id and r.provider_verified=true
+        and r.state in ('DELIVERED','READ')
+    );
+$$;
+
 revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
 revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) from public,anon,authenticated;
 revoke all on function public.dabbir_whatsapp_finalize_outbound(uuid,text) from public,anon,authenticated;
 revoke all on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) from public,anon,authenticated;
 revoke all on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon,authenticated;
 
 grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;
 grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) to service_role;
 grant execute on function public.dabbir_whatsapp_finalize_outbound(uuid,text) to service_role;
 grant execute on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) to service_role;
 grant execute on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) to service_role;
-
--- Evidence is intentionally callable only by authenticated DABBIR users and
--- is tenant-authorized inside the function with has_permission().
-revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon;
-grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to authenticated;
+grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to service_role;

--- a/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
+++ b/supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql
@@ -1,27 +1,28 @@
--- DABBIR WhatsApp RPC privilege hardening.
--- Live WhatsApp mutation/evidence RPCs are server-only and called with the
--- Supabase service role from DABBIR server functions. They do not need to run
--- with the function owner's privileges. Keep them in the exposed RPC schema for
--- PostgREST service access, but make execution SECURITY INVOKER and service-role
--- only. This removes an unnecessary SECURITY DEFINER privilege boundary.
+-- DABBIR WhatsApp RPC privilege hardening aligned to BAR-13 v2.
+-- Server-side mutation RPCs are invoked only with the Supabase service role and
+-- therefore do not need function-owner privilege. The authenticated evidence
+-- RPC remains SECURITY DEFINER because it performs its own fail-closed
+-- has_permission(view_integrations) check and must read the service-only ledger.
 
 alter function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) security invoker;
-alter function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) security invoker;
-alter function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) security invoker;
-alter function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) security invoker;
+alter function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) security invoker;
+alter function public.dabbir_whatsapp_finalize_outbound(uuid,text) security invoker;
+alter function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) security invoker;
 alter function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) security invoker;
-alter function public.dabbir_whatsapp_operational_evidence(uuid) security invoker;
 
 revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
-revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) from public,anon,authenticated;
-revoke all on function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) from public,anon,authenticated;
-revoke all on function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_finalize_outbound(uuid,text) from public,anon,authenticated;
+revoke all on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) from public,anon,authenticated;
 revoke all on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) from public,anon,authenticated;
-revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon,authenticated;
 
 grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;
-grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text) to service_role;
-grant execute on function public.dabbir_whatsapp_finalize_outbound(uuid,uuid,text,text,uuid,timestamptz) to service_role;
-grant execute on function public.dabbir_whatsapp_mark_outbound_ambiguous(uuid,uuid,text) to service_role;
+grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) to service_role;
+grant execute on function public.dabbir_whatsapp_finalize_outbound(uuid,text) to service_role;
+grant execute on function public.dabbir_whatsapp_mark_outbound_result(uuid,text,text) to service_role;
 grant execute on function public.dabbir_whatsapp_apply_status(text,text,text,timestamptz) to service_role;
-grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to service_role;
+
+-- Evidence is intentionally callable only by authenticated DABBIR users and
+-- is tenant-authorized inside the function with has_permission().
+revoke all on function public.dabbir_whatsapp_operational_evidence(uuid) from public,anon;
+grant execute on function public.dabbir_whatsapp_operational_evidence(uuid) to authenticated;

--- a/test/ci-static-gates.test.mjs
+++ b/test/ci-static-gates.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const pkg = JSON.parse(await readFile(new URL('package.json', root), 'utf8'));
+const ci = await readFile(new URL('.github/workflows/ci.yml', root), 'utf8');
+
+test('CI exposes a repository-wide JavaScript syntax gate', () => {
+  assert.match(String(pkg.scripts?.['check:syntax'] || ''), /node --check/);
+  assert.match(String(pkg.scripts?.['check:syntax'] || ''), /git ls-files/);
+  assert.match(ci, /npm run check:syntax/);
+});
+
+test('CI audits production dependency vulnerabilities at high severity', () => {
+  assert.equal(pkg.scripts?.['audit:prod'], 'npm audit --omit=dev --audit-level=high');
+  assert.match(ci, /npm run audit:prod/);
+});
+
+test('static gates run before the main DABBIR test suite', () => {
+  const syntax = ci.indexOf('npm run check:syntax');
+  const audit = ci.indexOf('npm run audit:prod');
+  const tests = ci.indexOf('npm test');
+  assert.ok(syntax >= 0 && audit >= 0 && tests >= 0);
+  assert.ok(syntax < tests && audit < tests);
+});

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -52,8 +52,12 @@ test('WhatsApp becomes operational only through the explicit evidence state mach
 });
 
 test('Meta verification failure remains fail closed',()=>{
-  const catchStart=status.indexOf('} catch (error) {');
-  const catchBody=status.slice(catchStart, status.indexOf('\n  }\n}\n\nasync function tenantStatus',catchStart));
+  const embeddedStart=status.indexOf('async function embeddedStatus');
+  const tenantStart=status.indexOf('async function tenantStatus',embeddedStart);
+  const embeddedBody=status.slice(embeddedStart,tenantStart);
+  const catchStart=embeddedBody.lastIndexOf('} catch (error) {');
+  const catchBody=embeddedBody.slice(catchStart);
+  assert.ok(catchStart>0,'embedded status catch path missing');
   assert.match(catchBody,/connected: false/);
   assert.match(catchBody,/outbound_configured: false/);
   assert.match(catchBody,/meta_authorized: false/);

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -6,19 +6,22 @@ import { spawnSync } from 'node:child_process';
 const statusPath='api/dabbir-whatsapp-status.js';
 const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
+const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
 const status=fs.readFileSync(statusPath,'utf8');
 const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
+const migration=fs.readFileSync(migrationPath,'utf8');
 
-test('WhatsApp operational evidence is tenant-scoped and excludes simulation',()=>{
-  assert.match(status,/dabbir_conversations\?select=id/);
-  assert.match(status,/channel_type=eq\.whatsapp/);
-  assert.match(status,/demo_mode=eq\.false/);
-  assert.match(status,/dabbir_messages\?select=sender_type,simulated/);
-  assert.match(status,/simulated=eq\.false/);
-  assert.match(status,/dabbir_conversation_outcomes\?select=verified_external_result/);
-  assert.match(status,/verified_external_result=eq\.true/);
-  assert.match(status,/business_id=eq\.\$\{encodedBusinessId\}/);
+test('WhatsApp operational evidence is tenant-scoped, non-demo, and provider-backed',()=>{
+  assert.match(status,/supabaseRpc/);
+  assert.match(status,/dabbir_whatsapp_operational_evidence/);
+  assert.match(status,/\{ p_business_id: businessId \}/);
+  assert.match(migration,/function public\.dabbir_whatsapp_operational_evidence\(p_business_id uuid\)/);
+  assert.match(migration,/has_permission\(p_business_id,'view_integrations'\)/);
+  assert.match(migration,/c\.business_id=p_business_id and c\.channel_type='whatsapp' and c\.demo_mode=false/);
+  assert.match(migration,/e\.business_id=p_business_id and e\.direction='inbound' and e\.event_type='message' and e\.message_id is not null/);
+  assert.match(migration,/r\.business_id=p_business_id and r\.message_id is not null and r\.provider_message_id is not null/);
+  assert.match(migration,/r\.business_id=p_business_id and r\.provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
 });
 
 test('WhatsApp becomes operational only through the explicit evidence state machine',()=>{
@@ -37,6 +40,15 @@ test('WhatsApp becomes operational only through the explicit evidence state mach
   assert.match(machine,/operational: true/);
 });
 
+test('Meta verification failure remains fail closed',()=>{
+  const catchStart=status.indexOf('} catch (error) {');
+  const catchBody=status.slice(catchStart, status.indexOf('\n  }\n}\n\nasync function tenantStatus',catchStart));
+  assert.match(catchBody,/connected: false/);
+  assert.match(catchBody,/outbound_configured: false/);
+  assert.match(catchBody,/meta_authorized: false/);
+  assert.doesNotMatch(catchBody,/connected: true/);
+});
+
 test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
   assert.match(activation,/function whatsappLinked\(\)/);
   assert.match(activation,/function whatsappReady\(\)/);
@@ -52,7 +64,7 @@ test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
 });
 
 test('operational truth files parse as Node modules',()=>{
-  for(const path of [statusPath,machinePath,activationPath]){
+  for(const path of [statusPath,machinePath,activationPath,'api/_whatsapp-live-core.js','api/dabbir-whatsapp-reply.js','api/dabbir-whatsapp-webhook.js']){
     const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
     assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
   }

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -7,10 +7,12 @@ const statusPath='api/dabbir-whatsapp-status.js';
 const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
 const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
+const raceMigrationPath='supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql';
 const status=fs.readFileSync(statusPath,'utf8');
 const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
 const migration=fs.readFileSync(migrationPath,'utf8');
+const raceMigration=fs.readFileSync(raceMigrationPath,'utf8');
 
 test('WhatsApp operational evidence is tenant-scoped, non-demo, and provider-backed',()=>{
   assert.match(status,/supabaseRpc/);
@@ -22,6 +24,15 @@ test('WhatsApp operational evidence is tenant-scoped, non-demo, and provider-bac
   assert.match(migration,/e\.business_id=p_business_id and e\.direction='inbound' and e\.event_type='message' and e\.message_id is not null/);
   assert.match(migration,/r\.business_id=p_business_id and r\.message_id is not null and r\.provider_message_id is not null/);
   assert.match(migration,/r\.business_id=p_business_id and r\.provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
+});
+
+test('distinct inbound messages from one new sender serialize conversation ownership',()=>{
+  assert.match(raceMigration,/hashtextextended\(v_connection\.business_id::text \|\| ':wa-sender:' \|\| v_sender, 0\)/);
+  const senderLock=raceMigration.indexOf("':wa-sender:'");
+  const customerUpsert=raceMigration.indexOf('insert into public.dabbir_customers');
+  const conversationLookup=raceMigration.indexOf('select c.id into v_conversation_id');
+  assert.ok(senderLock>0&&senderLock<customerUpsert&&customerUpsert<conversationLookup);
+  assert.match(raceMigration,/on conflict \(business_id,channel_handle\) where channel_handle is not null/);
 });
 
 test('WhatsApp becomes operational only through the explicit evidence state machine',()=>{

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -8,22 +8,27 @@ const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
 const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
 const raceMigrationPath='supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql';
+const hardeningPath='supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql';
 const status=fs.readFileSync(statusPath,'utf8');
 const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
 const migration=fs.readFileSync(migrationPath,'utf8');
 const raceMigration=fs.readFileSync(raceMigrationPath,'utf8');
+const hardening=fs.readFileSync(hardeningPath,'utf8');
 
-test('WhatsApp operational evidence is tenant-scoped, non-demo, and provider-backed',()=>{
-  assert.match(status,/supabaseRpc/);
+test('WhatsApp operational evidence is tenant-scoped, non-demo, provider-backed, and server-only',()=>{
+  assert.match(status,/serviceRpc/);
+  assert.doesNotMatch(status,/supabaseRpc/);
   assert.match(status,/dabbir_whatsapp_operational_evidence/);
   assert.match(status,/\{ p_business_id: businessId \}/);
   assert.match(migration,/function public\.dabbir_whatsapp_operational_evidence\(p_business_id uuid\)/);
-  assert.match(migration,/has_permission\(p_business_id,'view_integrations'\)/);
   assert.match(migration,/c\.business_id=p_business_id and c\.channel_type='whatsapp' and c\.demo_mode=false/);
   assert.match(migration,/e\.business_id=p_business_id and e\.direction='inbound' and e\.event_type='message' and e\.message_id is not null/);
   assert.match(migration,/r\.business_id=p_business_id and r\.message_id is not null and r\.provider_message_id is not null/);
   assert.match(migration,/r\.business_id=p_business_id and r\.provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
+  assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) from public,anon,authenticated/i);
+  assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to service_role/i);
+  assert.doesNotMatch(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
 });
 
 test('distinct inbound messages from one new sender serialize conversation ownership',()=>{

--- a/test/dabbir-whatsapp-outbound-idempotency.test.mjs
+++ b/test/dabbir-whatsapp-outbound-idempotency.test.mjs
@@ -1,0 +1,70 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { spawnSync } from 'node:child_process';
+
+const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
+const replyPath='api/dabbir-whatsapp-reply.js';
+const corePath='api/_whatsapp-live-core.js';
+const appPath='api/app.js';
+const migration=fs.readFileSync(migrationPath,'utf8');
+const reply=fs.readFileSync(replyPath,'utf8');
+const core=fs.readFileSync(corePath,'utf8');
+const app=fs.readFileSync(appPath,'utf8');
+
+test('migration version does not collide with the already-applied 04:29 root fix',()=>{
+  assert.match(migrationPath,/20260828044500_/);
+  assert.doesNotMatch(migrationPath,/20260828043000_/);
+});
+
+test('outbound reply reserves durably before any Meta send and finalizes only after provider acceptance',()=>{
+  const reserveAt=reply.indexOf('await reserveOutboundReply');
+  const sendAt=reply.indexOf('await sendMetaText');
+  const finalizeAt=reply.indexOf('await finalizeOutboundReply');
+  assert.ok(reserveAt>0,'reserve call missing');
+  assert.ok(sendAt>reserveAt,'Meta send must occur after reservation');
+  assert.ok(finalizeAt>sendAt,'finalize must occur after provider acceptance');
+  assert.match(reply,/automatic_resend_blocked: true/);
+  assert.match(reply,/WHATSAPP_REPLY_REQUIRES_RECONCILIATION/);
+  assert.match(reply,/AMBIGUOUS_NO_AUTOMATIC_RESEND/);
+});
+
+test('same idempotency key can never trigger a second external send',()=>{
+  assert.match(migration,/unique \(business_id, idempotency_key\)/i);
+  assert.match(migration,/if found then[\s\S]*return query select v_existing\.id,false/i);
+  assert.match(migration,/WHATSAPP_IDEMPOTENCY_KEY_REUSED_DIFFERENT_REQUEST/);
+  assert.match(reply,/if \(!reservation\.shouldSend\)/);
+  const replayBranch=reply.slice(reply.indexOf('if (!reservation.shouldSend)'),reply.indexOf('if (String(connection.id)',reply.indexOf('if (!reservation.shouldSend)')));
+  assert.doesNotMatch(replayBranch,/sendMetaText/);
+});
+
+test('service-role reservation independently enforces active account and membership state',()=>{
+  assert.match(migration,/account_access_state[\s\S]*status='suspended'/);
+  assert.match(migration,/auth\.users[\s\S]*deleted_at is null[\s\S]*banned_until/);
+  assert.match(migration,/m\.status='active'/);
+  assert.match(migration,/m\.suspended_at is null/);
+  assert.match(migration,/m\.removed_at is null/);
+  assert.match(migration,/m\.role in \('owner','admin'\)/);
+});
+
+test('provider verification requires delivered or read evidence, not send acceptance alone',()=>{
+  assert.match(migration,/v_verified:=v_status in \('delivered','read'\)/);
+  assert.match(migration,/provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
+  assert.doesNotMatch(migration,/v_verified:=v_status in \('sent','delivered','read'\)/);
+});
+
+test('browser keeps one stable operation key across ambiguous retries without storing message plaintext',()=>{
+  assert.match(app,/dabbir-wa-pending:/);
+  assert.match(app,/pending\.payload_hash===payloadHash/);
+  assert.match(app,/pending\.idempotency_key/);
+  assert.match(app,/localStorage\.setItem\(whatsappStorageKey\(conversation\),JSON\.stringify\(pending\)\)/);
+  assert.match(app,/automatic_resend_blocked/);
+  assert.doesNotMatch(app,/localStorage\.setItem\([^\n]*message:text/);
+});
+
+test('WhatsApp live-path modules parse as Node modules',()=>{
+  for(const path of [replyPath,corePath,appPath]){
+    const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
+    assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
+  }
+});

--- a/test/dabbir-whatsapp-rpc-security.test.mjs
+++ b/test/dabbir-whatsapp-rpc-security.test.mjs
@@ -1,0 +1,39 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const status=fs.readFileSync('api/dabbir-whatsapp-status.js','utf8');
+const hardening=fs.readFileSync('supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql','utf8');
+
+const serverOnlyFunctions=[
+  'dabbir_whatsapp_persist_inbound',
+  'dabbir_whatsapp_reserve_outbound',
+  'dabbir_whatsapp_finalize_outbound',
+  'dabbir_whatsapp_mark_outbound_result',
+  'dabbir_whatsapp_apply_status',
+  'dabbir_whatsapp_operational_evidence',
+];
+
+test('WhatsApp operational evidence is fetched server-side rather than with the user token',()=>{
+  assert.match(status,/import \{ serviceRpc, whatsappLiveServerCapability \} from '.\/_whatsapp-live-core\.js'/);
+  assert.match(status,/serviceRpc\('dabbir_whatsapp_operational_evidence', \{ p_business_id: businessId \}\)/);
+  assert.doesNotMatch(status,/supabaseRpc/);
+  assert.match(status,/await ownerContext\(req, businessId\)/);
+});
+
+test('all live WhatsApp RPCs are service-role only and do not retain SECURITY DEFINER',()=>{
+  for(const fn of serverOnlyFunctions){
+    assert.match(hardening,new RegExp(`(?:alter function public\\.${fn}\\([^;]+\\) security invoker|create or replace function public\\.${fn}\\([\\s\\S]*?security invoker)`,'i'),`${fn} must be SECURITY INVOKER`);
+    assert.match(hardening,new RegExp(`revoke all on function public\\.${fn}\\([^;]+\\) from public,anon,authenticated`,'i'),`${fn} client execute must be revoked`);
+    assert.match(hardening,new RegExp(`grant execute on function public\\.${fn}\\([^;]+\\) to service_role`,'i'),`${fn} must be service-role executable`);
+  }
+  assert.doesNotMatch(hardening,/grant execute on function public\.dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
+});
+
+test('server-only operational evidence does not depend on auth.uid or client permission bypass',()=>{
+  const start=hardening.indexOf('create or replace function public.dabbir_whatsapp_operational_evidence');
+  const body=hardening.slice(start);
+  assert.match(body,/security invoker/i);
+  assert.doesNotMatch(body,/auth\.uid\(\)/i);
+  assert.doesNotMatch(body,/security definer/i);
+});

--- a/test/phase2-observability-outcomes.test.mjs
+++ b/test/phase2-observability-outcomes.test.mjs
@@ -13,6 +13,7 @@ const translation = await read('api/translate.js');
 const whatsapp = await read('api/dabbir-whatsapp-webhook.js');
 const appSecretEnv = ['DABBIR', 'WHATSAPP', 'APP', 'SECRET'].join('_');
 const projectEnv = ['DABBIR', 'PROJECT'].join('_');
+const serviceRoleEnv = 'SUPABASE_SERVICE_ROLE_KEY';
 
 test('failure taxonomy includes authorization and classifies provider 403 as external provider', () => {
   assert.equal(FAILURE_CLASSES.has('AUTHORIZATION'), true);
@@ -44,11 +45,13 @@ test('translation failure is truthful and degraded rather than silently switchin
   assert.doesNotMatch(translation, /fallbackModels|models:\s*\[/i);
 });
 
-test('signed WhatsApp webhook response never echoes customer content or identifiers', async () => {
+test('signed WhatsApp webhook never acknowledges an unpersisted real message as success', async () => {
   const oldSecret = process.env[appSecretEnv];
   const oldProject = process.env[projectEnv];
+  const oldServiceRole = process.env[serviceRoleEnv];
   process.env[appSecretEnv] = 'synthetic-test-app-key';
   process.env[projectEnv] = 'dabbir_clinics';
+  delete process.env[serviceRoleEnv];
 
   try {
     const sensitive = {
@@ -88,12 +91,11 @@ test('signed WhatsApp webhook response never echoes customer content or identifi
     };
 
     await whatsappHandler(req, res);
-    assert.equal(res.statusCode, 200);
+    assert.equal(res.statusCode, 503);
     assert.equal(res.body.signature_verified, true);
-    assert.equal(res.body.state, 'CONFIGURED_NOT_OPERATIONAL');
+    assert.equal(res.body.state, 'SERVER_PERSISTENCE_NOT_CONFIGURED');
     assert.equal(res.body.persisted, false);
     assert.equal(res.body.outbound_messages_sent, false);
-    assert.equal(res.body.classifications.includes('APPOINTMENT_REQUEST'), true);
     assert.ok(res.headers['x-dabbir-correlation-id']);
 
     const responseText = JSON.stringify(res.body);
@@ -103,12 +105,16 @@ test('signed WhatsApp webhook response never echoes customer content or identifi
     else process.env[appSecretEnv] = oldSecret;
     if (oldProject === undefined) delete process.env[projectEnv];
     else process.env[projectEnv] = oldProject;
+    if (oldServiceRole === undefined) delete process.env[serviceRoleEnv];
+    else process.env[serviceRoleEnv] = oldServiceRole;
   }
 });
 
-test('WhatsApp source does not claim persistence, outbound delivery, or operational connection', () => {
-  assert.match(whatsapp, /state: 'CONFIGURED_NOT_OPERATIONAL'/);
-  assert.match(whatsapp, /persisted: false/);
+test('WhatsApp source requires persistence and never claims operational state from signature alone', () => {
+  assert.match(whatsapp, /persistSignedInbound/);
+  assert.match(whatsapp, /SIGNED_EVENT_PERSISTENCE_FAILED/);
+  assert.match(whatsapp, /SERVER_PERSISTENCE_NOT_CONFIGURED/);
   assert.match(whatsapp, /outbound_messages_sent: false/);
   assert.doesNotMatch(whatsapp, /state: 'CONNECTED'/);
+  assert.doesNotMatch(whatsapp, /state: 'OPERATIONAL'/);
 });


### PR DESCRIPTION
BAR-13 v2 rebuilt on the hardened DABBIR line after PR #139 was correctly rejected.

## Root causes removed
- Reserve before external side effect: outbound replies now use `Reserve → single Meta send → Finalize`; same idempotency key never triggers a second send.
- Ambiguous Meta outcomes fail closed and block automatic resend until reconciliation.
- Service-role reservation independently enforces active account, non-banned/non-deleted user, active/non-suspended/non-removed owner/admin membership.
- Unique migration versions avoid the previously detected 04:30 collision.
- Meta authorization failure stays fail closed (`connected=false`, `outbound_configured=false`).
- Signed inbound messages persist tenant-scoped with provider-message idempotency and sender-level serialization to avoid parallel conversations.
- Operational truth comes from a tenant-scoped evidence RPC and requires real inbound, finalized outbound, and Meta `delivered`/`read` evidence; `sent` or provider acceptance alone is insufficient.
- The conversation UI routes WhatsApp replies to the live endpoint and preserves a stable idempotency key across ambiguous retries without storing message plaintext in localStorage. Web chat remains on `/api/chat-send`.

## Safety
- No raw Meta webhook payloads or access tokens are stored in the evidence ledger.
- No global/legacy WhatsApp number fallback.
- No automatic resend after ambiguous external side effects.
- No `OPERATIONAL` claim without real external delivery proof.

BAR-13 remains open after merge until a real tenant completes Embedded Signup and the exact Production path proves real inbound + approved outbound + Meta delivered/read evidence.