### PR TITLE
DABBIR runtime: harden fast auth/data reads with truthful timeout evidence

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -93,17 +93,19 @@ export async function supabaseRpc(name, accessToken, params = {}) {
   });
 }
 
-async function verifiedUserBase(accessToken) {
+async function verifiedUserBase(accessToken, options = {}) {
   if (!accessToken) return null;
-  const response = await supabaseAuth('/auth/v1/user', { headers: { authorization: `Bearer ${accessToken}` } });
+  const headers = new Headers(options.headers || {});
+  headers.set('authorization', `Bearer ${accessToken}`);
+  const response = await supabaseAuth('/auth/v1/user', { ...options, headers });
   if (!response.ok) return null;
   const user = await response.json();
   if (!UUID_RE.test(String(user?.id || ''))) return null;
   return { id: user.id, email: user.email ?? null, aud: user.aud ?? null };
 }
 
-export async function getVerifiedUserWithAccess(accessToken) {
-  const user = await verifiedUserBase(accessToken);
+export async function getVerifiedUserWithAccess(accessToken, options = {}) {
+  const user = await verifiedUserBase(accessToken, options);
   if (!user) return null;
 
   // This is an ordinary RLS-protected self-read. The authenticated browser/user
@@ -111,7 +113,11 @@ export async function getVerifiedUserWithAccess(accessToken) {
   const response = await supabaseRest(
     `account_access_state?select=status,reason,suspended_at&user_id=eq.${encodeURIComponent(user.id)}&limit=1`,
     accessToken,
-  ).catch(() => null);
+    options,
+  ).catch(error => {
+    if (options.signal?.aborted) throw error;
+    return null;
+  });
   if (!response?.ok) return null;
   const rows = await response.json().catch(() => null);
   if (!Array.isArray(rows)) return null;
@@ -126,8 +132,8 @@ export async function getVerifiedUserWithAccess(accessToken) {
   };
 }
 
-export async function getVerifiedUser(accessToken) {
-  const user = await getVerifiedUserWithAccess(accessToken);
+export async function getVerifiedUser(accessToken, options = {}) {
+  const user = await getVerifiedUserWithAccess(accessToken, options);
   if (!user || user.dabbir_access === 'suspended') return null;
   return user;
 }
@@ -164,8 +170,12 @@ export function userClaimsFromValidatedAccessToken(accessToken, nowSeconds = Mat
   };
 }
 
-export async function getBusinessMemberships(accessToken) {
-  const response = await supabaseRest('dabbir_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active', accessToken);
+export async function getBusinessMemberships(accessToken, options = {}) {
+  const response = await supabaseRest(
+    'dabbir_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active',
+    accessToken,
+    options,
+  );
   if (!response.ok) {
     const status = Number(response.status || 500);
     const error = new Error(status === 401 || status === 403 ? 'AUTH_REQUIRED' : 'MEMBERSHIP_LOOKUP_FAILED');

--- a/api/dabbir-runtime-fast.js
+++ b/api/dabbir-runtime-fast.js
@@ -13,23 +13,32 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-
 const safeId = value => UUID_RE.test(String(value || '').trim()) ? String(value).trim() : null;
 const DABBIR_TIME_ZONE = 'Asia/Dubai';
 const DABBIR_UTC_OFFSET = '+04:00';
+const DABBIR_FAST_RUNTIME_VERSION = 'fast-v7-timeout-guarded';
 
-// === إصلاح: مهلة زمنية لكل استعلام على حدة ===
-// كل استعلام Supabase له مهلة قصوى مستقلة. إذا تعلّق أي استعلام واحد،
-// يفشل هو فقط بعد DB_TIMEOUT_MS بدل ما يعلّق الطلب كامل حتى حد Vercel (300 ثانية).
+// Every required Supabase request in the fast runtime is bounded independently
+// so a hung auth or tenant-data call cannot consume the full Vercel function
+// lifetime. Required workspace reads remain fail-fast as a group.
 const DB_TIMEOUT_MS = 10_000;
 
 function withTimeout(promiseFactory, label, ms = DB_TIMEOUT_MS) {
   const controller = new AbortController();
+  const timeoutError = () => {
+    const error = new Error(`${label}_TIMEOUT`);
+    error.status = 504;
+    return error;
+  };
   const timer = setTimeout(() => controller.abort(), ms);
+  const operation = Promise.resolve()
+    .then(() => promiseFactory(controller.signal))
+    .catch(error => {
+      if (controller.signal.aborted) throw timeoutError();
+      throw error;
+    })
+    .finally(() => clearTimeout(timer));
   return Promise.race([
-    promiseFactory(controller.signal).finally(() => clearTimeout(timer)),
+    operation,
     new Promise((_, reject) => {
-      controller.signal.addEventListener('abort', () => {
-        const error = new Error(`${label}_TIMEOUT`);
-        error.status = 504;
-        reject(error);
-      });
+      controller.signal.addEventListener('abort', () => reject(timeoutError()), { once: true });
     }),
   ]);
 }
@@ -108,7 +117,6 @@ async function readData(response, fallback = 'DATA_REQUEST_FAILED') {
   return payload;
 }
 
-// === إصلاح: rest() و restCount() الآن تلتزم بمهلة زمنية عبر withTimeout ===
 const rest = (token, path, fallback) =>
   withTimeout(
     signal => supabaseRest(path, token, { signal }).then(response => readData(response, fallback)),
@@ -199,6 +207,7 @@ function buildDataTruth({ business, conversations, customers, appointments, hand
   return {
     state: 'VERIFIED_TENANT_READ',
     source: 'SUPABASE_RLS_TENANT_DATA',
+    runtime_version: DABBIR_FAST_RUNTIME_VERSION,
     read_at: new Date().toISOString(),
     business_updated_at: business?.updated_at || null,
     runtime_ms: duration,
@@ -222,17 +231,31 @@ async function handleFastGet(req, res) {
 
   let memberships;
   try {
-    memberships = await getBusinessMemberships(accessToken);
+    memberships = await withTimeout(
+      signal => getBusinessMemberships(accessToken, { signal }),
+      'MEMBERSHIP_LOOKUP_FAILED',
+    );
   } catch (error) {
-    const status = Number(error?.code || 500);
+    const status = Number(error?.status || error?.code || 500);
     if (status === 401 || status === 403) {
       return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
     }
+    if (status === 504) throw error;
     return json(res, 503, { ok: false, authenticated: false, error: 'AUTH_VERIFICATION_UNAVAILABLE' });
   }
 
   let user = userClaimsFromValidatedAccessToken(accessToken);
-  if (!user) user = await getVerifiedUser(accessToken).catch(() => null);
+  if (!user) {
+    try {
+      user = await withTimeout(
+        signal => getVerifiedUser(accessToken, { signal }),
+        'AUTH_USER_VERIFICATION_FAILED',
+      );
+    } catch (error) {
+      if (Number(error?.status || 0) === 504) throw error;
+      user = null;
+    }
+  }
   if (!user) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
 
   const requestedBusinessId = safeId(singleQueryValue(req, 'business_id'));
@@ -254,6 +277,7 @@ async function handleFastGet(req, res) {
       data_truth: {
         state: 'NO_TENANT_SELECTED',
         source: 'SUPABASE_AUTH_AND_MEMBERSHIP',
+        runtime_version: DABBIR_FAST_RUNTIME_VERSION,
         read_at: new Date().toISOString(),
       },
       verified_metrics: null,
@@ -307,7 +331,8 @@ async function handleFastGet(req, res) {
     ? loadMessages(accessToken, businessId, requestedConversationId)
     : Promise.resolve(null);
 
-  // === إصلاح: كل استعلام يفشل بمفرده عند التعليق بدل تعليق الطلب كامل ===
+  // These reads are all required to claim a verified workspace response. Promise.all
+  // intentionally fails the whole request if any required read times out or fails.
   const [businessRows, rawConversations, customers, appointments, handoffs, followups, metrics, requestedMessages] =
     await Promise.all([
       businessPromise,
@@ -352,7 +377,6 @@ async function handleFastGet(req, res) {
   const duration = Date.now() - started;
   const dataTruth = buildDataTruth({ business, conversations, customers, appointments, handoffs, followups, messages, metrics, duration, summaryOnly });
   res.setHeader('server-timing', `dabbir;dur=${duration}`);
-  res.setHeader('x-dabbir-runtime', 'fast-v6-exact-metrics');
   return json(res, 200, {
     ok: true,
     authenticated: true,
@@ -381,12 +405,13 @@ async function handleFastGet(req, res) {
       state: aiConfig.configured ? 'OPERATIONAL_PROVIDER_READY' : 'UNCONFIGURED',
     },
     whatsapp: { state: 'NOT_OPERATIONAL', blocker: 'META_AUTHORIZATION_NOT_COMPLETED' },
-    performance: { runtime_ms: duration, summary_only: summaryOnly, conversation_dedupe: true, auth_fast_path: true, exact_metrics: true },
+    performance: { runtime_ms: duration, runtime_version: DABBIR_FAST_RUNTIME_VERSION, summary_only: summaryOnly, conversation_dedupe: true, auth_fast_path: true, exact_metrics: true },
   });
 }
 
 export default async function handler(req, res) {
   if (req.method === 'GET') {
+    res.setHeader('x-dabbir-runtime', DABBIR_FAST_RUNTIME_VERSION);
     try {
       return await handleFastGet(req, res);
     } catch (error) {
@@ -395,9 +420,10 @@ export default async function handler(req, res) {
       return json(res, safeStatus, {
         ok: false,
         state: 'FAILED_OR_UNVERIFIED',
+        runtime_version: DABBIR_FAST_RUNTIME_VERSION,
         error: String(error?.message || 'FAST_RUNTIME_FAILED').slice(0, 120),
         detail: error?.detail || undefined,
-        truth: { state: 'UNVERIFIED' },
+        truth: { state: 'UNVERIFIED', runtime_version: DABBIR_FAST_RUNTIME_VERSION },
       });
     }
   }

--- a/test/dabbir-auth-abort-signal.test.mjs
+++ b/test/dabbir-auth-abort-signal.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getBusinessMemberships, getVerifiedUser } from '../api/_auth-core.js';
+
+const VALID_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('membership lookup forwards the caller AbortSignal to the Supabase Data API fetch', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  let observedSignal = null;
+  globalThis.fetch = async (_url, options = {}) => {
+    observedSignal = options.signal || null;
+    return jsonResponse([]);
+  };
+
+  const memberships = await getBusinessMemberships('test-access-token', { signal: controller.signal });
+  assert.deepEqual(memberships, []);
+  assert.equal(observedSignal, controller.signal);
+});
+
+test('verified-user fallback forwards one AbortSignal through Auth and access-state reads', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), signal: options.signal || null });
+    if (String(url).includes('/auth/v1/user')) {
+      return jsonResponse({ id: VALID_USER_ID, email: 'qa@example.invalid', aud: 'authenticated' });
+    }
+    if (String(url).includes('/rest/v1/account_access_state')) return jsonResponse([]);
+    throw new Error(`UNEXPECTED_FETCH:${String(url)}`);
+  };
+
+  const user = await getVerifiedUser('test-access-token', { signal: controller.signal });
+  assert.equal(user?.id, VALID_USER_ID);
+  assert.equal(user?.dabbir_access, 'active');
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0].url.includes('/auth/v1/user'));
+  assert.ok(calls[1].url.includes('/rest/v1/account_access_state'));
+  assert.equal(calls[0].signal, controller.signal);
+  assert.equal(calls[1].signal, controller.signal);
+});
+
+test('an aborted membership request rejects instead of becoming a successful empty result', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  globalThis.fetch = (_url, options = {}) => new Promise((_resolve, reject) => {
+    const rejectAbort = () => {
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    if (options.signal?.aborted) return rejectAbort();
+    options.signal?.addEventListener('abort', rejectAbort, { once: true });
+  });
+
+  const request = getBusinessMemberships('test-access-token', { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(request, error => error?.name === 'AbortError');
+});

--- a/test/dabbir-auth-fastpath.test.mjs
+++ b/test/dabbir-auth-fastpath.test.mjs
@@ -47,14 +47,15 @@ test('validated-token claims fail closed for wrong issuer, role, audience, expir
 });
 
 test('fast runtime validates membership before trusting decoded claims and retains fallback verification', () => {
-  const membershipLookup = runtimeSource.indexOf('memberships = await getBusinessMemberships(accessToken)');
+  const membershipLookup = runtimeSource.indexOf('signal => getBusinessMemberships(accessToken, { signal })');
   const claimsRead = runtimeSource.indexOf('userClaimsFromValidatedAccessToken(accessToken)');
-  const fallback = runtimeSource.indexOf('getVerifiedUser(accessToken)');
-  assert.ok(membershipLookup >= 0, 'membership validation must exist');
+  const fallback = runtimeSource.indexOf('signal => getVerifiedUser(accessToken, { signal })');
+  assert.ok(membershipLookup >= 0, 'abort-bounded membership validation must exist');
   assert.ok(claimsRead > membershipLookup, 'claims may only be trusted after Supabase Data API accepts the token');
-  assert.ok(fallback > claimsRead, 'legacy/unexpected token shapes must retain server verification fallback');
+  assert.ok(fallback > claimsRead, 'legacy/unexpected token shapes must retain abort-bounded server verification fallback');
   assert.match(runtimeSource, /AUTH_VERIFICATION_UNAVAILABLE/);
-  assert.match(runtimeSource, /x-dabbir-runtime', 'fast-v6-exact-metrics'/);
+  assert.match(runtimeSource, /const DABBIR_FAST_RUNTIME_VERSION = 'fast-v7-timeout-guarded'/);
+  assert.match(runtimeSource, /x-dabbir-runtime', DABBIR_FAST_RUNTIME_VERSION/);
 });
 
 test('fast runtime parses query parameters with WHATWG URL instead of legacy req.query', () => {

--- a/test/dabbir-runtime-timeout-truth.test.mjs
+++ b/test/dabbir-runtime-timeout-truth.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const runtime = fs.readFileSync('api/dabbir-runtime-fast.js', 'utf8');
+const authCore = fs.readFileSync('api/_auth-core.js', 'utf8');
+
+test('fast runtime has one timeout-aware version authority on success and failure', () => {
+  assert.match(runtime, /const DABBIR_FAST_RUNTIME_VERSION = 'fast-v7-timeout-guarded'/);
+  assert.match(runtime, /if \(req\.method === 'GET'\) \{\s*res\.setHeader\('x-dabbir-runtime', DABBIR_FAST_RUNTIME_VERSION\)/);
+  assert.match(runtime, /runtime_version: DABBIR_FAST_RUNTIME_VERSION/);
+  assert.match(runtime, /truth: \{ state: 'UNVERIFIED', runtime_version: DABBIR_FAST_RUNTIME_VERSION \}/);
+  assert.doesNotMatch(runtime, /x-dabbir-runtime', 'fast-v6-exact-metrics'/);
+});
+
+test('tenant and authentication Supabase reads are abort-bounded', () => {
+  assert.match(runtime, /const DB_TIMEOUT_MS = 10_000/);
+  assert.match(runtime, /new AbortController\(\)/);
+  assert.match(runtime, /controller\.signal\.addEventListener\('abort'/);
+  assert.match(runtime, /supabaseRest\(path, token, \{ signal \}\)/);
+  assert.match(runtime, /prefer: 'count=exact' \}, signal/);
+  assert.match(runtime, /getBusinessMemberships\(accessToken, \{ signal \}\)/);
+  assert.match(runtime, /getVerifiedUser\(accessToken, \{ signal \}\)/);
+
+  assert.match(authCore, /verifiedUserBase\(accessToken, options = \{\}\)/);
+  assert.match(authCore, /getVerifiedUserWithAccess\(accessToken, options = \{\}\)/);
+  assert.match(authCore, /getVerifiedUser\(accessToken, options = \{\}\)/);
+  assert.match(authCore, /getBusinessMemberships\(accessToken, options = \{\}\)/);
+  assert.match(authCore, /supabaseAuth\('\/auth\/v1\/user', \{ \.\.\.options, headers \}\)/);
+  assert.match(authCore, /accessToken,\s*options,\s*\)\.catch/);
+});
+
+test('required workspace reads fail the response fast instead of claiming partial verification', () => {
+  assert.match(runtime, /await Promise\.all\(/);
+  assert.match(runtime, /intentionally fails the whole request if any required read times out or fails/);
+  assert.match(runtime, /if \(status === 504\) throw error/);
+  assert.match(runtime, /AUTH_USER_VERIFICATION_FAILED/);
+  assert.match(runtime, /\[400, 401, 403, 404, 409, 413, 429, 502, 503, 504\]/);
+});
+
+test('runtime documentation cannot claim a single required query fails in isolation', () => {
+  assert.doesNotMatch(runtime, /يفشل هو فقط بعد DB_TIMEOUT_MS/);
+  assert.doesNotMatch(runtime, /كل استعلام يفشل بمفرده عند التعليق بدل تعليق الطلب كامل/);
+});

--- a/test/dabbir-truth-visibility.test.mjs
+++ b/test/dabbir-truth-visibility.test.mjs
@@ -22,12 +22,15 @@ test('fast runtime exposes verified tenant read provenance and exact read timest
   assert.match(runtime, /read_at:\s*new Date\(\)\.toISOString\(\)/);
   assert.match(runtime, /business_updated_at/);
   assert.match(runtime, /exact_metrics_state/);
-  assert.match(runtime, /x-dabbir-runtime', 'fast-v6-exact-metrics'/);
+  assert.match(runtime, /const DABBIR_FAST_RUNTIME_VERSION = 'fast-v7-timeout-guarded'/);
+  assert.match(runtime, /x-dabbir-runtime', DABBIR_FAST_RUNTIME_VERSION/);
+  assert.match(runtime, /runtime_version: DABBIR_FAST_RUNTIME_VERSION/);
 });
 
-test('fast runtime failures are explicit unverified states', () => {
+test('fast runtime failures are explicit unverified states with runtime evidence', () => {
   assert.match(runtime, /state:\s*'FAILED_OR_UNVERIFIED'/);
-  assert.match(runtime, /truth:\s*\{ state: 'UNVERIFIED' \}/);
+  assert.match(runtime, /truth:\s*\{ state: 'UNVERIFIED', runtime_version: DABBIR_FAST_RUNTIME_VERSION \}/);
+  assert.match(runtime, /runtime_version:\s*DABBIR_FAST_RUNTIME_VERSION/);
 });
 
 test('owner interface renders a compact verified-data badge', () => {

--- a/test/phase2-security-contract.test.mjs
+++ b/test/phase2-security-contract.test.mjs
@@ -89,7 +89,8 @@ test('state-changing auth endpoints require same-origin and bounded request bodi
 test('session identity is verified server-side and memberships are resolved under user bearer RLS', () => {
   assert.match(authCore, /\/auth\/v1\/user/);
   assert.match(authCore, /dabbir_memberships\?select=business_id,role/);
-  assert.match(authCore, /authorization: `Bearer \$\{accessToken\}`/);
+  assert.match(authCore, /headers\.set\('authorization', `Bearer \$\{accessToken\}`\)/);
+  assert.match(authCore, /supabaseRest\([\s\S]*accessToken,[\s\S]*options/);
   assert.match(session, /getVerifiedUser/);
   assert.match(session, /getBusinessMemberships/);
   assert.doesNotMatch(session, /dabbir_customers/);


### PR DESCRIPTION
Clean successor to #152, rebuilt directly on the current authoritative main SHA `348778875a024b0cbfc8014fab0e5c9db4d4fea8` so no stale Browser QA/release history can be reintroduced.

Root cause:
- DABBIR fast tenant data reads were bounded, but membership and Auth fallback reads were not consistently AbortSignal-bounded.
- The runtime still advertised stale `fast-v6-exact-metrics` evidence.
- Comments claimed an individual required query could fail alone, while the required workspace contract uses `Promise.all` and correctly fails the whole verified response when any required read fails.

Repair:
- Add one `DABBIR_FAST_RUNTIME_VERSION = fast-v7-timeout-guarded` authority on success and failure evidence.
- Forward AbortSignal through membership lookup and verified-user Auth/access-state reads.
- Preserve 504 timeout truth instead of collapsing it into an authentication success/failure shape.
- Clarify required workspace reads are fail-fast as a verified group.
- Add source-contract regression tests plus behavior tests proving the exact AbortSignal reaches both Supabase Data API and Auth fetches and aborted membership reads reject rather than returning an empty success.

Scope is exactly seven files relative to current main: two runtime/auth files and five tests. No database migration, tenant data, Meta asset, Stripe configuration, Vercel protection setting, or browser QA contract is changed.

Pre-PR evidence:
- Exact branch head `17dcd2f9d0df6c73417b65facafc54d077c809c9` is ahead of current main by 2 commits and behind by 0.
- Exact-head Vercel Preview `dpl_CcsNmQyGzqsdWvVKuHbQPi1tAJ3M` is READY.
- Vercel Build Gate verified the exact head; new AbortSignal behavior tests passed.

Merge gate: GitHub syntax + production dependency audit + full tests + secret scan must pass on the exact head. After merge: exact Production SHA READY + Protected iPhone WebKit exact-SHA evidence + runtime error check.