### PR TITLE
DABBIR: complete MFA login without post-login UI deadlock

### DIFF
--- a/api/_dabbir-auth-session-state-machine.js
+++ b/api/_dabbir-auth-session-state-machine.js
@@ -2,6 +2,7 @@
 export const AUTH_SESSION_STAGES = Object.freeze({
   SIGNED_OUT: 'signed_out',
   AUTHENTICATING: 'authenticating',
+  MFA_REQUIRED: 'mfa_required',
   SESSION_VERIFIED: 'session_verified',
   WORKSPACE_READY: 'workspace_ready',
   SUSPENDED: 'suspended',
@@ -14,7 +15,14 @@ export const AUTH_SESSION_TRANSITIONS = Object.freeze({
   ]),
   [AUTH_SESSION_STAGES.AUTHENTICATING]: Object.freeze([
     AUTH_SESSION_STAGES.SIGNED_OUT,
+    AUTH_SESSION_STAGES.MFA_REQUIRED,
     AUTH_SESSION_STAGES.SESSION_VERIFIED,
+    AUTH_SESSION_STAGES.SUSPENDED,
+    AUTH_SESSION_STAGES.DEGRADED,
+  ]),
+  [AUTH_SESSION_STAGES.MFA_REQUIRED]: Object.freeze([
+    AUTH_SESSION_STAGES.SESSION_VERIFIED,
+    AUTH_SESSION_STAGES.SIGNED_OUT,
     AUTH_SESSION_STAGES.SUSPENDED,
     AUTH_SESSION_STAGES.DEGRADED,
   ]),
@@ -45,6 +53,7 @@ export function isAllowedAuthSessionTransition(from, to) {
 
 export function deriveAuthSessionState({
   attempting = false,
+  mfaRequired = false,
   sessionVerified = false,
   workspaceReady = false,
   suspended = false,
@@ -68,12 +77,21 @@ export function deriveAuthSessionState({
     };
   }
 
-  if (workspaceReady && !sessionVerified) {
+  if (workspaceReady && (!sessionVerified || mfaRequired)) {
     return {
       stage: AUTH_SESSION_STAGES.DEGRADED,
       authenticated: false,
       workspace_ready: false,
-      reason: 'WORKSPACE_WITHOUT_VERIFIED_SESSION',
+      reason: mfaRequired ? 'WORKSPACE_BEFORE_MFA_VERIFICATION' : 'WORKSPACE_WITHOUT_VERIFIED_SESSION',
+    };
+  }
+
+  if (mfaRequired) {
+    return {
+      stage: AUTH_SESSION_STAGES.MFA_REQUIRED,
+      authenticated: true,
+      workspace_ready: false,
+      reason: 'MFA_REQUIRED',
     };
   }
 

--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -1,19 +1,21 @@
 import { AUTH_SESSION_STAGES, AUTH_SESSION_TRANSITIONS } from './_dabbir-auth-session-state-machine.js';
 
-// The auth state machine is observability/validation only. The base application
-// owns gate visibility so a valid session can never be hidden by a second UI
-// authority after login.
+// The auth state machine observes/validates presentation state. The base
+// application remains the sole gate-visibility authority; MFA continuation
+// stays inside the already-visible auth gate and never creates a second gate.
 const authSessionMachine = JSON.stringify({
   stages: AUTH_SESSION_STAGES,
   transitions: AUTH_SESSION_TRANSITIONS,
 });
 
 const script = String.raw`(()=>{
-  if(window.__dabbirAuthSessionStabilityV4) return;
-  window.__dabbirAuthSessionStabilityV4=true;
+  if(window.__dabbirAuthSessionStabilityV5) return;
+  window.__dabbirAuthSessionStabilityV5=true;
 
   const authMachine=${authSessionMachine};
   let authStage=authMachine.stages.SIGNED_OUT;
+  let pendingMfaFactorId=null;
+  let pendingMfaFactorType=null;
 
   function publishAuthStage(stage,reason=null){
     authStage=stage;
@@ -36,12 +38,15 @@ const script = String.raw`(()=>{
   }
 
   const style=document.createElement('style');
-  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v4';
+  style.dataset.dabbirAuthGateAuthority='ios-auth-stability-v5';
   style.textContent=[
     '.bottomNav.hidden{display:none!important}',
     '#appShell.hidden{display:none!important}',
     '#authGate:not(.hidden),#onboardingGate:not(.hidden){position:fixed!important;inset:0!important;z-index:90!important;overflow:auto!important;min-height:100dvh!important;overscroll-behavior:contain!important}',
     '#authGate:not(.hidden)~#bottomNav,#onboardingGate:not(.hidden)~#bottomNav{display:none!important}',
+    '#mfaContinuation.hidden{display:none!important}',
+    '#mfaContinuation .mfaHint{margin-top:10px;color:var(--muted);font-size:11px;line-height:1.7}',
+    '#mfaContinuation .mfaActions{display:grid;grid-template-columns:1fr auto;gap:8px;align-items:center;margin-top:14px}',
   ].join('');
   document.head.appendChild(style);
 
@@ -62,26 +67,144 @@ const script = String.raw`(()=>{
     return {ready:false,suspended:false};
   }
 
+  async function mfaStatus(){
+    const {r,j}=await api('/api/auth/mfa-status',{credentials:'same-origin'});
+    if(!r.ok||!j?.ok||j?.authenticated!==true) throw new Error('MFA_STATUS_UNAVAILABLE');
+    return j;
+  }
+
   function localized(keyAr,keyEn){
     return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')?keyAr:keyEn;
   }
 
+  function ensureMfaContinuation(){
+    let panel=document.querySelector('#mfaContinuation');
+    if(panel) return panel;
+    const card=document.querySelector('#authGate .authCard');
+    if(!card) return null;
+    panel=document.createElement('div');
+    panel.id='mfaContinuation';
+    panel.className='hidden';
+    panel.innerHTML='<div class="field"><label id="mfaCodeLabel" for="mfaCode"></label><input id="mfaCode" type="text" inputmode="numeric" autocomplete="one-time-code" pattern="[0-9]*" minlength="6" maxlength="8"></div><p class="mfaHint" id="mfaHint"></p><div class="authMsg" id="mfaMsg" role="status" aria-live="polite"></div><div class="mfaActions"><button class="primary" id="mfaSubmit" type="button"></button><button class="secondary" id="mfaCancel" type="button"></button></div>';
+    card.appendChild(panel);
+
+    panel.querySelector('#mfaSubmit').onclick=async()=>{
+      const submit=panel.querySelector('#mfaSubmit');
+      const msg=panel.querySelector('#mfaMsg');
+      const code=String(panel.querySelector('#mfaCode')?.value||'').trim();
+      if(authStage!==authMachine.stages.MFA_REQUIRED) return;
+      if(!pendingMfaFactorId||pendingMfaFactorType!=='totp'){
+        if(msg) msg.textContent=localized('تعذر تحديد عامل المصادقة الآمن. أعد تسجيل الدخول.','A supported secure authentication factor is unavailable. Sign in again.');
+        return;
+      }
+      if(!/^\\d{6,8}$/.test(code)){
+        if(msg) msg.textContent=localized('أدخل رمز التحقق الصحيح.','Enter a valid verification code.');
+        return;
+      }
+      submit.disabled=true;
+      if(msg) msg.textContent='';
+      try{
+        const {r,j}=await api('/api/auth/mfa-verify',{
+          method:'POST',
+          credentials:'same-origin',
+          body:JSON.stringify({factor_id:pendingMfaFactorId,code}),
+        });
+        if(!r.ok||!j?.ok||j?.aal!=='aal2'){
+          if(msg) msg.textContent=localized('رمز التحقق غير صحيح أو انتهت صلاحيته.','The verification code is invalid or expired.');
+          return;
+        }
+        const state=await sessionReady();
+        if(!state.ready||state.suspended) throw new Error('MFA_SESSION_NOT_READY');
+        const status=await mfaStatus();
+        if(status.current_level!=='aal2'||status.mfa_required===true) throw new Error('MFA_AAL2_NOT_PROVEN');
+        restorePrimaryAuth();
+        pendingMfaFactorId=null;
+        pendingMfaFactorType=null;
+        if(!setAuthStage(authMachine.stages.SESSION_VERIFIED,'MFA_AAL2_VERIFIED')) throw new Error('MFA_STATE_TRANSITION_FAILED');
+        await boot();
+      }catch{
+        if(msg) msg.textContent=localized('تعذر إكمال التحقق الآمن. حاول مرة أخرى.','Secure verification could not be completed. Please try again.');
+      }finally{
+        submit.disabled=false;
+      }
+    };
+
+    panel.querySelector('#mfaCancel').onclick=async()=>{
+      const cancel=panel.querySelector('#mfaCancel');
+      cancel.disabled=true;
+      try{await api('/api/auth/logout',{method:'POST',credentials:'same-origin',body:'{}'});}catch{}
+      pendingMfaFactorId=null;
+      pendingMfaFactorType=null;
+      restorePrimaryAuth();
+      publishAuthStage(authMachine.stages.SIGNED_OUT,'MFA_CANCELLED');
+      const authMsg=document.querySelector('#authMsg');
+      if(authMsg) authMsg.textContent='';
+      cancel.disabled=false;
+    };
+    return panel;
+  }
+
+  function showMfaContinuation(status){
+    const panel=ensureMfaContinuation();
+    if(!panel) throw new Error('MFA_PANEL_UNAVAILABLE');
+    pendingMfaFactorId=String(status?.factor_id||'').trim()||null;
+    pendingMfaFactorType=String(status?.factor_type||'').trim().toLowerCase()||null;
+    document.querySelector('#authGate .authTabs')?.classList.add('hidden');
+    document.querySelector('#authForm')?.classList.add('hidden');
+    panel.classList.remove('hidden');
+    const label=panel.querySelector('#mfaCodeLabel');
+    const hint=panel.querySelector('#mfaHint');
+    const submit=panel.querySelector('#mfaSubmit');
+    const cancel=panel.querySelector('#mfaCancel');
+    const msg=panel.querySelector('#mfaMsg');
+    if(label) label.textContent=localized('رمز المصادقة','Authentication code');
+    if(submit) submit.textContent=localized('تحقق وادخل','Verify and continue');
+    if(cancel) cancel.textContent=localized('إلغاء','Cancel');
+    if(msg) msg.textContent='';
+    if(hint){
+      hint.textContent=pendingMfaFactorType==='totp'
+        ? localized('أدخل الرمز الحالي من تطبيق المصادقة لإكمال تسجيل الدخول.','Enter the current code from your authenticator app to complete sign in.')
+        : localized('هذا الحساب يتطلب وسيلة تحقق إضافية غير مدعومة هنا. ألغِ العملية واستخدم وسيلة المصادقة المعتمدة.','This account requires an additional verification method not supported here. Cancel and use the approved authentication method.');
+    }
+    setTimeout(()=>panel.querySelector('#mfaCode')?.focus(),0);
+  }
+
+  function restorePrimaryAuth(){
+    const panel=document.querySelector('#mfaContinuation');
+    if(panel){
+      panel.classList.add('hidden');
+      const code=panel.querySelector('#mfaCode');
+      if(code) code.value='';
+    }
+    document.querySelector('#authGate .authTabs')?.classList.remove('hidden');
+    document.querySelector('#authForm')?.classList.remove('hidden');
+  }
+
   function syncStageFromGate(name,reason='GATE_RENDERED'){
     if(name==='app'){
-      publishAuthStage(authMachine.stages.WORKSPACE_READY,reason);
+      if(authStage===authMachine.stages.MFA_REQUIRED){
+        publishAuthStage(authMachine.stages.DEGRADED,'WORKSPACE_BEFORE_MFA_VERIFICATION');
+      }else{
+        publishAuthStage(authMachine.stages.WORKSPACE_READY,reason);
+      }
     }else if(name==='onboarding'){
-      publishAuthStage(authMachine.stages.SESSION_VERIFIED,reason);
-    }else if(name==='auth'&&authStage!==authMachine.stages.SUSPENDED){
+      if(authStage===authMachine.stages.MFA_REQUIRED){
+        publishAuthStage(authMachine.stages.DEGRADED,'ONBOARDING_BEFORE_MFA_VERIFICATION');
+      }else{
+        publishAuthStage(authMachine.stages.SESSION_VERIFIED,reason);
+      }
+    }else if(name==='auth'&&authStage!==authMachine.stages.SUSPENDED&&authStage!==authMachine.stages.MFA_REQUIRED){
       publishAuthStage(authMachine.stages.SIGNED_OUT,reason);
+      restorePrimaryAuth();
     }
     document.body.dataset.dabbirGate=String(name||'');
     const bottom=document.querySelector('#bottomNav');
     if(bottom&&name!=='app') bottom.classList.add('hidden');
   }
 
-  // IMPORTANT: visibility is owned by the base application. This wrapper must
-  // never delay, veto, reconcile, or redirect a requested gate. It only records
-  // the state after the base gate has been rendered.
+  // IMPORTANT: visibility remains owned by the base application. This wrapper
+  // always renders the requested gate first, then only records the resulting
+  // state/content. MFA continuation stays inside authGate.
   const baseShowGate=showGate;
   showGate=function(name){
     baseShowGate(name);
@@ -141,11 +264,23 @@ const script = String.raw`(()=>{
           return;
         }
 
+        const status=await mfaStatus();
+        if(status.mfa_required===true){
+          if(!status.factor_id){
+            publishAuthStage(authMachine.stages.DEGRADED,'MFA_FACTOR_MISSING');
+            if(msg) msg.textContent=localized('يتطلب الحساب تحققًا إضافيًا لكن عامل المصادقة غير متاح.','This account requires additional verification, but no authentication factor is available.');
+            return;
+          }
+          if(!setAuthStage(authMachine.stages.MFA_REQUIRED,'MFA_REQUIRED_AFTER_PRIMARY_AUTH')) return;
+          showMfaContinuation(status);
+          return;
+        }
+
         publishAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED');
         await boot();
       }catch{
         publishAuthStage(authMachine.stages.DEGRADED,'AUTH_REQUEST_FAILED');
-        if(msg) msg.textContent=localized('تعذر الاتصال. حاول مرة أخرى.','Connection failed. Please try again.');
+        if(msg) msg.textContent=localized('تعذر الاتصال أو التحقق من متطلبات الأمان. حاول مرة أخرى.','Connection or security verification failed. Please try again.');
       }finally{
         btn.disabled=false;
       }
@@ -166,7 +301,7 @@ const script = String.raw`(()=>{
     document.body.dataset.dabbirGate=authVisible?'auth':'';
   }
 
-  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v4',session_retry:true,gate_isolation:true,state_machine:true,gate_observer_only:true};
+  window.__dabbirAuthSessionStability={version:'ios-auth-stability-v5',session_retry:true,gate_isolation:true,state_machine:true,gate_observer_only:true,mfa_continuation:true};
 })();`;
 
 export default function handler(req,res){

--- a/api/auth/mfa-status.js
+++ b/api/auth/mfa-status.js
@@ -1,0 +1,73 @@
+import {
+  accessTokenFromRequest,
+  getVerifiedUser,
+  json,
+  supabaseAuth,
+} from '../_auth-core.js';
+
+const FACTOR_ID_RE = /^[0-9a-f-]{16,80}$/i;
+
+function decodeJwtPayload(accessToken) {
+  try {
+    const parts = String(accessToken || '').split('.');
+    if (parts.length !== 3 || !parts[1]) return null;
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function safeVerifiedFactors(user) {
+  const rows = Array.isArray(user?.factors) ? user.factors : [];
+  return rows
+    .filter(factor => factor?.status === 'verified' && FACTOR_ID_RE.test(String(factor?.id || '')))
+    .map(factor => ({
+      id: String(factor.id),
+      factor_type: String(factor.factor_type || factor.type || '').toLowerCase(),
+      friendly_name: factor.friendly_name == null ? null : String(factor.friendly_name).slice(0, 120),
+    }))
+    .filter(factor => ['totp', 'phone'].includes(factor.factor_type));
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
+
+  const accessToken = accessTokenFromRequest(req);
+  const verifiedUser = await getVerifiedUser(accessToken).catch(() => null);
+  if (!verifiedUser) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+  try {
+    const response = await supabaseAuth('/auth/v1/user', {
+      method: 'GET',
+      headers: { authorization: `Bearer ${accessToken}` },
+    });
+    if (!response.ok) return json(res, 502, { ok: false, error: 'MFA_STATUS_UNAVAILABLE' });
+
+    const authUser = await response.json().catch(() => null);
+    if (!authUser || String(authUser.id || '') !== String(verifiedUser.id)) {
+      return json(res, 502, { ok: false, error: 'MFA_STATUS_IDENTITY_MISMATCH' });
+    }
+
+    const factors = safeVerifiedFactors(authUser);
+    const claims = decodeJwtPayload(accessToken);
+    const currentLevel = claims?.aal === 'aal2' ? 'aal2' : 'aal1';
+    const nextLevel = factors.length ? 'aal2' : currentLevel;
+    const challengeFactor = currentLevel !== 'aal2'
+      ? factors.find(factor => factor.factor_type === 'totp') || factors[0] || null
+      : null;
+    const mfaRequired = Boolean(challengeFactor);
+
+    return json(res, 200, {
+      ok: true,
+      authenticated: true,
+      current_level: currentLevel,
+      next_level: nextLevel,
+      mfa_required: mfaRequired,
+      factor_id: challengeFactor?.id || null,
+      factor_type: challengeFactor?.factor_type || null,
+      factors,
+    });
+  } catch {
+    return json(res, 500, { ok: false, error: 'MFA_STATUS_UNAVAILABLE' });
+  }
+}

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,5 +1,5 @@
 {
-  "version": 5,
+  "version": 6,
   "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
   "authorities": {
     "root_shell": "api/app-recovery.js",
@@ -51,6 +51,7 @@
     "meta_authorized_equals_operational_whatsapp": false,
     "unverified_metrics_may_fall_back_to_bounded_lists": false,
     "workspace_ready_requires_verified_session": true,
+    "workspace_ready_requires_mfa_when_enrolled": true,
     "invalid_auth_transition_may_open_workspace": false,
     "presentation_observer_may_veto_verified_gate": false,
     "release_ready_requires_exact_tested_sha": true,

--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -33,6 +33,8 @@ let productId = null;
 let orderId = null;
 let browser = null;
 let browserContext = null;
+let mfaFactorId = null;
+let mfaSecret = null;
 
 function redact(value) {
   const text = typeof value === 'string' ? value : JSON.stringify(value ?? '');
@@ -260,6 +262,7 @@ async function verifyTotp(session, factorId, secret) {
 }
 
 async function browserJourney() {
+  assert(mfaSecret, 'BROWSER_MFA_SECRET_REQUIRED');
   const { webkit } = await import('playwright');
   browser = await webkit.launch({ headless: true });
   browserContext = await browser.newContext({
@@ -280,14 +283,23 @@ async function browserJourney() {
   await page.locator('#authEmail').fill(owner.email);
   await page.locator('#authPassword').fill(owner.password);
   await page.locator('#authSubmit').click();
+
+  await page.locator('#mfaContinuation:not(.hidden)').waitFor({ state: 'visible', timeout: 20_000 });
+  assert(await page.locator('body').getAttribute('data-dabbir-auth-stage') === 'mfa_required', 'BROWSER_MFA_STAGE_NOT_REQUIRED');
+  const secondsRemaining = 30 - (Math.floor(Date.now() / 1000) % 30);
+  if (secondsRemaining <= 4) await sleep((secondsRemaining + 1) * 1000);
+  await page.locator('#mfaCode').fill(totp(mfaSecret));
+  await page.locator('#mfaSubmit').click();
+
   await page.locator('#appShell:not(.hidden)').waitFor({ state: 'visible', timeout: 25_000 });
+  await page.waitForFunction(() => document.body.dataset.dabbirAuthStage === 'workspace_ready', null, { timeout: 10_000 });
   // The unauthenticated bootstrap intentionally receives one 401 to reveal the login gate.
   // From this point onward, every page/console error is unexpected and remains fatal.
   pageErrors.length = 0;
   consoleErrors.length = 0;
   assert((await page.locator('#workspaceName').textContent())?.includes(RUN_LABEL), 'BROWSER_WORKSPACE_MISMATCH');
 
-  const logo = page.locator('.brand .logo').first();
+  const logo = page.locator('#appShell:not(.hidden) .brand .logo').first();
   await logo.waitFor({ state: 'visible', timeout: 10_000 });
   assert(String(await logo.evaluate(el => getComputedStyle(el).backgroundImage)).includes('dabbir-approved-icon'), 'BROWSER_APPROVED_LOGO_MISSING');
 
@@ -309,7 +321,7 @@ async function browserJourney() {
   report.artifacts.screenshot = 'dabbir-ai-customer-journey-screenshot.png';
   assert(pageErrors.length === 0, `BROWSER_PAGE_ERRORS:${pageErrors.join(' | ')}`);
   assert(consoleErrors.length === 0, `BROWSER_CONSOLE_ERRORS:${consoleErrors.slice(0, 5).join(' | ')}`);
-  return { detail: 'WebKit iPhone-size journey rendered owner workspace, conversation, product, and approved DABBIR identity.' };
+  return { detail: 'WebKit iPhone-size journey completed password + TOTP MFA, then rendered owner workspace, conversation, product, and approved DABBIR identity.' };
 }
 
 async function runJourney() {
@@ -368,8 +380,6 @@ async function runJourney() {
   });
   if (!business) throw new Error('FATAL_BUSINESS_CREATE_FAILED');
 
-  let mfaFactorId = null;
-  let mfaSecret = null;
   const enrolled = await step('07_owner_enrolls_totp_mfa', async () => {
     const result = await waitForMfaEnrollment(ownerSession);
     assert(result?.ok && result.json?.ok, `MFA_ENROLL_FAILED_${result?.status}:${small(result?.text)}`);

--- a/test/dabbir-auth-session-state-machine.test.mjs
+++ b/test/dabbir-auth-session-state-machine.test.mjs
@@ -13,32 +13,47 @@ const read = path => readFile(new URL(path, root), 'utf8');
 const authUi = await read('api/auth-session-stability-ui.js');
 const architecture = JSON.parse(await read('config/dabbir-architecture-ownership.json'));
 
-test('auth session state machine exposes the explicit BAR-30 lifecycle', () => {
+test('auth session state machine exposes explicit MFA continuation before verified workspace', () => {
   assert.deepEqual(AUTH_SESSION_STAGES, {
     SIGNED_OUT: 'signed_out',
     AUTHENTICATING: 'authenticating',
+    MFA_REQUIRED: 'mfa_required',
     SESSION_VERIFIED: 'session_verified',
     WORKSPACE_READY: 'workspace_ready',
     SUSPENDED: 'suspended',
     DEGRADED: 'degraded',
   });
   assert.equal(isAllowedAuthSessionTransition('signed_out', 'authenticating'), true);
+  assert.equal(isAllowedAuthSessionTransition('authenticating', 'mfa_required'), true);
+  assert.equal(isAllowedAuthSessionTransition('mfa_required', 'session_verified'), true);
+  assert.equal(isAllowedAuthSessionTransition('mfa_required', 'workspace_ready'), false);
   assert.equal(isAllowedAuthSessionTransition('authenticating', 'session_verified'), true);
   assert.equal(isAllowedAuthSessionTransition('session_verified', 'workspace_ready'), true);
   assert.equal(isAllowedAuthSessionTransition('signed_out', 'workspace_ready'), false);
 });
 
-test('workspace readiness fails closed unless the session is verified', () => {
+test('workspace readiness fails closed unless session and enrolled MFA are verified', () => {
   assert.equal(deriveAuthSessionState({}).stage, AUTH_SESSION_STAGES.SIGNED_OUT);
   assert.equal(deriveAuthSessionState({ attempting: true }).stage, AUTH_SESSION_STAGES.AUTHENTICATING);
+
+  const mfa = deriveAuthSessionState({ mfaRequired: true });
+  assert.equal(mfa.stage, AUTH_SESSION_STAGES.MFA_REQUIRED);
+  assert.equal(mfa.authenticated, true);
+  assert.equal(mfa.workspace_ready, false);
+
   assert.equal(deriveAuthSessionState({ sessionVerified: true }).stage, AUTH_SESSION_STAGES.SESSION_VERIFIED);
   assert.equal(
     deriveAuthSessionState({ sessionVerified: true, workspaceReady: true }).stage,
     AUTH_SESSION_STAGES.WORKSPACE_READY,
   );
+
   const invalid = deriveAuthSessionState({ workspaceReady: true });
   assert.equal(invalid.stage, AUTH_SESSION_STAGES.DEGRADED);
   assert.equal(invalid.reason, 'WORKSPACE_WITHOUT_VERIFIED_SESSION');
+
+  const beforeMfa = deriveAuthSessionState({ sessionVerified: true, workspaceReady: true, mfaRequired: true });
+  assert.equal(beforeMfa.stage, AUTH_SESSION_STAGES.DEGRADED);
+  assert.equal(beforeMfa.reason, 'WORKSPACE_BEFORE_MFA_VERIFICATION');
 });
 
 test('suspended and failed verification are explicit non-ready states', () => {
@@ -51,17 +66,31 @@ test('suspended and failed verification are explicit non-ready states', () => {
   assert.equal(degraded.authenticated, false);
 });
 
-test('auth UI verifies the session before boot but only observes gate visibility', () => {
+test('auth UI verifies MFA before boot while preserving the base showGate visibility authority', () => {
   assert.match(authUi, /dataset\.dabbirAuthStage/);
   assert.match(authUi, /INVALID_AUTH_TRANSITION/);
-  assert.match(authUi, /state_machine:true/);
-  assert.match(authUi, /SESSION_COOKIE_VERIFIED/);
+  assert.match(authUi, /MFA_REQUIRED_AFTER_PRIMARY_AUTH/);
+  assert.match(authUi, /MFA_AAL2_VERIFIED/);
+  assert.match(authUi, /\/api\/auth\/mfa-status/);
+  assert.match(authUi, /\/api\/auth\/mfa-verify/);
+  assert.match(authUi, /status\.current_level!=='aal2'/);
   assert.match(authUi, /gate_observer_only:true/);
+  assert.match(authUi, /mfa_continuation:true/);
+  assert.match(authUi, /#mfaContinuation/);
+  assert.doesNotMatch(authUi, /#mfaGate/);
   assert.doesNotMatch(authUi, /reconcileVerifiedGate/);
 
-  const verifiedIndex = authUi.indexOf("publishAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED')");
-  const bootIndex = authUi.indexOf('await boot()');
-  assert.ok(verifiedIndex >= 0 && bootIndex > verifiedIndex);
+  const statusIndex = authUi.indexOf('const status=await mfaStatus()');
+  const mfaRequiredIndex = authUi.indexOf("authMachine.stages.MFA_REQUIRED,'MFA_REQUIRED_AFTER_PRIMARY_AUTH'");
+  const ordinaryVerifiedIndex = authUi.indexOf("publishAuthStage(authMachine.stages.SESSION_VERIFIED,'SESSION_COOKIE_VERIFIED')");
+  const ordinaryBootIndex = authUi.indexOf('await boot()', ordinaryVerifiedIndex);
+  assert.ok(statusIndex >= 0 && mfaRequiredIndex > statusIndex);
+  assert.ok(ordinaryVerifiedIndex > statusIndex && ordinaryBootIndex > ordinaryVerifiedIndex);
+
+  const aal2Index = authUi.indexOf("status.current_level!=='aal2'");
+  const mfaVerifiedIndex = authUi.indexOf("authMachine.stages.SESSION_VERIFIED,'MFA_AAL2_VERIFIED'");
+  const mfaBootIndex = authUi.indexOf('await boot()', mfaVerifiedIndex);
+  assert.ok(aal2Index >= 0 && mfaVerifiedIndex > aal2Index && mfaBootIndex > mfaVerifiedIndex);
 
   const wrapperIndex = authUi.indexOf('showGate=function(name)');
   const baseGateIndex = authUi.indexOf('baseShowGate(name)', wrapperIndex);
@@ -69,7 +98,7 @@ test('auth UI verifies the session before boot but only observes gate visibility
   assert.ok(wrapperIndex >= 0 && baseGateIndex > wrapperIndex && observerIndex > baseGateIndex);
 });
 
-test('architecture contract separates auth truth from presentation visibility ownership', () => {
+test('architecture contract keeps one visibility authority while requiring enrolled MFA', () => {
   assert.equal(
     architecture.authorities.auth_session_state_machine,
     'api/_dabbir-auth-session-state-machine.js',
@@ -77,6 +106,7 @@ test('architecture contract separates auth truth from presentation visibility ow
   assert.equal(architecture.authorities.auth_gate_visibility, 'index.html#showGate');
   assert.equal(architecture.authorities.auth_session_observer, 'api/auth-session-stability-ui.js');
   assert.equal(architecture.truth_rules.workspace_ready_requires_verified_session, true);
+  assert.equal(architecture.truth_rules.workspace_ready_requires_mfa_when_enrolled, true);
   assert.equal(architecture.truth_rules.invalid_auth_transition_may_open_workspace, false);
   assert.equal(architecture.truth_rules.presentation_observer_may_veto_verified_gate, false);
   assert.equal(architecture.shell.last_loaded_ui_observer, '/api/auth-session-stability-ui');

--- a/test/dabbir-mfa-status.test.mjs
+++ b/test/dabbir-mfa-status.test.mjs
@@ -1,0 +1,147 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/auth/mfa-status.js';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const TOTP_FACTOR_ID = '22222222-2222-4222-8222-222222222222';
+const PHONE_FACTOR_ID = '33333333-3333-4333-8333-333333333333';
+
+function token(aal = 'aal1') {
+  const enc = value => Buffer.from(JSON.stringify(value)).toString('base64url');
+  return `${enc({ alg: 'none', typ: 'JWT' })}.${enc({
+    sub: USER_ID,
+    email: 'qa@example.com',
+    aud: 'authenticated',
+    role: 'authenticated',
+    iss: 'https://spohjzrsymsmzsseygtw.supabase.co/auth/v1',
+    exp: Math.floor(Date.now() / 1000) + 3600,
+    aal,
+  })}.signature`;
+}
+
+function response(status, body) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function invoke(accessToken, method = 'GET') {
+  const headers = new Map();
+  let text = '';
+  const res = {
+    statusCode: 0,
+    setHeader(name, value) { headers.set(String(name).toLowerCase(), value); },
+    end(value = '') { text = String(value); },
+  };
+  return Promise.resolve(handler({ method, headers: { cookie: `__Host-dabbir_access=${encodeURIComponent(accessToken)}` } }, res))
+    .then(() => ({ status: res.statusCode, headers, body: JSON.parse(text) }));
+}
+
+function installFetch({ factors = [], accountAccess = [] } = {}) {
+  const calls = [];
+  const original = global.fetch;
+  global.fetch = async (url, options = {}) => {
+    const value = String(url);
+    calls.push({ url: value, method: String(options.method || 'GET') });
+    if (value.endsWith('/auth/v1/user')) {
+      return response(200, { id: USER_ID, email: 'qa@example.com', aud: 'authenticated', factors });
+    }
+    if (value.includes('/rest/v1/account_access_state?')) return response(200, accountAccess);
+    throw new Error(`UNEXPECTED_FETCH:${value}`);
+  };
+  return { calls, restore() { global.fetch = original; } };
+}
+
+test('aal1 session with verified TOTP requires MFA and exposes only safe factor metadata', async () => {
+  const mock = installFetch({
+    factors: [{ id: TOTP_FACTOR_ID, factor_type: 'totp', status: 'verified', friendly_name: 'DABBIR Authenticator', secret: 'MUST_NOT_LEAK' }],
+  });
+  try {
+    const result = await invoke(token('aal1'));
+    assert.equal(result.status, 200);
+    assert.equal(result.body.ok, true);
+    assert.equal(result.body.current_level, 'aal1');
+    assert.equal(result.body.next_level, 'aal2');
+    assert.equal(result.body.mfa_required, true);
+    assert.equal(result.body.factor_id, TOTP_FACTOR_ID);
+    assert.equal(result.body.factor_type, 'totp');
+    assert.deepEqual(result.body.factors, [{ id: TOTP_FACTOR_ID, factor_type: 'totp', friendly_name: 'DABBIR Authenticator' }]);
+    assert.equal(JSON.stringify(result.body).includes('MUST_NOT_LEAK'), false);
+    assert.equal(mock.calls.filter(call => call.url.endsWith('/auth/v1/user')).length, 2);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('TOTP is preferred over phone factor for browser continuation', async () => {
+  const mock = installFetch({
+    factors: [
+      { id: PHONE_FACTOR_ID, factor_type: 'phone', status: 'verified', friendly_name: 'Phone' },
+      { id: TOTP_FACTOR_ID, factor_type: 'totp', status: 'verified', friendly_name: 'Authenticator' },
+    ],
+  });
+  try {
+    const result = await invoke(token('aal1'));
+    assert.equal(result.status, 200);
+    assert.equal(result.body.mfa_required, true);
+    assert.equal(result.body.factor_id, TOTP_FACTOR_ID);
+    assert.equal(result.body.factor_type, 'totp');
+  } finally {
+    mock.restore();
+  }
+});
+
+test('aal2 session does not request another MFA challenge', async () => {
+  const mock = installFetch({
+    factors: [{ id: TOTP_FACTOR_ID, factor_type: 'totp', status: 'verified', friendly_name: 'DABBIR Authenticator' }],
+  });
+  try {
+    const result = await invoke(token('aal2'));
+    assert.equal(result.status, 200);
+    assert.equal(result.body.current_level, 'aal2');
+    assert.equal(result.body.next_level, 'aal2');
+    assert.equal(result.body.mfa_required, false);
+    assert.equal(result.body.factor_id, null);
+    assert.equal(result.body.factor_type, null);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('unverified factors never force an MFA continuation', async () => {
+  const mock = installFetch({
+    factors: [{ id: TOTP_FACTOR_ID, factor_type: 'totp', status: 'unverified', friendly_name: 'Pending' }],
+  });
+  try {
+    const result = await invoke(token('aal1'));
+    assert.equal(result.status, 200);
+    assert.equal(result.body.mfa_required, false);
+    assert.equal(result.body.next_level, 'aal1');
+    assert.deepEqual(result.body.factors, []);
+  } finally {
+    mock.restore();
+  }
+});
+
+test('suspended DABBIR account cannot use MFA status as an authentication oracle', async () => {
+  const mock = installFetch({ accountAccess: [{ status: 'suspended', reason: 'test', suspended_at: new Date().toISOString() }] });
+  try {
+    const result = await invoke(token('aal1'));
+    assert.equal(result.status, 401);
+    assert.deepEqual(result.body, { ok: false, error: 'AUTH_REQUIRED' });
+  } finally {
+    mock.restore();
+  }
+});
+
+test('MFA status is read-only', async () => {
+  const mock = installFetch();
+  try {
+    const result = await invoke(token('aal1'), 'POST');
+    assert.equal(result.status, 405);
+    assert.equal(result.body.error, 'METHOD_NOT_ALLOWED');
+  } finally {
+    mock.restore();
+  }
+});


### PR DESCRIPTION
Root cause:
- Production had a post-login presentation deadlock caused by a second gate-visibility authority; current main correctly fixed that in `aa7cc810508e6535689121caf16ba78cb9713d23` by keeping `index.html#showGate` authoritative and making the late auth layer observer-first.
- Separately, accounts with a verified MFA factor still receive an AAL1 session after password sign-in. The auth flow then attempted `boot()` without offering the required AAL2 continuation, so tenant/workspace reads could fail immediately after a visually successful login.

Repair:
- preserve `index.html#showGate` as the only gate-visibility authority; no new `mfaGate` and no reconciliation/veto wrapper is introduced;
- add safe read-only `/api/auth/mfa-status` that exposes only verified factor metadata and current/next AAL, never TOTP secrets;
- add explicit `MFA_REQUIRED` auth lifecycle state and forbid MFA_REQUIRED -> WORKSPACE_READY;
- render MFA continuation only inside the already-visible `authGate`; primary login content is temporarily replaced, but gate visibility remains owned by the base application;
- verify TOTP through the existing `/api/auth/mfa-verify`, prove the refreshed session is AAL2, then and only then call `boot()`;
- keep the latest observer ordering: `baseShowGate(name)` always executes before stage observation;
- update the canonical iPhone WebKit full journey to prove password -> visible MFA continuation -> real TOTP -> AAL2 -> workspace_ready -> dashboard/conversations/operations.

Regression contracts:
- tests forbid a separate `#mfaGate` and forbid the removed `reconcileVerifiedGate` path;
- tests require `baseShowGate(name)` before `syncStageFromGate(name)`;
- tests require enrolled MFA before workspace readiness;
- MFA status tests cover safe metadata, TOTP preference, AAL2 no-loop, unverified factors, suspended accounts, and read-only method enforcement.

Scope:
7 files only. No database migration, RLS change, Meta/WhatsApp, Stripe, credentials, or production protection setting changes.

Acceptance:
DABBIR CI + exact-head Vercel Preview. Merge only if the latest post-login deadlock regression tests remain green. After merge, require exact-SHA Production deployment and the protected full customer journey to execute and PASS before declaring the user-visible post-login flow fixed.