### PR TITLE
DABBIR: fix browser MFA code validation after login

### DIFF
--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -77,6 +77,10 @@ const script = String.raw`(()=>{
     return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')?keyAr:keyEn;
   }
 
+  function validNumericMfaCode(code){
+    return code.length>=6&&code.length<=8&&[...code].every(char=>char>='0'&&char<='9');
+  }
+
   function ensureMfaContinuation(){
     let panel=document.querySelector('#mfaContinuation');
     if(panel) return panel;
@@ -97,7 +101,7 @@ const script = String.raw`(()=>{
         if(msg) msg.textContent=localized('تعذر تحديد عامل المصادقة الآمن. أعد تسجيل الدخول.','A supported secure authentication factor is unavailable. Sign in again.');
         return;
       }
-      if(!/^\\d{6,8}$/.test(code)){
+      if(!validNumericMfaCode(code)){
         if(msg) msg.textContent=localized('أدخل رمز التحقق الصحيح.','Enter a valid verification code.');
         return;
       }

--- a/test/dabbir-mfa-browser-code-validation.test.mjs
+++ b/test/dabbir-mfa-browser-code-validation.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/auth-session-stability-ui.js';
+
+function emittedScript() {
+  let body = '';
+  const headers = new Map();
+  const res = {
+    statusCode: 0,
+    setHeader(name, value) { headers.set(String(name).toLowerCase(), value); return this; },
+    status(code) { this.statusCode = code; return this; },
+    send(value = '') { body = String(value); return this; },
+    end(value = '') { body = String(value); return this; },
+  };
+  handler({ method: 'GET' }, res);
+  assert.equal(res.statusCode, 200);
+  assert.match(headers.get('content-type') || '', /javascript/);
+  return body;
+}
+
+test('served MFA UI validates 6-8 ASCII digits without String.raw regex escaping', () => {
+  const script = emittedScript();
+  assert.match(script, /function validNumericMfaCode\(code\)/);
+  assert.match(script, /code\.length>=6&&code\.length<=8/);
+  assert.match(script, /char>='0'&&char<='9'/);
+  assert.doesNotMatch(script, /\\\\d\{6,8\}/);
+  assert.match(script, /if\(!validNumericMfaCode\(code\)\)/);
+});
+
+test('served MFA submit reaches verification only after numeric validation', () => {
+  const script = emittedScript();
+  const validation = script.indexOf('if(!validNumericMfaCode(code))');
+  const verify = script.indexOf("api('/api/auth/mfa-verify'");
+  assert.ok(validation >= 0, 'MFA_NUMERIC_VALIDATION_MISSING');
+  assert.ok(verify > validation, 'MFA_VERIFY_MUST_FOLLOW_NUMERIC_VALIDATION');
+});


### PR DESCRIPTION
Root cause proven by exact Production full-journey evidence:
- password login reached the new MFA continuation and `GET /api/auth/mfa-status` returned 200;
- the WebKit journey then clicked Verify but no browser `POST /api/auth/mfa-verify` ever reached Production;
- the emitted browser script used `String.raw` and contained `/^\\d{6,8}$/`, so a correct six-digit TOTP was rejected locally as if it contained a literal backslash-d sequence;
- this is why `#appShell` never became visible even though the backend MFA endpoints themselves had already passed earlier in the same journey.

Repair:
- remove regex escaping from the critical MFA submit guard;
- validate 6–8 ASCII digits explicitly with length and character bounds;
- leave the single `index.html#showGate` visibility authority, MFA state machine, AAL2 proof, Supabase auth, RLS and all other runtime behavior unchanged;
- add a regression test against the actual emitted JavaScript, not only source text, proving the broken escaped regex cannot return and `/api/auth/mfa-verify` remains downstream of numeric validation.

Scope: 2 files only, 6 runtime-line changes plus one regression test. No database, migration, RLS, WhatsApp, Stripe, secrets, deployment policy or release-gate changes.

Acceptance: exact-head DABBIR CI + Vercel Preview. After merge, require exact-SHA Production deployment and the canonical full WebKit customer journey to PASS password -> MFA -> AAL2 -> workspace before declaring the post-login issue fixed.