### PR TITLE
DABBIR QA: harden protected journey OIDC after #160

### DIFF
--- a/.github/workflows/dabbir-protected-full-customer-journey.yml
+++ b/.github/workflows/dabbir-protected-full-customer-journey.yml
@@ -5,32 +5,24 @@ on:
   pull_request:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'package-lock.json'
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/dabbir-protected-full-journey-preload.mjs'
       - 'test/dabbir-protected-journey-access.test.mjs'
       - 'test/support/dabbir-protected-journey-access.mjs'
       - '.github/workflows/dabbir-protected-full-customer-journey.yml'
-      - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
-      - 'db/dabbir*.sql'
       - 'api/**'
       - 'index.html'
       - 'team.html'
   push:
     branches: [main]
     paths:
-      - 'package.json'
-      - 'package-lock.json'
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/dabbir-protected-full-journey-preload.mjs'
       - 'test/dabbir-protected-journey-access.test.mjs'
       - 'test/support/dabbir-protected-journey-access.mjs'
       - '.github/workflows/dabbir-protected-full-customer-journey.yml'
-      - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
-      - 'db/dabbir*.sql'
       - 'api/**'
       - 'index.html'
       - 'team.html'
@@ -42,135 +34,124 @@ permissions:
   id-token: write
 
 concurrency:
-  group: dabbir-protected-full-customer-journey
+  group: dabbir-protected-full-customer-journey-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'main' }}
   cancel-in-progress: false
 
+env:
+  PRODUCTION_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
+  SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+
 jobs:
-  protected-full-customer-journey:
-    name: Protected production owner + employee + customer + AI journey
+  pr-access-contract:
+    name: PR-safe protected access contract
+    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 22
-    env:
-      PRODUCTION_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
-      SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
-      JOURNEY_REPORT_PATH: dabbir-protected-full-customer-journey-report.json
-      VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
-      VERCEL_TEAM_ID: team_pwfKq8jHuyW1XFVSZirAJiId
-      EXPECTED_BASE_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.base.sha || '' }}
+    timeout-minutes: 8
     steps:
       - uses: actions/checkout@v7
-
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
 
-      - name: Prepare protected Production automation access
+      - name: Test protected-access header injection
+        run: node --test test/dabbir-protected-journey-access.test.mjs
+
+      - name: Prove QA broker remains main-only and workflow-scoped
+        shell: bash
+        run: |
+          set -euo pipefail
+          source_file='supabase/functions/barman-qa-suite-runner/index.ts'
+          grep -F "const GH_REF='refs/heads/main'" "$source_file"
+          grep -F "dabbir-ai-customer-journey.yml@refs/heads/main" "$source_file"
+          grep -F "dabbir-protected-full-customer-journey.yml@refs/heads/main" "$source_file"
+          ! grep -F 'refs/pull/' "$source_file"
+          echo 'QA_OIDC_ALLOWLIST_MAIN_ONLY'
+
+      - name: Prove protected Production is reachable with short-lived GitHub OIDC
+        shell: bash
+        env:
+          EXPECTED_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          set -euo pipefail
+          request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          test -n "$request_url" && test -n "$request_token"
+          oidc_response="$(curl --fail-with-body --silent --show-error -H "Authorization: Bearer ${request_token}" "$request_url")"
+          oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
+          test -n "$oidc_token"
+          echo "::add-mask::$oidc_token"
+          body="$(curl --fail-with-body --silent --show-error \
+            -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" \
+            -H 'accept: application/json' \
+            "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)")"
+          observed="$(printf '%s' "$body" | jq -r '.commit_sha // empty')"
+          ok="$(printf '%s' "$body" | jq -r '.ok // false')"
+          test "$ok" = 'true'
+          test "$observed" = "$EXPECTED_BASE_SHA"
+          echo "PR_SAFE_PROTECTED_ACCESS_PASS production_sha=$observed"
+
+  protected-full-customer-journey:
+    name: Main-only owner + employee + customer + AI journey
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 22
+    env:
+      JOURNEY_REPORT_PATH: dabbir-protected-full-customer-journey-report.json
+      EXPECTED_PRODUCTION_SHA: ${{ github.event_name == 'push' && github.sha || '' }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Prepare protected Production trusted OIDC access
         id: access
         shell: bash
         run: |
           set -euo pipefail
-
-          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-            echo 'ready=true' >> "$GITHUB_OUTPUT"
-            echo 'generated=false' >> "$GITHUB_OUTPUT"
-            echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
-            echo 'PROTECTED_ACCESS_FROM_EXISTING_BYPASS'
-            exit 0
-          fi
-
-          if [ -n "${VERCEL_TOKEN:-}" ]; then
-            endpoint="https://api.vercel.com/v1/projects/${VERCEL_PROJECT_ID}/protection-bypass?teamId=${VERCEL_TEAM_ID}"
-            response="$(curl --fail-with-body --silent --show-error \
-              -X PATCH "$endpoint" \
-              -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-              -H 'Content-Type: application/json' \
-              --data '{"generate":{"note":"DABBIR protected full journey temporary"}}')"
-            secret="$(printf '%s' "$response" | jq -r '.protectionBypass // empty')"
-            if [ -n "$secret" ]; then
-              echo "::add-mask::$secret"
-              echo "VERCEL_AUTOMATION_BYPASS_SECRET=$secret" >> "$GITHUB_ENV"
-              echo 'ready=true' >> "$GITHUB_OUTPUT"
-              echo 'generated=true' >> "$GITHUB_OUTPUT"
-              echo 'method=automation_bypass' >> "$GITHUB_OUTPUT"
-              echo 'PROTECTED_ACCESS_TEMP_BYPASS_GENERATED'
-              exit 0
-            fi
-          fi
-
           request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
           request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
-          if [ -n "$request_url" ] && [ -n "$request_token" ]; then
-            oidc_response="$(curl --fail-with-body --silent --show-error \
-              -H "Authorization: Bearer ${request_token}" \
-              "$request_url")"
-            oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
-            if [ -n "$oidc_token" ]; then
-              echo "::add-mask::$oidc_token"
-              probe_body="$(mktemp)"
-              probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' \
-                -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" \
-                -H 'accept: text/html' \
-                "$PRODUCTION_ORIGIN/")"
-              if [ "$probe_status" = '200' ] && grep -qi 'DABBIR' "$probe_body"; then
-                echo "VERCEL_TRUSTED_OIDC_TOKEN=$oidc_token" >> "$GITHUB_ENV"
-                echo 'ready=true' >> "$GITHUB_OUTPUT"
-                echo 'generated=false' >> "$GITHUB_OUTPUT"
-                echo 'method=trusted_oidc' >> "$GITHUB_OUTPUT"
-                echo 'PROTECTED_ACCESS_TRUSTED_OIDC_READY'
-                exit 0
-              fi
-              echo "TRUSTED_OIDC_REJECTED_HTTP_${probe_status}"
-            fi
-          fi
-
-          echo 'ready=false' >> "$GITHUB_OUTPUT"
-          echo 'generated=false' >> "$GITHUB_OUTPUT"
-          echo 'method=none' >> "$GITHUB_OUTPUT"
-          echo 'BLOCKED_VERCEL_AUTOMATION_ACCESS_NOT_CONFIGURED'
-          exit 2
+          test -n "$request_url" && test -n "$request_token"
+          oidc_response="$(curl --fail-with-body --silent --show-error -H "Authorization: Bearer ${request_token}" "$request_url")"
+          oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
+          test -n "$oidc_token"
+          echo "::add-mask::$oidc_token"
+          probe_body="$(mktemp)"
+          probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' \
+            -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" \
+            -H 'accept: text/html' \
+            "$PRODUCTION_ORIGIN/")"
+          test "$probe_status" = '200'
+          grep -qi 'DABBIR' "$probe_body"
+          echo "VERCEL_TRUSTED_OIDC_TOKEN=$oidc_token" >> "$GITHUB_ENV"
+          echo 'method=trusted_oidc' >> "$GITHUB_OUTPUT"
+          echo 'PROTECTED_ACCESS_TRUSTED_OIDC_READY'
 
       - name: Lock exact Production release before journey
         id: before
         shell: bash
         run: |
           set -euo pipefail
-          auth_args=()
-          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-            auth_args+=( -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" -H 'x-vercel-set-bypass-cookie: true' )
-          elif [ -n "${VERCEL_TRUSTED_OIDC_TOKEN:-}" ]; then
-            auth_args+=( -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" )
-          else
-            echo 'PROTECTED_ACCESS_MISSING_AFTER_PREPARE'
-            exit 2
-          fi
-
-          body=''
-          sha=''
-          deployment=''
-          for attempt in $(seq 1 36); do
+          body=''; sha=''; deployment=''
+          for attempt in $(seq 1 48); do
             body="$(curl --silent --show-error \
-              "${auth_args[@]}" \
+              -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" \
               -H 'accept: application/json' \
               "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
             sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty' 2>/dev/null || true)"
             deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty' 2>/dev/null || true)"
-            environment="$(printf '%s' "$body" | jq -r '.environment // empty' 2>/dev/null || true)"
             ok="$(printf '%s' "$body" | jq -r '.ok // false' 2>/dev/null || true)"
-            if [ "$ok" = 'true' ] && [[ "$sha" =~ ^[0-9a-f]{40}$ ]] && { [ -z "$environment" ] || [ "$environment" = 'production' ]; }; then
-              break
+            if [ "$ok" = 'true' ] && [[ "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+              if [ -z "${EXPECTED_PRODUCTION_SHA:-}" ] || [ "$sha" = "$EXPECTED_PRODUCTION_SHA" ]; then
+                break
+              fi
             fi
             sha=''
             sleep 5
           done
           if [ -z "$sha" ]; then
-            echo "EXACT_PRODUCTION_RELEASE_UNVERIFIED: ${body:0:500}"
+            echo "EXACT_PRODUCTION_RELEASE_UNVERIFIED expected=${EXPECTED_PRODUCTION_SHA:-CURRENT} body=${body:0:400}"
             exit 3
-          fi
-          if [ -n "${EXPECTED_BASE_SHA:-}" ] && [ "$sha" != "$EXPECTED_BASE_SHA" ]; then
-            echo "PRODUCTION_SHA_DOES_NOT_MATCH_PR_BASE expected=${EXPECTED_BASE_SHA} observed=${sha}"
-            exit 4
           fi
           echo "sha=$sha" >> "$GITHUB_OUTPUT"
           echo "deployment=$deployment" >> "$GITHUB_OUTPUT"
@@ -184,7 +165,7 @@ jobs:
       - name: Run full customer journey through protected Production
         run: node --import ./test/dabbir-protected-full-journey-preload.mjs test/ai-full-customer-journey-v2.mjs
 
-      - name: Require a real full-journey PASS
+      - name: Require real full-journey PASS
         shell: bash
         run: |
           set -euo pipefail
@@ -197,17 +178,8 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          auth_args=()
-          if [ -n "${VERCEL_AUTOMATION_BYPASS_SECRET:-}" ]; then
-            auth_args+=( -H "x-vercel-protection-bypass: ${VERCEL_AUTOMATION_BYPASS_SECRET}" -H 'x-vercel-set-bypass-cookie: true' )
-          elif [ -n "${VERCEL_TRUSTED_OIDC_TOKEN:-}" ]; then
-            auth_args+=( -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" )
-          else
-            echo 'PROTECTED_ACCESS_MISSING_AFTER_JOURNEY'
-            exit 2
-          fi
           body="$(curl --fail-with-body --silent --show-error \
-            "${auth_args[@]}" \
+            -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" \
             -H 'accept: application/json' \
             "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)")"
           sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty')"
@@ -226,16 +198,13 @@ jobs:
         run: |
           echo '## DABBIR Protected Full Customer Journey' >> "$GITHUB_STEP_SUMMARY"
           echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo "**Access method:** ${{ steps.access.outputs.method || 'none' }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "**Access:** trusted_oidc" >> "$GITHUB_STEP_SUMMARY"
           echo "**Production SHA before:** ${{ steps.before.outputs.sha || 'UNVERIFIED' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Production SHA after:** ${{ steps.after.outputs.sha || 'UNVERIFIED' }}" >> "$GITHUB_STEP_SUMMARY"
           echo "**Deployment:** ${{ steps.before.outputs.deployment || 'UNAVAILABLE' }}" >> "$GITHUB_STEP_SUMMARY"
           if [ -f "$JOURNEY_REPORT_PATH" ]; then
             echo "**Verdict:** $(jq -r '.verdict' "$JOURNEY_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
             echo "**Required failures:** $(jq -r '.required_failures' "$JOURNEY_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
-            echo '| Step | Status | Duration ms | Detail |' >> "$GITHUB_STEP_SUMMARY"
-            echo '|---|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
-            jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' "$JOURNEY_REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"
           else
             echo '**Verdict:** NO_REPORT' >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -250,18 +219,3 @@ jobs:
             dabbir-ai-customer-journey-screenshot.png
           if-no-files-found: warn
           retention-days: 14
-
-      - name: Revoke temporary automation bypass
-        if: ${{ always() && steps.access.outputs.generated == 'true' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          endpoint="https://api.vercel.com/v1/projects/${VERCEL_PROJECT_ID}/protection-bypass?teamId=${VERCEL_TEAM_ID}"
-          payload="$(jq -nc --arg secret "$VERCEL_AUTOMATION_BYPASS_SECRET" '{revoke:{secret:$secret,regenerate:false}}')"
-          curl --fail-with-body --silent --show-error \
-            -X PATCH "$endpoint" \
-            -H "Authorization: Bearer ${VERCEL_TOKEN}" \
-            -H 'Content-Type: application/json' \
-            --data "$payload" \
-            >/dev/null
-          echo 'TEMPORARY_AUTOMATION_BYPASS_REVOKED'

--- a/supabase/functions/barman-qa-suite-runner/index.ts
+++ b/supabase/functions/barman-qa-suite-runner/index.ts
@@ -11,8 +11,13 @@ const GH_REPOSITORY='barman-systems/pilot';
 const GH_REF='refs/heads/main';
 const GH_EVENTS=new Set(['push','schedule','workflow_dispatch']);
 const OIDC_PROFILES={
-  ai:{audience:'dabbir-ai-qa',workflowRef:'barman-systems/pilot/.github/workflows/dabbir-ai-customer-journey.yml@refs/heads/main'},
-  readiness:{audience:'dabbir-bar12-readiness',workflowRef:'barman-systems/pilot/.github/workflows/dabbir-bar12-readiness.yml@refs/heads/main'},
+  ai:{audience:'dabbir-ai-qa',workflowRefs:new Set([
+    'barman-systems/pilot/.github/workflows/dabbir-ai-customer-journey.yml@refs/heads/main',
+    'barman-systems/pilot/.github/workflows/dabbir-protected-full-customer-journey.yml@refs/heads/main',
+  ])},
+  readiness:{audience:'dabbir-bar12-readiness',workflowRefs:new Set([
+    'barman-systems/pilot/.github/workflows/dabbir-bar12-readiness.yml@refs/heads/main',
+  ])},
 } as const;
 
 async function auth(req:Request){const s=req.headers.get('x-barman-worker-secret')||'';if(!s)return false;const {data}=await db.rpc('barman_validate_worker_secret',{p_secret:s});return data===true}
@@ -45,7 +50,7 @@ async function verifyGitHubOidc(req:Request,profile:keyof typeof OIDC_PROFILES){
   if(Number(payload.exp||0)<=now||Number(payload.nbf||0)>now+30)throw new Error('OIDC_TIME_INVALID');
   if(payload.repository!==GH_REPOSITORY)throw new Error('OIDC_REPOSITORY_DENIED');
   if(payload.ref!==GH_REF)throw new Error('OIDC_REF_DENIED');
-  if(payload.workflow_ref!==expected.workflowRef)throw new Error('OIDC_WORKFLOW_DENIED');
+  if(!expected.workflowRefs.has(String(payload.workflow_ref||'')))throw new Error('OIDC_WORKFLOW_DENIED');
   if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
   return payload;
 }


### PR DESCRIPTION
## Root cause
#160 merged while its protected PR journey was still attempting the destructive QA bootstrap from a pull-request OIDC ref. The live QA broker correctly rejected that identity with `OIDC_REF_DENIED` because privileged QA creation is restricted to `refs/heads/main`.

## Repair
- keep the QA broker hard-locked to `refs/heads/main`;
- allow only two exact main workflow identities for the `dabbir-ai-qa` audience: the existing authoritative AI journey and the protected journey;
- never allow `refs/pull/*`;
- make pull requests run only non-destructive access/header/OIDC contract checks and verify protected Production still equals the PR base SHA;
- run the disposable owner + employee + customer + AI journey only on main / schedule / manual dispatch;
- on push to main, wait for and bind to the exact pushed Production SHA before running;
- require real report `PASS`, `required_failures=0`, and prove Production SHA/deployment does not move during the journey.

## Security boundary
This does not grant PRs authority to create QA identities. `GH_REF` remains exactly `refs/heads/main`, and workflow identities remain exact allowlist entries.

## Acceptance
PR-safe contract must pass. After merge, deploy the exact broker source and require the main-only protected full journey to execute and PASS against the exact Production release before closing the tenant-isolation/prelaunch QA blocker.