### PR TITLE
DABBIR QA: verify the visible auth brand in protected iPhone smoke

### DIFF
--- a/test/dabbir-protected-live-smoke-oidc.test.mjs
+++ b/test/dabbir-protected-live-smoke-oidc.test.mjs
@@ -48,6 +48,20 @@ test('release evidence exposes only safe deployment identity and fails closed wi
   assert.doesNotMatch(releaseEvidence,/SERVICE_ROLE|SUPABASE_KEY|TOKEN|SECRET|PASSWORD/);
 });
 
+test('iPhone brand assertion is scoped to the visible auth gate, never the hidden mobile shell brand',()=>{
+  assert.match(runner,/const authGate = page\.locator\('#authGate:not\(\.hidden\)'\)/);
+  assert.match(runner,/authGate\.locator\('\.authCard \.brand \.logo'\)/);
+  assert.match(runner,/AUTH_APPROVED_LOGO_COUNT_/);
+  assert.match(runner,/AUTH_APPROVED_LOGO_NOT_RENDERED/);
+  assert.doesNotMatch(runner,/page\.locator\('\.brand \.logo'\)\.first\(\)/);
+});
+
+test('failure evidence captures the iPhone screen before brand-specific assertions',()=>{
+  const screenshotAt=runner.indexOf("page.screenshot({ path: 'dabbir-protected-live-smoke.png'");
+  const logoAt=runner.indexOf("authGate.locator('.authCard .brand .logo')");
+  assert.ok(screenshotAt>0&&logoAt>0&&screenshotAt<logoAt,'screenshot must be captured before brand assertion failures');
+});
+
 test('smoke runner supports either documented protection access method',()=>{
   assert.match(runner,/VERCEL_AUTOMATION_BYPASS_SECRET/);
   assert.match(runner,/VERCEL_TRUSTED_OIDC_TOKEN/);

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -137,7 +137,8 @@ try {
 
     const response = await page.goto(ORIGIN, { waitUntil: 'domcontentloaded', timeout: 45_000 });
     assert(response?.status() === 200, `BROWSER_HOME_STATUS_${response?.status()}`);
-    await page.locator('#authGate:not(.hidden)').waitFor({ state: 'visible', timeout: 20_000 });
+    const authGate = page.locator('#authGate:not(.hidden)');
+    await authGate.waitFor({ state: 'visible', timeout: 20_000 });
     await page.locator('#authEmail').waitFor({ state: 'visible', timeout: 10_000 });
     await page.locator('#authPassword').waitFor({ state: 'visible', timeout: 10_000 });
     await page.locator('#authSubmit').waitFor({ state: 'visible', timeout: 10_000 });
@@ -145,17 +146,21 @@ try {
     const authority = await page.evaluate(() => window.__dabbirUiAuthority || null);
     assert(authority?.version === 'owner-first-v4', `UI_AUTHORITY_INVALID_${JSON.stringify(authority)}`);
 
-    const logo = page.locator('.brand .logo').first();
-    await logo.waitFor({ state: 'visible', timeout: 10_000 });
-    const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
-    assert(String(logoBg).includes('dabbir-approved-icon'), 'APPROVED_LOGO_NOT_RENDERED');
-
     await page.screenshot({ path: 'dabbir-protected-live-smoke.png', fullPage: true });
     report.artifacts.screenshot = 'dabbir-protected-live-smoke.png';
+
+    // Brand UI intentionally prepends a mobile app-shell brand that stays hidden on auth.
+    // Scope the assertion to the visible auth gate so a hidden sibling can never satisfy or break this check.
+    const logo = authGate.locator('.authCard .brand .logo');
+    assert(await logo.count() === 1, `AUTH_APPROVED_LOGO_COUNT_${await logo.count()}`);
+    await logo.waitFor({ state: 'visible', timeout: 10_000 });
+    const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
+    assert(String(logoBg).includes('dabbir-approved-icon'), 'AUTH_APPROVED_LOGO_NOT_RENDERED');
+
     assert(pageErrors.length === 0, `PAGE_ERRORS:${pageErrors.join(' | ')}`);
     assert(consoleErrors.length === 0, `CONSOLE_ERRORS:${consoleErrors.slice(0, 8).join(' | ')}`);
     await context.close();
-    return `WebKit rendered the iPhone-size Arabic login gate on exact production SHA ${EXPECTED_SHA}, approved logo, and authoritative owner-first-v4 shell without page errors.`;
+    return `WebKit rendered the iPhone-size Arabic login gate on exact production SHA ${EXPECTED_SHA}, visible approved auth logo, and authoritative owner-first-v4 shell without page errors.`;
   });
 
   report.verdict = 'PASS';


### PR DESCRIPTION
Fixes the first real WebKit failure revealed after #151 eliminated false-green protected QA.

Root cause:
- `api/brand-ui.js` intentionally prepends `.dabbirMobileBrand` at the top of `<body>` and keeps it hidden until the authenticated app shell is active.
- The protected iPhone smoke used `page.locator('.brand .logo').first()`, so on the unauthenticated login gate it selected that hidden mobile-shell brand instead of the visible approved logo inside `#authGate`.
- Production UI itself had a visible auth logo; the test selector had no presentation scope.

Fix:
- Scope the logo assertion to `#authGate:not(.hidden) .authCard .brand .logo`.
- Require exactly one auth-gate logo and verify it is visible and uses `dabbir-approved-icon`.
- Capture the iPhone screenshot before brand-specific assertions, so future visual failures still leave evidence.
- Add regression tests that forbid returning to the generic `.brand .logo.first()` selector and enforce screenshot-before-brand-assertion ordering.

Evidence before merge:
- Exact branch head `3a7ab6b8fb1378bf0ae7991c4a3d626058a33690` passed the full Vercel Build Gate: 444/444 tests, 0 failed, 0 skipped.
- Exact-head Preview `dpl_J9C14oL7K3MwDhYfsBebBdbzrg5c` reached READY.

No application runtime, auth logic, customer data, Supabase data, Meta configuration, payment code, or production protection setting is changed.