### PR TITLE
DABBIR release: force exact-SHA deploy for canonical journey contracts

### DIFF
--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -39,6 +39,15 @@ function runGuard(cwd, current, previousDeployment = '', ref = 'main') {
   });
 }
 
+function commitPath(dir, relativePath, content = 'export {};\n') {
+  const target = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+  git(dir, 'add', '.');
+  git(dir, 'commit', '-qm', `change ${relativePath}`);
+  return git(dir, 'rev-parse', 'HEAD');
+}
+
 test('all non-main branches run the full Vercel verification gate even for test-only commits', () => {
   const dir = setupRepo();
   const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
@@ -65,7 +74,7 @@ test('protected Production smoke runner changes on main force exact-SHA Vercel d
   const head = git(dir, 'rev-parse', 'HEAD');
   const result = runGuard(dir, head, lastSuccessfulDeployment);
   assert.equal(result.status, 1);
-  assert.match(result.stdout, /Protected Production smoke contract changed; deploy exact SHA for browser evidence/);
+  assert.match(result.stdout, /Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence/);
 });
 
 test('protected Production smoke workflow changes on main force exact-SHA Vercel deployment', () => {
@@ -77,7 +86,29 @@ test('protected Production smoke workflow changes on main force exact-SHA Vercel
   const head = git(dir, 'rev-parse', 'HEAD');
   const result = runGuard(dir, head, lastSuccessfulDeployment);
   assert.equal(result.status, 1);
-  assert.match(result.stdout, /Protected Production smoke contract changed; deploy exact SHA for browser evidence/);
+  assert.match(result.stdout, /Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence/);
+});
+
+test('every ignored-path trigger of the canonical exact-SHA customer journey forces a Production deployment', () => {
+  const contractPaths = [
+    '.github/workflows/dabbir-ai-customer-journey.yml',
+    'test/ai-full-customer-journey-v2.mjs',
+    'test/dabbir-protected-full-journey-preload.mjs',
+    'test/dabbir-protected-journey-access.test.mjs',
+    'test/dabbir-authorized-journey-workflow.test.mjs',
+    'test/support/dabbir-protected-journey-access.mjs',
+    'test/dabbir-capacity-load.mjs',
+    'test/dabbir-activity-regression.test.mjs',
+  ];
+
+  for (const relativePath of contractPaths) {
+    const dir = setupRepo();
+    const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+    const head = commitPath(dir, relativePath, relativePath.endsWith('.yml') ? 'name: journey\n' : 'export {};\n');
+    const result = runGuard(dir, head, lastSuccessfulDeployment);
+    assert.equal(result.status, 1, `${relativePath}: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence/);
+  }
 });
 
 test('Supabase migrations on main force Vercel deployment so production SHA cannot drift', () => {

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -13,10 +13,10 @@ set -u
 #    build whenever any application, database migration, or unknown path changed
 #    in that range. Database schema is part of the Production artifact contract;
 #    a migration must not leave main SHA ahead of the deployed SHA.
-# 3) The protected Production browser-smoke runner and workflow are themselves
-#    release-verification contracts. Because that smoke is exact-SHA-bound, any
-#    change to either contract must deploy the same SHA before it can produce
-#    truthful browser evidence.
+# 3) Exact-SHA Production verification contracts are deployment-affecting even
+#    when their source files live under .github/ or test/. If one of those files
+#    changes, Production must advance to the same commit before the verification
+#    workflow can truthfully claim exact-artifact evidence.
 # 4) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 ref="${VERCEL_GIT_COMMIT_REF:-}"
@@ -62,8 +62,17 @@ fi
 
 while IFS= read -r path; do
   case "$path" in
-    test/dabbir-protected-live-smoke.mjs|.github/workflows/dabbir-protected-live-smoke.yml)
-      echo "Protected Production smoke contract changed; deploy exact SHA for browser evidence: $path"
+    test/dabbir-protected-live-smoke.mjs|\
+    .github/workflows/dabbir-protected-live-smoke.yml|\
+    .github/workflows/dabbir-ai-customer-journey.yml|\
+    test/ai-full-customer-journey-v2.mjs|\
+    test/dabbir-protected-full-journey-preload.mjs|\
+    test/dabbir-protected-journey-access.test.mjs|\
+    test/dabbir-authorized-journey-workflow.test.mjs|\
+    test/support/dabbir-protected-journey-access.mjs|\
+    test/dabbir-capacity-load.mjs|\
+    test/dabbir-activity-regression.test.mjs)
+      echo "Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence: $path"
       exit 1
       ;;
     .github/*|docs/*|test/*|README.md|.gitignore)


### PR DESCRIPTION
Root cause proven from canceled Production deployment `dpl_AHMpfurFRCDfeW5E76CfGFFZixSq`: Vercel's Ignored Build Step classified the canonical full-customer-journey workflow as non-runtime and canceled deployment of main SHA `9aa9d5b7f773bc958a39a7f25ba689914ccd849e`. That makes the new exact-artifact journey invariant impossible to satisfy.

Repair:
- classify the canonical exact-SHA customer-journey workflow and every otherwise-ignored test/support path that triggers it as deployment-affecting;
- preserve skip behavior for unrelated test/docs changes;
- preserve fail-safe builds for runtime/database/unknown paths and every non-main preview;
- add regression coverage across all 8 ignored-path canonical journey triggers.

No runtime application code, Supabase policy, auth or product behavior changes.

Acceptance: exact-head DABBIR CI and Vercel Preview pass. After merge, Vercel must build the merge SHA instead of canceling it; canonical customer journey must then lock and verify that exact Production SHA before and after the journey.