### PR TITLE
DABBIR release: deploy protected browser-smoke contract changes

### DIFF
--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -57,6 +57,29 @@ test('test-only changes on main skip Vercel deployment when no runtime drift exi
   assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 0);
 });
 
+test('protected Production smoke runner changes on main force exact-SHA Vercel deployment', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+  fs.writeFileSync(path.join(dir, 'test', 'dabbir-protected-live-smoke.mjs'), 'export const smoke = 1;\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'protected smoke contract');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  const result = runGuard(dir, head, lastSuccessfulDeployment);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Protected Production smoke contract changed; deploy exact SHA for browser evidence/);
+});
+
+test('protected Production smoke workflow changes on main force exact-SHA Vercel deployment', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+  fs.mkdirSync(path.join(dir, '.github', 'workflows'), { recursive: true });
+  fs.writeFileSync(path.join(dir, '.github', 'workflows', 'dabbir-protected-live-smoke.yml'), 'name: protected smoke\n');
+  git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'protected smoke workflow contract');
+  const head = git(dir, 'rev-parse', 'HEAD');
+  const result = runGuard(dir, head, lastSuccessfulDeployment);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Protected Production smoke contract changed; deploy exact SHA for browser evidence/);
+});
+
 test('Supabase migrations on main force Vercel deployment so production SHA cannot drift', () => {
   const dir = setupRepo();
   const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -13,7 +13,11 @@ set -u
 #    build whenever any application, database migration, or unknown path changed
 #    in that range. Database schema is part of the Production artifact contract;
 #    a migration must not leave main SHA ahead of the deployed SHA.
-# 3) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
+# 3) The protected Production browser-smoke runner and workflow are themselves
+#    release-verification contracts. Because that smoke is exact-SHA-bound, any
+#    change to either contract must deploy the same SHA before it can produce
+#    truthful browser evidence.
+# 4) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 ref="${VERCEL_GIT_COMMIT_REF:-}"
 previous_success="${VERCEL_GIT_PREVIOUS_SHA:-}"
@@ -58,6 +62,10 @@ fi
 
 while IFS= read -r path; do
   case "$path" in
+    test/dabbir-protected-live-smoke.mjs|.github/workflows/dabbir-protected-live-smoke.yml)
+      echo "Protected Production smoke contract changed; deploy exact SHA for browser evidence: $path"
+      exit 1
+      ;;
     .github/*|docs/*|test/*|README.md|.gitignore)
       ;;
     *)


### PR DESCRIPTION
Fixes the exact-SHA release-integrity conflict exposed by #153.

Root cause:
- Protected Production Smoke is now correctly bound to `EXPECTED_PRODUCTION_SHA=${{ github.sha }}`.
- `vercel-ignore-if-unaffected.sh` still classified every `test/*` and `.github/*` change as non-runtime.
- A change to the actual protected smoke runner/workflow could therefore trigger a browser run expecting the new SHA while Vercel deliberately skipped deploying that SHA. This made truthful exact-SHA verification impossible.

Fix:
- Treat `test/dabbir-protected-live-smoke.mjs` as a release-verification contract and force a Vercel deployment when it changes on main.
- Treat `.github/workflows/dabbir-protected-live-smoke.yml` the same way.
- Preserve the existing optimization for ordinary test/docs/GitHub-only changes.
- Preserve fail-safe behavior for runtime, DB, migration, and unknown paths.
- Add regression tests proving both protected-smoke contract paths force exact-SHA deployment while generic test-only changes still skip.

Evidence before merge:
- Exact branch head `a483a4754a8d4f20f0d6833850d6062c131d87fd` passed the full Vercel Build Gate: 446/446 tests, 0 failures, 0 skipped.
- Both new release-contract regression tests passed.
- Exact-head Preview `dpl_24d8azDXMXrTmMxGCqUmavqyzmtJ` reached READY.

No DABBIR business runtime, auth logic, customer data, Supabase data, Meta settings, payment code, or Vercel protection setting is changed.