### PR TITLE
DABBIR: accept current Meta WhatsApp completion events

### DIFF
--- a/api/dabbir-whatsapp-embedded-ui.js
+++ b/api/dabbir-whatsapp-embedded-ui.js
@@ -4,11 +4,10 @@ const script = String.raw`(()=>{
 
   const SESSION_TIMEOUT_MS=15*60*1000;
   const COEXISTENCE_FEATURE='whatsapp_business_app_onboarding';
-  const META_MESSAGE_ORIGINS=new Set([
-    'https://www.facebook.com',
-    'https://web.facebook.com',
-    'https://m.facebook.com',
-    'https://business.facebook.com'
+  const META_FINISH_EVENTS=new Set([
+    'FINISH',
+    'FINISH_ONLY_WABA',
+    'FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING'
   ]);
 
   const css=document.createElement('style');
@@ -35,6 +34,13 @@ const script = String.raw`(()=>{
   function ar(){return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')}
   function tell(text){try{if(typeof toast==='function')toast(text)}catch{}}
   function businessId(){try{return String(workspace?.business?.id||'')}catch{return ''}}
+  function trustedMetaOrigin(origin){
+    try{
+      const url=new URL(String(origin||''));
+      const host=String(url.hostname||'').toLowerCase();
+      return url.protocol==='https:'&&(host==='facebook.com'||host.endsWith('.facebook.com'));
+    }catch{return false}
+  }
 
   function report(event,extra={}){
     try{
@@ -61,33 +67,33 @@ const script = String.raw`(()=>{
   }
 
   function parseMetaMessage(event){
-    if(!META_MESSAGE_ORIGINS.has(String(event.origin||''))) return;
+    if(!trustedMetaOrigin(event.origin)) return;
     let data=event.data;
     if(typeof data==='string'){
       try{data=JSON.parse(data)}catch{return}
     }
     if(!data||data.type!=='WA_EMBEDDED_SIGNUP') return;
 
-    const finished=data.event==='FINISH'||data.event==='FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING';
-    if(finished){
+    const metaEvent=String(data.event||'');
+    if(META_FINISH_EVENTS.has(metaEvent)){
       const payload=data.data||{};
       embeddedSession={
         waba_id:String(payload.waba_id||payload.whatsapp_business_account_id||''),
         phone_number_id:String(payload.phone_number_id||''),
-        onboarding_mode:data.event==='FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING'?COEXISTENCE_FEATURE:COEXISTENCE_FEATURE
+        onboarding_mode:COEXISTENCE_FEATURE
       };
       report('session_finish',{
         stage:'meta_session',
-        meta_event:String(data.event||''),
+        meta_event:metaEvent,
         onboarding_mode:embeddedSession.onboarding_mode,
         has_waba:Boolean(embeddedSession.waba_id),
         has_phone:Boolean(embeddedSession.phone_number_id)
       });
-      settleSession(embeddedSession);
-    }else if(data.event==='CANCEL'){
+      if(embeddedSession.waba_id) settleSession(embeddedSession);
+    }else if(metaEvent==='CANCEL'){
       report('session_cancel',{stage:'meta_session'});
       settleSession(null);
-    }else if(data.event==='ERROR'){
+    }else if(metaEvent==='ERROR'){
       report('session_error',{stage:'meta_session',error:String(data?.data?.error_message||data?.data?.error||'META_EMBEDDED_SIGNUP_ERROR').slice(0,160)});
       settleSession(null);
       tell(ar()?'تعذر إكمال ربط WhatsApp Business من Meta':'Meta could not complete WhatsApp Business setup');

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -38,6 +38,7 @@ test('DABBIR prefers WhatsApp Business app coexistence so verification happens t
   assert.match(ui, /whatsapp_business_app_onboarding/);
   assert.match(ui, /featureType:COEXISTENCE_FEATURE/);
   assert.match(ui, /FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING/);
+  assert.match(ui, /FINISH_ONLY_WABA/);
   assert.match(ui, /onboarding_mode:COEXISTENCE_FEATURE/);
   assert.doesNotMatch(ui, /featureType:''/);
 
@@ -66,12 +67,13 @@ test('iPhone Meta login preserves the original user activation by prewarming the
   assert.match(body, /login_invoked/);
 });
 
-test('Embedded Signup does not time out during a normal multi-step Meta mobile journey', async () => {
+test('Embedded Signup does not time out during a normal multi-step Meta mobile journey and trusts only HTTPS facebook.com hosts', async () => {
   const ui = await read('api/dabbir-whatsapp-embedded-ui.js');
   assert.match(ui, /SESSION_TIMEOUT_MS=15\*60\*1000/);
   assert.doesNotMatch(ui, /waitForSession\(timeoutMs=12000\)/);
-  assert.match(ui, /https:\/\/m\.facebook\.com/);
-  assert.match(ui, /https:\/\/business\.facebook\.com/);
+  assert.match(ui, /function trustedMetaOrigin\(origin\)/);
+  assert.match(ui, /url\.protocol==='https:'/);
+  assert.match(ui, /host==='facebook\.com'\|\|host\.endsWith\('\.facebook\.com'\)/);
 });
 
 test('Embedded Signup reports safe client stages to production logs without tokens or asset IDs', async () => {

--- a/test/dabbir-whatsapp-meta-session-events.test.mjs
+++ b/test/dabbir-whatsapp-meta-session-events.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root=new URL('../',import.meta.url);
+const read=path=>readFile(new URL(path,root),'utf8');
+
+test('Embedded Signup accepts current Meta completion variants including WABA-only coexistence',async()=>{
+  const ui=await read('api/dabbir-whatsapp-embedded-ui.js');
+  assert.match(ui,/META_FINISH_EVENTS=new Set/);
+  assert.match(ui,/['"]FINISH['"]/);
+  assert.match(ui,/['"]FINISH_ONLY_WABA['"]/);
+  assert.match(ui,/['"]FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING['"]/);
+  assert.match(ui,/META_FINISH_EVENTS\.has\(metaEvent\)/);
+  assert.match(ui,/if\(embeddedSession\.waba_id\) settleSession\(embeddedSession\)/);
+});
+
+test('Meta session listener trusts HTTPS facebook.com hosts without a brittle subdomain list',async()=>{
+  const ui=await read('api/dabbir-whatsapp-embedded-ui.js');
+  assert.match(ui,/function trustedMetaOrigin\(origin\)/);
+  assert.match(ui,/url\.protocol==='https:'/);
+  assert.match(ui,/host==='facebook\.com'\|\|host\.endsWith\('\.facebook\.com'\)/);
+  assert.match(ui,/if\(!trustedMetaOrigin\(event\.origin\)\) return/);
+  assert.doesNotMatch(ui,/META_MESSAGE_ORIGINS=new Set/);
+});
+
+test('WABA-only completion remains server-resolvable for existing WhatsApp Business app numbers',async()=>{
+  const endpoint=await read('api/dabbir-whatsapp-embedded-complete.js');
+  assert.match(endpoint,/if \(!phoneNumberId && onboardingMode === 'whatsapp_business_app_onboarding'\)/);
+  assert.match(endpoint,/resolveCoexistencePhoneNumberId/);
+  assert.match(endpoint,/if \(!phoneNumberId\) return json\(res, 400/);
+});


### PR DESCRIPTION
Production evidence from the owner's real DABBIR attempt shows Meta SDK ready, connect_start/login_invoked, and FB.login returning an authorization code (`has_code=true`), but no accepted Embedded Signup completion session, eventually producing `META_EMBEDDED_SIGNUP_SESSION_MISSING`.

Root cause in the current client listener:
- completion accepts only `FINISH` and `FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING`;
- Meta can return `FINISH_ONLY_WABA` when the WABA is completed without a phone number in the session payload;
- the server already supports this coexistence case by resolving the Phone Number ID from the WABA after exchanging the code;
- the client origin allowlist is a brittle fixed list of Facebook subdomains rather than securely accepting HTTPS `facebook.com` hosts.

Repair:
- accept `FINISH`, `FINISH_ONLY_WABA`, and `FINISH_WHATSAPP_BUSINESS_APP_ONBOARDING`;
- keep completion fail-closed unless a WABA ID is present;
- accept only HTTPS origins whose hostname is exactly `facebook.com` or ends in `.facebook.com`, rejecting lookalikes and non-HTTPS origins;
- preserve 15-minute mobile onboarding timeout, code exchange, tenant scoping, encryption, RLS, and server-side asset verification unchanged;
- add regression tests for current Meta completion variants and origin validation.

No database schema, auth, billing, tenant permissions, Meta secret, or stored customer connection is changed by this PR.