### PR TITLE
DABBIR: stop owner-away UI observer from freezing post-MFA workspace

### DIFF
--- a/api/dabbir-customer-number-ui.js
+++ b/api/dabbir-customer-number-ui.js
@@ -32,20 +32,32 @@ const script=String.raw`(()=>{
     return customerNo;
   }
 
+  function setText(node,value){if(node&&node.textContent!==value)node.textContent=value}
+
   function render(){
     const list=document.querySelector('#settingsList');
     if(!list||!customerNo)return;
-    const existing=list.querySelector('[data-dabbir-customer-number]');
     const c=copy();
-    const html='<div class="item" data-dabbir-customer-number="v1"><div class="grow"><b>'+c.label+'</b><small dir="ltr" style="font-size:12px;font-weight:900;letter-spacing:.04em;color:var(--text)">'+customerNo+'</small><small style="display:block;margin-top:3px">'+c.help+'</small></div><button type="button" class="secondary" data-copy-dabbir-number style="min-height:38px;padding:7px 10px">'+c.copy+'</button></div>';
-    if(existing)existing.outerHTML=html;
-    else list.insertAdjacentHTML('afterbegin',html);
-    list.querySelector('[data-copy-dabbir-number]')?.addEventListener('click',async()=>{
-      try{
-        await navigator.clipboard.writeText(customerNo);
-        if(typeof toast==='function')toast(copy().copied);
-      }catch{}
-    });
+    let row=list.querySelector('[data-dabbir-customer-number]');
+    if(!row){
+      list.insertAdjacentHTML('afterbegin','<div class="item" data-dabbir-customer-number="v1"><div class="grow"><b data-dabbir-customer-number-label></b><small data-dabbir-customer-number-value dir="ltr" style="font-size:12px;font-weight:900;letter-spacing:.04em;color:var(--text)"></small><small data-dabbir-customer-number-help style="display:block;margin-top:3px"></small></div><button type="button" class="secondary" data-copy-dabbir-number style="min-height:38px;padding:7px 10px"></button></div>');
+      row=list.querySelector('[data-dabbir-customer-number]');
+    }
+    if(!row)return;
+    setText(row.querySelector('[data-dabbir-customer-number-label]'),c.label);
+    setText(row.querySelector('[data-dabbir-customer-number-value]'),customerNo);
+    setText(row.querySelector('[data-dabbir-customer-number-help]'),c.help);
+    const button=row.querySelector('[data-copy-dabbir-number]');
+    setText(button,c.copy);
+    if(button&&button.dataset.dabbirCopyBound!=='true'){
+      button.dataset.dabbirCopyBound='true';
+      button.addEventListener('click',async()=>{
+        try{
+          await navigator.clipboard.writeText(customerNo);
+          if(typeof toast==='function')toast(copy().copied);
+        }catch{}
+      });
+    }
   }
 
   const originalRender=typeof window.renderSettings==='function'?window.renderSettings:null;

--- a/api/dabbir-owner-away-ui.js
+++ b/api/dabbir-owner-away-ui.js
@@ -27,6 +27,7 @@ const client=String.raw`
 
   let mode=null;
   let checkedBusiness=null;
+  let modeLoaded=false;
   let loading=false;
   const ar=()=>String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar');
   const copy=()=>ar()?{
@@ -43,14 +44,14 @@ const client=String.raw`
   async function refreshMode(force=false){
     const id=businessId();
     if(!id||!isOwner()||loading)return;
-    if(!force&&checkedBusiness===id&&mode)return renderButton();
+    if(!force&&checkedBusiness===id&&modeLoaded)return renderButton();
     loading=true;
     try{
       const response=await nativeFetch('/api/owner-away-mode?business_id='+encodeURIComponent(id),{credentials:'same-origin',cache:'no-store',headers:{accept:'application/json'}});
       const payload=await response.json().catch(()=>null);
       if(!response.ok||!payload?.ok)throw new Error(payload?.error||'OWNER_AWAY_LOOKUP_FAILED');
-      mode=payload.mode||null;checkedBusiness=id;renderButton();
-    }catch{mode=null;checkedBusiness=id;renderButton()}
+      mode=payload.mode||null;checkedBusiness=id;modeLoaded=true;renderButton();
+    }catch{mode=null;checkedBusiness=id;modeLoaded=true;renderButton()}
     finally{loading=false}
   }
 
@@ -66,8 +67,10 @@ const client=String.raw`
       if(refresh?.parentNode)refresh.parentNode.insertBefore(button,refresh);else head.append(button);
     }
     const t=copy();
-    button.classList.toggle('active',mode?.active===true);
-    button.textContent=mode?.active?(t.active+' · '+t.until+' '+dateLabel(mode.ends_at)):t.button;
+    const active=mode?.active===true;
+    button.classList.toggle('active',active);
+    const nextLabel=active?(t.active+' · '+t.until+' '+dateLabel(mode.ends_at)):t.button;
+    if(button.textContent!==nextLabel)button.textContent=nextLabel;
   }
 
   function closeDialog(){document.querySelector('#dabbirAwayOverlay')?.remove()}
@@ -99,13 +102,22 @@ const client=String.raw`
       });
       const payload=await response.json().catch(()=>null);
       if(!response.ok||!payload?.ok)throw new Error(payload?.error||'OWNER_AWAY_UPDATE_FAILED');
-      mode=payload.mode;checkedBusiness=id;closeDialog();renderButton();notify(t.saved);
+      mode=payload.mode;checkedBusiness=id;modeLoaded=true;closeDialog();renderButton();notify(t.saved);
       if(window.__dabbirOwnerActionCenter?.refresh)window.__dabbirOwnerActionCenter.refresh();
     }catch(error){notify(String(error?.message||'').includes('LOOKUP')?t.unavailable:t.failed)}
     finally{loading=false}
   }
 
-  const observer=new MutationObserver(()=>{if(document.querySelector('#dabbirActionCenter')){renderButton();refreshMode(false)}});
+  let observerFrame=0;
+  function scheduleObservedSync(){
+    if(observerFrame)return;
+    const run=()=>{
+      observerFrame=0;
+      if(document.querySelector('#dabbirActionCenter')){renderButton();refreshMode(false)}
+    };
+    observerFrame=typeof requestAnimationFrame==='function'?requestAnimationFrame(run):setTimeout(run,0);
+  }
+  const observer=new MutationObserver(scheduleObservedSync);
   observer.observe(document.documentElement,{subtree:true,childList:true});
   setTimeout(()=>refreshMode(true),500);
   window.__dabbirOwnerAway={refresh:()=>refreshMode(true),version:'owner-away-ui-v1'};

--- a/api/dabbir-owner-decision-memory-ui.js
+++ b/api/dabbir-owner-decision-memory-ui.js
@@ -55,7 +55,11 @@ const client=String.raw`
     const host=actionHead||autoHero;if(!host)return;
     let button=document.querySelector('#dabbirMemoryButton');
     if(!button){button=document.createElement('button');button.id='dabbirMemoryButton';button.type='button';button.className='dabbir-memory-btn';button.addEventListener('click',openDialog);const refresh=actionHead?.querySelector('#dacRefresh');refresh?.parentNode?refresh.parentNode.insertBefore(button,refresh):host.append(button)}
-    const x=copy();button.classList.toggle('has-candidate',state.candidates.length>0);button.textContent=state.candidates.length?x.candidate+' · '+state.candidates.length:x.button;
+    const x=copy();
+    const hasCandidate=state.candidates.length>0;
+    button.classList.toggle('has-candidate',hasCandidate);
+    const nextLabel=hasCandidate?x.candidate+' · '+state.candidates.length:x.button;
+    if(button.textContent!==nextLabel)button.textContent=nextLabel;
   }
   function closeDialog(){document.querySelector('#dabbirMemoryOverlay')?.remove()}
   function policyActions(card,policy,isCandidate){
@@ -94,7 +98,16 @@ const client=String.raw`
       state.loading=false;await load(true);closeDialog();openDialog();notify(x.saved);
     }catch{state.loading=false;notify(x.failed)}
   }
-  const observer=new MutationObserver(()=>{if(document.querySelector('#dabbirActionCenter')||document.querySelector('#screen-automations')){renderButton();load(false)}});observer.observe(document.documentElement,{subtree:true,childList:true});
+  let observerFrame=0;
+  function scheduleObservedSync(){
+    if(observerFrame)return;
+    const run=()=>{
+      observerFrame=0;
+      if(document.querySelector('#dabbirActionCenter')||document.querySelector('#screen-automations')){renderButton();load(false)}
+    };
+    observerFrame=typeof requestAnimationFrame==='function'?requestAnimationFrame(run):setTimeout(run,0);
+  }
+  const observer=new MutationObserver(scheduleObservedSync);observer.observe(document.documentElement,{subtree:true,childList:true});
   setTimeout(()=>load(true),700);window.__dabbirOwnerDecisionMemory={refresh:()=>load(true),version:'owner-decision-memory-ui-v1'};
 })();
 `;

--- a/test/dabbir-owner-away-observer-loop.test.mjs
+++ b/test/dabbir-owner-away-observer-loop.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import awayUiHandler from '../api/dabbir-owner-away-ui.js';
+
+function renderClient(){
+  let body='';
+  const headers=new Map();
+  const res={
+    status(){return this},
+    setHeader(k,v){headers.set(String(k).toLowerCase(),String(v));return this},
+    end(v=''){body=String(v);return this},
+    set statusCode(v){this._status=v},
+    get statusCode(){return this._status||200},
+  };
+  awayUiHandler({method:'GET'},res);
+  return {body,headers};
+}
+
+test('owner-away MutationObserver cannot self-trigger forever after owner workspace renders',()=>{
+  const {body}=renderClient();
+  assert.match(body,/const nextLabel=active\?/);
+  assert.match(body,/if\(button\.textContent!==nextLabel\)button\.textContent=nextLabel/);
+  assert.doesNotMatch(body,/button\.textContent=mode\?\.active\?/);
+  assert.match(body,/let observerFrame=0/);
+  assert.match(body,/function scheduleObservedSync\(\)/);
+  assert.match(body,/new MutationObserver\(scheduleObservedSync\)/);
+});
+
+test('owner-away inactive state is cached instead of refetched on every DOM mutation',()=>{
+  const {body}=renderClient();
+  assert.match(body,/let modeLoaded=false/);
+  assert.match(body,/checkedBusiness===id&&modeLoaded/);
+  assert.match(body,/mode=payload\.mode\|\|null;checkedBusiness=id;modeLoaded=true;renderButton\(\)/);
+  assert.match(body,/catch\{mode=null;checkedBusiness=id;modeLoaded=true;renderButton\(\)\}/);
+});

--- a/test/dabbir-owner-away-observer-loop.test.mjs
+++ b/test/dabbir-owner-away-observer-loop.test.mjs
@@ -2,6 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import awayUiHandler from '../api/dabbir-owner-away-ui.js';
 import memoryUiHandler from '../api/dabbir-owner-decision-memory-ui.js';
+import customerNumberUiHandler from '../api/dabbir-customer-number-ui.js';
 
 function renderClient(handler){
   let body='';
@@ -44,4 +45,14 @@ test('owner decision-memory MutationObserver cannot self-trigger through its but
   assert.match(body,/let observerFrame=0/);
   assert.match(body,/function scheduleObservedSync\(\)/);
   assert.match(body,/new MutationObserver\(scheduleObservedSync\)/);
+});
+
+test('customer-number settings observer updates an existing row without replacing it',()=>{
+  const {body}=renderClient(customerNumberUiHandler);
+  assert.match(body,/function setText\(node,value\)/);
+  assert.match(body,/if\(!row\)\{/);
+  assert.match(body,/data-dabbir-customer-number-value/);
+  assert.match(body,/button\.dataset\.dabbirCopyBound/);
+  assert.doesNotMatch(body,/existing\.outerHTML=html/);
+  assert.doesNotMatch(body,/outerHTML=/);
 });

--- a/test/dabbir-owner-away-observer-loop.test.mjs
+++ b/test/dabbir-owner-away-observer-loop.test.mjs
@@ -1,8 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import awayUiHandler from '../api/dabbir-owner-away-ui.js';
+import memoryUiHandler from '../api/dabbir-owner-decision-memory-ui.js';
 
-function renderClient(){
+function renderClient(handler){
   let body='';
   const headers=new Map();
   const res={
@@ -12,12 +13,12 @@ function renderClient(){
     set statusCode(v){this._status=v},
     get statusCode(){return this._status||200},
   };
-  awayUiHandler({method:'GET'},res);
+  handler({method:'GET'},res);
   return {body,headers};
 }
 
 test('owner-away MutationObserver cannot self-trigger forever after owner workspace renders',()=>{
-  const {body}=renderClient();
+  const {body}=renderClient(awayUiHandler);
   assert.match(body,/const nextLabel=active\?/);
   assert.match(body,/if\(button\.textContent!==nextLabel\)button\.textContent=nextLabel/);
   assert.doesNotMatch(body,/button\.textContent=mode\?\.active\?/);
@@ -27,9 +28,20 @@ test('owner-away MutationObserver cannot self-trigger forever after owner worksp
 });
 
 test('owner-away inactive state is cached instead of refetched on every DOM mutation',()=>{
-  const {body}=renderClient();
+  const {body}=renderClient(awayUiHandler);
   assert.match(body,/let modeLoaded=false/);
   assert.match(body,/checkedBusiness===id&&modeLoaded/);
   assert.match(body,/mode=payload\.mode\|\|null;checkedBusiness=id;modeLoaded=true;renderButton\(\)/);
   assert.match(body,/catch\{mode=null;checkedBusiness=id;modeLoaded=true;renderButton\(\)\}/);
+});
+
+test('owner decision-memory MutationObserver cannot self-trigger through its button label',()=>{
+  const {body}=renderClient(memoryUiHandler);
+  assert.match(body,/const hasCandidate=state\.candidates\.length>0/);
+  assert.match(body,/const nextLabel=hasCandidate\?/);
+  assert.match(body,/if\(button\.textContent!==nextLabel\)button\.textContent=nextLabel/);
+  assert.doesNotMatch(body,/button\.textContent=state\.candidates\.length\?/);
+  assert.match(body,/let observerFrame=0/);
+  assert.match(body,/function scheduleObservedSync\(\)/);
+  assert.match(body,/new MutationObserver\(scheduleObservedSync\)/);
 });


### PR DESCRIPTION
Production root cause evidence:
- canonical WebKit journey reaches browser MFA successfully;
- POST /api/auth/mfa-verify returns 200, MFA status returns 200, and /api/dabbir-runtime-fast returns 200;
- immediately after workspace runtime resolves, GET /api/owner-away-mode returns 200, then the browser produces no further requests and the GitHub journey remains stuck before cleanup;
- dabbir-owner-away-ui observes documentElement childList and renderButton() unconditionally rewrites button.textContent. That text rewrite itself creates another childList mutation, creating an unbounded MutationObserver microtask feedback loop once the owner action center exists.

Repair:
- make owner-away label writes idempotent;
- coalesce observer callbacks to one animation frame instead of recursively running inside the mutation microtask chain;
- cache the inactive/null away-mode lookup for the current business so unrelated DOM mutations do not refetch it;
- preserve owner-only behavior, away-mode policy, API routes, RLS, auth, MFA and all business logic unchanged.

Regression coverage asserts the emitted browser JS contains the idempotent label guard, frame-coalesced observer, and inactive-state cache.

Do not merge until the currently locked diagnostic Production journey on SHA 6f5e2825 finishes, so its exact-release evidence is not invalidated. After merge, require exact-SHA Production deployment and a complete Password -> TOTP MFA -> AAL2 -> Workspace WebKit PASS.