### PR TITLE
DABBIR QA: prove AbortSignal reaches auth and membership fetches

### DIFF
--- a/test/dabbir-auth-abort-signal.test.mjs
+++ b/test/dabbir-auth-abort-signal.test.mjs
@@ -1,0 +1,73 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getBusinessMemberships, getVerifiedUser } from '../api/_auth-core.js';
+
+const VALID_USER_ID = '00000000-0000-4000-8000-000000000001';
+
+function jsonResponse(body, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+test('membership lookup forwards the caller AbortSignal to the Supabase Data API fetch', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  let observedSignal = null;
+  globalThis.fetch = async (_url, options = {}) => {
+    observedSignal = options.signal || null;
+    return jsonResponse([]);
+  };
+
+  const memberships = await getBusinessMemberships('test-access-token', { signal: controller.signal });
+  assert.deepEqual(memberships, []);
+  assert.equal(observedSignal, controller.signal);
+});
+
+test('verified-user fallback forwards one AbortSignal through Auth and access-state reads', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), signal: options.signal || null });
+    if (String(url).includes('/auth/v1/user')) {
+      return jsonResponse({ id: VALID_USER_ID, email: 'qa@example.invalid', aud: 'authenticated' });
+    }
+    if (String(url).includes('/rest/v1/account_access_state')) return jsonResponse([]);
+    throw new Error(`UNEXPECTED_FETCH:${String(url)}`);
+  };
+
+  const user = await getVerifiedUser('test-access-token', { signal: controller.signal });
+  assert.equal(user?.id, VALID_USER_ID);
+  assert.equal(user?.dabbir_access, 'active');
+  assert.equal(calls.length, 2);
+  assert.ok(calls[0].url.includes('/auth/v1/user'));
+  assert.ok(calls[1].url.includes('/rest/v1/account_access_state'));
+  assert.equal(calls[0].signal, controller.signal);
+  assert.equal(calls[1].signal, controller.signal);
+});
+
+test('an aborted membership request rejects instead of becoming a successful empty result', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  const controller = new AbortController();
+  globalThis.fetch = (_url, options = {}) => new Promise((_resolve, reject) => {
+    const rejectAbort = () => {
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    if (options.signal?.aborted) return rejectAbort();
+    options.signal?.addEventListener('abort', rejectAbort, { once: true });
+  });
+
+  const request = getBusinessMemberships('test-access-token', { signal: controller.signal });
+  controller.abort();
+  await assert.rejects(request, error => error?.name === 'AbortError');
+});


### PR DESCRIPTION
Regression-only follow-up to merged #152.

Purpose:
- Prove behavior, not only source shape: the exact caller AbortSignal reaches Supabase membership, Auth user, and access-state fetches.
- Prove an aborted membership read rejects rather than degrading into a successful empty result.

Scope: one new test file only. No runtime, Auth, database, Meta, Stripe, Vercel protection, or customer data changes.

Evidence before PR:
- Current main is exact #152 production SHA `e1431341463ff6b5cec2d9a6e7bcfe9bab834328`.
- Branch head `84f773b4b33b3f16bad9bc68d3b1ed978d96dfad` is ahead by 1, behind by 0, and differs by exactly one new test file.
- Exact-head Vercel Preview `dpl_ETGSBPkZYM3U4xwbeDGKyP7SxCGg` is READY.
- Full Vercel gate ran because it is non-main; all three new behavior tests passed.

Merge gate: GitHub syntax, dependency audit, full tests, and secret scan must pass on this exact head. Main test-only deployment may then be intentionally skipped by Vercel because runtime remains the already verified #152 artifact.