### PR TITLE
DABBIR: harden WhatsApp FK index coverage

### DIFF
--- a/supabase/migrations/20260828051000_dabbir_whatsapp_fk_index_hardening_v1.sql
+++ b/supabase/migrations/20260828051000_dabbir_whatsapp_fk_index_hardening_v1.sql
@@ -1,0 +1,22 @@
+-- DABBIR WhatsApp FK index hardening.
+-- These service-only tables are expected to grow with inbound/status traffic.
+-- Cover every currently unindexed FK used by tenant-scoped joins/deletes so
+-- referential checks and cleanup do not degrade into sequential scans.
+
+create index if not exists dabbir_whatsapp_event_business_conversation_idx
+  on public.dabbir_whatsapp_event_ledger(business_id, conversation_id);
+
+create index if not exists dabbir_whatsapp_event_business_message_idx
+  on public.dabbir_whatsapp_event_ledger(business_id, message_id);
+
+create index if not exists dabbir_whatsapp_event_connection_idx
+  on public.dabbir_whatsapp_event_ledger(connection_id);
+
+create index if not exists dabbir_whatsapp_outbound_business_message_idx
+  on public.dabbir_whatsapp_outbound_reservations(business_id, message_id);
+
+create index if not exists dabbir_whatsapp_outbound_connection_idx
+  on public.dabbir_whatsapp_outbound_reservations(connection_id);
+
+create index if not exists dabbir_whatsapp_outbound_sender_user_idx
+  on public.dabbir_whatsapp_outbound_reservations(sender_user_id);

--- a/test/dabbir-whatsapp-fk-index-hardening.test.mjs
+++ b/test/dabbir-whatsapp-fk-index-hardening.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migrationPath='supabase/migrations/20260828051000_dabbir_whatsapp_fk_index_hardening_v1.sql';
+const sql=fs.readFileSync(migrationPath,'utf8');
+
+const requiredIndexes=[
+  ['dabbir_whatsapp_event_business_conversation_idx',/dabbir_whatsapp_event_ledger\(business_id, conversation_id\)/],
+  ['dabbir_whatsapp_event_business_message_idx',/dabbir_whatsapp_event_ledger\(business_id, message_id\)/],
+  ['dabbir_whatsapp_event_connection_idx',/dabbir_whatsapp_event_ledger\(connection_id\)/],
+  ['dabbir_whatsapp_outbound_business_message_idx',/dabbir_whatsapp_outbound_reservations\(business_id, message_id\)/],
+  ['dabbir_whatsapp_outbound_connection_idx',/dabbir_whatsapp_outbound_reservations\(connection_id\)/],
+  ['dabbir_whatsapp_outbound_sender_user_idx',/dabbir_whatsapp_outbound_reservations\(sender_user_id\)/],
+];
+
+test('WhatsApp service ledgers keep covering indexes for every currently unindexed FK',()=>{
+  for(const [name,columns] of requiredIndexes){
+    assert.match(sql,new RegExp(`create index if not exists ${name}`));
+    assert.match(sql,columns);
+  }
+});
+
+test('WhatsApp FK index migration is additive and does not loosen security',()=>{
+  assert.doesNotMatch(sql,/drop\s+(table|index|policy|function)/i);
+  assert.doesNotMatch(sql,/grant\s+/i);
+  assert.doesNotMatch(sql,/disable\s+row\s+level\s+security/i);
+});


### PR DESCRIPTION
Completes the post-BAR-13 WhatsApp database hardening by adding covering indexes for the six FK paths Supabase flagged on the live event ledger and outbound reservation tables.

Verified before merge:
- Exact preview head `611c5c7f86f2b11817a60c47617c0916ac2bab67` passed the full Vercel Build Gate and reached READY.
- The additive migration was applied to Supabase Production successfully.
- Supabase performance advisor no longer reports unindexed foreign keys for `dabbir_whatsapp_event_ledger` or `dabbir_whatsapp_outbound_reservations`.
- No grants, RLS changes, drops, or data mutation are included.

The new indexes currently report unused because the live WhatsApp tables contain zero rows and there is no connected tenant yet; they are retained intentionally as FK coverage before traffic begins.