### PR TITLE
DABBIR: keep store Operations visible when iPhone menu opens

### DIFF
--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -81,9 +81,20 @@ const script=String.raw`(()=>{
     card.innerHTML='<h3>'+t.servicesTitle+'</h3><p>'+t.servicesDesc+'</p>';
   }
 
+  function bindMobileMenuResync(){
+    const menu=q('#menuBtn');
+    if(!menu||menu.dataset.dabbirContextRouterBound==='true')return;
+    menu.dataset.dabbirContextRouterBound='true';
+    menu.addEventListener('click',()=>{
+      if(typeof requestAnimationFrame==='function')requestAnimationFrame(enforce);
+      else setTimeout(enforce,0);
+    });
+  }
+
   function enforce(){
     adaptPrimaryActivitySlot();
     ensureMoreCard();
+    bindMobileMenuResync();
   }
 
   try{
@@ -98,7 +109,7 @@ const script=String.raw`(()=>{
 
   setTimeout(enforce,0);
   setTimeout(enforce,650);
-  window.__dabbirContextualNavigation={refresh:enforce,version:'v3',authority:'primary-context-router'};
+  window.__dabbirContextualNavigation={refresh:enforce,version:'v4',authority:'primary-context-router',mobile_menu_resync:true};
 })();`;
 
 export default function handler(req,res){
@@ -106,6 +117,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-contextual-navigation','v3');
+  res.setHeader('x-dabbir-contextual-navigation','v4');
   return res.status(200).send(script);
 }

--- a/test/dabbir-contextual-navigation.test.mjs
+++ b/test/dabbir-contextual-navigation.test.mjs
@@ -23,6 +23,15 @@ test('store resolves the shared activity slot to Operations in the router', () =
   assert.match(router, /authority:'primary-context-router'/);
 });
 
+test('opening the mobile menu re-enforces the same activity-slot authority', () => {
+  assert.match(router, /function bindMobileMenuResync\(\)/);
+  assert.match(router, /q\('#menuBtn'\)/);
+  assert.match(router, /dabbirContextRouterBound/);
+  assert.match(router, /menu\.addEventListener\('click'/);
+  assert.match(router, /requestAnimationFrame\(enforce\)/);
+  assert.match(router, /mobile_menu_resync:true/);
+});
+
 test('service businesses reach Services from More instead of a sixth primary destination', () => {
   assert.match(router, /id='dabbirContextServices'/);
   assert.match(router, /#screen-more \.moreGrid/);


### PR DESCRIPTION
Fixes the next failure exposed after the post-login freeze was removed.

Production full-customer-journey evidence on exact SHA `55fd075b5b16f85cefef14a9cd1e107d66a223cd` now completes password login, TOTP MFA, workspace boot, conversations, AI/human flows, orders, metrics and translation. The former MutationObserver freeze no longer occurs. The remaining WebKit failure is `BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_0` after opening the mobile side menu.

Root cause:
- The contextual router is the sole owner of the shared activity slot.
- Store businesses correctly resolve that slot from Appointments to Operations in both `#nav` and `#bottomNav`.
- Earlier presentation/runtime layers can re-hide or restore the base Appointments slot after the router's initial enforcement.
- The mobile side menu can therefore open before the side activity slot is re-synchronized, while the bottom activity slot remains the intended Operations destination.

Fix:
- Bind one event-driven resync to the existing mobile menu button.
- Re-run the same contextual `enforce()` authority on the next animation frame when the menu opens.
- Keep the router idempotent and single-owner; no new navigation destination is created.
- Preserve the five-destination contract and the store Operations / non-store Appointments mapping.
- Add regression coverage for the mobile menu resync and keep the no-MutationObserver/no-setInterval invariant.

No auth, database, payment, Meta, customer data, or permission changes.