### PR TITLE
DABBIR auth: fast verified browser workspace bootstrap

### DIFF
--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -13,6 +13,7 @@ const script = String.raw`(()=>{
   const authMachine=${authSessionMachine};
   let authStage=authMachine.stages.SIGNED_OUT;
   let gateRecoveryPromise=null;
+  const verifiedRuntimeReadEndpoint='/api/dabbir-runtime-fast';
 
   function publishAuthStage(stage,reason=null){
     authStage=stage;
@@ -69,6 +70,58 @@ const script = String.raw`(()=>{
     const msg=document.querySelector('#authMsg');
     if(msg) msg.textContent=localized(textAr,textEn);
   }
+
+  // This module is the final auth/session UI authority. Keep authenticated workspace
+  // reads on the bounded fast runtime so a successful login cannot be stranded behind
+  // the older unbounded/heavier bootstrap path. Mutations remain delegated by the fast
+  // endpoint to the canonical runtime handler, so business-write semantics are unchanged.
+  boot=async function(){
+    applyLang();
+    const {r,j}=await api(verifiedRuntimeReadEndpoint,{credentials:'same-origin'});
+    if(r.status===401){
+      workspace=null;
+      showGate('auth');
+      return;
+    }
+    if(!r.ok||!j?.ok){
+      workspace=null;
+      showGate('auth');
+      const msg=document.querySelector('#authMsg');
+      if(msg) msg.textContent=j?.error||T().invalid;
+      return;
+    }
+    if(j.needs_onboarding){
+      workspace=j;
+      showGate('onboarding');
+      return;
+    }
+    workspace=j;
+    selectedConversationId=j.selected_conversation_id||null;
+    showGate('app');
+    renderAll();
+  };
+
+  loadRuntime=async function(businessId,conversationId){
+    const q=new URLSearchParams();
+    if(businessId) q.set('business_id',businessId);
+    if(conversationId) q.set('conversation_id',conversationId);
+    const url=q.toString()?verifiedRuntimeReadEndpoint+'?'+q.toString():verifiedRuntimeReadEndpoint;
+    const {r,j}=await api(url,{credentials:'same-origin'});
+    if(r.status===401){
+      workspace=null;
+      showGate('auth');
+      toast(T().authRequired);
+      return;
+    }
+    if(!r.ok||!j?.ok){
+      toast(j?.error||T().invalid);
+      return;
+    }
+    workspace=j;
+    selectedConversationId=j.selected_conversation_id||conversationId||null;
+    showGate('app');
+    renderAll();
+  };
 
   const baseShowGate=showGate;
 
@@ -216,7 +269,7 @@ const script = String.raw`(()=>{
   }
   document.body.dataset.dabbirGate=authVisible?'auth':onboardingVisible?'onboarding':appVisible?'app':'';
 
-  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v3',session_retry:true,gate_isolation:true,state_machine:true,gate_reconciliation:true};
+  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v4-fast-workspace',session_retry:true,gate_isolation:true,state_machine:true,gate_reconciliation:true,fast_workspace_bootstrap:true};
 })();`;
 
 export default function handler(req,res){

--- a/test/dabbir-browser-auth-fast-bootstrap.test.mjs
+++ b/test/dabbir-browser-auth-fast-bootstrap.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root = new URL('../', import.meta.url);
+const authUi = await readFile(new URL('api/auth-session-stability-ui.js', root), 'utf8');
+const fastRuntime = await readFile(new URL('api/dabbir-runtime-fast.js', root), 'utf8');
+const ownership = JSON.parse(await readFile(new URL('config/dabbir-architecture-ownership.json', root), 'utf8'));
+
+test('final auth UI authority owns authenticated browser workspace bootstrap', () => {
+  assert.equal(ownership.authorities.auth_session_gate, 'api/auth-session-stability-ui.js');
+  assert.equal(ownership.shell.final_ui_authority, '/api/auth-session-stability-ui');
+  assert.match(authUi, /const verifiedRuntimeReadEndpoint='\/api\/dabbir-runtime-fast'/);
+  assert.match(authUi, /boot=async function\(\)/);
+  assert.match(authUi, /loadRuntime=async function\(businessId,conversationId\)/);
+  assert.match(authUi, /await api\(verifiedRuntimeReadEndpoint,\{credentials:'same-origin'\}\)/);
+  assert.match(authUi, /fast_workspace_bootstrap:true/);
+});
+
+test('browser workspace reads no longer call the legacy runtime from the final auth authority', () => {
+  const bootStart = authUi.indexOf('boot=async function()');
+  const formStart = authUi.indexOf("const baseShowGate=showGate");
+  assert.ok(bootStart >= 0 && formStart > bootStart);
+  const bootstrapBlock = authUi.slice(bootStart, formStart);
+  assert.doesNotMatch(bootstrapBlock, /api\('\/api\/dabbir-runtime(?:\?|')/);
+  assert.match(bootstrapBlock, /verifiedRuntimeReadEndpoint/);
+});
+
+test('fast runtime preserves mutation semantics by delegating every non-GET request', () => {
+  assert.match(fastRuntime, /if \(req\.method === 'GET'\)/);
+  assert.match(fastRuntime, /return dabbirRuntimeHandler\(req, res\);/);
+});


### PR DESCRIPTION
Superseded by #168 after stronger production evidence confirmed the root cause is the second presentation/auth gate authority vetoing `#appShell` even when `/api/auth/login`, `/api/auth/session`, and `/api/dabbir-runtime-fast` all return 200. The fast-runtime bootstrap patch is therefore not being merged independently. #168 removes the competing gate authority and preserves the base application as the single visibility owner; it must still pass exact-head CI, Preview, and the real protected Production full customer journey before #155 can close.