### PR TITLE
DABBIR auth: fix rendered TOTP digit validation

### DIFF
--- a/api/auth-session-stability-ui.js
+++ b/api/auth-session-stability-ui.js
@@ -97,7 +97,7 @@ const script = String.raw`(()=>{
         if(msg) msg.textContent=localized('تعذر تحديد عامل المصادقة الآمن. أعد تسجيل الدخول.','A supported secure authentication factor is unavailable. Sign in again.');
         return;
       }
-      if(!/^\\d{6,8}$/.test(code)){
+      if(!/^\d{6,8}$/.test(code)){
         if(msg) msg.textContent=localized('أدخل رمز التحقق الصحيح.','Enter a valid verification code.');
         return;
       }

--- a/test/dabbir-mfa-rendered-digit-regression.test.mjs
+++ b/test/dabbir-mfa-rendered-digit-regression.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/auth-session-stability-ui.js';
+
+function renderAuthStabilityScript() {
+  let statusCode = null;
+  let body = '';
+  const headers = new Map();
+  const req = { method: 'GET' };
+  const res = {
+    setHeader(name, value) {
+      headers.set(String(name).toLowerCase(), value);
+      return this;
+    },
+    status(code) {
+      statusCode = Number(code);
+      return this;
+    },
+    send(value) {
+      body = String(value ?? '');
+      return this;
+    },
+    end(value = '') {
+      body = String(value ?? '');
+      return this;
+    },
+  };
+  handler(req, res);
+  return { statusCode, body, headers };
+}
+
+test('rendered browser script accepts numeric TOTP codes instead of a literal backslash-d sequence', () => {
+  const rendered = renderAuthStabilityScript();
+  assert.equal(rendered.statusCode, 200);
+  assert.match(String(rendered.headers.get('content-type') || ''), /application\/javascript/);
+
+  const expected = "if(!/^\\d{6,8}$/.test(code)){";
+  const broken = "if(!/^\\\\d{6,8}$/.test(code)){";
+  assert.ok(rendered.body.includes(expected), 'RENDERED_TOTP_DIGIT_REGEX_MISSING');
+  assert.equal(rendered.body.includes(broken), false, 'RENDERED_TOTP_REGEX_DOUBLE_ESCAPED');
+  assert.doesNotThrow(() => new Function(rendered.body));
+});


### PR DESCRIPTION
Superseded by #172, which landed the same root-cause repair on current `main` as commit `304a75df010c6ae44d0e865cafc310f53b360711` using an even safer approach: no regex inside `String.raw`; numeric MFA validation is explicit ASCII digit validation, with rendered-script regression coverage. Closing this duplicate to avoid two competing implementations. Production exact-SHA Full Customer Journey remains the acceptance gate.