### PR TITLE
DABBIR: bind protected browser QA to every exact production release

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -27,6 +27,7 @@ on:
       - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
       - 'db/dabbir*.sql'
+      - 'api/**'
       - 'api/auth/**'
       - 'api/team/**'
       - 'api/chat*.js'

--- a/.github/workflows/dabbir-protected-live-smoke.yml
+++ b/.github/workflows/dabbir-protected-live-smoke.yml
@@ -5,6 +5,16 @@ on:
   push:
     branches: [main]
     paths:
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vercel.json'
+      - 'vercel-ignore-if-unaffected.sh'
+      - 'scripts/vercel-build-gate.mjs'
+      - 'api/**'
+      - 'index.html'
+      - 'team.html'
+      - 'supabase/migrations/*dabbir*'
+      - 'db/dabbir*.sql'
       - 'test/dabbir-protected-live-smoke.mjs'
       - 'test/dabbir-protected-live-smoke-oidc.test.mjs'
       - '.github/workflows/dabbir-protected-live-smoke.yml'
@@ -20,6 +30,8 @@ jobs:
     timeout-minutes: 12
     env:
       PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
+      EXPECTED_PRODUCTION_SHA: ${{ github.sha }}
+      PROTECTED_QA_RELEASE_WAIT_MS: '240000'
       VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
@@ -112,8 +124,11 @@ jobs:
         run: |
           if [ -f dabbir-protected-live-smoke-report.json ]; then
             echo '## DABBIR Protected Live Smoke' >> "$GITHUB_STEP_SUMMARY"
+            echo "**Expected SHA:** $EXPECTED_PRODUCTION_SHA" >> "$GITHUB_STEP_SUMMARY"
             echo "**Access method:** ${{ steps.bypass.outputs.method }}" >> "$GITHUB_STEP_SUMMARY"
             echo "**Verdict:** $(jq -r '.verdict' dabbir-protected-live-smoke-report.json)" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Verified production SHA:** $(jq -r '.verified_production_sha // "UNVERIFIED"' dabbir-protected-live-smoke-report.json)" >> "$GITHUB_STEP_SUMMARY"
+            echo "**Verified deployment ID:** $(jq -r '.verified_deployment_id // "UNAVAILABLE"' dabbir-protected-live-smoke-report.json)" >> "$GITHUB_STEP_SUMMARY"
             echo '| Step | Status | Duration ms | Detail |' >> "$GITHUB_STEP_SUMMARY"
             echo '|---|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
             jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' dabbir-protected-live-smoke-report.json >> "$GITHUB_STEP_SUMMARY"

--- a/api/release-evidence.js
+++ b/api/release-evidence.js
@@ -1,0 +1,35 @@
+function sendJson(res,status,payload,extraHeaders={}){
+  res.statusCode=status;
+  res.setHeader('content-type','application/json; charset=utf-8');
+  res.setHeader('cache-control','no-store, max-age=0');
+  res.setHeader('x-content-type-options','nosniff');
+  for(const [key,value] of Object.entries(extraHeaders))res.setHeader(key,value);
+  res.end(JSON.stringify(payload));
+}
+
+export default function handler(req,res){
+  if(req.method!=='GET'){
+    return sendJson(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  }
+
+  const commitSha=String(process.env.VERCEL_GIT_COMMIT_SHA||'').trim();
+  const deploymentId=String(process.env.VERCEL_DEPLOYMENT_ID||'').trim();
+  const environment=String(process.env.VERCEL_TARGET_ENV||process.env.VERCEL_ENV||'').trim();
+  const gitRef=String(process.env.VERCEL_GIT_COMMIT_REF||'').trim();
+
+  if(!/^[a-f0-9]{40}$/i.test(commitSha)){
+    return sendJson(res,503,{
+      ok:false,
+      error:'RELEASE_COMMIT_EVIDENCE_UNAVAILABLE',
+      environment:environment||null,
+    });
+  }
+
+  return sendJson(res,200,{
+    ok:true,
+    commit_sha:commitSha.toLowerCase(),
+    deployment_id:deploymentId||null,
+    environment:environment||null,
+    git_ref:gitRef||null,
+  });
+}

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -21,6 +21,12 @@ test('runtime dependency changes trigger the production customer journey',()=>{
   must(/- 'package-lock\.json'/,'package-lock.json changes must trigger the full production journey');
 });
 
+test('every root and nested API runtime change triggers the production customer journey',()=>{
+  must(/- 'api\/\*\*'/,'all DABBIR API runtime changes must trigger the full production journey');
+  must(/- 'index\.html'/,'the authoritative shell must trigger the full production journey');
+  must(/- 'team\.html'/,'team UI changes must trigger the full production journey');
+});
+
 test('capacity never runs automatically on push or schedule',()=>{
   const manualGate=/github\.event_name == 'workflow_dispatch'/g;
   assert.ok((workflow.match(manualGate)||[]).length>=2,'both capacity jobs must be workflow_dispatch-only');

--- a/test/dabbir-protected-live-smoke-oidc.test.mjs
+++ b/test/dabbir-protected-live-smoke-oidc.test.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 
 const workflow=await readFile(new URL('../.github/workflows/dabbir-protected-live-smoke.yml',import.meta.url),'utf8');
 const runner=await readFile(new URL('./dabbir-protected-live-smoke.mjs',import.meta.url),'utf8');
+const releaseEvidence=await readFile(new URL('../api/release-evidence.js',import.meta.url),'utf8');
 
 test('protected smoke can use short-lived GitHub trusted OIDC without opening production',()=>{
   assert.match(workflow,/id-token:\s*write/);
@@ -18,6 +19,33 @@ test('blocked automation access is a real failing gate, never a green skipped jo
   assert.ok(blocked,'blocked protection access must terminate the job with exit 2');
   assert.match(workflow,/browser journey did not run/);
   assert.match(workflow,/BLOCKED_VERCEL_BYPASS_GENERATION_FAILED'[\s\S]{0,240}?exit 2/);
+});
+
+test('protected smoke is bound to the exact production release SHA',()=>{
+  assert.match(workflow,/EXPECTED_PRODUCTION_SHA:\s*\$\{\{ github\.sha \}\}/);
+  assert.match(runner,/EXPECTED_PRODUCTION_SHA/);
+  assert.match(runner,/00_exact_production_sha/);
+  assert.match(runner,/\/api\/release-evidence/);
+  assert.match(runner,/observed === EXPECTED_SHA/);
+  assert.match(runner,/EXACT_PRODUCTION_SHA_NOT_READY/);
+  assert.match(runner,/verified_production_sha/);
+});
+
+test('every DABBIR runtime release can trigger the protected smoke',()=>{
+  assert.match(workflow,/- 'api\/\*\*'/);
+  assert.match(workflow,/- 'index\.html'/);
+  assert.match(workflow,/- 'package\.json'/);
+  assert.match(workflow,/- 'supabase\/migrations\/\*dabbir\*'/);
+  assert.match(workflow,/- 'db\/dabbir\*\.sql'/);
+});
+
+test('release evidence exposes only safe deployment identity and fails closed without commit evidence',()=>{
+  assert.match(releaseEvidence,/VERCEL_GIT_COMMIT_SHA/);
+  assert.match(releaseEvidence,/VERCEL_DEPLOYMENT_ID/);
+  assert.match(releaseEvidence,/VERCEL_TARGET_ENV/);
+  assert.match(releaseEvidence,/RELEASE_COMMIT_EVIDENCE_UNAVAILABLE/);
+  assert.match(releaseEvidence,/cache-control','no-store/);
+  assert.doesNotMatch(releaseEvidence,/SERVICE_ROLE|SUPABASE_KEY|TOKEN|SECRET|PASSWORD/);
 });
 
 test('smoke runner supports either documented protection access method',()=>{

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -3,14 +3,20 @@ import fs from 'node:fs';
 const ORIGIN = String(process.env.PROTECTED_QA_ORIGIN || '').trim().replace(/\/$/, '');
 const BYPASS = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
 const TRUSTED_OIDC = String(process.env.VERCEL_TRUSTED_OIDC_TOKEN || '').trim();
+const EXPECTED_SHA = String(process.env.EXPECTED_PRODUCTION_SHA || '').trim().toLowerCase();
 const REPORT_PATH = process.env.PROTECTED_QA_REPORT_PATH || 'dabbir-protected-live-smoke-report.json';
+const RELEASE_WAIT_MS = Math.min(Math.max(Number(process.env.PROTECTED_QA_RELEASE_WAIT_MS || 180_000), 15_000), 300_000);
 
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PROTECTED_QA_ORIGIN_REQUIRED');
 if (!BYPASS && !TRUSTED_OIDC) throw new Error('VERCEL_PROTECTED_ACCESS_REQUIRED');
+if (!/^[a-f0-9]{40}$/i.test(EXPECTED_SHA)) throw new Error('EXPECTED_PRODUCTION_SHA_REQUIRED');
 
 const report = {
   journey: 'DABBIR_PROTECTED_LIVE_IPHONE_SMOKE',
   origin: ORIGIN,
+  expected_production_sha: EXPECTED_SHA,
+  verified_production_sha: null,
+  verified_deployment_id: null,
   protection_access: BYPASS ? 'automation_bypass' : 'trusted_oidc',
   started_at: new Date().toISOString(),
   completed_at: null,
@@ -21,6 +27,10 @@ const report = {
 
 function assert(condition, message) {
   if (!condition) throw new Error(message || 'ASSERTION_FAILED');
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 async function step(name, fn) {
@@ -52,17 +62,48 @@ function protectionHeaders(extra = {}) {
 async function fetchProtected(path, init = {}) {
   const headers = new Headers(init.headers || {});
   for (const [key, value] of Object.entries(protectionHeaders())) headers.set(key, value);
-  return fetch(`${ORIGIN}${path}`, { redirect: 'follow', ...init, headers });
+  return fetch(`${ORIGIN}${path}`, { redirect: 'follow', cache: 'no-store', ...init, headers });
+}
+
+async function waitForExactProductionSha() {
+  const deadline = Date.now() + RELEASE_WAIT_MS;
+  let last = 'NO_RESPONSE';
+  while (Date.now() < deadline) {
+    try {
+      const response = await fetchProtected(`/api/release-evidence?t=${Date.now()}`, { headers: { accept: 'application/json' } });
+      const text = await response.text();
+      let body = {};
+      try { body = JSON.parse(text); } catch {}
+      const observed = String(body?.commit_sha || '').trim().toLowerCase();
+      const environment = String(body?.environment || '').trim().toLowerCase();
+      last = `HTTP_${response.status}:${observed || body?.error || text.slice(0, 120)}`;
+      if (response.status === 200 && body?.ok === true && observed === EXPECTED_SHA) {
+        assert(!environment || environment === 'production', `EXACT_SHA_NOT_PRODUCTION_${environment}`);
+        report.verified_production_sha = observed;
+        report.verified_deployment_id = body?.deployment_id || null;
+        return body;
+      }
+    } catch (error) {
+      last = String(error?.message || error).slice(0, 180);
+    }
+    await sleep(5_000);
+  }
+  throw new Error(`EXACT_PRODUCTION_SHA_NOT_READY_EXPECTED_${EXPECTED_SHA}_LAST_${last}`);
 }
 
 let browser;
 try {
+  await step('00_exact_production_sha', async () => {
+    const evidence = await waitForExactProductionSha();
+    return `Production release evidence matches ${EXPECTED_SHA}${evidence?.deployment_id ? ` on ${evidence.deployment_id}` : ''}.`;
+  });
+
   await step('01_protected_home_reachable', async () => {
     const response = await fetchProtected('/', { headers: { accept: 'text/html' } });
     const text = await response.text();
     assert(response.status === 200, `HOME_STATUS_${response.status}`);
     assert(/DABBIR/i.test(text), 'HOME_DABBIR_IDENTITY_MISSING');
-    return `Protected production home returned 200 with DABBIR identity via ${BYPASS ? 'automation bypass' : 'trusted GitHub OIDC'}.`;
+    return `Exact protected production home returned 200 with DABBIR identity via ${BYPASS ? 'automation bypass' : 'trusted GitHub OIDC'}.`;
   });
 
   await step('02_runtime_auth_still_fails_closed', async () => {
@@ -114,7 +155,7 @@ try {
     assert(pageErrors.length === 0, `PAGE_ERRORS:${pageErrors.join(' | ')}`);
     assert(consoleErrors.length === 0, `CONSOLE_ERRORS:${consoleErrors.slice(0, 8).join(' | ')}`);
     await context.close();
-    return 'WebKit rendered the iPhone-size Arabic login gate, approved logo, and authoritative owner-first-v4 shell without page errors.';
+    return `WebKit rendered the iPhone-size Arabic login gate on exact production SHA ${EXPECTED_SHA}, approved logo, and authoritative owner-first-v4 shell without page errors.`;
   });
 
   report.verdict = 'PASS';


### PR DESCRIPTION
Eliminates two release-verification gaps that allowed runtime changes to reach Production without exact protected iPhone evidence.

Root causes:
1. `DABBIR Protected Live Smoke` only triggered when its own test/workflow files changed, so normal auth/runtime/UI releases could bypass it.
2. The smoke targeted the production alias but did not prove that alias was serving the same `github.sha` that triggered the run.
3. `DABBIR AI Full Customer Journey` used a narrow API path allowlist that omitted root API UI modules such as `api/auth-session-stability-ui.js`.

Fix:
- Add safe read-only `/api/release-evidence` returning only Vercel commit SHA, deployment ID, environment, and git ref.
- Protected smoke receives `EXPECTED_PRODUCTION_SHA=${{ github.sha }}` and waits fail-closed until Production release evidence matches that exact SHA before any home/runtime/WebKit PASS.
- Expand protected-smoke runtime triggers to API, shell, package, Vercel gate, and DABBIR DB/migration surfaces.
- Expand full-customer-journey trigger to `api/**` so root and nested API runtime changes cannot bypass the production journey.
- Preserve fail-closed protected access: missing automation bypass / Vercel token / accepted Trusted OIDC is a real job failure, never green-skipped.
- Add regression coverage for exact-SHA binding, safe release evidence, broad runtime triggers, and full-journey API coverage.

Evidence before merge:
- `/api/release-evidence` was exercised on a real Vercel Preview and returned the exact preview commit SHA + deployment ID + `environment=preview` with HTTP 200.
- Final branch head `022a7a4ac8906261875b9950ddb0782928bbf0a6` passed the full Vercel Build Gate: 442/442 tests, 0 failed, 0 skipped.
- Exact-head Preview deployment `dpl_GDiyuUC6kfe74kqJfPHkkrbPy6Ma` reached READY.

No payment, customer data, Meta assets, Supabase data, auth credentials, or production protection settings are modified.