### PR TITLE
DABBIR: make database migrations production deployment-affecting

### DIFF
--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -57,6 +57,26 @@ test('test-only changes on main skip Vercel deployment when no runtime drift exi
   assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 0);
 });
 
+test('Supabase migrations on main force Vercel deployment so production SHA cannot drift', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+  fs.mkdirSync(path.join(dir, 'supabase', 'migrations'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'supabase', 'migrations', '20260828000000_test.sql'), 'select 1;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'database migration');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 1);
+});
+
+test('db paths on main are production-affecting and force Vercel deployment', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+  fs.mkdirSync(path.join(dir, 'db'), { recursive: true });
+  fs.writeFileSync(path.join(dir, 'db', 'schema.sql'), 'select 1;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'database schema');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 1);
+});
+
 test('failed or unverified runtime change on main cannot be hidden by a later test-only commit', () => {
   const dir = setupRepo();
   const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -61,7 +61,7 @@ while IFS= read -r path; do
     .github/*|docs/*|test/*|README.md|.gitignore)
       ;;
     *)
-      echo "Runtime, database, or unknown path changed since verification baseline: $path; continue deployment."
+      echo "Runtime or unknown path changed since verification baseline (database paths are runtime-affecting): $path; continue deployment."
       exit 1
       ;;
   esac

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -10,8 +10,10 @@ set -u
 #    commit is evidence, not an optimization target; test/docs follow-ups may
 #    contain the repair for a previously failing runtime commit.
 # 2) On main, compare against Vercel's last successful deployment baseline and
-#    build whenever any runtime/unknown path changed in that range.
-# 3) Any uncertainty fails safe to a build.
+#    build whenever any application, database migration, or unknown path changed
+#    in that range. Database schema is part of the Production artifact contract;
+#    a migration must not leave main SHA ahead of the deployed SHA.
+# 3) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 ref="${VERCEL_GIT_COMMIT_REF:-}"
 previous_success="${VERCEL_GIT_PREVIOUS_SHA:-}"
@@ -56,14 +58,14 @@ fi
 
 while IFS= read -r path; do
   case "$path" in
-    .github/*|docs/*|test/*|db/*|supabase/*|README.md|.gitignore)
+    .github/*|docs/*|test/*|README.md|.gitignore)
       ;;
     *)
-      echo "Runtime or unknown path changed since verification baseline: $path; continue deployment."
+      echo "Runtime, database, or unknown path changed since verification baseline: $path; continue deployment."
       exit 1
       ;;
   esac
 done <<< "$changed"
 
-echo "Only non-runtime DABBIR paths changed since verification baseline; skip Vercel deployment."
+echo "Only explicitly non-runtime DABBIR paths changed since verification baseline; skip Vercel deployment."
 exit 0


### PR DESCRIPTION
Root-cause fix for the exact-artifact drift discovered after PR #144.

Problem:
- `vercel-ignore-if-unaffected.sh` treated `supabase/*` and `db/*` as non-runtime paths on `main`.
- A DB-only merge could therefore advance GitHub/main and Production schema while Vercel canceled the matching Production deployment, leaving the deployed application SHA behind main.

Fix:
- Database schema/migrations are now part of the Production artifact contract.
- `supabase/*` and `db/*` no longer qualify for ignored Production builds.
- Only explicitly non-runtime paths (`.github`, docs, tests, README, gitignore) may skip on main.
- Unknown paths still fail safe to a build.
- Added regression tests proving both Supabase migrations and db paths force deployment on main.

Verification on exact head `a0d7db9f564fe61b78465a40a0aacc456309b3f3`:
- Full Vercel Build Gate ran on the non-main preview.
- 432/432 tests pass, including the new migration/deployment drift guards.
- The prior diagnostic contract is preserved so existing release-gate coverage remains valid.