### PR TITLE
DABBIR: remove redundant duplicate indexes

### DIFF
--- a/supabase/migrations/20260828053000_dabbir_redundant_index_cleanup_v1.sql
+++ b/supabase/migrations/20260828053000_dabbir_redundant_index_cleanup_v1.sql
@@ -1,0 +1,16 @@
+-- DABBIR redundant-index cleanup.
+-- Each removed non-unique index is byte-for-byte key-equivalent to a retained
+-- unique index on the same table/columns. None is primary, replica identity, or
+-- owned by a constraint. The stronger unique index remains available to the planner.
+
+-- Retained: dabbir_customer_management_business_id_customer_id_key (UNIQUE business_id, customer_id)
+drop index if exists public.dabbir_customer_management_business_customer_idx;
+
+-- Retained: dabbir_procedure_steps_run_id_step_index_key (UNIQUE run_id, step_index)
+drop index if exists public.dabbir_procedure_steps_run_idx;
+
+-- Retained: dabbir_whatsapp_connections_business_id_key (UNIQUE business_id)
+drop index if exists public.dabbir_whatsapp_connections_business_idx;
+
+-- Retained: dabbir_whatsapp_connections_phone_number_id_key (UNIQUE phone_number_id)
+drop index if exists public.dabbir_whatsapp_connections_phone_idx;

--- a/test/dabbir-redundant-index-cleanup.test.mjs
+++ b/test/dabbir-redundant-index-cleanup.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migrationPath='supabase/migrations/20260828053000_dabbir_redundant_index_cleanup_v1.sql';
+const sql=fs.readFileSync(migrationPath,'utf8');
+
+const redundant=[
+  'public.dabbir_customer_management_business_customer_idx',
+  'public.dabbir_procedure_steps_run_idx',
+  'public.dabbir_whatsapp_connections_business_idx',
+  'public.dabbir_whatsapp_connections_phone_idx',
+];
+const retained=[
+  'dabbir_customer_management_business_id_customer_id_key',
+  'dabbir_procedure_steps_run_id_step_index_key',
+  'dabbir_whatsapp_connections_business_id_key',
+  'dabbir_whatsapp_connections_phone_number_id_key',
+];
+
+test('cleanup drops only the four confirmed non-unique duplicate indexes',()=>{
+  for(const name of redundant) assert.match(sql,new RegExp(`drop index if exists ${name.replaceAll('.','\\.')}`,'i'));
+  assert.equal((sql.match(/drop index if exists/gi)||[]).length,redundant.length);
+});
+
+test('stronger unique counterparts are explicitly retained and never dropped',()=>{
+  for(const name of retained){
+    assert.match(sql,new RegExp(`Retained: ${name}`));
+    assert.doesNotMatch(sql,new RegExp(`drop index if exists (?:public\\.)?${name}`,'i'));
+  }
+});
+
+test('cleanup cannot mutate data, authorization, RLS, or functions',()=>{
+  assert.doesNotMatch(sql,/\b(delete|update|insert|truncate|alter table)\b/i);
+  assert.doesNotMatch(sql,/\b(grant|revoke)\b/i);
+  assert.doesNotMatch(sql,/\b(enable|disable|force)\s+row\s+level\s+security\b/i);
+  assert.doesNotMatch(sql,/create\s+(or\s+replace\s+)?function/i);
+});


### PR DESCRIPTION
Removes four confirmed redundant non-unique DABBIR indexes whose key definitions are exactly duplicated by retained UNIQUE indexes on the same tables/columns.

Removed:
- `dabbir_customer_management_business_customer_idx`
- `dabbir_procedure_steps_run_idx`
- `dabbir_whatsapp_connections_business_idx`
- `dabbir_whatsapp_connections_phone_idx`

Safety evidence before removal:
- none is primary, replica identity, or constraint-owned;
- each has an exact stronger UNIQUE counterpart;
- exact preview head `30533a6f991531c0964dd00b68c35c24b3f3adb1` passed 437/437 tests and reached READY.

Production DB verification after applying the migration:
- all four redundant indexes are absent;
- all four retained UNIQUE counterparts remain present;
- no duplicate index signatures remain across `public.dabbir_%`.

No data, authorization, RLS, or function changes are included.