### PR TITLE
DABBIR QA: expose post-MFA WebKit gate state on failure

### DIFF
--- a/test/dabbir-protected-full-journey-preload.mjs
+++ b/test/dabbir-protected-full-journey-preload.mjs
@@ -11,4 +11,71 @@ const installed = installProtectedFetchAccess({ origin, bypass, trustedOidc });
 const { webkit } = await import('playwright');
 installProtectedPlaywrightAccess(webkit, installed.accessHeaders);
 
+// Keep the application behavior untouched, but make the exact WebKit failure
+// self-diagnosing. The journey previously reported only a 25s locator timeout,
+// which hid whether the base gate chose auth/onboarding/app or whether CSS kept
+// an already-selected app shell invisible. This wrapper only enriches a failed
+// app-shell wait with non-sensitive DOM/state facts.
+const protectedLaunch = webkit.launch.bind(webkit);
+webkit.launch = async (...launchArgs) => {
+  const browser = await protectedLaunch(...launchArgs);
+  const protectedNewContext = browser.newContext.bind(browser);
+  browser.newContext = async (...contextArgs) => {
+    const context = await protectedNewContext(...contextArgs);
+    const protectedNewPage = context.newPage.bind(context);
+    context.newPage = async (...pageArgs) => {
+      const page = await protectedNewPage(...pageArgs);
+      const protectedLocator = page.locator.bind(page);
+      page.locator = (selector, ...locatorArgs) => {
+        const locator = protectedLocator(selector, ...locatorArgs);
+        if (String(selector) !== '#appShell:not(.hidden)') return locator;
+        const protectedWaitFor = locator.waitFor.bind(locator);
+        locator.waitFor = async options => {
+          try {
+            return await protectedWaitFor(options);
+          } catch (error) {
+            let diagnostic = { diagnostic_error: 'DOM_SNAPSHOT_UNAVAILABLE' };
+            try {
+              diagnostic = await page.evaluate(() => {
+                const snapshot = id => {
+                  const element = document.querySelector(id);
+                  if (!element) return null;
+                  const style = getComputedStyle(element);
+                  const rect = element.getBoundingClientRect();
+                  return {
+                    class_name: element.className,
+                    display: style.display,
+                    visibility: style.visibility,
+                    width: Math.round(rect.width),
+                    height: Math.round(rect.height),
+                  };
+                };
+                return {
+                  auth_stage: document.body?.dataset?.dabbirAuthStage || null,
+                  gate: document.body?.dataset?.dabbirGate || null,
+                  app: snapshot('#appShell'),
+                  auth: snapshot('#authGate'),
+                  onboarding: snapshot('#onboardingGate'),
+                  mfa: snapshot('#mfaContinuation'),
+                  mfa_message: String(document.querySelector('#mfaMsg')?.textContent || '').trim().slice(0, 160),
+                  auth_message: String(document.querySelector('#authMsg')?.textContent || '').trim().slice(0, 160),
+                  workspace_present: Boolean(globalThis.workspace?.business),
+                  workspace_membership_present: Boolean(globalThis.workspace?.membership),
+                  selected_conversation_present: Boolean(globalThis.selectedConversationId),
+                };
+              });
+            } catch {}
+            error.message += `\nDABBIR_GATE_DIAGNOSTIC=${JSON.stringify(diagnostic)}`;
+            throw error;
+          }
+        };
+        return locator;
+      };
+      return page;
+    };
+    return context;
+  };
+  return browser;
+};
+
 console.log(`DABBIR_PROTECTED_FULL_JOURNEY_ACCESS=${bypass ? 'automation_bypass' : 'trusted_oidc'}`);


### PR DESCRIPTION
Diagnostic hardening for the remaining exact-Production WebKit failure after successful MFA.

Current exact Production evidence on `304a75df010c6ae44d0e865cafc310f53b360711` proves:
- browser TOTP reaches `/api/auth/mfa-verify` = 200;
- post-verify `/api/auth/mfa-status` = 200;
- post-AAL2 `/api/dabbir-runtime-fast` = 200;
- tenant/owner background reads begin;
- yet Step 25 still times out waiting for `#appShell:not(.hidden)`.

This PR does not modify application behavior, auth, RLS, or gate ownership. It enriches only a failed WebKit app-shell wait with a non-sensitive DOM snapshot: auth stage, rendered gate, classes/computed visibility for auth/onboarding/app/MFA, safe messages, and boolean workspace/membership presence. This turns the existing opaque timeout into root-cause evidence while preserving the same fail-closed acceptance gate.