### PR TITLE
DABBIR: cover remaining core foreign keys

### DIFF
--- a/supabase/migrations/20260828052000_dabbir_core_fk_index_hardening_v1.sql
+++ b/supabase/migrations/20260828052000_dabbir_core_fk_index_hardening_v1.sql
@@ -1,0 +1,90 @@
+-- DABBIR core FK index hardening.
+-- Scope is deliberately limited to DABBIR-owned tables reported by the live
+-- Supabase performance advisor. This migration is additive only: no data,
+-- privilege, policy, or RLS changes.
+
+-- Recovery / account access.
+create index if not exists recovery_restore_events_journal_event_idx
+  on dabbir_private.recovery_restore_events(journal_event_id);
+create index if not exists recovery_runtime_context_recovery_case_idx
+  on dabbir_private.recovery_runtime_context(recovery_case_id);
+create index if not exists account_access_state_reinstated_by_idx
+  on public.account_access_state(reinstated_by);
+create index if not exists account_access_state_suspended_by_idx
+  on public.account_access_state(suspended_by);
+
+-- Access and invitation audit paths.
+create index if not exists dabbir_access_audit_actor_user_idx
+  on public.dabbir_access_audit(actor_user_id);
+create index if not exists dabbir_access_audit_invitation_idx
+  on public.dabbir_access_audit(invitation_id);
+create index if not exists dabbir_access_audit_target_user_idx
+  on public.dabbir_access_audit(target_user_id);
+create index if not exists dabbir_employee_invitations_accepted_by_idx
+  on public.dabbir_employee_invitations(accepted_by);
+create index if not exists dabbir_employee_invitations_invited_by_idx
+  on public.dabbir_employee_invitations(invited_by);
+create index if not exists dabbir_memberships_invited_by_idx
+  on public.dabbir_memberships(invited_by);
+
+-- Conversation/event runtime paths.
+create index if not exists dabbir_conversation_outcomes_conversation_idx
+  on public.dabbir_conversation_outcomes(conversation_id);
+create index if not exists dabbir_conversation_outcomes_customer_idx
+  on public.dabbir_conversation_outcomes(customer_id);
+create index if not exists dabbir_customer_evidence_conversation_fk_idx
+  on public.dabbir_customer_evidence(conversation_id);
+create index if not exists dabbir_customer_evidence_customer_fk_idx
+  on public.dabbir_customer_evidence(customer_id);
+create index if not exists dabbir_customer_evidence_message_fk_idx
+  on public.dabbir_customer_evidence(message_id);
+create index if not exists dabbir_event_inbox_customer_fk_idx
+  on public.dabbir_event_inbox(customer_id);
+create index if not exists dabbir_followups_conversation_fk_idx
+  on public.dabbir_followups(conversation_id);
+create index if not exists dabbir_handoffs_assigned_user_idx
+  on public.dabbir_handoffs(assigned_user_id);
+create index if not exists dabbir_messages_sender_user_fk_idx
+  on public.dabbir_messages(sender_user_id);
+
+-- Message batching.
+create index if not exists dabbir_message_batch_items_message_idx
+  on public.dabbir_message_batch_items(message_id);
+create index if not exists dabbir_message_batches_conversation_idx
+  on public.dabbir_message_batches(conversation_id);
+create index if not exists dabbir_message_batches_customer_idx
+  on public.dabbir_message_batches(customer_id);
+
+-- Owner memory/policy and privacy evidence.
+create index if not exists dabbir_owner_decision_observations_owner_user_idx
+  on public.dabbir_owner_decision_observations(owner_user_id);
+create index if not exists dabbir_owner_policy_audit_actor_user_idx
+  on public.dabbir_owner_policy_audit(actor_user_id);
+create index if not exists dabbir_owner_policy_audit_policy_idx
+  on public.dabbir_owner_policy_audit(policy_id);
+create index if not exists dabbir_owner_policy_versions_owner_user_idx
+  on public.dabbir_owner_policy_versions(owner_user_id);
+create index if not exists dabbir_privacy_audit_request_idx
+  on public.dabbir_privacy_audit(privacy_request_id);
+
+-- Procedure execution and quality evidence.
+create index if not exists dabbir_procedure_audit_business_idx
+  on public.dabbir_procedure_audit(business_id);
+create index if not exists dabbir_procedure_audit_step_idx
+  on public.dabbir_procedure_audit(step_id);
+create index if not exists dabbir_procedure_definitions_created_by_idx
+  on public.dabbir_procedure_definitions(created_by);
+create index if not exists dabbir_procedure_runs_owner_approved_by_idx
+  on public.dabbir_procedure_runs(owner_approved_by);
+create index if not exists dabbir_quality_events_conversation_idx
+  on public.dabbir_quality_events(conversation_id);
+create index if not exists dabbir_quality_regression_cases_business_idx
+  on public.dabbir_quality_regression_cases(business_id);
+create index if not exists dabbir_retention_policies_data_category_idx
+  on public.dabbir_retention_policies(data_category);
+
+-- Verification / identity challenge paths.
+create index if not exists dabbir_verification_challenges_customer_fk_idx
+  on public.dabbir_verification_challenges(customer_id);
+create index if not exists dabbir_verification_challenges_identity_idx
+  on public.dabbir_verification_challenges(identity_id);

--- a/test/dabbir-core-fk-index-hardening.test.mjs
+++ b/test/dabbir-core-fk-index-hardening.test.mjs
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migrationPath='supabase/migrations/20260828052000_dabbir_core_fk_index_hardening_v1.sql';
+const sql=fs.readFileSync(migrationPath,'utf8');
+
+const required=[
+  ['dabbir_private.recovery_restore_events','journal_event_id'],
+  ['dabbir_private.recovery_runtime_context','recovery_case_id'],
+  ['public.account_access_state','reinstated_by'],
+  ['public.account_access_state','suspended_by'],
+  ['public.dabbir_access_audit','actor_user_id'],
+  ['public.dabbir_access_audit','invitation_id'],
+  ['public.dabbir_access_audit','target_user_id'],
+  ['public.dabbir_employee_invitations','accepted_by'],
+  ['public.dabbir_employee_invitations','invited_by'],
+  ['public.dabbir_memberships','invited_by'],
+  ['public.dabbir_conversation_outcomes','conversation_id'],
+  ['public.dabbir_conversation_outcomes','customer_id'],
+  ['public.dabbir_customer_evidence','conversation_id'],
+  ['public.dabbir_customer_evidence','customer_id'],
+  ['public.dabbir_customer_evidence','message_id'],
+  ['public.dabbir_event_inbox','customer_id'],
+  ['public.dabbir_followups','conversation_id'],
+  ['public.dabbir_handoffs','assigned_user_id'],
+  ['public.dabbir_messages','sender_user_id'],
+  ['public.dabbir_message_batch_items','message_id'],
+  ['public.dabbir_message_batches','conversation_id'],
+  ['public.dabbir_message_batches','customer_id'],
+  ['public.dabbir_owner_decision_observations','owner_user_id'],
+  ['public.dabbir_owner_policy_audit','actor_user_id'],
+  ['public.dabbir_owner_policy_audit','policy_id'],
+  ['public.dabbir_owner_policy_versions','owner_user_id'],
+  ['public.dabbir_privacy_audit','privacy_request_id'],
+  ['public.dabbir_procedure_audit','business_id'],
+  ['public.dabbir_procedure_audit','step_id'],
+  ['public.dabbir_procedure_definitions','created_by'],
+  ['public.dabbir_procedure_runs','owner_approved_by'],
+  ['public.dabbir_quality_events','conversation_id'],
+  ['public.dabbir_quality_regression_cases','business_id'],
+  ['public.dabbir_retention_policies','data_category'],
+  ['public.dabbir_verification_challenges','customer_id'],
+  ['public.dabbir_verification_challenges','identity_id'],
+];
+
+test('migration covers every currently confirmed DABBIR-only unindexed foreign key',()=>{
+  const normalized=sql.replace(/\s+/g,' ');
+  for(const [table,column] of required){
+    const escapedTable=table.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
+    const escapedColumn=column.replace(/[.*+?^${}()|[\]\\]/g,'\\$&');
+    assert.match(normalized,new RegExp(`create index if not exists [a-z0-9_]+ on ${escapedTable}\\(${escapedColumn}\\)`));
+  }
+  assert.equal((sql.match(/create index if not exists/gi)||[]).length,required.length);
+});
+
+test('core FK hardening is additive and cannot change data or authorization',()=>{
+  assert.doesNotMatch(sql,/\b(drop|delete|update|insert|truncate)\b/i);
+  assert.doesNotMatch(sql,/\b(grant|revoke)\b/i);
+  assert.doesNotMatch(sql,/\b(enable|disable|force)\s+row\s+level\s+security\b/i);
+  assert.doesNotMatch(sql,/create\s+(or\s+replace\s+)?function/i);
+});


### PR DESCRIPTION
Completes DABBIR-only FK index hardening without touching shared ZAJEL/R&A/BARMAN schemas.

Scope:
- 36 confirmed uncovered FK paths across DABBIR recovery, account access, audit/invitations, conversations/evidence, messaging, owner policy/memory, privacy, procedures, quality, retention, and verification tables.
- Additive indexes only; no data mutation, grants, functions, policies, or RLS changes.

Verification:
- Exact preview head `c7d36e120c7ac7c03e38469a14c9e0d4be48e9c6` ran the full Vercel Build Gate and passed 434/434 tests, then reached READY.
- The exact migration was applied successfully to Supabase Production.
- Direct PostgreSQL catalog verification now returns zero uncovered FKs for all `public.dabbir_%` tables plus the DABBIR recovery/account-access scope handled here.

The database migration must also force a matching Production Vercel deployment under the release-integrity fix merged in #145.