### PR TITLE
DABBIR: silence non-admin platform capability probe

### DIFF
--- a/api/platform-customers-ui.js
+++ b/api/platform-customers-ui.js
@@ -41,13 +41,15 @@ const script = String.raw`(()=>{
   const notify = message => { try { if (typeof toast === 'function') toast(message); } catch {} };
 
   let enabled = false;
+  let capabilityDenied = false;
+  let capabilityProbePromise = null;
   let accounts = [];
   let selected = null;
   let recoveryPreview = null;
   let recoveryCase = null;
 
   const style = document.createElement('style');
-  style.dataset.dabbirPlatformCustomers = 'v3';
+  style.dataset.dabbirPlatformCustomers = 'v4';
   style.textContent = '.pcGrid{display:grid;grid-template-columns:repeat(3,1fr);gap:10px}.pcToolbar{display:flex;gap:8px;margin-bottom:12px}.pcToolbar input{flex:1;border:1px solid var(--line);background:#171a1d;color:#fff;border-radius:12px;padding:10px}.pcAccount{border:1px solid var(--line);background:#131619;border-radius:16px;padding:13px}.pcAccount b{display:block;font-size:12px}.pcAccount small{display:block;color:var(--muted);font-size:9px;margin-top:3px}.pcCode{direction:ltr;display:inline-block;font-weight:950;letter-spacing:.04em;color:var(--accent)}.pcBiz{border:1px solid var(--line);border-radius:15px;padding:12px;margin-top:10px;background:#121416}.pcCounts{display:grid;grid-template-columns:repeat(3,1fr);gap:7px;margin-top:9px}.pcCount{background:#191c20;border-radius:10px;padding:8px}.pcCount span{font-size:8px;color:var(--muted);display:block}.pcCount b{font-size:15px}.pcDanger{border:1px solid #5b3030;background:#2b1717;border-radius:14px;padding:11px;margin-top:12px}.pcAccess{border:1px solid #3d4654;background:#151a20;border-radius:14px;padding:12px;margin-top:12px}.pcAccess.suspended{border-color:#6a4c2c;background:#261d12}.pcAccess input{width:100%;border:1px solid var(--line);background:#101316;color:#fff;border-radius:10px;padding:9px;margin-top:7px}.pcRecoveryResult{margin-top:9px;padding:9px;border:1px solid var(--line);border-radius:11px;font-size:10px}.pcRecoverySafe{border-color:#28583a;background:#12251a}.pcRecoveryBlocked{border-color:#6c4030;background:#2d1d15}.pcMetrics{display:grid;grid-template-columns:repeat(3,1fr);gap:9px;margin-bottom:12px}.pcMetric{border:1px solid var(--line);border-radius:14px;padding:12px;background:#131619}.pcMetric span{font-size:9px;color:var(--muted);display:block}.pcMetric strong{font-size:21px}.pcActions{display:flex;gap:7px;flex-wrap:wrap;margin-top:9px}@media(max-width:760px){.pcGrid{grid-template-columns:1fr}.pcMetrics{grid-template-columns:repeat(2,1fr)}.pcToolbar{flex-direction:column}.pcCounts{grid-template-columns:repeat(2,1fr)}}';
   document.head.appendChild(style);
 
@@ -67,6 +69,11 @@ const script = String.raw`(()=>{
     applyLabels();
   }
 
+  function removeScreen(){
+    q('#screen-platform-customers')?.remove();
+    q('#nav [data-screen="platform-customers"]')?.remove();
+  }
+
   function applyLabels(){
     const t = text();
     if (q('#pcTitle')) q('#pcTitle').textContent = t.title;
@@ -76,12 +83,21 @@ const script = String.raw`(()=>{
   }
 
   async function capability(){
-    const {response,payload} = await api('/api/platform-customers?action=capability');
-    if (!response.ok || !payload.allowed) return false;
-    enabled = true;
-    ensureScreen();
-    await loadAccounts('');
-    return true;
+    if(enabled||capabilityDenied)return enabled;
+    if(capabilityProbePromise)return capabilityProbePromise;
+    capabilityProbePromise=(async()=>{
+      const {response,payload} = await api('/api/platform-customers?action=capability');
+      if(!response.ok)return false;
+      if(!payload.allowed){
+        if(payload.reason==='PLATFORM_ADMIN_REQUIRED'||payload.reason==='SERVER_ADMIN_NOT_CONFIGURED')capabilityDenied=true;
+        return false;
+      }
+      enabled = true;
+      ensureScreen();
+      await loadAccounts('');
+      return true;
+    })();
+    try{return await capabilityProbePromise}finally{capabilityProbePromise=null}
   }
 
   function loading(){ const body=q('#pcBody'); if(body) body.innerHTML='<div class="empty">'+esc(text().loading)+'</div>'; }
@@ -218,9 +234,21 @@ const script = String.raw`(()=>{
 
   const langObserver=new MutationObserver(()=>{ if(enabled){ applyLabels(); selected ? renderDetail() : renderAccounts(); } });
   langObserver.observe(document.documentElement,{attributes:true,attributeFilter:['lang']});
-  let attempts=0;
-  const timer=setInterval(async()=>{ attempts++; if(enabled||attempts>120){clearInterval(timer);return;} await capability(); },1500);
-  capability();
+
+  const authStage=()=>String(document.body?.dataset?.dabbirAuthStage||'');
+  const authReady=()=>authStage()==='session_verified'||authStage()==='workspace_ready';
+  const probeWhenReady=()=>{ if(authReady()&&!enabled&&!capabilityDenied) capability(); };
+  const authObserver=new MutationObserver(()=>{
+    if(authStage()==='signed_out'){
+      enabled=false;
+      capabilityDenied=false;
+      capabilityProbePromise=null;
+      removeScreen();
+    }
+    probeWhenReady();
+  });
+  if(document.body)authObserver.observe(document.body,{attributes:true,attributeFilter:['data-dabbir-auth-stage']});
+  setTimeout(probeWhenReady,0);
 })();`;
 
 export default function handler(req,res){
@@ -233,6 +261,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-platform-customer-admin-ui','v3');
+  res.setHeader('x-dabbir-platform-customer-admin-ui','v4');
   return res.end(script);
 }

--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -36,25 +36,52 @@ async function serviceRpc(key,name,params={}){
   return readResponse(response,'PLATFORM_ADMIN_RPC_FAILED');
 }
 
-async function adminContext(req,res,{capabilityProbe=false}={}){
+function quietCapability(res,{authenticated=false,role=null,allowed=false,serviceConfigured=false,reason=null}={}){
+  return json(res,200,{
+    ok:true,
+    allowed:Boolean(allowed),
+    authenticated:Boolean(authenticated),
+    role:allowed?role:null,
+    service_configured:allowed?Boolean(serviceConfigured):false,
+    reason:reason||null,
+  });
+}
+
+async function platformCapability(req,res){
+  const token=accessTokenFromRequest(req);
+  if(!token)return quietCapability(res,{reason:'AUTH_REQUIRED'});
+
+  const user=await getVerifiedUser(token).catch(()=>null);
+  if(!user?.id)return quietCapability(res,{reason:'AUTH_REQUIRED'});
+
+  const response=await supabaseRest(`dabbir_platform_admins?select=role,active&user_id=eq.${user.id}&active=eq.true&limit=1`,token).catch(()=>null);
+  if(!response?.ok)return quietCapability(res,{authenticated:true,reason:'PLATFORM_ADMIN_REQUIRED'});
+
+  const rows=await response.json().catch(()=>[]);
+  const admin=Array.isArray(rows)?rows[0]:null;
+  if(!admin?.active)return quietCapability(res,{authenticated:true,reason:'PLATFORM_ADMIN_REQUIRED'});
+
+  const serviceConfigured=Boolean(serviceKey());
+  return quietCapability(res,{
+    authenticated:true,
+    role:admin.role,
+    allowed:serviceConfigured,
+    serviceConfigured,
+    reason:serviceConfigured?null:'SERVER_ADMIN_NOT_CONFIGURED',
+  });
+}
+
+async function adminContext(req,res){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   const user=await getVerifiedUser(token).catch(()=>null);
   if(!user?.id){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   const response=await supabaseRest(`dabbir_platform_admins?select=role,active&user_id=eq.${user.id}&active=eq.true&limit=1`,token).catch(()=>null);
-  if(!response?.ok){
-    if(capabilityProbe&&response?.status===403)return {user,role:null,key:null,allowed:false};
-    json(res,response?.status===401?401:403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});
-    return null;
-  }
+  if(!response?.ok){json(res,response?.status===401?401:403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
   const rows=await response.json().catch(()=>[]);
   const admin=Array.isArray(rows)?rows[0]:null;
-  if(!admin?.active){
-    if(capabilityProbe)return {user,role:null,key:null,allowed:false};
-    json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});
-    return null;
-  }
-  return {user,role:admin.role,key:serviceKey(),allowed:true};
+  if(!admin?.active){json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
+  return {user,role:admin.role,key:serviceKey()};
 }
 
 function adminServiceUnavailable(res){
@@ -79,26 +106,15 @@ function rpcError(error){
 
 export default async function handler(req,res){
   if(!['GET','POST'].includes(req.method))return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
-  const getAction=req.method==='GET'?String(singleQueryValue(req,'action')||'capability').trim():null;
-  const context=await adminContext(req,res,{capabilityProbe:getAction==='capability'});
+
+  const action=req.method==='GET'?String(singleQueryValue(req,'action')||'capability').trim():null;
+  if(req.method==='GET'&&action==='capability')return platformCapability(req,res);
+
+  const context=await adminContext(req,res);
   if(!context)return;
 
   try{
     if(req.method==='GET'){
-      const action=getAction;
-      if(action==='capability'){
-        if(!context.allowed){
-          return json(res,200,{ok:true,allowed:false,reason:'PLATFORM_ADMIN_REQUIRED'});
-        }
-        const serviceConfigured=Boolean(context.key);
-        return json(res,200,{
-          ok:true,
-          allowed:serviceConfigured,
-          role:context.role,
-          service_configured:serviceConfigured,
-          reason:serviceConfigured?null:'SERVER_ADMIN_NOT_CONFIGURED',
-        });
-      }
       if(!context.key)return adminServiceUnavailable(res);
       if(action==='overview'){
         const payload=await serviceRpc(context.key,'dabbir_platform_owner_overview',{p_actor_user_id:context.user.id});

--- a/api/platform-customers.js
+++ b/api/platform-customers.js
@@ -36,17 +36,25 @@ async function serviceRpc(key,name,params={}){
   return readResponse(response,'PLATFORM_ADMIN_RPC_FAILED');
 }
 
-async function adminContext(req,res){
+async function adminContext(req,res,{capabilityProbe=false}={}){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   const user=await getVerifiedUser(token).catch(()=>null);
   if(!user?.id){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   const response=await supabaseRest(`dabbir_platform_admins?select=role,active&user_id=eq.${user.id}&active=eq.true&limit=1`,token).catch(()=>null);
-  if(!response?.ok){json(res,response?.status===401?401:403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
+  if(!response?.ok){
+    if(capabilityProbe&&response?.status===403)return {user,role:null,key:null,allowed:false};
+    json(res,response?.status===401?401:403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});
+    return null;
+  }
   const rows=await response.json().catch(()=>[]);
   const admin=Array.isArray(rows)?rows[0]:null;
-  if(!admin?.active){json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});return null}
-  return {user,role:admin.role,key:serviceKey()};
+  if(!admin?.active){
+    if(capabilityProbe)return {user,role:null,key:null,allowed:false};
+    json(res,403,{ok:false,error:'PLATFORM_ADMIN_REQUIRED'});
+    return null;
+  }
+  return {user,role:admin.role,key:serviceKey(),allowed:true};
 }
 
 function adminServiceUnavailable(res){
@@ -71,13 +79,17 @@ function rpcError(error){
 
 export default async function handler(req,res){
   if(!['GET','POST'].includes(req.method))return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
-  const context=await adminContext(req,res);
+  const getAction=req.method==='GET'?String(singleQueryValue(req,'action')||'capability').trim():null;
+  const context=await adminContext(req,res,{capabilityProbe:getAction==='capability'});
   if(!context)return;
 
   try{
     if(req.method==='GET'){
-      const action=String(singleQueryValue(req,'action')||'capability').trim();
+      const action=getAction;
       if(action==='capability'){
+        if(!context.allowed){
+          return json(res,200,{ok:true,allowed:false,reason:'PLATFORM_ADMIN_REQUIRED'});
+        }
         const serviceConfigured=Boolean(context.key);
         return json(res,200,{
           ok:true,

--- a/test/dabbir-platform-account-suspension.test.mjs
+++ b/test/dabbir-platform-account-suspension.test.mjs
@@ -54,7 +54,7 @@ test('platform access mutation is same-origin, reason-gated and service-side', (
   assert.match(ui, /PLATFORM_ADMIN_IMMUTABLE/);
 });
 
-test('admin UI exposes suspension and reactivation while enforcing recovery v3 safety controls', () => {
+test('admin UI exposes suspension and reactivation while enforcing recovery safety controls', () => {
   assert.match(ui, /Suspend account|تعليق الحساب/);
   assert.match(ui, /Reactivate account|إعادة تفعيل الحساب/);
   assert.match(ui, /recovery_preview/);
@@ -62,5 +62,5 @@ test('admin UI exposes suspension and reactivation while enforcing recovery v3 s
   assert.match(ui, /apply_recovery/);
   assert.match(ui, /frozenRequired|يجب تعليق حساب العميل أولًا/);
   assert.match(ui, /manualRequired|مصالحة يدوية/);
-  assert.match(ui, /x-dabbir-platform-customer-admin-ui','v3'/);
+  assert.match(ui, /x-dabbir-platform-customer-admin-ui','v4'/);
 });

--- a/test/dabbir-platform-admin-fail-soft.test.mjs
+++ b/test/dabbir-platform-admin-fail-soft.test.mjs
@@ -5,17 +5,28 @@ import { readFile } from 'node:fs/promises';
 const root = new URL('../', import.meta.url);
 const source = await readFile(new URL('api/platform-customers.js', root), 'utf8');
 
-test('platform customer admin capability verifies admin identity before failing soft on missing server config', () => {
+test('platform customer admin capability is a quiet fail-closed probe before privileged admin context', () => {
+  const capabilityRouteIndex = source.indexOf("if(req.method==='GET'&&action==='capability')return platformCapability(req,res)");
   const contextIndex = source.indexOf('const context=await adminContext(req,res)');
-  const capabilityIndex = source.indexOf("if(action==='capability')");
-  assert.ok(contextIndex >= 0 && capabilityIndex > contextIndex, 'admin identity must be verified before capability is disclosed');
-  assert.match(source, /const serviceConfigured=Boolean\(context\.key\)/);
+  assert.ok(capabilityRouteIndex >= 0 && contextIndex > capabilityRouteIndex, 'capability must be resolved without invoking privileged adminContext first');
+  assert.match(source, /function quietCapability\(res,/);
+  assert.match(source, /return json\(res,200,/);
+  assert.match(source, /if\(!token\)return quietCapability\(res,\{reason:'AUTH_REQUIRED'\}\)/);
+  assert.match(source, /if\(!response\?\.ok\)return quietCapability\(res,\{authenticated:true,reason:'PLATFORM_ADMIN_REQUIRED'\}\)/);
+  assert.match(source, /role:allowed\?role:null/);
+  assert.match(source, /service_configured:allowed\?Boolean\(serviceConfigured\):false/);
+});
+
+test('platform admin capability discloses service configuration only to an active admin', () => {
+  assert.match(source, /if\(!admin\?\.active\)return quietCapability\(res,\{authenticated:true,reason:'PLATFORM_ADMIN_REQUIRED'\}\)/);
+  assert.match(source, /const serviceConfigured=Boolean\(serviceKey\(\)\)/);
   assert.match(source, /allowed:serviceConfigured/);
-  assert.match(source, /service_configured:serviceConfigured/);
   assert.match(source, /reason:serviceConfigured\?null:'SERVER_ADMIN_NOT_CONFIGURED'/);
 });
 
-test('privileged platform customer operations remain fail-closed without the server admin key', () => {
+test('privileged platform customer operations remain fail-closed without platform admin authority or server admin key', () => {
+  assert.match(source, /async function adminContext\(req,res\)/);
+  assert.match(source, /json\(res,response\?\.status===401\?401:403,\{ok:false,error:'PLATFORM_ADMIN_REQUIRED'\}\)/);
   assert.match(source, /function adminServiceUnavailable\(res\)/);
   assert.match(source, /json\(res,503,\{ok:false,error:'SERVER_ADMIN_NOT_CONFIGURED'\}\)/);
   assert.match(source, /if\(!context\.key\)return adminServiceUnavailable\(res\)/);

--- a/test/dabbir-recovery-center-safety-v2.test.mjs
+++ b/test/dabbir-recovery-center-safety-v2.test.mjs
@@ -64,5 +64,5 @@ test('Customer 360 UI hides apply path until preview is safe and account is froz
   assert.match(ui, /RECOVERY_ACCOUNT_MUST_BE_SUSPENDED/);
   assert.match(ui, /RECOVERY_EXTERNAL_RECONCILIATION_REQUIRED/);
   assert.match(ui, /const canPrepare=preview && !blocked && accountSuspended/);
-  assert.match(ui, /x-dabbir-platform-customer-admin-ui','v3'/);
+  assert.match(ui, /x-dabbir-platform-customer-admin-ui','v4'/);
 });

--- a/test/dabbir-stability-audit.test.mjs
+++ b/test/dabbir-stability-audit.test.mjs
@@ -11,13 +11,20 @@ function injectedApiScripts(source) {
   return [...source.matchAll(/<script src=\"(\/api\/[^\"]+)\"><\/script>/g)].map(match => match[1]);
 }
 
-test('platform capability fails closed without emitting a capability 503', () => {
-  assert.match(platformApi, /return \{user,role:admin\.role,key:serviceKey\(\)\}/);
-  assert.match(platformApi, /if\(action==='capability'\)[\s\S]*serviceConfigured=Boolean\(context\.key\)/);
-  assert.match(platformApi, /allowed:serviceConfigured/);
-  assert.match(platformApi, /service_configured:serviceConfigured/);
+test('platform capability is quiet and fail-closed while privileged operations retain admin enforcement', () => {
+  const capabilityRouteIndex = platformApi.indexOf("if(req.method==='GET'&&action==='capability')return platformCapability(req,res)");
+  const adminContextIndex = platformApi.indexOf('const context=await adminContext(req,res)');
+  assert.ok(capabilityRouteIndex >= 0 && adminContextIndex > capabilityRouteIndex, 'capability probe must resolve before privileged admin context');
+  assert.match(platformApi, /function quietCapability\(res,/);
+  assert.match(platformApi, /return json\(res,200,/);
+  assert.match(platformApi, /if\(!token\)return quietCapability\(res,\{reason:'AUTH_REQUIRED'\}\)/);
+  assert.match(platformApi, /if\(!response\?\.ok\)return quietCapability\(res,\{authenticated:true,reason:'PLATFORM_ADMIN_REQUIRED'\}\)/);
+  assert.match(platformApi, /role:allowed\?role:null/);
+  assert.match(platformApi, /service_configured:allowed\?Boolean\(serviceConfigured\):false/);
+  assert.match(platformApi, /const serviceConfigured=Boolean\(serviceKey\(\)\)/);
   assert.match(platformApi, /reason:serviceConfigured\?null:'SERVER_ADMIN_NOT_CONFIGURED'/);
   assert.match(platformApi, /if\(!context\.key\)return adminServiceUnavailable\(res\)/);
+  assert.match(platformApi, /json\(res,response\?\.status===401\?401:403,\{ok:false,error:'PLATFORM_ADMIN_REQUIRED'\}\)/);
   assert.doesNotMatch(platformApi, /if\(!key\)\{json\(res,503,\{ok:false,error:'SERVER_ADMIN_NOT_CONFIGURED'\}\);return null\}/);
 });
 


### PR DESCRIPTION
Fix the remaining authenticated WebKit console 403s from `/api/platform-customers?action=capability` without weakening privileged authorization.

- Capability probe now returns HTTP 200 with `allowed:false` for unauthenticated/non-admin callers.
- Role/service configuration is disclosed only to an active platform admin.
- Search/detail/access/recovery operations still use the existing fail-closed admin context and 401/403 behavior.
- Regression tests lock probe ordering, disclosure limits, and privileged fail-closed behavior.

Root cause: the platform customer admin UI probes capability repeatedly; expected authorization denial was surfacing as browser console resource errors and failing the production iPhone/WebKit journey.