### PR TITLE
DABBIR: fix duplicated mobile navigation labels and icons

### DIFF
--- a/api/activity-profile-ui.js
+++ b/api/activity-profile-ui.js
@@ -11,12 +11,12 @@ const script=String.raw`(()=>{
   };
 
   const style=document.createElement('style');
-  style.textContent='.activityIdentity{display:flex;align-items:center;gap:8px;margin:8px 0 0}.activityPill{display:inline-flex;align-items:center;border:1px solid #3a4330;background:#172016;color:var(--accent);padding:5px 9px;border-radius:999px;font-size:9px;font-weight:900}.activityTaskCard{margin-bottom:12px}.activityTaskGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.activityTask{border:1px solid #292f34;background:#15181b;border-radius:14px;padding:11px;display:flex;gap:10px;align-items:flex-start}.activityTask .grow{flex:1;min-width:0}.activityTask b{display:block;font-size:11px;line-height:1.5}.activityTask small{display:block;color:var(--muted);font-size:8px;margin-top:4px}.activityTask button{min-height:34px;padding:6px 9px}.activityDone{opacity:.58}.activityPriority{font-size:8px;color:var(--yellow);font-weight:900}@media(max-width:700px){.activityTaskGrid{grid-template-columns:1fr}}';
+  style.textContent='.activityIdentity{display:flex;align-items:center;gap:8px;margin:8px 0 0}.activityPill{display:inline-flex;align-items:center;border:1px solid #3a4330;background:#172016;color:var(--accent);padding:5px 9px;border-radius:999px;font-size:9px;font-weight:900}.activityTaskCard{margin-bottom:12px}.activityTaskGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.activityTask{border:1px solid #292f34;background:#15181b;border-radius:14px;padding:11px;display:flex;gap:10px;align-items:flex-start}.activityTask .grow{flex:1;min-width:0}.activityTask b{display:block;font-size:11px;line-height:1.5}.activityTask small{display:block;color:var(--muted);font-size:8px;margin-top:4px}.activityTask button{min-height:34px;padding:6px 9px}.activityDone{opacity:.58}.activityPriority{font-size:8px;color:var(--yellow);font-weight:900}.navBtn>.navIcon{display:none!important}@media(max-width:700px){.activityTaskGrid{grid-template-columns:1fr}}';
   document.head.append(style);
 
   function businessId(){return workspace?.business?.id||null}
   function setText(selector,value){const el=q(selector);if(el&&value!==undefined&&value!==null)el.textContent=value}
-  function setLabel(screen,value){qa('[data-screen="'+screen+'"] [data-label], [data-screen="'+screen+'"] span').forEach(el=>{if(value)el.textContent=value})}
+  function setLabel(screen,value){qa('[data-screen="'+screen+'"] [data-label]').forEach(el=>{if(value)el.textContent=value})}
 
   function ensureTaskCard(){
     const screen=q('#screen-tasks');if(!screen)return null;

--- a/test/dabbir-mobile-nav-label-safety.test.mjs
+++ b/test/dabbir-mobile-nav-label-safety.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const source = fs.readFileSync(new URL('api/activity-profile-ui.js', root), 'utf8');
+
+test('activity profile updates only navigation label nodes', () => {
+  assert.match(
+    source,
+    /function setLabel\(screen,value\)\{qa\('\[data-screen="'\+screen\+'"\] \[data-label\]'\)/,
+    'activity labels must target only [data-label] nodes'
+  );
+  assert.doesNotMatch(
+    source,
+    /\[data-screen="'\+screen\+'"\] span/,
+    'activity profile must never overwrite icon spans with label text'
+  );
+});
+
+test('legacy sidebar icon is hidden once owner-first icon system is active', () => {
+  assert.match(
+    source,
+    /\.navBtn>\.navIcon\{display:none!important\}/,
+    'legacy navIcon must not render beside the owner-first d4 navigation icon'
+  );
+});


### PR DESCRIPTION
Root cause from the current iPhone production screenshot:

- `activity-profile-ui` updated every `span` inside activity navigation buttons, so the activity label overwrote icon spans as text.
- owner-first navigation keeps a modern `d4-nav-icon` while the base shell still contains the legacy `.navIcon`, so the corrupted button could render the same Arabic label multiple times and show duplicate icons.

Fix:
- Scope activity-specific label updates strictly to `[data-label]`.
- Hide the legacy sidebar `.navIcon` once the owner-first icon system is present.
- Add a regression test that fails if activity labels can target generic icon spans again.

This is intentionally narrow: no auth, WhatsApp, business data, or routing behavior changes.