### PR TITLE
DABBIR: bind release evidence to live Vercel source identity

### DIFF
--- a/api/release-evidence.js
+++ b/api/release-evidence.js
@@ -1,3 +1,7 @@
+const EXPECTED_PROJECT_ID='prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq';
+const EXPECTED_REPOSITORY='barman-systems/pilot';
+const EXPECTED_GIT_PROVIDER='github';
+
 function sendJson(res,status,payload,extraHeaders={}){
   res.statusCode=status;
   res.setHeader('content-type','application/json; charset=utf-8');
@@ -16,6 +20,11 @@ export default function handler(req,res){
   const deploymentId=String(process.env.VERCEL_DEPLOYMENT_ID||'').trim();
   const environment=String(process.env.VERCEL_TARGET_ENV||process.env.VERCEL_ENV||'').trim();
   const gitRef=String(process.env.VERCEL_GIT_COMMIT_REF||'').trim();
+  const projectId=String(process.env.VERCEL_PROJECT_ID||'').trim();
+  const gitProvider=String(process.env.VERCEL_GIT_PROVIDER||'').trim().toLowerCase();
+  const repositoryOwner=String(process.env.VERCEL_GIT_REPO_OWNER||'').trim();
+  const repositorySlug=String(process.env.VERCEL_GIT_REPO_SLUG||'').trim();
+  const repository=repositoryOwner&&repositorySlug?`${repositoryOwner}/${repositorySlug}`:'';
 
   if(!/^[a-f0-9]{40}$/i.test(commitSha)){
     return sendJson(res,503,{
@@ -25,11 +34,33 @@ export default function handler(req,res){
     });
   }
 
+  if(!deploymentId.startsWith('dpl_')||!projectId||!gitProvider||!repository){
+    return sendJson(res,503,{
+      ok:false,
+      error:'RELEASE_SOURCE_IDENTITY_UNAVAILABLE',
+      environment:environment||null,
+    });
+  }
+
+  if(projectId!==EXPECTED_PROJECT_ID||gitProvider!==EXPECTED_GIT_PROVIDER||repository!==EXPECTED_REPOSITORY){
+    return sendJson(res,503,{
+      ok:false,
+      error:'RELEASE_SOURCE_IDENTITY_MISMATCH',
+      environment:environment||null,
+      project_id:projectId||null,
+      git_provider:gitProvider||null,
+      repository:repository||null,
+    });
+  }
+
   return sendJson(res,200,{
     ok:true,
     commit_sha:commitSha.toLowerCase(),
-    deployment_id:deploymentId||null,
+    deployment_id:deploymentId,
     environment:environment||null,
     git_ref:gitRef||null,
+    project_id:projectId,
+    git_provider:gitProvider,
+    repository,
   });
 }

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -4,6 +4,8 @@ const ORIGIN = String(process.env.PROTECTED_QA_ORIGIN || '').trim().replace(/\/$
 const BYPASS = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
 const TRUSTED_OIDC = String(process.env.VERCEL_TRUSTED_OIDC_TOKEN || '').trim();
 const EXPECTED_SHA = String(process.env.EXPECTED_PRODUCTION_SHA || '').trim().toLowerCase();
+const EXPECTED_PROJECT_ID = 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq';
+const EXPECTED_REPOSITORY = 'barman-systems/pilot';
 const REPORT_PATH = process.env.PROTECTED_QA_REPORT_PATH || 'dabbir-protected-live-smoke-report.json';
 const RELEASE_WAIT_MS = Math.min(Math.max(Number(process.env.PROTECTED_QA_RELEASE_WAIT_MS || 180_000), 15_000), 300_000);
 
@@ -79,6 +81,9 @@ async function waitForExactProductionSha() {
       last = `HTTP_${response.status}:${observed || body?.error || text.slice(0, 120)}`;
       if (response.status === 200 && body?.ok === true && observed === EXPECTED_SHA) {
         assert(!environment || environment === 'production', `EXACT_SHA_NOT_PRODUCTION_${environment}`);
+        assert(body?.project_id === EXPECTED_PROJECT_ID, `EXACT_PROJECT_ID_MISMATCH_${body?.project_id || 'missing'}`);
+        assert(body?.git_provider === 'github', `EXACT_GIT_PROVIDER_MISMATCH_${body?.git_provider || 'missing'}`);
+        assert(body?.repository === EXPECTED_REPOSITORY, `EXACT_REPOSITORY_MISMATCH_${body?.repository || 'missing'}`);
         report.verified_production_sha = observed;
         report.verified_deployment_id = body?.deployment_id || null;
         return body;
@@ -95,7 +100,7 @@ let browser;
 try {
   await step('00_exact_production_sha', async () => {
     const evidence = await waitForExactProductionSha();
-    return `Production release evidence matches ${EXPECTED_SHA}${evidence?.deployment_id ? ` on ${evidence.deployment_id}` : ''}.`;
+    return `Production release evidence matches ${EXPECTED_SHA}${evidence?.deployment_id ? ` on ${evidence.deployment_id}` : ''}, ${evidence.project_id}, ${evidence.repository}.`;
   });
 
   await step('01_protected_home_reachable', async () => {
@@ -149,8 +154,6 @@ try {
     await page.screenshot({ path: 'dabbir-protected-live-smoke.png', fullPage: true });
     report.artifacts.screenshot = 'dabbir-protected-live-smoke.png';
 
-    // Brand UI intentionally prepends a mobile app-shell brand that stays hidden on auth.
-    // Scope the assertion to the visible auth gate so a hidden sibling can never satisfy or break this check.
     const logo = authGate.locator('.authCard .brand .logo');
     assert(await logo.count() === 1, `AUTH_APPROVED_LOGO_COUNT_${await logo.count()}`);
     await logo.waitFor({ state: 'visible', timeout: 10_000 });

--- a/test/dabbir-release-evidence-source-identity.test.mjs
+++ b/test/dabbir-release-evidence-source-identity.test.mjs
@@ -1,0 +1,111 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/release-evidence.js';
+
+const EXPECTED = {
+  VERCEL_GIT_COMMIT_SHA: '4c61654500a8bf309cd59ca1dcbdabf6915a6d8a',
+  VERCEL_DEPLOYMENT_ID: 'dpl_7h53fmTenbsfZRAEiYrhv5Qrse6V',
+  VERCEL_TARGET_ENV: 'production',
+  VERCEL_GIT_COMMIT_REF: 'main',
+  VERCEL_PROJECT_ID: 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq',
+  VERCEL_GIT_PROVIDER: 'github',
+  VERCEL_GIT_REPO_OWNER: 'barman-systems',
+  VERCEL_GIT_REPO_SLUG: 'pilot',
+};
+const KEYS = Object.keys(EXPECTED);
+
+function invoke(method = 'GET') {
+  const headers = new Map();
+  let text = '';
+  const res = {
+    statusCode: 0,
+    setHeader(name, value) { headers.set(String(name).toLowerCase(), String(value)); },
+    end(value = '') { text = String(value); },
+  };
+  handler({ method }, res);
+  return { status: res.statusCode, headers, body: JSON.parse(text) };
+}
+
+async function withEnv(overrides, fn) {
+  const before = Object.fromEntries(KEYS.map(key => [key, process.env[key]]));
+  try {
+    for (const key of KEYS) {
+      const value = Object.hasOwn(overrides, key) ? overrides[key] : EXPECTED[key];
+      if (value === undefined || value === null) delete process.env[key];
+      else process.env[key] = String(value);
+    }
+    return await fn();
+  } finally {
+    for (const [key, value] of Object.entries(before)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('release evidence returns exact Vercel project and Git source identity', async () => {
+  await withEnv({}, () => {
+    const result = invoke();
+    assert.equal(result.status, 200);
+    assert.equal(result.body.ok, true);
+    assert.equal(result.body.commit_sha, EXPECTED.VERCEL_GIT_COMMIT_SHA);
+    assert.equal(result.body.deployment_id, EXPECTED.VERCEL_DEPLOYMENT_ID);
+    assert.equal(result.body.environment, 'production');
+    assert.equal(result.body.git_ref, 'main');
+    assert.equal(result.body.project_id, EXPECTED.VERCEL_PROJECT_ID);
+    assert.equal(result.body.git_provider, 'github');
+    assert.equal(result.body.repository, 'barman-systems/pilot');
+    assert.equal(result.headers.get('cache-control'), 'no-store, max-age=0');
+  });
+});
+
+test('release evidence fails closed when Vercel project identity is missing', async () => {
+  await withEnv({ VERCEL_PROJECT_ID: null }, () => {
+    const result = invoke();
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, 'RELEASE_SOURCE_IDENTITY_UNAVAILABLE');
+  });
+});
+
+test('release evidence fails closed when Vercel project is not DABBIR', async () => {
+  await withEnv({ VERCEL_PROJECT_ID: 'prj_wrong' }, () => {
+    const result = invoke();
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, 'RELEASE_SOURCE_IDENTITY_MISMATCH');
+    assert.equal(result.body.project_id, 'prj_wrong');
+  });
+});
+
+test('release evidence fails closed when the live Git repository is relinked', async () => {
+  await withEnv({ VERCEL_GIT_REPO_SLUG: 'other-repository' }, () => {
+    const result = invoke();
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, 'RELEASE_SOURCE_IDENTITY_MISMATCH');
+    assert.equal(result.body.repository, 'barman-systems/other-repository');
+  });
+});
+
+test('release evidence fails closed when Git provider identity drifts', async () => {
+  await withEnv({ VERCEL_GIT_PROVIDER: 'gitlab' }, () => {
+    const result = invoke();
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, 'RELEASE_SOURCE_IDENTITY_MISMATCH');
+  });
+});
+
+test('release evidence still rejects unavailable commit evidence', async () => {
+  await withEnv({ VERCEL_GIT_COMMIT_SHA: null }, () => {
+    const result = invoke();
+    assert.equal(result.status, 503);
+    assert.equal(result.body.error, 'RELEASE_COMMIT_EVIDENCE_UNAVAILABLE');
+  });
+});
+
+test('release evidence rejects non-GET requests without source disclosure', async () => {
+  await withEnv({}, () => {
+    const result = invoke('POST');
+    assert.equal(result.status, 405);
+    assert.deepEqual(result.body, { ok: false, error: 'METHOD_NOT_ALLOWED' });
+    assert.equal(result.headers.get('allow'), 'GET');
+  });
+});


### PR DESCRIPTION
Root cause found while hardening control-plane production evidence: `/api/release-evidence` proved commit/deployment/environment/ref but did not prove the live Vercel project and linked Git repository identity. A relinked project could therefore produce syntactically valid release evidence.

Repair:
- read Vercel runtime system metadata for project ID, Git provider, repo owner and repo slug;
- fail 503 when source identity is unavailable or differs from authoritative DABBIR (`prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq`, GitHub, `barman-systems/pilot`);
- expose only non-secret source identity on successful release evidence;
- regression tests for missing/wrong project, relinked repo, provider drift, commit absence and method gate;
- Protected Production iPhone smoke now requires exact project/repository identity in addition to exact SHA/deployment.

Acceptance: DABBIR CI + Codex + exact-head Vercel Preview. After merge, exact-SHA Production Protected WebKit smoke must pass with the new source identity fields before control-plane #521 can proceed.