### PR TITLE
DABBIR: make Platform Admin capability probe quiet for ordinary owners

### DIFF
--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -36,17 +36,52 @@ async function serviceRpc(key,name,params={}){
   return readResponse(response,'PLATFORM_ADMIN_RPC_FAILED');
 }
 
-async function adminContext(req,res){
+async function authenticatedContext(req,res){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   const user=await getVerifiedUser(token).catch(()=>null);
   if(!user?.id){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
-  const response=await supabaseRest(`dabbir_platform_admins?select=role,active&user_id=eq.${user.id}&active=eq.true&limit=1`,token).catch(()=>null);
-  if(!response?.ok){json(res,response?.status===401?401:403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
-  const rows=await response.json().catch(()=>[]);
-  const admin=Array.isArray(rows)?rows[0]:null;
-  if(!admin?.active){json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
-  return {user,role:admin.role,key:serviceKey()};
+  return {token,user};
+}
+
+async function readPlatformAdmin(token,user){
+  const response=await supabaseRest(`dabbir_platform_admins?select=role,active&user_id=eq.${user.id}&active=eq.true&limit=1`,token);
+  if(!response.ok){
+    const error=new Error('PLATFORM_ADMIN_LOOKUP_FAILED');
+    error.status=Number(response.status||500);
+    throw error;
+  }
+  const rows=await response.json().catch(()=>null);
+  if(!Array.isArray(rows)){
+    const error=new Error('PLATFORM_ADMIN_LOOKUP_INVALID');
+    error.status=502;
+    throw error;
+  }
+  const admin=rows[0]||null;
+  return admin?.active?admin:null;
+}
+
+async function adminContext(req,res,{capabilityProbe=false}={}){
+  const auth=await authenticatedContext(req,res);
+  if(!auth)return null;
+  let admin=null;
+  try{
+    admin=await readPlatformAdmin(auth.token,auth.user);
+  }catch(error){
+    const status=Number(error?.status||500);
+    if(status===401){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+    if(status===403&&capabilityProbe){
+      return {user:auth.user,role:null,key:'',allowed:false};
+    }
+    json(res,status>=500?503:403,{ok:false,error:status>=500?'PLATFORM_ADMIN_LOOKUP_FAILED':'PLATFORM_ADMIN_REQUIRED'});
+    return null;
+  }
+  if(!admin){
+    if(capabilityProbe)return {user:auth.user,role:null,key:'',allowed:false};
+    json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});
+    return null;
+  }
+  return {user:auth.user,role:admin.role,key:serviceKey(),allowed:true};
 }
 
 function adminServiceUnavailable(res){
@@ -71,13 +106,22 @@ function rpcError(error){
 
 export default async function handler(req,res){
   if(!['GET','POST'].includes(req.method))return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
-  const context=await adminContext(req,res);
+  const action=req.method==='GET'?String(singleQueryValue(req,'action')||'capability').trim():null;
+  const context=await adminContext(req,res,{capabilityProbe:req.method==='GET'&&action==='capability'});
   if(!context)return;
 
   try{
     if(req.method==='GET'){
-      const action=String(singleQueryValue(req,'action')||'capability').trim();
       if(action==='capability'){
+        if(!context.allowed){
+          return json(res,200,{
+            ok:true,
+            allowed:false,
+            role:null,
+            service_configured:false,
+            reason:'PLATFORM_ADMIN_REQUIRED',
+          });
+        }
         const serviceConfigured=Boolean(context.key);
         return json(res,200,{
           ok:true,

--- a/test/dabbir-platform-capability-probe-runtime.test.mjs
+++ b/test/dabbir-platform-capability-probe-runtime.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import handler from '../api/platform-customers.js';
+
+const USER_ID='11111111-1111-4111-8111-111111111111';
+
+function responseRecorder(){
+  const headers=new Map();
+  return {
+    statusCode:200,
+    setHeader(name,value){headers.set(String(name).toLowerCase(),value)},
+    end(value=''){this.body=String(value)},
+    headers,
+    body:'',
+  };
+}
+
+function request(url,{authenticated=true}={}){
+  return {
+    method:'GET',
+    url,
+    headers:authenticated?{cookie:'__Host-dabbir_access=test-access-token'}:{},
+  };
+}
+
+async function invoke(url,{authenticated=true,adminRows=[]}={}){
+  const originalFetch=globalThis.fetch;
+  globalThis.fetch=async input=>{
+    const target=String(input);
+    if(target.includes('/auth/v1/user')){
+      return new Response(JSON.stringify({id:USER_ID,email:'owner@example.test',aud:'authenticated'}),{status:200,headers:{'content-type':'application/json'}});
+    }
+    if(target.includes('/rest/v1/account_access_state?')){
+      return new Response('[]',{status:200,headers:{'content-type':'application/json'}});
+    }
+    if(target.includes('/rest/v1/dabbir_platform_admins?')){
+      return new Response(JSON.stringify(adminRows),{status:200,headers:{'content-type':'application/json'}});
+    }
+    throw new Error(`UNEXPECTED_FETCH_${target}`);
+  };
+  const res=responseRecorder();
+  try{
+    await handler(request(url,{authenticated}),res);
+  }finally{
+    globalThis.fetch=originalFetch;
+  }
+  return {status:res.statusCode,json:JSON.parse(res.body||'{}'),headers:res.headers};
+}
+
+test('platform capability probe is non-error only after real authentication while privileged actions remain fail-closed',async()=>{
+  const originalKey=process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.SUPABASE_SERVICE_ROLE_KEY='test-service-key';
+  try{
+    const anonymous=await invoke('/api/platform-customers?action=capability',{authenticated:false});
+    assert.equal(anonymous.status,401);
+    assert.equal(anonymous.json.error,'AUTH_REQUIRED');
+
+    const ordinaryCapability=await invoke('/api/platform-customers?action=capability',{adminRows:[]});
+    assert.equal(ordinaryCapability.status,200);
+    assert.deepEqual(ordinaryCapability.json,{
+      ok:true,
+      allowed:false,
+      role:null,
+      service_configured:false,
+      reason:'PLATFORM_ADMIN_REQUIRED',
+    });
+    assert.equal(ordinaryCapability.headers.get('cache-control'),'no-store');
+
+    const ordinarySearch=await invoke('/api/platform-customers?action=search&q=test',{adminRows:[]});
+    assert.equal(ordinarySearch.status,403);
+    assert.equal(ordinarySearch.json.error,'PLATFORM_ADMIN_REQUIRED');
+
+    const adminCapability=await invoke('/api/platform-customers?action=capability',{
+      adminRows:[{role:'platform_owner',active:true}],
+    });
+    assert.equal(adminCapability.status,200);
+    assert.equal(adminCapability.json.allowed,true);
+    assert.equal(adminCapability.json.role,'platform_owner');
+    assert.equal(adminCapability.json.service_configured,true);
+  }finally{
+    if(originalKey===undefined)delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY=originalKey;
+  }
+});


### PR DESCRIPTION
Superseded by merged PR #186, which implements the same quiet Platform Admin capability semantics plus removes the repeated UI polling loop and preserves privileged 401/403 fail-closed behavior. Closing without merge to keep one authoritative fix path.