### PR TITLE
DABBIR: fix store navigation workspace source

### DIFF
--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -7,7 +7,19 @@ const script=String.raw`(()=>{
   const q=s=>document.querySelector(s);
   const qa=s=>[...document.querySelectorAll(s)];
   const ar=()=>document.documentElement.lang!=='en';
-  const businessType=()=>String(window.workspace?.business?.business_type||'').toLowerCase();
+
+  // index.html intentionally owns workspace as a top-level `let`, which creates a
+  // global lexical binding rather than window.workspace. Read that canonical
+  // binding first; window.workspace is retained only as a compatibility fallback
+  // for alternate shells that explicitly publish their state on window.
+  function currentWorkspace(){
+    try{
+      if(typeof workspace!=='undefined'&&workspace)return workspace;
+    }catch{}
+    return window.workspace||null;
+  }
+
+  const businessType=()=>String(currentWorkspace()?.business?.business_type||'').toLowerCase();
   const isStore=()=>businessType()==='store';
   const isServiceBusiness=()=>Boolean(businessType())&&!isStore();
   const copy=()=>ar()?{
@@ -21,7 +33,7 @@ const script=String.raw`(()=>{
   };
 
   function activitySlots(){
-    qa('#nav [data-screen="appointments"],#bottomNav [data-screen="appointments"],#nav [data-dabbir-activity-slot="true"],#bottomNav [data-dabbir-activity-slot="true"]').forEach(node=>{
+    qa('#nav [data-screen="appointments"],#bottomNav [data-screen="appointments"],#nav [data-screen="operations"],#bottomNav [data-screen="operations"],#nav [data-dabbir-activity-slot="true"],#bottomNav [data-dabbir-activity-slot="true"]').forEach(node=>{
       node.dataset.dabbirActivitySlot='true';
     });
     return qa('[data-dabbir-activity-slot="true"]');
@@ -29,7 +41,9 @@ const script=String.raw`(()=>{
 
   function setActivitySlot(node,target,label){
     node.dataset.screen=target;
-    node.style.display='';
+    node.hidden=false;
+    node.classList.remove('hidden');
+    node.style.removeProperty('display');
     const labelNode=node.querySelector('[data-label]');
     if(labelNode)labelNode.textContent=label;
     node.setAttribute('aria-label',label);
@@ -53,7 +67,7 @@ const script=String.raw`(()=>{
         setActivitySlot(node,'appointments',appointmentLabel||(ar()?'المواعيد':'Appointments'));
       }
     }
-    if(isStore()&&current==='appointments'&&typeof showScreen==='function')showScreen('operations');
+    if(isStore()&&typeof current!=='undefined'&&current==='appointments'&&typeof showScreen==='function')showScreen('operations');
   }
 
   function openServices(){
@@ -109,7 +123,7 @@ const script=String.raw`(()=>{
 
   setTimeout(enforce,0);
   setTimeout(enforce,650);
-  window.__dabbirContextualNavigation={refresh:enforce,version:'v4',authority:'primary-context-router',mobile_menu_resync:true};
+  window.__dabbirContextualNavigation={refresh:enforce,version:'v5',authority:'primary-context-router',workspace_source:'global-lexical-first',mobile_menu_resync:true};
 })();`;
 
 export default function handler(req,res){
@@ -117,6 +131,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-contextual-navigation','v4');
+  res.setHeader('x-dabbir-contextual-navigation','v5');
   return res.status(200).send(script);
 }

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -8,10 +8,8 @@ const script=String.raw`(()=>{
   const qa=s=>[...document.querySelectorAll(s)];
   const ar=()=>document.documentElement.lang!=='en';
 
-  // index.html intentionally owns workspace as a top-level `let`, which creates a
-  // global lexical binding rather than window.workspace. Read that canonical
-  // binding first; window.workspace is retained only as a compatibility fallback
-  // for alternate shells that explicitly publish their state on window.
+  // index.html owns workspace as a top-level lexical binding, not a window property.
+  // Read that canonical binding first; keep window.workspace only as a compatibility fallback.
   function currentWorkspace(){
     try{
       if(typeof workspace!=='undefined'&&workspace)return workspace;

--- a/test/dabbir-context-router-lexical-workspace-runtime.test.mjs
+++ b/test/dabbir-context-router-lexical-workspace-runtime.test.mjs
@@ -1,0 +1,116 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import fs from 'node:fs';
+
+const source = fs.readFileSync(new URL('../api/dabbir-contextual-navigation-ui.js', import.meta.url), 'utf8');
+const match = source.match(/const script=String\.raw`([\s\S]*?)`;\n\nexport default/);
+assert.ok(match?.[1], 'CONTEXT_ROUTER_BROWSER_SCRIPT_NOT_FOUND');
+const browserScript = match[1];
+
+function navNode(screen) {
+  const label = { textContent: '' };
+  const classes = new Set(['navBtn']);
+  const style = {
+    display: 'none',
+    removeProperty(name) { if (name === 'display') this.display = ''; },
+  };
+  return {
+    dataset: { screen },
+    hidden: true,
+    style,
+    label,
+    classList: {
+      remove(value) { classes.delete(value); },
+      contains(value) { return classes.has(value); },
+    },
+    querySelector(selector) { return selector === '[data-label]' ? label : null; },
+    setAttribute(name, value) { this[name] = value; },
+    addEventListener() {},
+  };
+}
+
+test('store lexical workspace converts side and bottom activity slots to visible Operations', () => {
+  const side = navNode('appointments');
+  const bottom = navNode('appointments');
+  side.classList.remove = value => { if (value === 'hidden') side.hiddenClassRemoved = true; };
+  bottom.classList.remove = value => { if (value === 'hidden') bottom.hiddenClassRemoved = true; };
+  const all = [side, bottom];
+
+  const document = {
+    documentElement: { lang: 'en' },
+    querySelector(selector) {
+      if (selector === '#menuBtn') return null;
+      if (selector === '#screen-more .moreGrid') return null;
+      if (selector === '#dabbirContextServices') return null;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector.includes('appointments') || selector.includes('operations')) {
+        return all.filter(item => selector.includes(`data-screen="${item.dataset.screen}"`));
+      }
+      if (selector === '[data-dabbir-activity-slot="true"]') {
+        return all.filter(item => item.dataset.dabbirActivitySlot === 'true');
+      }
+      return [];
+    },
+    createElement() { throw new Error('UNEXPECTED_CREATE_ELEMENT'); },
+  };
+
+  const context = {
+    window: {},
+    document,
+    workspace: { business: { business_type: 'store' } },
+    current: 'dashboard',
+    T: () => ({ appointments: 'Appointments' }),
+    showScreen() {},
+    renderAll() {},
+    applyLang() {},
+    setTimeout(fn) { fn(); return 1; },
+    clearTimeout() {},
+  };
+
+  vm.createContext(context);
+  vm.runInContext(browserScript, context);
+
+  for (const item of all) {
+    assert.equal(item.dataset.screen, 'operations');
+    assert.equal(item.hidden, false);
+    assert.equal(item.style.display, '');
+    assert.equal(item.label.textContent, 'Operations');
+    assert.equal(item['aria-label'], 'Operations');
+  }
+  assert.equal(context.window.__dabbirContextualNavigation.workspace_source, 'global-lexical-first');
+});
+
+test('window.workspace remains a compatibility fallback only when no lexical workspace exists', () => {
+  const side = navNode('appointments');
+  const document = {
+    documentElement: { lang: 'en' },
+    querySelector(selector) {
+      if (selector === '#menuBtn' || selector === '#screen-more .moreGrid' || selector === '#dabbirContextServices') return null;
+      return null;
+    },
+    querySelectorAll(selector) {
+      if (selector.includes('appointments')) return side.dataset.screen === 'appointments' ? [side] : [];
+      if (selector.includes('operations')) return side.dataset.screen === 'operations' ? [side] : [];
+      if (selector === '[data-dabbir-activity-slot="true"]') return side.dataset.dabbirActivitySlot === 'true' ? [side] : [];
+      return [];
+    },
+    createElement() { throw new Error('UNEXPECTED_CREATE_ELEMENT'); },
+  };
+  const context = {
+    window: { workspace: { business: { business_type: 'store' } } },
+    document,
+    current: 'dashboard',
+    T: () => ({ appointments: 'Appointments' }),
+    showScreen() {},
+    renderAll() {},
+    applyLang() {},
+    setTimeout(fn) { fn(); return 1; },
+    clearTimeout() {},
+  };
+  vm.createContext(context);
+  vm.runInContext(browserScript, context);
+  assert.equal(side.dataset.screen, 'operations');
+});

--- a/test/dabbir-contextual-navigation.test.mjs
+++ b/test/dabbir-contextual-navigation.test.mjs
@@ -36,7 +36,7 @@ test('activity slots are unhidden when the router maps store Appointments to Ope
   assert.match(router, /node\.hidden=false/);
   assert.match(router, /node\.classList\.remove\('hidden'\)/);
   assert.match(router, /node\.style\.removeProperty\('display'\)/);
-  assert.match(router, /#nav \[data-screen=\\"operations\\"\]/);
+  assert.match(router, /data-screen="operations"/);
 });
 
 test('opening the mobile menu re-enforces the same activity-slot authority', () => {

--- a/test/dabbir-contextual-navigation.test.mjs
+++ b/test/dabbir-contextual-navigation.test.mjs
@@ -6,6 +6,7 @@ const shell = fs.readFileSync(new URL('../api/app-recovery.js', import.meta.url)
 const ownerOperations = fs.readFileSync(new URL('../api/owner-operations-ui.js', import.meta.url), 'utf8');
 const services = fs.readFileSync(new URL('../api/service-operations-ui.js', import.meta.url), 'utf8');
 const router = fs.readFileSync(new URL('../api/dabbir-contextual-navigation-ui.js', import.meta.url), 'utf8');
+const index = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 
 test('feature operation modules do not own primary navigation', () => {
   for (const source of [ownerOperations, services]) {
@@ -21,6 +22,21 @@ test('store resolves the shared activity slot to Operations in the router', () =
   assert.match(router, /setActivitySlot\(node,'operations',t\.operations\)/);
   assert.match(router, /setActivitySlot\(node,'appointments'/);
   assert.match(router, /authority:'primary-context-router'/);
+});
+
+test('context router reads the canonical lexical workspace instead of assuming window.workspace', () => {
+  assert.match(index, /let lang=.*workspace=null/);
+  assert.match(router, /function currentWorkspace\(\)/);
+  assert.match(router, /typeof workspace!=='undefined'&&workspace/);
+  assert.match(router, /workspace_source:'global-lexical-first'/);
+  assert.doesNotMatch(router, /const businessType=\(\)=>String\(window\.workspace\?\.business/);
+});
+
+test('activity slots are unhidden when the router maps store Appointments to Operations', () => {
+  assert.match(router, /node\.hidden=false/);
+  assert.match(router, /node\.classList\.remove\('hidden'\)/);
+  assert.match(router, /node\.style\.removeProperty\('display'\)/);
+  assert.match(router, /#nav \[data-screen=\\"operations\\"\]/);
 });
 
 test('opening the mobile menu re-enforces the same activity-slot authority', () => {


### PR DESCRIPTION
Root-cause fix for the authenticated iPhone full-journey failure `BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_0`.

Verified cause:
- The canonical shell declares `workspace` as a top-level `let` in `index.html`.
- A top-level `let` creates a global lexical binding and is not exposed as `window.workspace`.
- The contextual navigation router incorrectly derived business type only from `window.workspace`, so it saw an empty business type even after the real store workspace had loaded.
- Because of that, the shared activity slot remained Appointments instead of being mapped to Operations. Re-running the router on mobile menu open could not fix the wrong source value.

Fix:
- Read the canonical lexical `workspace` binding first with a safe `typeof workspace` guard.
- Retain `window.workspace` only as a compatibility fallback for alternate shells.
- Include both Appointments and Operations in activity-slot rediscovery so the mapping stays reversible and idempotent.
- Explicitly remove hidden/display state when mapping the activity slot.
- Preserve one router authority, five primary destinations, and no MutationObserver/setInterval polling.
- Add regression tests binding this decision to the shell's actual workspace ownership contract.

No auth, database, payment, Meta, customer data, or permission changes.