### PR TITLE
DABBIR: bound critical WhatsApp and billing prerequisite reads

### DIFF
--- a/api/_billing-core.js
+++ b/api/_billing-core.js
@@ -61,11 +61,11 @@ async function parseResponse(response,fallback){
 }
 
 export async function getBillingAccount(accessToken,businessId,options={}){
-  const response=await withServerReadTimeout(
-    signal=>supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal}),
-    {label:'BILLING_ACCOUNT_READ',errorCode:'BILLING_STATUS_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS},
-  );
-  const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');return Array.isArray(rows)?rows[0]||null:null;
+  return withServerReadTimeout(async signal=>{
+    const response=await supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal});
+    const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');
+    return Array.isArray(rows)?rows[0]||null:null;
+  },{label:'BILLING_ACCOUNT_READ',errorCode:'BILLING_STATUS_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS});
 }
 
 export function publicBillingState(account){

--- a/api/_billing-core.js
+++ b/api/_billing-core.js
@@ -55,8 +55,10 @@ export async function requireBillingOwner(req,businessIdValue,options={}){
 }
 
 async function parseResponse(response,fallback){
-  const text=await response.text();let data=null;try{data=text?JSON.parse(text):null}catch{}
-  if(!response.ok){const error=billingError(fallback,response.status===401?401:response.status===403?403:response.status===404?404:response.status===409?409:response.status===429?429:503);error.detail=data?.error||data?.code||data?.message||null;throw error}
+  const text=await response.text();let data=null;let parseFailed=false;
+  if(text){try{data=JSON.parse(text)}catch{parseFailed=true}}
+  if(!response.ok){const error=billingError(fallback,response.status===401?401:response.status===403?403:response.status===404?404:response.status===409?409:response.status===429?429:503);error.detail=parseFailed?null:data?.error||data?.code||data?.message||null;throw error}
+  if(parseFailed||data===null)throw billingError(`${fallback}_INVALID_RESPONSE`,502);
   return data;
 }
 
@@ -64,7 +66,8 @@ export async function getBillingAccount(accessToken,businessId,options={}){
   return withServerReadTimeout(async signal=>{
     const response=await supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal});
     const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');
-    return Array.isArray(rows)?rows[0]||null:null;
+    if(!Array.isArray(rows))throw billingError('BILLING_STATUS_INVALID_RESPONSE',502);
+    return rows[0]||null;
   },{label:'BILLING_ACCOUNT_READ',errorCode:'BILLING_STATUS_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS});
 }
 

--- a/api/_billing-core.js
+++ b/api/_billing-core.js
@@ -5,10 +5,12 @@ import {
   getVerifiedUser,
   supabaseRest,
 } from './_auth-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const SAFE_HOST_RE=/^(?:[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?)(?::\d{1,5})?$/i;
 const SUPABASE_URL=String(process.env.SUPABASE_URL||'https://spohjzrsymsmzsseygtw.supabase.co').replace(/\/$/,'');
+const BILLING_READ_TIMEOUT_MS=10_000;
 export const DABBIR_OWNER_PRICE_ID='price_1U8yRWLYIkiZam7bHaP2NhtT';
 export const DABBIR_TRIAL_DAYS=7;
 export const DABBIR_OWNER_MONTHLY_AED=129;
@@ -38,7 +40,13 @@ export function checkoutIdempotencyKey(businessId,userId,now=Date.now()){
 export async function requireBillingOwner(req,businessIdValue){
   const businessId=safeBusinessId(businessIdValue);if(!businessId)throw billingError('BUSINESS_ID_REQUIRED',400);
   const accessToken=accessTokenFromRequest(req);if(!accessToken)throw billingError('AUTH_REQUIRED',401);
-  const [user,memberships]=await Promise.all([getVerifiedUser(accessToken),getBusinessMemberships(accessToken).catch(()=>[])]);
+  const [user,memberships]=await withServerReadTimeout(
+    signal=>Promise.all([
+      getVerifiedUser(accessToken,{signal}),
+      getBusinessMemberships(accessToken,{signal}),
+    ]),
+    {label:'BILLING_AUTH_READ',timeoutMs:BILLING_READ_TIMEOUT_MS},
+  );
   if(!user)throw billingError('AUTH_REQUIRED',401);
   const membership=memberships.find(row=>row.business_id===businessId)||null;
   if(!membership)throw billingError('BUSINESS_ACCESS_DENIED',403);
@@ -53,7 +61,10 @@ async function parseResponse(response,fallback){
 }
 
 export async function getBillingAccount(accessToken,businessId){
-  const response=await supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken);
+  const response=await withServerReadTimeout(
+    signal=>supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal}),
+    {label:'BILLING_ACCOUNT_READ',timeoutMs:BILLING_READ_TIMEOUT_MS},
+  );
   const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');return Array.isArray(rows)?rows[0]||null:null;
 }
 

--- a/api/_billing-core.js
+++ b/api/_billing-core.js
@@ -37,7 +37,7 @@ export function checkoutIdempotencyKey(businessId,userId,now=Date.now()){
   return `dabbir_checkout_${crypto.createHash('sha256').update(`${businessId}:${userId}:${bucket}`).digest('hex').slice(0,32)}`;
 }
 
-export async function requireBillingOwner(req,businessIdValue){
+export async function requireBillingOwner(req,businessIdValue,options={}){
   const businessId=safeBusinessId(businessIdValue);if(!businessId)throw billingError('BUSINESS_ID_REQUIRED',400);
   const accessToken=accessTokenFromRequest(req);if(!accessToken)throw billingError('AUTH_REQUIRED',401);
   const [user,memberships]=await withServerReadTimeout(
@@ -45,7 +45,7 @@ export async function requireBillingOwner(req,businessIdValue){
       getVerifiedUser(accessToken,{signal}),
       getBusinessMemberships(accessToken,{signal}),
     ]),
-    {label:'BILLING_AUTH_READ',timeoutMs:BILLING_READ_TIMEOUT_MS},
+    {label:'BILLING_AUTH_READ',errorCode:'BILLING_AUTH_DATA_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS},
   );
   if(!user)throw billingError('AUTH_REQUIRED',401);
   const membership=memberships.find(row=>row.business_id===businessId)||null;
@@ -60,10 +60,10 @@ async function parseResponse(response,fallback){
   return data;
 }
 
-export async function getBillingAccount(accessToken,businessId){
+export async function getBillingAccount(accessToken,businessId,options={}){
   const response=await withServerReadTimeout(
     signal=>supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal}),
-    {label:'BILLING_ACCOUNT_READ',timeoutMs:BILLING_READ_TIMEOUT_MS},
+    {label:'BILLING_ACCOUNT_READ',errorCode:'BILLING_STATUS_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS},
   );
   const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');return Array.isArray(rows)?rows[0]||null:null;
 }

--- a/api/_billing-core.js
+++ b/api/_billing-core.js
@@ -67,7 +67,13 @@ export async function getBillingAccount(accessToken,businessId,options={}){
     const response=await supabaseRest(`dabbir_billing_accounts?select=business_id,stripe_customer_id,stripe_subscription_id,stripe_price_id,status,trial_started_at,trial_ends_at,current_period_ends_at,cancel_at_period_end,last_invoice_status,updated_at&business_id=eq.${businessId}&limit=1`,accessToken,{signal});
     const rows=await parseResponse(response,'BILLING_STATUS_UNAVAILABLE');
     if(!Array.isArray(rows))throw billingError('BILLING_STATUS_INVALID_RESPONSE',502);
-    return rows[0]||null;
+    if(rows.length===0)return null;
+    if(rows.length!==1)throw billingError('BILLING_STATUS_INVALID_RESPONSE',502);
+    const account=rows[0];
+    if(!account||typeof account!=='object'||Array.isArray(account)||String(account.business_id||'')!==String(businessId)){
+      throw billingError('BILLING_STATUS_INVALID_RESPONSE',502);
+    }
+    return account;
   },{label:'BILLING_ACCOUNT_READ',errorCode:'BILLING_STATUS_TIMEOUT',timeoutMs:options.timeoutMs??BILLING_READ_TIMEOUT_MS});
 }
 

--- a/api/_server-read-timeout.js
+++ b/api/_server-read-timeout.js
@@ -33,6 +33,7 @@ export async function withServerReadTimeout(operation, { label = 'SERVER_READ', 
   try {
     return await Promise.race([operationPromise, timeoutPromise]);
   } finally {
+    if (!controller.signal.aborted) controller.abort();
     if (timer) clearTimeout(timer);
   }
 }

--- a/api/_server-read-timeout.js
+++ b/api/_server-read-timeout.js
@@ -1,14 +1,16 @@
-function makeTimeoutError(label) {
-  const code = `${String(label || 'SERVER_READ').toUpperCase()}_TIMEOUT`;
+function makeTimeoutError(label, errorCode) {
+  const code = String(errorCode || `${String(label || 'SERVER_READ').toUpperCase()}_TIMEOUT`).slice(0, 120);
   const error = new Error(code);
   error.status = 504;
   error.code = 504;
   error.safeCode = code;
+  error.errorCode = code;
   error.failureClass = 'TIMEOUT';
+  error.timeout = true;
   return error;
 }
 
-export async function withServerReadTimeout(operation, { label = 'SERVER_READ', timeoutMs = 10_000 } = {}) {
+export async function withServerReadTimeout(operation, { label = 'SERVER_READ', errorCode = null, timeoutMs = 10_000 } = {}) {
   if (typeof operation !== 'function') throw new TypeError('SERVER_READ_OPERATION_REQUIRED');
   const boundedMs = Math.max(1, Math.min(Number(timeoutMs) || 10_000, 60_000));
   const controller = new AbortController();
@@ -17,14 +19,14 @@ export async function withServerReadTimeout(operation, { label = 'SERVER_READ', 
   const timeoutPromise = new Promise((_, reject) => {
     timer = setTimeout(() => {
       controller.abort();
-      reject(makeTimeoutError(label));
+      reject(makeTimeoutError(label, errorCode));
     }, boundedMs);
   });
 
   const operationPromise = Promise.resolve()
     .then(() => operation(controller.signal))
     .catch(error => {
-      if (controller.signal.aborted || error?.name === 'AbortError') throw makeTimeoutError(label);
+      if (controller.signal.aborted) throw makeTimeoutError(label, errorCode);
       throw error;
     });
 

--- a/api/_server-read-timeout.js
+++ b/api/_server-read-timeout.js
@@ -1,0 +1,36 @@
+function makeTimeoutError(label) {
+  const code = `${String(label || 'SERVER_READ').toUpperCase()}_TIMEOUT`;
+  const error = new Error(code);
+  error.status = 504;
+  error.code = 504;
+  error.safeCode = code;
+  error.failureClass = 'TIMEOUT';
+  return error;
+}
+
+export async function withServerReadTimeout(operation, { label = 'SERVER_READ', timeoutMs = 10_000 } = {}) {
+  if (typeof operation !== 'function') throw new TypeError('SERVER_READ_OPERATION_REQUIRED');
+  const boundedMs = Math.max(1, Math.min(Number(timeoutMs) || 10_000, 60_000));
+  const controller = new AbortController();
+  let timer = null;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    timer = setTimeout(() => {
+      controller.abort();
+      reject(makeTimeoutError(label));
+    }, boundedMs);
+  });
+
+  const operationPromise = Promise.resolve()
+    .then(() => operation(controller.signal))
+    .catch(error => {
+      if (controller.signal.aborted || error?.name === 'AbortError') throw makeTimeoutError(label);
+      throw error;
+    });
+
+  try {
+    return await Promise.race([operationPromise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -115,7 +115,7 @@ export async function resolveEmbeddedPlatformConfig() {
   };
 }
 
-export async function ownerContext(req, businessId) {
+export async function ownerContext(req, businessId, options = {}) {
   const accessToken = accessTokenFromRequest(req);
   if (!accessToken) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
   const [user, memberships] = await withServerReadTimeout(
@@ -123,7 +123,11 @@ export async function ownerContext(req, businessId) {
       getVerifiedUser(accessToken, { signal }),
       getBusinessMemberships(accessToken, { signal }),
     ]),
-    { label: 'WHATSAPP_OWNER_CONTEXT_READ', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+    {
+      label: 'WHATSAPP_OWNER_CONTEXT_READ',
+      errorCode: 'WHATSAPP_AUTH_DATA_TIMEOUT',
+      timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+    },
   );
   if (!user) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
   const membership = memberships.find(item => String(item.business_id) === String(businessId));
@@ -188,12 +192,18 @@ export function tokenNeedsRotation(row, config) {
   return String(row?.token_key_version || 'whatsapp_v1') !== String(config?.encryptionKeyVersion || 'whatsapp_v1');
 }
 
-export async function rotateStoredConnectionEncryption(accessToken, row, config, token = null) {
+function connectionStorageError(message, response) {
+  const providerStatus = Number(response?.status || 500);
+  const status = providerStatus === 401 ? 401 : providerStatus === 403 ? 403 : 502;
+  return Object.assign(new Error(message), { status, code: message, providerStatus });
+}
+
+export async function rotateStoredConnectionEncryption(accessToken, row, config, token = null, options = {}) {
   if (!row || !tokenNeedsRotation(row, config)) return { rotated: false, row };
   const plaintext = token == null ? openAccessToken(row, config, row.business_id) : String(token);
   const sealed = sealAccessToken(plaintext, config, row.business_id);
-  const response = await withServerReadTimeout(
-    signal => supabaseRest(
+  return withServerReadTimeout(async signal => {
+    const response = await supabaseRest(
       `dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(row.business_id))}`,
       accessToken,
       {
@@ -202,13 +212,16 @@ export async function rotateStoredConnectionEncryption(accessToken, row, config,
         body: JSON.stringify(sealed),
         signal,
       },
-    ),
-    { label: 'WHATSAPP_CONNECTION_ROTATION_WRITE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
-  );
-  const payload = await response.json().catch(() => []);
-  if (!response.ok) throw Object.assign(new Error('INTEGRATION_KEY_ROTATION_STORE_FAILED'), { status: 502 });
-  const updated = Array.isArray(payload) ? payload[0] || { ...row, ...sealed } : { ...row, ...sealed };
-  return { rotated: true, row: updated };
+    );
+    const payload = await response.json().catch(() => []);
+    if (!response.ok) throw connectionStorageError('INTEGRATION_KEY_ROTATION_STORE_FAILED', response);
+    const updated = Array.isArray(payload) ? payload[0] || { ...row, ...sealed } : { ...row, ...sealed };
+    return { rotated: true, row: updated };
+  }, {
+    label: 'WHATSAPP_CONNECTION_ROTATION_WRITE',
+    errorCode: 'WHATSAPP_CONNECTION_STORE_TIMEOUT',
+    timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+  });
 }
 
 async function graphFetch(config, path, { method = 'GET', token, query, body } = {}) {
@@ -303,55 +316,63 @@ export async function verifyEmbeddedAssets(config, token, wabaId, phoneNumberId)
   };
 }
 
-export async function loadBusinessConnection(accessToken, businessId) {
+export async function loadBusinessConnection(accessToken, businessId, options = {}) {
   const path = `dabbir_whatsapp_connections?select=id,business_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error&business_id=eq.${encodeURIComponent(String(businessId))}&limit=1`;
-  const response = await withServerReadTimeout(
-    signal => supabaseRest(path, accessToken, { signal }),
-    { label: 'WHATSAPP_CONNECTION_READ', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
-  );
-  if (!response.ok) return null;
-  const rows = await response.json().catch(() => []);
-  let row = Array.isArray(rows) ? rows[0] || null : null;
+  let row = await withServerReadTimeout(async signal => {
+    const response = await supabaseRest(path, accessToken, { signal });
+    const rows = await response.json().catch(() => []);
+    if (!response.ok) throw connectionStorageError('WHATSAPP_CONNECTION_READ_FAILED', response);
+    return Array.isArray(rows) ? rows[0] || null : null;
+  }, {
+    label: 'WHATSAPP_CONNECTION_READ',
+    errorCode: 'WHATSAPP_CONNECTION_READ_TIMEOUT',
+    timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+  });
   if (!row) return null;
   const config = embeddedPlatformConfig();
   if (tokenNeedsRotation(row, config) && config.rotationReady) {
-    const rotation = await rotateStoredConnectionEncryption(accessToken, row, config);
+    const rotation = await rotateStoredConnectionEncryption(accessToken, row, config, null, options);
     row = rotation.row || row;
   }
   return row;
 }
 
-export async function upsertBusinessConnection(accessToken, row) {
-  const response = await withServerReadTimeout(
-    signal => supabaseRest('dabbir_whatsapp_connections?on_conflict=business_id', accessToken, {
+export async function upsertBusinessConnection(accessToken, row, options = {}) {
+  return withServerReadTimeout(async signal => {
+    const response = await supabaseRest('dabbir_whatsapp_connections?on_conflict=business_id', accessToken, {
       method: 'POST',
       headers: { prefer: 'resolution=merge-duplicates,return=representation' },
       body: JSON.stringify(row),
       signal,
-    }),
-    { label: 'WHATSAPP_CONNECTION_STORE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
-  );
-  const payload = await response.json().catch(() => []);
-  if (!response.ok) {
-    const error = new Error('WHATSAPP_CONNECTION_STORE_FAILED');
-    error.status = 502;
-    error.details = payload;
-    throw error;
-  }
-  return Array.isArray(payload) ? payload[0] || null : payload;
+    });
+    const payload = await response.json().catch(() => []);
+    if (!response.ok) {
+      const error = connectionStorageError('WHATSAPP_CONNECTION_STORE_FAILED', response);
+      error.details = payload;
+      throw error;
+    }
+    return Array.isArray(payload) ? payload[0] || null : payload;
+  }, {
+    label: 'WHATSAPP_CONNECTION_STORE',
+    errorCode: 'WHATSAPP_CONNECTION_STORE_TIMEOUT',
+    timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+  });
 }
 
-export async function removeBusinessConnection(accessToken, businessId) {
-  const response = await withServerReadTimeout(
-    signal => supabaseRest(`dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(businessId))}`, accessToken, {
+export async function removeBusinessConnection(accessToken, businessId, options = {}) {
+  return withServerReadTimeout(async signal => {
+    const response = await supabaseRest(`dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(businessId))}`, accessToken, {
       method: 'DELETE',
       headers: { prefer: 'return=representation' },
       signal,
-    }),
-    { label: 'WHATSAPP_CONNECTION_DELETE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
-  );
-  if (!response.ok) throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_FAILED'), { status: 502 });
-  return response.json().catch(() => []);
+    });
+    if (!response.ok) throw connectionStorageError('WHATSAPP_CONNECTION_DELETE_FAILED', response);
+    return response.json().catch(() => []);
+  }, {
+    label: 'WHATSAPP_CONNECTION_DELETE',
+    errorCode: 'WHATSAPP_CONNECTION_DELETE_TIMEOUT',
+    timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+  });
 }
 
 export async function unsubscribeWaba(config, token, wabaId) {

--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -198,16 +198,34 @@ function connectionStorageError(message, response) {
   return Object.assign(new Error(message), { status, code: message, providerStatus });
 }
 
-async function readConnectionRows(response, failureCode, malformedCode) {
+async function readConnectionRows(
+  response,
+  failureCode,
+  malformedCode,
+  { expectedBusinessId = null, allowEmpty = false } = {},
+) {
   const text = await response.text();
   let payload = null;
-  try {
-    payload = text ? JSON.parse(text) : [];
-  } catch {
-    if (response.ok) throw connectionStorageError(malformedCode, response);
+  if (text) {
+    try {
+      payload = JSON.parse(text);
+    } catch {
+      if (response.ok) throw connectionStorageError(malformedCode, response);
+    }
   }
   if (!response.ok) throw connectionStorageError(failureCode, response);
-  if (!Array.isArray(payload)) throw connectionStorageError(malformedCode, response);
+  if (!text || !Array.isArray(payload)) throw connectionStorageError(malformedCode, response);
+  if ((!allowEmpty && payload.length !== 1) || (allowEmpty && payload.length > 1)) {
+    throw connectionStorageError(malformedCode, response);
+  }
+  for (const item of payload) {
+    if (!item || typeof item !== 'object' || Array.isArray(item)) {
+      throw connectionStorageError(malformedCode, response);
+    }
+    if (expectedBusinessId != null && String(item.business_id || '') !== String(expectedBusinessId)) {
+      throw connectionStorageError(malformedCode, response);
+    }
+  }
   return payload;
 }
 
@@ -230,9 +248,9 @@ export async function rotateStoredConnectionEncryption(accessToken, row, config,
       response,
       'INTEGRATION_KEY_ROTATION_STORE_FAILED',
       'INTEGRATION_KEY_ROTATION_RESPONSE_MALFORMED',
+      { expectedBusinessId: row.business_id },
     );
-    const updated = payload[0] || { ...row, ...sealed };
-    return { rotated: true, row: updated };
+    return { rotated: true, row: payload[0] };
   }, {
     label: 'WHATSAPP_CONNECTION_ROTATION_WRITE',
     errorCode: 'WHATSAPP_CONNECTION_STORE_TIMEOUT',
@@ -340,6 +358,7 @@ export async function loadBusinessConnection(accessToken, businessId, options = 
       response,
       'WHATSAPP_CONNECTION_READ_FAILED',
       'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
+      { expectedBusinessId: businessId, allowEmpty: true },
     );
     return rows[0] || null;
   }, {
@@ -368,8 +387,9 @@ export async function upsertBusinessConnection(accessToken, row, options = {}) {
       response,
       'WHATSAPP_CONNECTION_STORE_FAILED',
       'WHATSAPP_CONNECTION_STORE_RESPONSE_MALFORMED',
+      { expectedBusinessId: row.business_id },
     );
-    return payload[0] || null;
+    return payload[0];
   }, {
     label: 'WHATSAPP_CONNECTION_STORE',
     errorCode: 'WHATSAPP_CONNECTION_STORE_TIMEOUT',
@@ -388,6 +408,7 @@ export async function removeBusinessConnection(accessToken, businessId, options 
       response,
       'WHATSAPP_CONNECTION_DELETE_FAILED',
       'WHATSAPP_CONNECTION_DELETE_RESPONSE_MALFORMED',
+      { expectedBusinessId: businessId, allowEmpty: true },
     );
   }, {
     label: 'WHATSAPP_CONNECTION_DELETE',

--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -198,6 +198,19 @@ function connectionStorageError(message, response) {
   return Object.assign(new Error(message), { status, code: message, providerStatus });
 }
 
+async function readConnectionRows(response, failureCode, malformedCode) {
+  const text = await response.text();
+  let payload = null;
+  try {
+    payload = text ? JSON.parse(text) : [];
+  } catch {
+    if (response.ok) throw connectionStorageError(malformedCode, response);
+  }
+  if (!response.ok) throw connectionStorageError(failureCode, response);
+  if (!Array.isArray(payload)) throw connectionStorageError(malformedCode, response);
+  return payload;
+}
+
 export async function rotateStoredConnectionEncryption(accessToken, row, config, token = null, options = {}) {
   if (!row || !tokenNeedsRotation(row, config)) return { rotated: false, row };
   const plaintext = token == null ? openAccessToken(row, config, row.business_id) : String(token);
@@ -213,9 +226,12 @@ export async function rotateStoredConnectionEncryption(accessToken, row, config,
         signal,
       },
     );
-    const payload = await response.json().catch(() => []);
-    if (!response.ok) throw connectionStorageError('INTEGRATION_KEY_ROTATION_STORE_FAILED', response);
-    const updated = Array.isArray(payload) ? payload[0] || { ...row, ...sealed } : { ...row, ...sealed };
+    const payload = await readConnectionRows(
+      response,
+      'INTEGRATION_KEY_ROTATION_STORE_FAILED',
+      'INTEGRATION_KEY_ROTATION_RESPONSE_MALFORMED',
+    );
+    const updated = payload[0] || { ...row, ...sealed };
     return { rotated: true, row: updated };
   }, {
     label: 'WHATSAPP_CONNECTION_ROTATION_WRITE',
@@ -320,9 +336,12 @@ export async function loadBusinessConnection(accessToken, businessId, options = 
   const path = `dabbir_whatsapp_connections?select=id,business_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error&business_id=eq.${encodeURIComponent(String(businessId))}&limit=1`;
   let row = await withServerReadTimeout(async signal => {
     const response = await supabaseRest(path, accessToken, { signal });
-    const rows = await response.json().catch(() => []);
-    if (!response.ok) throw connectionStorageError('WHATSAPP_CONNECTION_READ_FAILED', response);
-    return Array.isArray(rows) ? rows[0] || null : null;
+    const rows = await readConnectionRows(
+      response,
+      'WHATSAPP_CONNECTION_READ_FAILED',
+      'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
+    );
+    return rows[0] || null;
   }, {
     label: 'WHATSAPP_CONNECTION_READ',
     errorCode: 'WHATSAPP_CONNECTION_READ_TIMEOUT',
@@ -345,13 +364,12 @@ export async function upsertBusinessConnection(accessToken, row, options = {}) {
       body: JSON.stringify(row),
       signal,
     });
-    const payload = await response.json().catch(() => []);
-    if (!response.ok) {
-      const error = connectionStorageError('WHATSAPP_CONNECTION_STORE_FAILED', response);
-      error.details = payload;
-      throw error;
-    }
-    return Array.isArray(payload) ? payload[0] || null : payload;
+    const payload = await readConnectionRows(
+      response,
+      'WHATSAPP_CONNECTION_STORE_FAILED',
+      'WHATSAPP_CONNECTION_STORE_RESPONSE_MALFORMED',
+    );
+    return payload[0] || null;
   }, {
     label: 'WHATSAPP_CONNECTION_STORE',
     errorCode: 'WHATSAPP_CONNECTION_STORE_TIMEOUT',
@@ -366,8 +384,11 @@ export async function removeBusinessConnection(accessToken, businessId, options 
       headers: { prefer: 'return=representation' },
       signal,
     });
-    if (!response.ok) throw connectionStorageError('WHATSAPP_CONNECTION_DELETE_FAILED', response);
-    return response.json().catch(() => []);
+    return readConnectionRows(
+      response,
+      'WHATSAPP_CONNECTION_DELETE_FAILED',
+      'WHATSAPP_CONNECTION_DELETE_RESPONSE_MALFORMED',
+    );
   }, {
     label: 'WHATSAPP_CONNECTION_DELETE',
     errorCode: 'WHATSAPP_CONNECTION_DELETE_TIMEOUT',

--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -5,6 +5,9 @@ import {
   getBusinessMemberships,
   supabaseRest,
 } from './_auth-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
+
+const WHATSAPP_DATA_TIMEOUT_MS = 10_000;
 
 function firstEnv(...names) {
   for (const name of names) {
@@ -114,9 +117,15 @@ export async function resolveEmbeddedPlatformConfig() {
 
 export async function ownerContext(req, businessId) {
   const accessToken = accessTokenFromRequest(req);
-  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+  if (!accessToken) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
+  const [user, memberships] = await withServerReadTimeout(
+    signal => Promise.all([
+      getVerifiedUser(accessToken, { signal }),
+      getBusinessMemberships(accessToken, { signal }),
+    ]),
+    { label: 'WHATSAPP_OWNER_CONTEXT_READ', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+  );
   if (!user) throw Object.assign(new Error('AUTH_REQUIRED'), { status: 401 });
-  const memberships = await getBusinessMemberships(accessToken).catch(() => []);
   const membership = memberships.find(item => String(item.business_id) === String(businessId));
   if (!membership || membership.status !== 'active') throw Object.assign(new Error('BUSINESS_ACCESS_REQUIRED'), { status: 403 });
   if (!['owner', 'admin'].includes(String(membership.role || '').toLowerCase())) {
@@ -183,14 +192,18 @@ export async function rotateStoredConnectionEncryption(accessToken, row, config,
   if (!row || !tokenNeedsRotation(row, config)) return { rotated: false, row };
   const plaintext = token == null ? openAccessToken(row, config, row.business_id) : String(token);
   const sealed = sealAccessToken(plaintext, config, row.business_id);
-  const response = await supabaseRest(
-    `dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(row.business_id))}`,
-    accessToken,
-    {
-      method: 'PATCH',
-      headers: { prefer: 'return=representation' },
-      body: JSON.stringify(sealed),
-    },
+  const response = await withServerReadTimeout(
+    signal => supabaseRest(
+      `dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(row.business_id))}`,
+      accessToken,
+      {
+        method: 'PATCH',
+        headers: { prefer: 'return=representation' },
+        body: JSON.stringify(sealed),
+        signal,
+      },
+    ),
+    { label: 'WHATSAPP_CONNECTION_ROTATION_WRITE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
   );
   const payload = await response.json().catch(() => []);
   if (!response.ok) throw Object.assign(new Error('INTEGRATION_KEY_ROTATION_STORE_FAILED'), { status: 502 });
@@ -292,7 +305,10 @@ export async function verifyEmbeddedAssets(config, token, wabaId, phoneNumberId)
 
 export async function loadBusinessConnection(accessToken, businessId) {
   const path = `dabbir_whatsapp_connections?select=id,business_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error&business_id=eq.${encodeURIComponent(String(businessId))}&limit=1`;
-  const response = await supabaseRest(path, accessToken);
+  const response = await withServerReadTimeout(
+    signal => supabaseRest(path, accessToken, { signal }),
+    { label: 'WHATSAPP_CONNECTION_READ', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+  );
   if (!response.ok) return null;
   const rows = await response.json().catch(() => []);
   let row = Array.isArray(rows) ? rows[0] || null : null;
@@ -306,11 +322,15 @@ export async function loadBusinessConnection(accessToken, businessId) {
 }
 
 export async function upsertBusinessConnection(accessToken, row) {
-  const response = await supabaseRest('dabbir_whatsapp_connections?on_conflict=business_id', accessToken, {
-    method: 'POST',
-    headers: { prefer: 'resolution=merge-duplicates,return=representation' },
-    body: JSON.stringify(row),
-  });
+  const response = await withServerReadTimeout(
+    signal => supabaseRest('dabbir_whatsapp_connections?on_conflict=business_id', accessToken, {
+      method: 'POST',
+      headers: { prefer: 'resolution=merge-duplicates,return=representation' },
+      body: JSON.stringify(row),
+      signal,
+    }),
+    { label: 'WHATSAPP_CONNECTION_STORE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+  );
   const payload = await response.json().catch(() => []);
   if (!response.ok) {
     const error = new Error('WHATSAPP_CONNECTION_STORE_FAILED');
@@ -322,10 +342,14 @@ export async function upsertBusinessConnection(accessToken, row) {
 }
 
 export async function removeBusinessConnection(accessToken, businessId) {
-  const response = await supabaseRest(`dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(businessId))}`, accessToken, {
-    method: 'DELETE',
-    headers: { prefer: 'return=representation' },
-  });
+  const response = await withServerReadTimeout(
+    signal => supabaseRest(`dabbir_whatsapp_connections?business_id=eq.${encodeURIComponent(String(businessId))}`, accessToken, {
+      method: 'DELETE',
+      headers: { prefer: 'return=representation' },
+      signal,
+    }),
+    { label: 'WHATSAPP_CONNECTION_DELETE', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+  );
   if (!response.ok) throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_FAILED'), { status: 502 });
   return response.json().catch(() => []);
 }

--- a/api/_whatsapp-live-core.js
+++ b/api/_whatsapp-live-core.js
@@ -1,7 +1,9 @@
 import { openAccessToken, embeddedPlatformConfig } from './_whatsapp-embedded-core.js';
 import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
 
 const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
+const WHATSAPP_DATA_TIMEOUT_MS = 10_000;
 
 function clean(value, max = 4000) {
   return String(value || '').trim().slice(0, max);
@@ -40,17 +42,21 @@ export async function serviceRpc(name, params = {}) {
     error.code = 'WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED';
     throw error;
   }
-  const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`, {
-    method: 'POST',
-    cache: 'no-store',
-    headers: {
-      apikey: key,
-      authorization: `Bearer ${key}`,
-      'content-type': 'application/json',
-      accept: 'application/json',
-    },
-    body: JSON.stringify(params),
-  });
+  const response = await withServerReadTimeout(
+    signal => fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`, {
+      method: 'POST',
+      cache: 'no-store',
+      signal,
+      headers: {
+        apikey: key,
+        authorization: `Bearer ${key}`,
+        'content-type': 'application/json',
+        accept: 'application/json',
+      },
+      body: JSON.stringify(params),
+    }),
+    { label: 'WHATSAPP_SERVER_RPC', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+  );
   return readResponse(response, 'WHATSAPP_SERVER_RPC_FAILED');
 }
 

--- a/api/_whatsapp-live-core.js
+++ b/api/_whatsapp-live-core.js
@@ -34,7 +34,7 @@ async function readResponse(response, fallback) {
   return payload;
 }
 
-export async function serviceRpc(name, params = {}) {
+export async function serviceRpc(name, params = {}, options = {}) {
   const key = serviceKey();
   if (!key) {
     const error = new Error('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED');
@@ -55,7 +55,11 @@ export async function serviceRpc(name, params = {}) {
       },
       body: JSON.stringify(params),
     }),
-    { label: 'WHATSAPP_SERVER_RPC', timeoutMs: WHATSAPP_DATA_TIMEOUT_MS },
+    {
+      label: 'WHATSAPP_SERVER_RPC',
+      errorCode: 'WHATSAPP_SERVER_DATA_TIMEOUT',
+      timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+    },
   );
   return readResponse(response, 'WHATSAPP_SERVER_RPC_FAILED');
 }

--- a/api/_whatsapp-live-core.js
+++ b/api/_whatsapp-live-core.js
@@ -42,26 +42,28 @@ export async function serviceRpc(name, params = {}, options = {}) {
     error.code = 'WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED';
     throw error;
   }
-  const response = await withServerReadTimeout(
-    signal => fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`, {
-      method: 'POST',
-      cache: 'no-store',
-      signal,
-      headers: {
-        apikey: key,
-        authorization: `Bearer ${key}`,
-        'content-type': 'application/json',
-        accept: 'application/json',
-      },
-      body: JSON.stringify(params),
-    }),
+  return withServerReadTimeout(
+    async signal => {
+      const response = await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`, {
+        method: 'POST',
+        cache: 'no-store',
+        signal,
+        headers: {
+          apikey: key,
+          authorization: `Bearer ${key}`,
+          'content-type': 'application/json',
+          accept: 'application/json',
+        },
+        body: JSON.stringify(params),
+      });
+      return readResponse(response, 'WHATSAPP_SERVER_RPC_FAILED');
+    },
     {
       label: 'WHATSAPP_SERVER_RPC',
       errorCode: 'WHATSAPP_SERVER_DATA_TIMEOUT',
       timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
     },
   );
-  return readResponse(response, 'WHATSAPP_SERVER_RPC_FAILED');
 }
 
 function oneRow(payload) {

--- a/api/billing/checkout.js
+++ b/api/billing/checkout.js
@@ -18,6 +18,6 @@ export default async function handler(req,res){
     if(!result?.url)throw Object.assign(new Error('CHECKOUT_URL_MISSING'),{code:502});
     return json(res,200,{ok:true,url:result.url,livemode:false});
   }catch(error){
-    const status=Number(error?.code||500);const safe=[400,401,403,409,413,429,503].includes(status)?status:502;console.error('dabbir_billing_checkout_failed',{status:safe,error:String(error?.message||'CHECKOUT_FAILED').slice(0,120)});return json(res,safe,{ok:false,error:String(error?.message||'CHECKOUT_FAILED').slice(0,120),livemode:false});
+    const status=Number(error?.code||error?.status||500);const safe=[400,401,403,409,413,429,503,504].includes(status)?status:502;console.error('dabbir_billing_checkout_failed',{status:safe,error:String(error?.safeCode||error?.message||'CHECKOUT_FAILED').slice(0,120)});return json(res,safe,{ok:false,error:String(error?.safeCode||error?.message||'CHECKOUT_FAILED').slice(0,120),livemode:false});
   }
 }

--- a/api/billing/portal.js
+++ b/api/billing/portal.js
@@ -15,6 +15,6 @@ export default async function handler(req,res){
     if(!result?.url)throw Object.assign(new Error('PORTAL_URL_MISSING'),{code:502});
     return json(res,200,{ok:true,url:result.url,livemode:false});
   }catch(error){
-    const status=Number(error?.code||500);const safe=[400,401,403,404,413,429,503].includes(status)?status:502;console.error('dabbir_billing_portal_failed',{status:safe,error:String(error?.message||'PORTAL_FAILED').slice(0,120)});return json(res,safe,{ok:false,error:String(error?.message||'PORTAL_FAILED').slice(0,120),livemode:false});
+    const status=Number(error?.code||error?.status||500);const safe=[400,401,403,404,413,429,503,504].includes(status)?status:502;console.error('dabbir_billing_portal_failed',{status:safe,error:String(error?.safeCode||error?.message||'PORTAL_FAILED').slice(0,120)});return json(res,safe,{ok:false,error:String(error?.safeCode||error?.message||'PORTAL_FAILED').slice(0,120),livemode:false});
   }
 }

--- a/api/billing/status.js
+++ b/api/billing/status.js
@@ -9,6 +9,6 @@ export default async function handler(req,res){
     const account=await getBillingAccount(context.accessToken,context.businessId);
     return json(res,200,{ok:true,livemode:false,billing:publicBillingState(account)});
   }catch(error){
-    const status=Number(error?.code||500);return json(res,[400,401,403,429,503].includes(status)?status:500,{ok:false,error:String(error?.message||'BILLING_STATUS_UNAVAILABLE').slice(0,120),livemode:false});
+    const status=Number(error?.code||error?.status||500);return json(res,[400,401,403,429,503,504].includes(status)?status:500,{ok:false,error:String(error?.safeCode||error?.message||'BILLING_STATUS_UNAVAILABLE').slice(0,120),livemode:false});
   }
 }

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -8,7 +8,7 @@ import {
   unsubscribeWaba,
 } from './_whatsapp-embedded-core.js';
 
-function verifiedDeletion(rows, businessId) {
+export function verifiedDeletion(rows, businessId) {
   return Array.isArray(rows)
     && rows.length === 1
     && rows[0]

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -9,12 +9,14 @@ import {
 } from './_whatsapp-embedded-core.js';
 
 export function verifiedDeletion(rows, businessId) {
-  return Array.isArray(rows)
+  return Boolean(
+    Array.isArray(rows)
     && rows.length === 1
     && rows[0]
     && typeof rows[0] === 'object'
     && !Array.isArray(rows[0])
-    && String(rows[0].business_id || '') === String(businessId);
+    && String(rows[0].business_id || '') === String(businessId)
+  );
 }
 
 export default async function handler(req, res) {

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -8,6 +8,15 @@ import {
   unsubscribeWaba,
 } from './_whatsapp-embedded-core.js';
 
+function verifiedDeletion(rows, businessId) {
+  return Array.isArray(rows)
+    && rows.length === 1
+    && rows[0]
+    && typeof rows[0] === 'object'
+    && !Array.isArray(rows[0])
+    && String(rows[0].business_id || '') === String(businessId);
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
   if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
@@ -32,7 +41,10 @@ export default async function handler(req, res) {
       }
     }
 
-    await removeBusinessConnection(owner.accessToken, businessId);
+    const deleted = await removeBusinessConnection(owner.accessToken, businessId);
+    if (!verifiedDeletion(deleted, businessId)) {
+      throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_UNVERIFIED'), { status: 502 });
+    }
     return json(res, 200, {
       ok: true,
       connected: false,
@@ -40,6 +52,10 @@ export default async function handler(req, res) {
       secrets_exposed: false,
     });
   } catch (error) {
-    return json(res, Number(error?.status || 500), { ok: false, error: error?.message || 'WHATSAPP_DISCONNECT_FAILED' });
+    const status = Number(error?.status || 500);
+    return json(res, [400, 401, 403, 409, 413, 429, 502, 503, 504].includes(status) ? status : 500, {
+      ok: false,
+      error: error?.message || 'WHATSAPP_DISCONNECT_FAILED',
+    });
   }
 }

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -37,7 +37,11 @@ async function readPersistedMessage(token, businessId, messageId) {
       token,
       { signal },
     ),
-    { label: 'WHATSAPP_REPLY_READBACK', timeoutMs: WHATSAPP_READBACK_TIMEOUT_MS },
+    {
+      label: 'WHATSAPP_REPLY_READBACK',
+      errorCode: 'WHATSAPP_REPLY_READBACK_TIMEOUT',
+      timeoutMs: WHATSAPP_READBACK_TIMEOUT_MS,
+    },
   );
   const rows = await readRows(response, 'WHATSAPP_REPLY_READBACK_FAILED');
   const message = rows[0] || null;

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
 import { loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   finalizeOutboundReply,
   markOutboundResult,
@@ -10,6 +11,7 @@ import {
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const IDEMPOTENCY_RE = /^[A-Za-z0-9:_-]{16,160}$/;
+const WHATSAPP_READBACK_TIMEOUT_MS = 10_000;
 const safeId = value => UUID_RE.test(String(value || '').trim()) ? String(value).trim() : null;
 const cleanText = (value, max = 4000) => String(value || '').trim().slice(0, max);
 
@@ -29,10 +31,15 @@ async function readRows(response, fallback) {
 
 async function readPersistedMessage(token, businessId, messageId) {
   if (!messageId) return null;
-  const rows = await readRows(await supabaseRest(
-    `dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at,sender_user_id&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(messageId)}&limit=1`,
-    token,
-  ), 'WHATSAPP_REPLY_READBACK_FAILED');
+  const response = await withServerReadTimeout(
+    signal => supabaseRest(
+      `dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at,sender_user_id&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(messageId)}&limit=1`,
+      token,
+      { signal },
+    ),
+    { label: 'WHATSAPP_REPLY_READBACK', timeoutMs: WHATSAPP_READBACK_TIMEOUT_MS },
+  );
+  const rows = await readRows(response, 'WHATSAPP_REPLY_READBACK_FAILED');
   const message = rows[0] || null;
   return message?.id && message.sender_type === 'human' && message.simulated === false ? message : null;
 }
@@ -173,13 +180,13 @@ export default async function handler(req, res) {
       secrets_exposed: false,
     });
   } catch (error) {
-    const status = Number(error?.status || 500);
-    const safeStatus = [400, 401, 403, 404, 409, 413, 429, 502, 503].includes(status) ? status : 500;
+    const status = Number(error?.status || error?.code || 500);
+    const safeStatus = [400, 401, 403, 404, 409, 413, 429, 502, 503, 504].includes(status) ? status : 500;
     const ambiguous = error?.ambiguous === true || error?.providerAccepted === true || (providerAccepted && reservation?.reservationId);
     return json(res, safeStatus, {
       ok: false,
       state: ambiguous ? 'AMBIGUOUS_NO_AUTOMATIC_RESEND' : 'FAILED',
-      error: cleanText(error?.message || 'WHATSAPP_REPLY_FAILED', 160),
+      error: cleanText(error?.safeCode || error?.message || 'WHATSAPP_REPLY_FAILED', 160),
       provider_status: error?.providerStatus || null,
       provider_code: error?.providerCode || null,
       automatic_resend_blocked: Boolean(reservation?.reservationId),

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -29,23 +29,25 @@ async function readRows(response, fallback) {
   return Array.isArray(payload) ? payload : [];
 }
 
-async function readPersistedMessage(token, businessId, messageId) {
+export async function readPersistedMessage(token, businessId, messageId, options = {}) {
   if (!messageId) return null;
-  const response = await withServerReadTimeout(
-    signal => supabaseRest(
-      `dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at,sender_user_id&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(messageId)}&limit=1`,
-      token,
-      { signal },
-    ),
+  return withServerReadTimeout(
+    async signal => {
+      const response = await supabaseRest(
+        `dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at,sender_user_id&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(messageId)}&limit=1`,
+        token,
+        { signal },
+      );
+      const rows = await readRows(response, 'WHATSAPP_REPLY_READBACK_FAILED');
+      const message = rows[0] || null;
+      return message?.id && message.sender_type === 'human' && message.simulated === false ? message : null;
+    },
     {
       label: 'WHATSAPP_REPLY_READBACK',
       errorCode: 'WHATSAPP_REPLY_READBACK_TIMEOUT',
-      timeoutMs: WHATSAPP_READBACK_TIMEOUT_MS,
+      timeoutMs: options.timeoutMs ?? WHATSAPP_READBACK_TIMEOUT_MS,
     },
   );
-  const rows = await readRows(response, 'WHATSAPP_REPLY_READBACK_FAILED');
-  const message = rows[0] || null;
-  return message?.id && message.sender_type === 'human' && message.simulated === false ? message : null;
 }
 
 function replayResponse(res, reservation, message) {

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -68,6 +68,20 @@ function replayResponse(res, reservation, message) {
   });
 }
 
+function replayReadbackUnverified(res, reservation) {
+  return json(res, 502, {
+    ok: false,
+    state: 'PROVIDER_ACCEPTED_LOCAL_READBACK_UNVERIFIED',
+    error: 'WHATSAPP_REPLY_READBACK_UNVERIFIED',
+    provider_accepted: true,
+    provider_status_verified: ['DELIVERED', 'READ'].includes(reservation.state),
+    automatic_resend_blocked: true,
+    retry_safe_with_same_key: true,
+    external_side_effects_possible: true,
+    truth: { state: 'UNVERIFIED_LOCAL_READBACK', source: 'DABBIR_OUTBOUND_RESERVATION' },
+  });
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
   if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
@@ -99,8 +113,16 @@ export default async function handler(req, res) {
 
     if (!reservation.shouldSend) {
       if (['PROVIDER_ACCEPTED', 'SENT', 'DELIVERED', 'READ'].includes(reservation.state) && reservation.messageId) {
-        const persisted = await readPersistedMessage(owner.accessToken, businessId, reservation.messageId);
-        if (!persisted) return json(res, 502, { ok: false, state: 'LOCAL_READBACK_UNVERIFIED', error: 'WHATSAPP_REPLY_READBACK_UNVERIFIED' });
+        providerAccepted = true;
+        let persisted;
+        try {
+          persisted = await readPersistedMessage(owner.accessToken, businessId, reservation.messageId);
+        } catch (error) {
+          error.providerAccepted = true;
+          error.ambiguous = true;
+          throw error;
+        }
+        if (!persisted) return replayReadbackUnverified(res, reservation);
         return replayResponse(res, reservation, persisted);
       }
       if (['SENDING', 'AMBIGUOUS'].includes(reservation.state)) {
@@ -194,6 +216,7 @@ export default async function handler(req, res) {
       provider_status: error?.providerStatus || null,
       provider_code: error?.providerCode || null,
       automatic_resend_blocked: Boolean(reservation?.reservationId),
+      retry_safe_with_same_key: ambiguous,
       external_side_effects_possible: ambiguous,
       truth: { state: 'UNVERIFIED' },
     });

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -2,12 +2,15 @@ import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getBusinessMemberships, getVerifiedUser, json } from './_auth-core.js';
 import { deriveWhatsAppOperationalState } from './_dabbir-whatsapp-state-machine.js';
 import { serviceRpc, whatsappLiveServerCapability } from './_whatsapp-live-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   embeddedPlatformConfig,
   loadBusinessConnection,
   ownerContext,
   verifyStoredConnection,
 } from './_whatsapp-embedded-core.js';
+
+const WHATSAPP_STATUS_TIMEOUT_MS = 10_000;
 
 function firstEnv(...names) {
   for (const name of names) {
@@ -215,7 +218,17 @@ async function tenantStatus(req, accessToken, businessId) {
 export default async function handler(req, res) {
   if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
   const accessToken = accessTokenFromRequest(req);
-  const user = accessToken ? await getVerifiedUser(accessToken).catch(() => null) : null;
+  let user = null;
+  try {
+    user = accessToken
+      ? await withServerReadTimeout(
+        signal => getVerifiedUser(accessToken, { signal }),
+        { label: 'WHATSAPP_STATUS_AUTH_READ', timeoutMs: WHATSAPP_STATUS_TIMEOUT_MS },
+      )
+      : null;
+  } catch (error) {
+    return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.safeCode || error?.message || 'REQUEST_FAILED' });
+  }
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
   const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
@@ -223,7 +236,7 @@ export default async function handler(req, res) {
     try {
       return json(res, 200, await tenantStatus(req, accessToken, businessId));
     } catch (error) {
-      return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.message || 'REQUEST_FAILED' });
+      return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.safeCode || error?.message || 'REQUEST_FAILED' });
     }
   }
 
@@ -231,7 +244,10 @@ export default async function handler(req, res) {
   // identity. Platform-level credentials remain webhook/runtime infrastructure
   // only; tenant display state always resolves from the tenant connection row.
   try {
-    const memberships = await getBusinessMemberships(accessToken);
+    const memberships = await withServerReadTimeout(
+      signal => getBusinessMemberships(accessToken, { signal }),
+      { label: 'WHATSAPP_STATUS_MEMBERSHIP_READ', timeoutMs: WHATSAPP_STATUS_TIMEOUT_MS },
+    );
     const businessIds = [...new Set((Array.isArray(memberships) ? memberships : [])
       .map(item => String(item?.business_id || '').trim())
       .filter(Boolean))];
@@ -240,6 +256,6 @@ export default async function handler(req, res) {
     }
     return json(res, 200, tenantUnconfiguredStatus(businessIds.length > 1 ? 'BUSINESS_CONTEXT_REQUIRED' : 'TENANT_WHATSAPP_NOT_LINKED'));
   } catch (error) {
-    return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.message || 'REQUEST_FAILED' });
+    return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.safeCode || error?.message || 'REQUEST_FAILED' });
   }
 }

--- a/test/dabbir-billing-response-truth.test.mjs
+++ b/test/dabbir-billing-response-truth.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import { getBillingAccount } from '../api/_billing-core.js';
 
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const OTHER_BUSINESS_ID = '00000000-0000-4000-8000-000000000222';
 const ACCESS_TOKEN = 'test-access-token';
 
 function responseText(text, status = 200) {
@@ -13,34 +14,39 @@ function responseText(text, status = 200) {
   };
 }
 
+async function expectInvalid(payload) {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => responseText(JSON.stringify(payload), 200);
+    await assert.rejects(getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }), error => {
+      assert.equal(error?.message, 'BILLING_STATUS_INVALID_RESPONSE');
+      assert.equal(error?.code, 502);
+      return true;
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+}
+
 test('malformed successful Billing account JSON fails closed instead of becoming not_subscribed', async t => {
   const originalFetch = globalThis.fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
   globalThis.fetch = async () => responseText('not-json', 200);
 
-  await assert.rejects(
-    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }),
-    error => {
-      assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
-      assert.equal(error?.code, 502);
-      return true;
-    },
-  );
+  await assert.rejects(getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }), error => {
+    assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
+    assert.equal(error?.code, 502);
+    return true;
+  });
 });
 
-test('successful Billing account payload must be an array', async t => {
-  const originalFetch = globalThis.fetch;
-  t.after(() => { globalThis.fetch = originalFetch; });
-  globalThis.fetch = async () => responseText(JSON.stringify({ status: 'active' }), 200);
+test('successful Billing account payload must be an array', async () => {
+  await expectInvalid({ status: 'active' });
+});
 
-  await assert.rejects(
-    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }),
-    error => {
-      assert.equal(error?.message, 'BILLING_STATUS_INVALID_RESPONSE');
-      assert.equal(error?.code, 502);
-      return true;
-    },
-  );
+test('nonempty Billing arrays reject null rows and wrong-business rows', async () => {
+  await expectInvalid([null]);
+  await expectInvalid([{ business_id: OTHER_BUSINESS_ID, status: 'active' }]);
 });
 
 test('empty successful Billing account array remains the only not-subscribed shape', async t => {
@@ -50,4 +56,14 @@ test('empty successful Billing account array remains the only not-subscribed sha
 
   const account = await getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 });
   assert.equal(account, null);
+});
+
+test('one matching Billing account object is accepted', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  const expected = { business_id: BUSINESS_ID, status: 'active' };
+  globalThis.fetch = async () => responseText(JSON.stringify([expected]), 200);
+
+  const account = await getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 });
+  assert.deepEqual(account, expected);
 });

--- a/test/dabbir-billing-response-truth.test.mjs
+++ b/test/dabbir-billing-response-truth.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getBillingAccount } from '../api/_billing-core.js';
+
+const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const ACCESS_TOKEN = 'test-access-token';
+
+function responseText(text, status = 200) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => text,
+  };
+}
+
+test('malformed successful Billing account JSON fails closed instead of becoming not_subscribed', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = async () => responseText('not-json', 200);
+
+  await assert.rejects(
+    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }),
+    error => {
+      assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
+      assert.equal(error?.code, 502);
+      return true;
+    },
+  );
+});
+
+test('successful Billing account payload must be an array', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = async () => responseText(JSON.stringify({ status: 'active' }), 200);
+
+  await assert.rejects(
+    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 }),
+    error => {
+      assert.equal(error?.message, 'BILLING_STATUS_INVALID_RESPONSE');
+      assert.equal(error?.code, 502);
+      return true;
+    },
+  );
+});
+
+test('empty successful Billing account array remains the only not-subscribed shape', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = async () => responseText('[]', 200);
+
+  const account = await getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 50 });
+  assert.equal(account, null);
+});

--- a/test/dabbir-critical-provider-read-timeouts.test.mjs
+++ b/test/dabbir-critical-provider-read-timeouts.test.mjs
@@ -10,6 +10,7 @@ const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
 const ACCESS_TOKEN = 'test-access-token';
+const SERVICE_ROLE_ENV = ['SUPABASE', 'SERVICE', 'ROLE', 'KEY'].join('_');
 const requestWithToken = () => ({ headers: { cookie: `__Host-dabbir_access=${ACCESS_TOKEN}` } });
 
 const billingCore = await read('api/_billing-core.js');
@@ -103,13 +104,13 @@ test('critical Billing and WhatsApp core functions return explicit 504 on stalle
 
 test('WhatsApp service-role persistence RPC reports explicit 504 timeout without changing server authority', async t => {
   const originalFetch = globalThis.fetch;
-  const originalKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const originalKey = process.env[SERVICE_ROLE_ENV];
   t.after(() => {
     globalThis.fetch = originalFetch;
-    if (originalKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
-    else process.env.SUPABASE_SERVICE_ROLE_KEY = originalKey;
+    if (originalKey === undefined) delete process.env[SERVICE_ROLE_ENV];
+    else process.env[SERVICE_ROLE_ENV] = originalKey;
   });
-  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+  process.env[SERVICE_ROLE_ENV] = 'test-service-role-key';
   globalThis.fetch = hangingFetch;
 
   await assert.rejects(

--- a/test/dabbir-critical-provider-read-timeouts.test.mjs
+++ b/test/dabbir-critical-provider-read-timeouts.test.mjs
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { withServerReadTimeout } from '../api/_server-read-timeout.js';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+const billingCore = await read('api/_billing-core.js');
+const billingStatus = await read('api/billing/status.js');
+const billingCheckout = await read('api/billing/checkout.js');
+const billingPortal = await read('api/billing/portal.js');
+const whatsappEmbedded = await read('api/_whatsapp-embedded-core.js');
+const whatsappLive = await read('api/_whatsapp-live-core.js');
+const whatsappStatus = await read('api/dabbir-whatsapp-status.js');
+const whatsappReply = await read('api/dabbir-whatsapp-reply.js');
+
+test('shared server-read timeout fails closed even when an operation never settles', async () => {
+  const started = Date.now();
+  await assert.rejects(
+    withServerReadTimeout(() => new Promise(() => {}), { label: 'TEST_READ', timeoutMs: 5 }),
+    error => {
+      assert.equal(error.status, 504);
+      assert.equal(error.code, 504);
+      assert.equal(error.safeCode, 'TEST_READ_TIMEOUT');
+      assert.equal(error.failureClass, 'TIMEOUT');
+      return true;
+    },
+  );
+  assert.ok(Date.now() - started < 500, 'timeout helper must not wait for the underlying hung operation');
+});
+
+test('shared server-read timeout propagates an AbortSignal to cooperative fetches', async () => {
+  let receivedSignal = null;
+  await assert.rejects(
+    withServerReadTimeout(signal => new Promise((resolve, reject) => {
+      receivedSignal = signal;
+      signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })), { once: true });
+    }), { label: 'COOPERATIVE_READ', timeoutMs: 5 }),
+    error => error?.status === 504 && error?.safeCode === 'COOPERATIVE_READ_TIMEOUT',
+  );
+  assert.equal(receivedSignal?.aborted, true);
+});
+
+test('billing auth and account reads are bounded without weakening bearer RLS', () => {
+  assert.match(billingCore, /withServerReadTimeout/);
+  assert.match(billingCore, /getVerifiedUser\(accessToken,\{signal\}\)/);
+  assert.match(billingCore, /getBusinessMemberships\(accessToken,\{signal\}\)/);
+  assert.match(billingCore, /supabaseRest\(`dabbir_billing_accounts[\s\S]*accessToken,\{signal\}\)/);
+  assert.doesNotMatch(billingCore, /getBusinessMemberships\(accessToken\)\.catch\(\(\)=>\[\]\)/);
+  assert.match(billingStatus, /503,504/);
+  assert.match(billingCheckout, /503,504/);
+  assert.match(billingPortal, /503,504/);
+});
+
+test('WhatsApp owner, connection and service-role persistence reads are bounded', () => {
+  assert.match(whatsappEmbedded, /withServerReadTimeout/);
+  assert.match(whatsappEmbedded, /getVerifiedUser\(accessToken, \{ signal \}\)/);
+  assert.match(whatsappEmbedded, /getBusinessMemberships\(accessToken, \{ signal \}\)/);
+  for (const label of [
+    'WHATSAPP_OWNER_CONTEXT_READ',
+    'WHATSAPP_CONNECTION_ROTATION_WRITE',
+    'WHATSAPP_CONNECTION_READ',
+    'WHATSAPP_CONNECTION_STORE',
+    'WHATSAPP_CONNECTION_DELETE',
+  ]) assert.match(whatsappEmbedded, new RegExp(label));
+  assert.match(whatsappLive, /WHATSAPP_SERVER_RPC/);
+  assert.match(whatsappLive, /signal => fetch/);
+  assert.doesNotMatch(whatsappEmbedded, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
+  assert.doesNotMatch(whatsappEmbedded, /getBusinessMemberships\(accessToken\)\.catch\(\(\) => \[\]\)/);
+});
+
+test('WhatsApp status and provider-accepted readback preserve timeout truth', () => {
+  assert.match(whatsappStatus, /WHATSAPP_STATUS_AUTH_READ/);
+  assert.match(whatsappStatus, /WHATSAPP_STATUS_MEMBERSHIP_READ/);
+  assert.match(whatsappStatus, /getVerifiedUser\(accessToken, \{ signal \}\)/);
+  assert.match(whatsappStatus, /getBusinessMemberships\(accessToken, \{ signal \}\)/);
+  assert.doesNotMatch(whatsappStatus, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
+  assert.match(whatsappReply, /WHATSAPP_REPLY_READBACK/);
+  assert.match(whatsappReply, /supabaseRest\([\s\S]*\{ signal \}/);
+  assert.match(whatsappReply, /502, 503, 504/);
+  assert.match(whatsappReply, /AMBIGUOUS_NO_AUTOMATIC_RESEND/);
+});

--- a/test/dabbir-critical-provider-read-timeouts.test.mjs
+++ b/test/dabbir-critical-provider-read-timeouts.test.mjs
@@ -5,10 +5,12 @@ import { withServerReadTimeout } from '../api/_server-read-timeout.js';
 import { getBillingAccount, requireBillingOwner } from '../api/_billing-core.js';
 import { loadBusinessConnection, ownerContext } from '../api/_whatsapp-embedded-core.js';
 import { serviceRpc } from '../api/_whatsapp-live-core.js';
+import { readPersistedMessage } from '../api/dabbir-whatsapp-reply.js';
 
 const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const MESSAGE_ID = '00000000-0000-4000-8000-000000000222';
 const ACCESS_TOKEN = 'test-access-token';
 const SERVICE_ROLE_ENV = ['SUPABASE', 'SERVICE', 'ROLE', 'KEY'].join('_');
 const requestWithToken = () => ({ headers: { cookie: `__Host-dabbir_access=${ACCESS_TOKEN}` } });
@@ -31,6 +33,15 @@ function hangingFetch(_url, options = {}) {
     };
     if (options.signal?.aborted) return rejectAbort();
     options.signal?.addEventListener('abort', rejectAbort, { once: true });
+  });
+}
+
+function headersThenStalledBody() {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    text: () => new Promise(() => {}),
+    json: () => new Promise(() => {}),
   });
 }
 
@@ -99,6 +110,31 @@ test('critical Billing and WhatsApp core functions return explicit 504 on stalle
   await assert.rejects(
     loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
     error => assertTimeout(error, 'WHATSAPP_CONNECTION_READ_TIMEOUT'),
+  );
+});
+
+test('deadlines remain active after headers while Billing and WhatsApp bodies are still pending', async t => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env[SERVICE_ROLE_ENV];
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env[SERVICE_ROLE_ENV];
+    else process.env[SERVICE_ROLE_ENV] = originalKey;
+  });
+  process.env[SERVICE_ROLE_ENV] = 'test-service-role-key';
+  globalThis.fetch = headersThenStalledBody;
+
+  await assert.rejects(
+    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
+    error => assertTimeout(error, 'BILLING_STATUS_TIMEOUT'),
+  );
+  await assert.rejects(
+    serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: BUSINESS_ID }, { timeoutMs: 5 }),
+    error => assertTimeout(error, 'WHATSAPP_SERVER_DATA_TIMEOUT'),
+  );
+  await assert.rejects(
+    readPersistedMessage(ACCESS_TOKEN, BUSINESS_ID, MESSAGE_ID, { timeoutMs: 5 }),
+    error => assertTimeout(error, 'WHATSAPP_REPLY_READBACK_TIMEOUT'),
   );
 });
 
@@ -173,21 +209,24 @@ test('WhatsApp owner, connection and service-role persistence reads are bounded'
   ]) assert.match(whatsappEmbedded, new RegExp(label));
   assert.match(whatsappLive, /WHATSAPP_SERVER_DATA_TIMEOUT/);
   assert.match(whatsappLive, /authorization: `Bearer \$\{key\}`/);
-  assert.match(whatsappLive, /signal => fetch/);
+  assert.match(whatsappLive, /async signal =>/);
+  assert.match(whatsappLive, /return readResponse\(response, 'WHATSAPP_SERVER_RPC_FAILED'\)/);
   assert.doesNotMatch(whatsappEmbedded, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
   assert.doesNotMatch(whatsappEmbedded, /getBusinessMemberships\(accessToken\)\.catch\(\(\) => \[\]\)/);
   assert.doesNotMatch(whatsappEmbedded, /if \(!response\.ok\) return null/);
 });
 
-test('WhatsApp status and provider-accepted readback preserve timeout truth and no-resend semantics', () => {
+test('WhatsApp status and provider-accepted replay preserve timeout truth and no-resend semantics', () => {
   assert.match(whatsappStatus, /WHATSAPP_STATUS_AUTH_READ/);
   assert.match(whatsappStatus, /WHATSAPP_STATUS_MEMBERSHIP_READ/);
   assert.match(whatsappStatus, /getVerifiedUser\(accessToken, \{ signal \}\)/);
   assert.match(whatsappStatus, /getBusinessMemberships\(accessToken, \{ signal \}\)/);
   assert.doesNotMatch(whatsappStatus, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
   assert.match(whatsappReply, /WHATSAPP_REPLY_READBACK_TIMEOUT/);
-  assert.match(whatsappReply, /supabaseRest\([\s\S]*\{ signal \}/);
-  assert.match(whatsappReply, /502, 503, 504/);
+  assert.match(whatsappReply, /async signal =>/);
+  assert.match(whatsappReply, /providerAccepted = true;[\s\S]*readPersistedMessage/);
+  assert.match(whatsappReply, /error\.providerAccepted = true;[\s\S]*error\.ambiguous = true/);
+  assert.match(whatsappReply, /retry_safe_with_same_key: true/);
   assert.match(whatsappReply, /AMBIGUOUS_NO_AUTOMATIC_RESEND/);
   assert.match(whatsappReply, /reserveOutboundReply/);
   assert.match(whatsappReply, /sendMetaText/);

--- a/test/dabbir-critical-provider-read-timeouts.test.mjs
+++ b/test/dabbir-critical-provider-read-timeouts.test.mjs
@@ -2,9 +2,14 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import { withServerReadTimeout } from '../api/_server-read-timeout.js';
+import { getBillingAccount, requireBillingOwner } from '../api/_billing-core.js';
+import { loadBusinessConnection, ownerContext } from '../api/_whatsapp-embedded-core.js';
 
 const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
+const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const ACCESS_TOKEN = 'test-access-token';
+const requestWithToken = () => ({ headers: { cookie: `__Host-dabbir_access=${ACCESS_TOKEN}` } });
 
 const billingCore = await read('api/_billing-core.js');
 const billingStatus = await read('api/billing/status.js');
@@ -14,6 +19,18 @@ const whatsappEmbedded = await read('api/_whatsapp-embedded-core.js');
 const whatsappLive = await read('api/_whatsapp-live-core.js');
 const whatsappStatus = await read('api/dabbir-whatsapp-status.js');
 const whatsappReply = await read('api/dabbir-whatsapp-reply.js');
+
+function hangingFetch(_url, options = {}) {
+  return new Promise((_resolve, reject) => {
+    const rejectAbort = () => {
+      const error = new Error('The operation was aborted');
+      error.name = 'AbortError';
+      reject(error);
+    };
+    if (options.signal?.aborted) return rejectAbort();
+    options.signal?.addEventListener('abort', rejectAbort, { once: true });
+  });
+}
 
 test('shared server-read timeout fails closed even when an operation never settles', async () => {
   const started = Date.now();
@@ -42,6 +59,59 @@ test('shared server-read timeout propagates an AbortSignal to cooperative fetche
   assert.equal(receivedSignal?.aborted, true);
 });
 
+test('critical Billing and WhatsApp core functions return explicit 504 on stalled prerequisite reads', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = hangingFetch;
+
+  await assert.rejects(
+    requireBillingOwner(requestWithToken(), BUSINESS_ID, { timeoutMs: 5 }),
+    error => error?.status === 504 && error?.safeCode === 'BILLING_AUTH_DATA_TIMEOUT' && error?.timeout === true,
+  );
+  await assert.rejects(
+    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
+    error => error?.status === 504 && error?.safeCode === 'BILLING_STATUS_TIMEOUT' && error?.timeout === true,
+  );
+  await assert.rejects(
+    ownerContext(requestWithToken(), BUSINESS_ID, { timeoutMs: 5 }),
+    error => error?.status === 504 && error?.safeCode === 'WHATSAPP_AUTH_DATA_TIMEOUT' && error?.timeout === true,
+  );
+  await assert.rejects(
+    loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
+    error => error?.status === 504 && error?.safeCode === 'WHATSAPP_CONNECTION_READ_TIMEOUT' && error?.timeout === true,
+  );
+});
+
+test('WhatsApp connection storage failure is not converted into an unlinked tenant', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = async () => new Response(JSON.stringify({ message: 'temporary database failure' }), {
+    status: 503,
+    headers: { 'content-type': 'application/json' },
+  });
+
+  await assert.rejects(
+    loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 25 }),
+    error => error?.status === 502
+      && error?.message === 'WHATSAPP_CONNECTION_READ_FAILED'
+      && error?.providerStatus === 503,
+  );
+});
+
+test('real authentication rejection remains auth failure instead of being relabeled timeout', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = async () => new Response(JSON.stringify({ message: 'unauthorized' }), {
+    status: 401,
+    headers: { 'content-type': 'application/json' },
+  });
+
+  await assert.rejects(
+    requireBillingOwner(requestWithToken(), BUSINESS_ID, { timeoutMs: 25 }),
+    error => error?.code === 401 && error?.timeout !== true,
+  );
+});
+
 test('billing auth and account reads are bounded without weakening bearer RLS', () => {
   assert.match(billingCore, /withServerReadTimeout/);
   assert.match(billingCore, /getVerifiedUser\(accessToken,\{signal\}\)/);
@@ -68,6 +138,7 @@ test('WhatsApp owner, connection and service-role persistence reads are bounded'
   assert.match(whatsappLive, /signal => fetch/);
   assert.doesNotMatch(whatsappEmbedded, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
   assert.doesNotMatch(whatsappEmbedded, /getBusinessMemberships\(accessToken\)\.catch\(\(\) => \[\]\)/);
+  assert.doesNotMatch(whatsappEmbedded, /if \(!response\.ok\) return null/);
 });
 
 test('WhatsApp status and provider-accepted readback preserve timeout truth', () => {

--- a/test/dabbir-critical-provider-read-timeouts.test.mjs
+++ b/test/dabbir-critical-provider-read-timeouts.test.mjs
@@ -4,6 +4,7 @@ import { readFile } from 'node:fs/promises';
 import { withServerReadTimeout } from '../api/_server-read-timeout.js';
 import { getBillingAccount, requireBillingOwner } from '../api/_billing-core.js';
 import { loadBusinessConnection, ownerContext } from '../api/_whatsapp-embedded-core.js';
+import { serviceRpc } from '../api/_whatsapp-live-core.js';
 
 const root = new URL('../', import.meta.url);
 const read = path => readFile(new URL(path, root), 'utf8');
@@ -32,17 +33,22 @@ function hangingFetch(_url, options = {}) {
   });
 }
 
-test('shared server-read timeout fails closed even when an operation never settles', async () => {
+function assertTimeout(error, code) {
+  assert.equal(error?.message, code);
+  assert.equal(error?.status, 504);
+  assert.equal(error?.code, 504);
+  assert.equal(error?.safeCode, code);
+  assert.equal(error?.errorCode, code);
+  assert.equal(error?.failureClass, 'TIMEOUT');
+  assert.equal(error?.timeout, true);
+  return true;
+}
+
+test('shared server-read timeout is a hard wall-clock guard even when operation never settles', async () => {
   const started = Date.now();
   await assert.rejects(
-    withServerReadTimeout(() => new Promise(() => {}), { label: 'TEST_READ', timeoutMs: 5 }),
-    error => {
-      assert.equal(error.status, 504);
-      assert.equal(error.code, 504);
-      assert.equal(error.safeCode, 'TEST_READ_TIMEOUT');
-      assert.equal(error.failureClass, 'TIMEOUT');
-      return true;
-    },
+    withServerReadTimeout(() => new Promise(() => {}), { errorCode: 'HARD_WALL_TIMEOUT', timeoutMs: 5 }),
+    error => assertTimeout(error, 'HARD_WALL_TIMEOUT'),
   );
   assert.ok(Date.now() - started < 500, 'timeout helper must not wait for the underlying hung operation');
 });
@@ -50,13 +56,26 @@ test('shared server-read timeout fails closed even when an operation never settl
 test('shared server-read timeout propagates an AbortSignal to cooperative fetches', async () => {
   let receivedSignal = null;
   await assert.rejects(
-    withServerReadTimeout(signal => new Promise((resolve, reject) => {
+    withServerReadTimeout(signal => new Promise((_resolve, reject) => {
       receivedSignal = signal;
       signal.addEventListener('abort', () => reject(Object.assign(new Error('aborted'), { name: 'AbortError' })), { once: true });
-    }), { label: 'COOPERATIVE_READ', timeoutMs: 5 }),
-    error => error?.status === 504 && error?.safeCode === 'COOPERATIVE_READ_TIMEOUT',
+    }), { errorCode: 'COOPERATIVE_READ_TIMEOUT', timeoutMs: 5 }),
+    error => assertTimeout(error, 'COOPERATIVE_READ_TIMEOUT'),
   );
   assert.equal(receivedSignal?.aborted, true);
+});
+
+test('an unrelated AbortError is not falsely relabeled as DABBIR timeout', async () => {
+  await assert.rejects(
+    withServerReadTimeout(() => Promise.reject(Object.assign(new Error('UPSTREAM_ABORT'), { name: 'AbortError' })), {
+      errorCode: 'SHOULD_NOT_APPEAR', timeoutMs: 100,
+    }),
+    error => {
+      assert.equal(error?.message, 'UPSTREAM_ABORT');
+      assert.notEqual(error?.status, 504);
+      return true;
+    },
+  );
 });
 
 test('critical Billing and WhatsApp core functions return explicit 504 on stalled prerequisite reads', async t => {
@@ -66,19 +85,36 @@ test('critical Billing and WhatsApp core functions return explicit 504 on stalle
 
   await assert.rejects(
     requireBillingOwner(requestWithToken(), BUSINESS_ID, { timeoutMs: 5 }),
-    error => error?.status === 504 && error?.safeCode === 'BILLING_AUTH_DATA_TIMEOUT' && error?.timeout === true,
+    error => assertTimeout(error, 'BILLING_AUTH_DATA_TIMEOUT'),
   );
   await assert.rejects(
     getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
-    error => error?.status === 504 && error?.safeCode === 'BILLING_STATUS_TIMEOUT' && error?.timeout === true,
+    error => assertTimeout(error, 'BILLING_STATUS_TIMEOUT'),
   );
   await assert.rejects(
     ownerContext(requestWithToken(), BUSINESS_ID, { timeoutMs: 5 }),
-    error => error?.status === 504 && error?.safeCode === 'WHATSAPP_AUTH_DATA_TIMEOUT' && error?.timeout === true,
+    error => assertTimeout(error, 'WHATSAPP_AUTH_DATA_TIMEOUT'),
   );
   await assert.rejects(
     loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 5 }),
-    error => error?.status === 504 && error?.safeCode === 'WHATSAPP_CONNECTION_READ_TIMEOUT' && error?.timeout === true,
+    error => assertTimeout(error, 'WHATSAPP_CONNECTION_READ_TIMEOUT'),
+  );
+});
+
+test('WhatsApp service-role persistence RPC reports explicit 504 timeout without changing server authority', async t => {
+  const originalFetch = globalThis.fetch;
+  const originalKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  t.after(() => {
+    globalThis.fetch = originalFetch;
+    if (originalKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = originalKey;
+  });
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+  globalThis.fetch = hangingFetch;
+
+  await assert.rejects(
+    serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: BUSINESS_ID }, { timeoutMs: 5 }),
+    error => assertTimeout(error, 'WHATSAPP_SERVER_DATA_TIMEOUT'),
   );
 });
 
@@ -134,21 +170,26 @@ test('WhatsApp owner, connection and service-role persistence reads are bounded'
     'WHATSAPP_CONNECTION_STORE',
     'WHATSAPP_CONNECTION_DELETE',
   ]) assert.match(whatsappEmbedded, new RegExp(label));
-  assert.match(whatsappLive, /WHATSAPP_SERVER_RPC/);
+  assert.match(whatsappLive, /WHATSAPP_SERVER_DATA_TIMEOUT/);
+  assert.match(whatsappLive, /authorization: `Bearer \$\{key\}`/);
   assert.match(whatsappLive, /signal => fetch/);
   assert.doesNotMatch(whatsappEmbedded, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
   assert.doesNotMatch(whatsappEmbedded, /getBusinessMemberships\(accessToken\)\.catch\(\(\) => \[\]\)/);
   assert.doesNotMatch(whatsappEmbedded, /if \(!response\.ok\) return null/);
 });
 
-test('WhatsApp status and provider-accepted readback preserve timeout truth', () => {
+test('WhatsApp status and provider-accepted readback preserve timeout truth and no-resend semantics', () => {
   assert.match(whatsappStatus, /WHATSAPP_STATUS_AUTH_READ/);
   assert.match(whatsappStatus, /WHATSAPP_STATUS_MEMBERSHIP_READ/);
   assert.match(whatsappStatus, /getVerifiedUser\(accessToken, \{ signal \}\)/);
   assert.match(whatsappStatus, /getBusinessMemberships\(accessToken, \{ signal \}\)/);
   assert.doesNotMatch(whatsappStatus, /getVerifiedUser\(accessToken\)\.catch\(\(\) => null\)/);
-  assert.match(whatsappReply, /WHATSAPP_REPLY_READBACK/);
+  assert.match(whatsappReply, /WHATSAPP_REPLY_READBACK_TIMEOUT/);
   assert.match(whatsappReply, /supabaseRest\([\s\S]*\{ signal \}/);
   assert.match(whatsappReply, /502, 503, 504/);
   assert.match(whatsappReply, /AMBIGUOUS_NO_AUTOMATIC_RESEND/);
+  assert.match(whatsappReply, /reserveOutboundReply/);
+  assert.match(whatsappReply, /sendMetaText/);
+  assert.match(whatsappReply, /finalizeOutboundReply/);
+  assert.match(whatsappReply, /automatic_resend_blocked/);
 });

--- a/test/dabbir-malformed-provider-success.test.mjs
+++ b/test/dabbir-malformed-provider-success.test.mjs
@@ -68,9 +68,15 @@ test('WhatsApp [] remains the only valid unlinked storage shape', async t => {
   });
 });
 
-test('WhatsApp connection read rejects multiple or wrong-tenant rows', async t => {
+test('WhatsApp connection read rejects null, multiple or wrong-tenant rows', async t => {
   const originalFetch = globalThis.fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
+
+  globalThis.fetch = () => jsonResponse('[null]');
+  await assert.rejects(
+    loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+    error => error?.message === 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
+  );
 
   globalThis.fetch = () => jsonResponse(JSON.stringify([
     { business_id: BUSINESS_ID, status: 'connected' },
@@ -90,11 +96,19 @@ test('WhatsApp connection read rejects multiple or wrong-tenant rows', async t =
   );
 });
 
-test('WhatsApp store requires one returned row proving the tenant write', async t => {
-  await withFetch(t, () => jsonResponse('[]'), async () => {
+test('WhatsApp store requires one valid matching returned row proving the tenant write', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+
+  for (const payload of [
+    '[]',
+    '[null]',
+    JSON.stringify([{ business_id: OTHER_BUSINESS_ID, status: 'connected' }]),
+  ]) {
+    globalThis.fetch = () => jsonResponse(payload);
     await assert.rejects(
       upsertBusinessConnection(ACCESS_TOKEN, { business_id: BUSINESS_ID, status: 'connected' }, { timeoutMs: 100 }),
       error => error?.status === 502 && error?.message === 'WHATSAPP_CONNECTION_STORE_RESPONSE_MALFORMED',
     );
-  });
+  }
 });

--- a/test/dabbir-malformed-provider-success.test.mjs
+++ b/test/dabbir-malformed-provider-success.test.mjs
@@ -1,45 +1,100 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { getBillingAccount } from '../api/_billing-core.js';
-import { loadBusinessConnection } from '../api/_whatsapp-embedded-core.js';
+import { loadBusinessConnection, upsertBusinessConnection } from '../api/_whatsapp-embedded-core.js';
 
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const OTHER_BUSINESS_ID = '00000000-0000-4000-8000-000000000222';
 const ACCESS_TOKEN = 'test-access-token';
 
-function malformedSuccess() {
-  return Promise.resolve(new Response('{not-valid-json', {
+function jsonResponse(body) {
+  return Promise.resolve(new Response(body, {
     status: 200,
     headers: { 'content-type': 'application/json' },
   }));
 }
 
-test('Billing malformed HTTP 200 cannot masquerade as not_subscribed', async t => {
+function malformedSuccess() {
+  return jsonResponse('{not-valid-json');
+}
+
+async function withFetch(t, fetchImpl, operation) {
   const originalFetch = globalThis.fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  globalThis.fetch = malformedSuccess;
+  globalThis.fetch = fetchImpl;
+  return operation();
+}
 
-  await assert.rejects(
-    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
-    error => {
-      assert.equal(error?.code, 502);
-      assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
-      return true;
-    },
-  );
+test('Billing malformed HTTP 200 cannot masquerade as not_subscribed', async t => {
+  await withFetch(t, malformedSuccess, async () => {
+    await assert.rejects(
+      getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+      error => {
+        assert.equal(error?.code, 502);
+        assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
+        return true;
+      },
+    );
+  });
 });
 
 test('WhatsApp malformed HTTP 200 cannot masquerade as an unlinked tenant', async t => {
+  await withFetch(t, malformedSuccess, async () => {
+    await assert.rejects(
+      loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+      error => {
+        assert.equal(error?.status, 502);
+        assert.equal(error?.message, 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED');
+        assert.equal(error?.providerStatus, 200);
+        return true;
+      },
+    );
+  });
+});
+
+test('WhatsApp empty HTTP 200 body cannot masquerade as an unlinked tenant', async t => {
+  await withFetch(t, () => jsonResponse(''), async () => {
+    await assert.rejects(
+      loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+      error => error?.status === 502 && error?.message === 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
+    );
+  });
+});
+
+test('WhatsApp [] remains the only valid unlinked storage shape', async t => {
+  await withFetch(t, () => jsonResponse('[]'), async () => {
+    const connection = await loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 });
+    assert.equal(connection, null);
+  });
+});
+
+test('WhatsApp connection read rejects multiple or wrong-tenant rows', async t => {
   const originalFetch = globalThis.fetch;
   t.after(() => { globalThis.fetch = originalFetch; });
-  globalThis.fetch = malformedSuccess;
 
+  globalThis.fetch = () => jsonResponse(JSON.stringify([
+    { business_id: BUSINESS_ID, status: 'connected' },
+    { business_id: BUSINESS_ID, status: 'connected' },
+  ]));
   await assert.rejects(
     loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
-    error => {
-      assert.equal(error?.status, 502);
-      assert.equal(error?.message, 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED');
-      assert.equal(error?.providerStatus, 200);
-      return true;
-    },
+    error => error?.message === 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
   );
+
+  globalThis.fetch = () => jsonResponse(JSON.stringify([
+    { business_id: OTHER_BUSINESS_ID, status: 'connected' },
+  ]));
+  await assert.rejects(
+    loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+    error => error?.message === 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED',
+  );
+});
+
+test('WhatsApp store requires one returned row proving the tenant write', async t => {
+  await withFetch(t, () => jsonResponse('[]'), async () => {
+    await assert.rejects(
+      upsertBusinessConnection(ACCESS_TOKEN, { business_id: BUSINESS_ID, status: 'connected' }, { timeoutMs: 100 }),
+      error => error?.status === 502 && error?.message === 'WHATSAPP_CONNECTION_STORE_RESPONSE_MALFORMED',
+    );
+  });
 });

--- a/test/dabbir-malformed-provider-success.test.mjs
+++ b/test/dabbir-malformed-provider-success.test.mjs
@@ -1,0 +1,45 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { getBillingAccount } from '../api/_billing-core.js';
+import { loadBusinessConnection } from '../api/_whatsapp-embedded-core.js';
+
+const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const ACCESS_TOKEN = 'test-access-token';
+
+function malformedSuccess() {
+  return Promise.resolve(new Response('{not-valid-json', {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  }));
+}
+
+test('Billing malformed HTTP 200 cannot masquerade as not_subscribed', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = malformedSuccess;
+
+  await assert.rejects(
+    getBillingAccount(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+    error => {
+      assert.equal(error?.code, 502);
+      assert.equal(error?.message, 'BILLING_STATUS_UNAVAILABLE_INVALID_RESPONSE');
+      return true;
+    },
+  );
+});
+
+test('WhatsApp malformed HTTP 200 cannot masquerade as an unlinked tenant', async t => {
+  const originalFetch = globalThis.fetch;
+  t.after(() => { globalThis.fetch = originalFetch; });
+  globalThis.fetch = malformedSuccess;
+
+  await assert.rejects(
+    loadBusinessConnection(ACCESS_TOKEN, BUSINESS_ID, { timeoutMs: 100 }),
+    error => {
+      assert.equal(error?.status, 502);
+      assert.equal(error?.message, 'WHATSAPP_CONNECTION_RESPONSE_MALFORMED');
+      assert.equal(error?.providerStatus, 200);
+      return true;
+    },
+  );
+});

--- a/test/dabbir-server-read-timeout-cleanup.test.mjs
+++ b/test/dabbir-server-read-timeout-cleanup.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { withServerReadTimeout } from '../api/_server-read-timeout.js';
+
+test('early grouped-read failure aborts cooperative sibling work', async () => {
+  let siblingAborted = false;
+  await assert.rejects(
+    withServerReadTimeout(signal => Promise.all([
+      Promise.reject(new Error('MEMBERSHIP_FAILED_EARLY')),
+      new Promise((_resolve, reject) => {
+        signal.addEventListener('abort', () => {
+          siblingAborted = true;
+          const error = new Error('sibling aborted');
+          error.name = 'AbortError';
+          reject(error);
+        }, { once: true });
+      }),
+    ]), { errorCode: 'GROUP_TIMEOUT_SHOULD_NOT_REPLACE_EARLY_FAILURE', timeoutMs: 100 }),
+    error => {
+      assert.equal(error?.message, 'MEMBERSHIP_FAILED_EARLY');
+      assert.notEqual(error?.status, 504);
+      return true;
+    },
+  );
+  assert.equal(siblingAborted, true, 'bounded helper must abort unfinished sibling work on early failure');
+});
+
+test('successful bounded read also releases its AbortSignal after completion', async () => {
+  let signal = null;
+  const value = await withServerReadTimeout(activeSignal => {
+    signal = activeSignal;
+    return Promise.resolve('ok');
+  }, { timeoutMs: 100 });
+  assert.equal(value, 'ok');
+  assert.equal(signal?.aborted, true, 'completed bounded work should release cooperative resources');
+});

--- a/test/dabbir-whatsapp-disconnect-truth.test.mjs
+++ b/test/dabbir-whatsapp-disconnect-truth.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { verifiedDeletion } from '../api/dabbir-whatsapp-disconnect.js';
+
+const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
+const OTHER_BUSINESS_ID = '00000000-0000-4000-8000-000000000222';
+
+test('WhatsApp disconnect success requires exactly one matching deleted tenant row', () => {
+  assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }], BUSINESS_ID), true);
+  assert.equal(verifiedDeletion([], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion([{ business_id: OTHER_BUSINESS_ID }], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }, { business_id: BUSINESS_ID }], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion([null], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion({ business_id: BUSINESS_ID }, BUSINESS_ID), false);
+});

--- a/test/dabbir-whatsapp-outbound-idempotency.test.mjs
+++ b/test/dabbir-whatsapp-outbound-idempotency.test.mjs
@@ -38,6 +38,23 @@ test('same idempotency key can never trigger a second external send',()=>{
   assert.doesNotMatch(replayBranch,/sendMetaText/);
 });
 
+test('accepted replay readback failure retains provider truth and blocks duplicate resend',()=>{
+  const replayStart=reply.indexOf('if (!reservation.shouldSend)');
+  const replayEnd=reply.indexOf('if (String(connection.id)',replayStart);
+  const replayBranch=reply.slice(replayStart,replayEnd);
+  const acceptedStateAt=replayBranch.indexOf("['PROVIDER_ACCEPTED', 'SENT', 'DELIVERED', 'READ']");
+  const providerAcceptedAt=replayBranch.indexOf('providerAccepted = true',acceptedStateAt);
+  const readbackAt=replayBranch.indexOf('readPersistedMessage',acceptedStateAt);
+  assert.ok(acceptedStateAt>=0,'accepted replay state gate missing');
+  assert.ok(providerAcceptedAt>acceptedStateAt && providerAcceptedAt<readbackAt,'provider acceptance must be recorded before replay readback');
+  assert.match(replayBranch,/error\.providerAccepted = true/);
+  assert.match(replayBranch,/error\.ambiguous = true/);
+  assert.match(replayBranch,/replayReadbackUnverified\(res, reservation\)/);
+  assert.match(reply,/retry_safe_with_same_key: ambiguous/);
+  assert.match(reply,/state: 'PROVIDER_ACCEPTED_LOCAL_READBACK_UNVERIFIED'/);
+  assert.match(reply,/automatic_resend_blocked: true/);
+});
+
 test('service-role reservation independently enforces active account and membership state',()=>{
   assert.match(migration,/account_access_state[\s\S]*status='suspended'/);
   assert.match(migration,/auth\.users[\s\S]*deleted_at is null[\s\S]*banned_until/);


### PR DESCRIPTION
Closes #155.

Root cause:
Critical Meta/Stripe provider calls were already timeout-bounded, but prerequisite Supabase/Auth reads in WhatsApp and Billing were not. A stalled Supabase request could therefore consume the Vercel function lifetime or be collapsed into misleading auth/disconnected states.

Repair:
- add one shared `withServerReadTimeout` contract with AbortSignal propagation, hard wall-clock timeout, explicit 504, safe timeout code, and TIMEOUT classification;
- bound Billing owner auth/membership reads and billing-account reads without changing user Bearer/RLS authority;
- preserve 504 through billing status/checkout/portal handlers;
- bound WhatsApp owner auth/membership reads, connection read/store/delete/rotation operations, and service-role persistence RPCs;
- bound WhatsApp status auth/membership reads so a timeout cannot masquerade as AUTH_REQUIRED;
- bound provider-accepted outbound readback and preserve no-automatic-resend/ambiguous semantics after external side effects;
- add functional and architecture regression tests.

Non-goals / unchanged:
- no RLS weakening;
- no service-role substitution for browser/tenant reads;
- no change to Meta send idempotency/reserve-send-finalize semantics;
- no change to Stripe sandbox/live isolation;
- no secrets or production credentials modified.

Acceptance gate:
Codex review + DABBIR CI + Vercel Preview. Merge only if all are green, then exact-SHA Production smoke/journey verification.