### PR TITLE
Fix DABBIR post-login UI gate deadlock

### DIFF
--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -1,18 +1,19 @@
 import { AUTH_SESSION_STAGES, AUTH_SESSION_TRANSITIONS } from './_dabbir-auth-session-state-machine.js';
 
-// BAR-30 exact-head preview marker: auth/session state machine v1.
+// The auth state machine is observability/validation only. The base application
+// owns gate visibility so a valid session can never be hidden by a second UI
+// authority after login.
 const authSessionMachine = JSON.stringify({
   stages: AUTH_SESSION_STAGES,
   transitions: AUTH_SESSION_TRANSITIONS,
 });
 
 const script = String.raw`(()=>{
-  if(window.__dabbirAuthSessionStabilityV2) return;
-  window.__dabbirAuthSessionStabilityV2=true;
+  if(window.__dabbirAuthSessionStabilityV4) return;
+  window.__dabbirAuthSessionStabilityV4=true;
 
   const authMachine=${authSessionMachine};
   let authStage=authMachine.stages.SIGNED_OUT;
-  let gateRecoveryPromise=null;
 
   function publishAuthStage(stage,reason=null){
     authStage=stage;
@@ -35,7 +36,7 @@ const script = String.raw`(()=>{
   }
 
   const style=document.createElement('style');
-  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v2';
+  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v4';
   style.textContent=[
     '.bottomNav.hidden{display:none!important}',
     '#appShell.hidden{display:none!important}',
@@ -65,79 +66,26 @@ const script = String.raw`(()=>{
     return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')?keyAr:keyEn;
   }
 
-  function showSessionError(textAr,textEn){
-    const msg=document.querySelector('#authMsg');
-    if(msg) msg.textContent=localized(textAr,textEn);
-  }
-
-  const baseShowGate=showGate;
-
-  async function reconcileVerifiedGate(name){
-    if(gateRecoveryPromise) return gateRecoveryPromise;
-    gateRecoveryPromise=(async()=>{
-      const state=await sessionReady();
-      if(state.suspended){
-        setAuthStage(authMachine.stages.SUSPENDED,'ACCOUNT_SUSPENDED',{bootstrap:true});
-        baseShowGate('auth');
-        document.body.dataset.dabbirGate='auth';
-        showSessionError('الحساب موقوف. تواصل مع دعم دبّر.','This account is suspended. Contact DABBIR support.');
-        return;
-      }
-      if(!state.ready){
-        publishAuthStage(authMachine.stages.DEGRADED,'GATE_SESSION_RECONCILIATION_FAILED');
-        baseShowGate('auth');
-        document.body.dataset.dabbirGate='auth';
-        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
-        return;
-      }
-
-      setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_RECONCILED_FOR_GATE',{bootstrap:true});
-      if(name==='app'){
-        setAuthStage(authMachine.stages.WORKSPACE_READY,'WORKSPACE_RENDERED');
-      }
-      baseShowGate(name);
-      document.body.dataset.dabbirGate=String(name||'');
-      const bottom=document.querySelector('#bottomNav');
-      if(bottom&&name!=='app') bottom.classList.add('hidden');
-    })().finally(()=>{gateRecoveryPromise=null});
-    return gateRecoveryPromise;
-  }
-
-  showGate=function(name){
-    if(name==='auth'){
-      if(authStage!==authMachine.stages.SUSPENDED){
-        setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_GATE_VISIBLE');
-      }
+  function syncStageFromGate(name,reason='GATE_RENDERED'){
+    if(name==='app'){
+      publishAuthStage(authMachine.stages.WORKSPACE_READY,reason);
     }else if(name==='onboarding'){
-      if(authStage!==authMachine.stages.SESSION_VERIFIED){
-        if(authStage===authMachine.stages.SIGNED_OUT||authStage===authMachine.stages.DEGRADED){
-          void reconcileVerifiedGate('onboarding');
-          return;
-        }
-        publishAuthStage(authMachine.stages.DEGRADED,'ONBOARDING_WITHOUT_VERIFIED_SESSION');
-        baseShowGate('auth');
-        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
-        return;
-      }
-    }else if(name==='app'){
-      if(authStage===authMachine.stages.SESSION_VERIFIED){
-        setAuthStage(authMachine.stages.WORKSPACE_READY,'WORKSPACE_RENDERED');
-      }else if(authStage!==authMachine.stages.WORKSPACE_READY){
-        if(authStage===authMachine.stages.SIGNED_OUT||authStage===authMachine.stages.DEGRADED){
-          void reconcileVerifiedGate('app');
-          return;
-        }
-        publishAuthStage(authMachine.stages.DEGRADED,'WORKSPACE_WITHOUT_VERIFIED_SESSION');
-        baseShowGate('auth');
-        showSessionError('تعذر التحقق من الجلسة. سجّل الدخول مرة أخرى.','The session could not be verified. Please log in again.');
-        return;
-      }
+      publishAuthStage(authMachine.stages.SESSION_VERIFIED,reason);
+    }else if(name==='auth'&&authStage!==authMachine.stages.SUSPENDED){
+      publishAuthStage(authMachine.stages.SIGNED_OUT,reason);
     }
-
-    baseShowGate(name);
     document.body.dataset.dabbirGate=String(name||'');
     const bottom=document.querySelector('#bottomNav');
     if(bottom&&name!=='app') bottom.classList.add('hidden');
+  }
+
+  // IMPORTANT: visibility is owned by the base application. This wrapper must
+  // never delay, veto, reconcile, or redirect a requested gate. It only records
+  // the state after the base gate has been rendered.
+  const baseShowGate=showGate;
+  showGate=function(name){
+    baseShowGate(name);
+    syncStageFromGate(name);
   };
 
   const form=document.querySelector('#authForm');
@@ -151,7 +99,7 @@ const script = String.raw`(()=>{
       if(msg) msg.textContent='';
 
       if(authStage===authMachine.stages.SUSPENDED){
-        setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_RETRY');
+        publishAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_RETRY');
       }
       if(!setAuthStage(authMachine.stages.AUTHENTICATING,authMode==='login'?'LOGIN_SUBMIT':'SIGNUP_SUBMIT')){
         if(msg) msg.textContent=localized('تعذر بدء جلسة آمنة. أعد المحاولة.','A secure session could not be started. Please try again.');
@@ -171,32 +119,32 @@ const script = String.raw`(()=>{
         });
 
         if(authMode==='signup'&&j?.verification_required){
-          setAuthStage(authMachine.stages.SIGNED_OUT,'EMAIL_VERIFICATION_REQUIRED');
+          publishAuthStage(authMachine.stages.SIGNED_OUT,'EMAIL_VERIFICATION_REQUIRED');
           if(msg) msg.textContent=T().verification;
           return;
         }
         if(!r.ok||!j?.ok){
-          setAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_REJECTED');
+          publishAuthStage(authMachine.stages.SIGNED_OUT,'AUTH_REJECTED');
           if(msg) msg.textContent=T().invalid;
           return;
         }
 
         const state=await sessionReady();
         if(state.suspended){
-          setAuthStage(authMachine.stages.SUSPENDED,'ACCOUNT_SUSPENDED');
+          publishAuthStage(authMachine.stages.SUSPENDED,'ACCOUNT_SUSPENDED');
           if(msg) msg.textContent=localized('الحساب موقوف. تواصل مع دعم دبّر.','This account is suspended. Contact DABBIR support.');
           return;
         }
         if(!state.ready){
-          setAuthStage(authMachine.stages.DEGRADED,'SESSION_VERIFICATION_FAILED');
+          publishAuthStage(authMachine.stages.DEGRADED,'SESSION_VERIFICATION_FAILED');
           if(msg) msg.textContent=localized('تم قبول البيانات لكن تعذر تثبيت الجلسة. حاول مرة أخرى.','The credentials were accepted but the session could not be established. Please try again.');
           return;
         }
 
-        setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED');
+        publishAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED');
         await boot();
       }catch{
-        setAuthStage(authMachine.stages.DEGRADED,'AUTH_REQUEST_FAILED');
+        publishAuthStage(authMachine.stages.DEGRADED,'AUTH_REQUEST_FAILED');
         if(msg) msg.textContent=localized('تعذر الاتصال. حاول مرة أخرى.','Connection failed. Please try again.');
       }finally{
         btn.disabled=false;
@@ -208,15 +156,17 @@ const script = String.raw`(()=>{
   const onboardingVisible=document.querySelector('#onboardingGate:not(.hidden)');
   const appVisible=document.querySelector('#appShell:not(.hidden)');
   if(appVisible){
-    setAuthStage(authMachine.stages.WORKSPACE_READY,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+    publishAuthStage(authMachine.stages.WORKSPACE_READY,'BASE_RUNTIME_BOOTSTRAP');
+    document.body.dataset.dabbirGate='app';
   }else if(onboardingVisible){
-    setAuthStage(authMachine.stages.SESSION_VERIFIED,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+    publishAuthStage(authMachine.stages.SESSION_VERIFIED,'BASE_RUNTIME_BOOTSTRAP');
+    document.body.dataset.dabbirGate='onboarding';
   }else{
-    setAuthStage(authMachine.stages.SIGNED_OUT,'BASE_RUNTIME_BOOTSTRAP',{bootstrap:true});
+    publishAuthStage(authMachine.stages.SIGNED_OUT,'BASE_RUNTIME_BOOTSTRAP');
+    document.body.dataset.dabbirGate=authVisible?'auth':'';
   }
-  document.body.dataset.dabbirGate=authVisible?'auth':onboardingVisible?'onboarding':appVisible?'app':'';
 
-  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v3',session_retry:true,gate_isolation:true,state_machine:true,gate_reconciliation:true};
+  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v4',session_retry:true,gate_isolation:true,state_machine:true,gate_observer_only:true};
 })();`;
 
 export default function handler(req,res){

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,5 +1,5 @@
 {
-  "version": 4,
+  "version": 5,
   "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
   "authorities": {
     "root_shell": "api/app-recovery.js",
@@ -7,7 +7,8 @@
     "primary_navigation_context_router": "api/dabbir-contextual-navigation-ui.js",
     "service_discovery_under_more": "api/dabbir-contextual-navigation-ui.js",
     "store_navigation_adaptation": "api/dabbir-contextual-navigation-ui.js",
-    "auth_session_gate": "api/auth-session-stability-ui.js",
+    "auth_gate_visibility": "index.html#showGate",
+    "auth_session_observer": "api/auth-session-stability-ui.js",
     "auth_session_state_machine": "api/_dabbir-auth-session-state-machine.js",
     "release_state_machine": "scripts/dabbir-release-state-machine.mjs",
     "release_readiness_gate": "scripts/dabbir-readiness-gate.mjs",
@@ -20,7 +21,7 @@
   "shell": {
     "maximum_injected_api_modules": 25,
     "require_unique_modules": true,
-    "final_ui_authority": "/api/auth-session-stability-ui",
+    "last_loaded_ui_observer": "/api/auth-session-stability-ui",
     "retired_modules_forbidden": [
       "/api/activity-mobile-polish-ui",
       "/api/dabbir-ui-refinement",
@@ -51,6 +52,7 @@
     "unverified_metrics_may_fall_back_to_bounded_lists": false,
     "workspace_ready_requires_verified_session": true,
     "invalid_auth_transition_may_open_workspace": false,
+    "presentation_observer_may_veto_verified_gate": false,
     "release_ready_requires_exact_tested_sha": true,
     "release_ready_requires_exact_ready_deployment": true,
     "release_ready_requires_real_production_journey": true

--- a/test/dabbir-architecture-invariants-v1.test.mjs
+++ b/test/dabbir-architecture-invariants-v1.test.mjs
@@ -27,10 +27,13 @@ test('architecture contract is fail-closed and gives contextual navigation one a
   assert.equal(ownership.primary_navigation.feature_modules_may_mutate_primary_destinations, false);
   assert.equal(ownership.authorities.primary_navigation_context_router, 'api/dabbir-contextual-navigation-ui.js');
   assert.equal(ownership.authorities.store_navigation_adaptation, 'api/dabbir-contextual-navigation-ui.js');
+  assert.equal(ownership.authorities.auth_gate_visibility, 'index.html#showGate');
+  assert.equal(ownership.authorities.auth_session_observer, 'api/auth-session-stability-ui.js');
   assert.deepEqual(ownership.temporary_exceptions, {});
   assert.equal(ownership.truth_rules.blocked_or_skipped_qa_is_pass, false);
   assert.equal(ownership.truth_rules.tenant_may_inherit_global_whatsapp_identity, false);
   assert.equal(ownership.truth_rules.meta_authorized_equals_operational_whatsapp, false);
+  assert.equal(ownership.truth_rules.presentation_observer_may_veto_verified_gate, false);
 });
 
 test('desktop and mobile primary navigation are exactly the five owner destinations', () => {
@@ -90,14 +93,17 @@ test('shell UI module growth is frozen to the explicit allowlist', () => {
   assert.deepEqual(modules, expected, 'new shell patch modules require an explicit architecture change');
   assert.equal(new Set(modules).size, modules.length, 'duplicate shell module injection detected');
   assert.ok(modules.length <= ownership.shell.maximum_injected_api_modules, 'shell module ceiling exceeded');
-  assert.equal(modules.at(-1), ownership.shell.final_ui_authority);
+  assert.equal(modules.at(-1), ownership.shell.last_loaded_ui_observer);
 
   for (const retired of ownership.shell.retired_modules_forbidden) {
     assert.equal(modules.includes(retired), false, `retired presentation layer returned: ${retired}`);
   }
 });
 
-test('presentation authorities cannot depend on continuous polling', () => {
+test('presentation observers cannot veto verified gate visibility or depend on continuous polling', () => {
+  assert.match(authStability, /gate_observer_only:true/);
+  assert.doesNotMatch(authStability, /reconcileVerifiedGate/);
+
   for (const [name, source] of [
     ['owner-first', ownerFirst],
     ['contextual-navigation', contextualNavigation],

--- a/test/dabbir-auth-session-state-machine.test.mjs
+++ b/test/dabbir-auth-session-state-machine.test.mjs
@@ -51,24 +51,33 @@ test('suspended and failed verification are explicit non-ready states', () => {
   assert.equal(degraded.authenticated, false);
 });
 
-test('auth UI publishes one machine stage and cannot open app from an unverified state', () => {
+test('auth UI verifies the session before boot but only observes gate visibility', () => {
   assert.match(authUi, /dataset\.dabbirAuthStage/);
   assert.match(authUi, /INVALID_AUTH_TRANSITION/);
-  assert.match(authUi, /WORKSPACE_WITHOUT_VERIFIED_SESSION/);
   assert.match(authUi, /state_machine:true/);
   assert.match(authUi, /SESSION_COOKIE_VERIFIED/);
+  assert.match(authUi, /gate_observer_only:true/);
+  assert.doesNotMatch(authUi, /reconcileVerifiedGate/);
 
-  const verifiedIndex = authUi.indexOf("setAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED')");
+  const verifiedIndex = authUi.indexOf("publishAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED')");
   const bootIndex = authUi.indexOf('await boot()');
   assert.ok(verifiedIndex >= 0 && bootIndex > verifiedIndex);
+
+  const wrapperIndex = authUi.indexOf('showGate=function(name)');
+  const baseGateIndex = authUi.indexOf('baseShowGate(name)', wrapperIndex);
+  const observerIndex = authUi.indexOf('syncStageFromGate(name)', wrapperIndex);
+  assert.ok(wrapperIndex >= 0 && baseGateIndex > wrapperIndex && observerIndex > baseGateIndex);
 });
 
-test('architecture contract names the auth machine and forbids workspace promotion without verified session', () => {
+test('architecture contract separates auth truth from presentation visibility ownership', () => {
   assert.equal(
     architecture.authorities.auth_session_state_machine,
     'api/_dabbir-auth-session-state-machine.js',
   );
+  assert.equal(architecture.authorities.auth_gate_visibility, 'index.html#showGate');
+  assert.equal(architecture.authorities.auth_session_observer, 'api/auth-session-stability-ui.js');
   assert.equal(architecture.truth_rules.workspace_ready_requires_verified_session, true);
   assert.equal(architecture.truth_rules.invalid_auth_transition_may_open_workspace, false);
-  assert.equal(architecture.shell.final_ui_authority, '/api/auth-session-stability-ui');
+  assert.equal(architecture.truth_rules.presentation_observer_may_veto_verified_gate, false);
+  assert.equal(architecture.shell.last_loaded_ui_observer, '/api/auth-session-stability-ui');
 });

--- a/test/dabbir-ios-auth-gate-stability.test.mjs
+++ b/test/dabbir-ios-auth-gate-stability.test.mjs
@@ -24,18 +24,18 @@ test('successful login waits for the HttpOnly session to become observable befor
   assert.ok(sessionIndex >= 0 && bootIndex > sessionIndex);
 });
 
-test('a valid server session can reconcile a lagging signed-out presentation gate', () => {
-  assert.match(authUi, /async function reconcileVerifiedGate\(name\)/);
-  assert.match(authUi, /SESSION_RECONCILED_FOR_GATE/);
-  assert.match(authUi, /authStage===authMachine\.stages\.SIGNED_OUT\|\|authStage===authMachine\.stages\.DEGRADED/);
-  assert.match(authUi, /void reconcileVerifiedGate\('app'\)/);
-  assert.match(authUi, /void reconcileVerifiedGate\('onboarding'\)/);
-  assert.match(authUi, /gate_reconciliation:true/);
+test('auth stability observes gate state but never vetoes or delays the base application gate', () => {
+  assert.match(authUi, /const baseShowGate=showGate/);
+  assert.match(authUi, /showGate=function\(name\)\{/);
+  assert.match(authUi, /baseShowGate\(name\);\s*syncStageFromGate\(name\)/);
+  assert.match(authUi, /gate_observer_only:true/);
+  assert.doesNotMatch(authUi, /reconcileVerifiedGate/);
+  assert.doesNotMatch(authUi, /void reconcileVerifiedGate/);
 
-  const reconcileIndex = authUi.indexOf('async function reconcileVerifiedGate(name)');
-  const sessionIndex = authUi.indexOf('const state=await sessionReady()', reconcileIndex);
-  const promoteIndex = authUi.indexOf("baseShowGate(name)", reconcileIndex);
-  assert.ok(reconcileIndex >= 0 && sessionIndex > reconcileIndex && promoteIndex > sessionIndex);
+  const wrapperIndex = authUi.indexOf('showGate=function(name)');
+  const baseIndex = authUi.indexOf('baseShowGate(name)', wrapperIndex);
+  const syncIndex = authUi.indexOf('syncStageFromGate(name)', wrapperIndex);
+  assert.ok(wrapperIndex >= 0 && baseIndex > wrapperIndex && syncIndex > baseIndex);
 });
 
 test('auth stability authority loads last after all owner and contextual presentation layers', () => {


### PR DESCRIPTION
Root-cause fix for the production/WebKit failure where credentials and runtime both return 200 but `#appShell` never becomes visible after login.

Changes:
- Keep HttpOnly session verification/retry and suspension handling.
- Remove the second auth state-machine authority that could veto/delay `showGate('app')`.
- Make the auth stability layer observer-only for gate state; the base application is the single visibility authority.
- Add regression coverage that fails if auth stability reintroduces reconciliation/veto behavior.

Production evidence before fix:
- `/api/auth/login` = 200
- `/api/auth/session` = 200
- `/api/dabbir-runtime-fast` = 200
- WebKit journey fails waiting 25s for `#appShell:not(.hidden)`.

No Supabase/RLS weakening and no auth bypass.