### PR TITLE
DABBIR: reconcile valid sessions before rejecting workspace gate

### DIFF
--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -12,6 +12,7 @@ const script = String.raw`(()=>{
 
   const authMachine=${authSessionMachine};
   let authStage=authMachine.stages.SIGNED_OUT;
+  let gateRecoveryPromise=null;
 
   function publishAuthStage(stage,reason=null){
     authStage=stage;
@@ -60,7 +61,48 @@ const script = String.raw`(()=>{
     return {ready:false,suspended:false};
   }
 
+  function localized(keyAr,keyEn){
+    return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')?keyAr:keyEn;
+  }
+
+  function showSessionError(textAr,textEn){
+    const msg=document.querySelector('#authMsg');
+    if(msg) msg.textContent=localized(textAr,textEn);
+  }
+
   const baseShowGate=showGate;
+
+  async function reconcileVerifiedGate(name){
+    if(gateRecoveryPromise) return gateRecoveryPromise;
+    gateRecoveryPromise=(async()=>{
+      const state=await sessionReady();
+      if(state.suspended){
+        setAuthStage(authMachine.stages.SUSPENDED,'ACCOUNT_SUSPENDED',{bootstrap:true});
+        baseShowGate('auth');
+        document.body.dataset.dabbirGate='auth';
+        showSessionError('الحساب موقوف. تواصل مع دعم دبّر.','This account is suspended. Contact DABBIR support.');
+        return;
+      }
+      if(!state.ready){
+        publishAuthStage(authMachine.stages.DEGRADED,'GATE_SESSION_RECONCILIATION_FAILED');
+        baseShowGate('auth');
+        document.body.dataset.dabbirGate='auth';
+        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
+        return;
+      }
+
+      setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_RECONCILED_FOR_GATE',{bootstrap:true});
+      if(name==='app'){
+        setAuthStage(authMachine.stages.WORKSPACE_READY,'WORKSPACE_RENDERED');
+      }
+      baseShowGate(name);
+      document.body.dataset.dabbirGate=String(name||'');
+      const bottom=document.querySelector('#bottomNav');
+      if(bottom&&name!=='app') bottom.classList.add('hidden');
+    })().finally(()=>{gateRecoveryPromise=null});
+    return gateRecoveryPromise;
+  }
+
   showGate=function(name){
     if(name==='auth'){
       if(authStage!==authMachine.stages.SUSPENDED){
@@ -68,20 +110,26 @@ const script = String.raw`(()=>{
       }
     }else if(name==='onboarding'){
       if(authStage!==authMachine.stages.SESSION_VERIFIED){
+        if(authStage===authMachine.stages.SIGNED_OUT||authStage===authMachine.stages.DEGRADED){
+          void reconcileVerifiedGate('onboarding');
+          return;
+        }
         publishAuthStage(authMachine.stages.DEGRADED,'ONBOARDING_WITHOUT_VERIFIED_SESSION');
         baseShowGate('auth');
-        const msg=document.querySelector('#authMsg');
-        if(msg) msg.textContent=localized('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
+        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
         return;
       }
     }else if(name==='app'){
       if(authStage===authMachine.stages.SESSION_VERIFIED){
         setAuthStage(authMachine.stages.WORKSPACE_READY,'WORKSPACE_RENDERED');
       }else if(authStage!==authMachine.stages.WORKSPACE_READY){
+        if(authStage===authMachine.stages.SIGNED_OUT||authStage===authMachine.stages.DEGRADED){
+          void reconcileVerifiedGate('app');
+          return;
+        }
         publishAuthStage(authMachine.stages.DEGRADED,'WORKSPACE_WITHOUT_VERIFIED_SESSION');
         baseShowGate('auth');
-        const msg=document.querySelector('#authMsg');
-        if(msg) msg.textContent=localized('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
+        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
         return;
       }
     }
@@ -91,10 +139,6 @@ const script = String.raw`(()=>{
     const bottom=document.querySelector('#bottomNav');
     if(bottom&&name!=='app') bottom.classList.add('hidden');
   };
-
-  function localized(keyAr,keyEn){
-    return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')?keyAr:keyEn;
-  }
 
   const form=document.querySelector('#authForm');
   if(form){
@@ -172,7 +216,7 @@ const script = String.raw`(()=>{
   }
   document.body.dataset.dabbirGate=authVisible?'auth':onboardingVisible?'onboarding':appVisible?'app':'';
 
-  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v2',session_retry:true,gate_isolation:true,state_machine:true};
+  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v3',session_retry:true,gate_isolation:true,state_machine:true,gate_reconciliation:true};
 })();`;
 
 export default function handler(req,res){

--- a/test/dabbir-ios-auth-gate-stability.test.mjs
+++ b/test/dabbir-ios-auth-gate-stability.test.mjs
@@ -24,6 +24,20 @@ test('successful login waits for the HttpOnly session to become observable befor
   assert.ok(sessionIndex >= 0 && bootIndex > sessionIndex);
 });
 
+test('a valid server session can reconcile a lagging signed-out presentation gate', () => {
+  assert.match(authUi, /async function reconcileVerifiedGate\(name\)/);
+  assert.match(authUi, /SESSION_RECONCILED_FOR_GATE/);
+  assert.match(authUi, /authStage===authMachine\.stages\.SIGNED_OUT\|\|authStage===authMachine\.stages\.DEGRADED/);
+  assert.match(authUi, /void reconcileVerifiedGate\('app'\)/);
+  assert.match(authUi, /void reconcileVerifiedGate\('onboarding'\)/);
+  assert.match(authUi, /gate_reconciliation:true/);
+
+  const reconcileIndex = authUi.indexOf('async function reconcileVerifiedGate(name)');
+  const sessionIndex = authUi.indexOf('const state=await sessionReady()', reconcileIndex);
+  const promoteIndex = authUi.indexOf("baseShowGate(name)", reconcileIndex);
+  assert.ok(reconcileIndex >= 0 && sessionIndex > reconcileIndex && promoteIndex > sessionIndex);
+});
+
 test('auth stability authority loads last after all owner and contextual presentation layers', () => {
   const ownerIndex = appRecovery.indexOf('/api/dabbir-owner-first-ui');
   const copilotIndex = appRecovery.indexOf('/api/owner-copilot-ui');
@@ -38,5 +52,5 @@ test('auth stability authority loads last after all owner and contextual present
 test('auth stability handler is no-store JavaScript and rejects non-GET requests', () => {
   assert.match(authUi, /application\/javascript; charset=utf-8/);
   assert.match(authUi, /cache-control','no-store/);
-  assert.match(authUi, /req\.method!=='GET'/);
+  assert.match(authUi, /req\.method!==\'GET\'/);
 });


### PR DESCRIPTION
P0 login repair from live evidence on 2026-08-28.

Verified production facts before this change:
- owner password login reaches Supabase successfully (HTTP 200);
- `/api/auth/session` returns authenticated successfully;
- `/api/dabbir-runtime-fast` then returns HTTP 200;
- the owner membership is active and not suspended;
- therefore the remaining failure is client gate/session presentation drift, not credentials, Supabase Auth, or tenant membership.

Root cause:
`auth-session-stability-ui` could reject an `app`/`onboarding` promotion solely because its local presentation state still read `signed_out`/`degraded`, even when the server session and runtime were already valid. That leaves the login gate visible after a real successful login.

Fix:
- when workspace/onboarding promotion arrives from lagging presentation state, re-verify the HttpOnly session against `/api/auth/session`;
- only after verified server evidence, reconcile to `session_verified` and promote the requested gate;
- fail closed to auth on failed/suspended reconciliation;
- serialize recovery so concurrent gate requests cannot fan out;
- keep existing iPhone bounded session retry and gate-isolation controls;
- add regression coverage locking this server-evidence reconciliation behavior.

No database, payment, Meta, KYC, membership, or credential mutation is included.