### PR TITLE
DABBIR: finish WhatsApp signup from Meta code on iPhone

### DIFF
--- a/api/dabbir-whatsapp-embedded-complete.js
+++ b/api/dabbir-whatsapp-embedded-complete.js
@@ -14,6 +14,75 @@ function cleanId(value) {
   return /^[0-9]{5,40}$/.test(text) ? text : '';
 }
 
+function firstEnv(...names) {
+  for (const name of names) {
+    const value = String(process.env[name] || '').trim();
+    if (value) return value;
+  }
+  return '';
+}
+
+function existingMetaDebugToken() {
+  return firstEnv(
+    'DABBIR_WHATSAPP_ACCESS_TOKEN',
+    'PILOT_WHATSAPP_ACCESS_TOKEN',
+    'WHATSAPP_ACCESS_TOKEN',
+    'META_WHATSAPP_ACCESS_TOKEN',
+  );
+}
+
+function metaProviderError(payload, response, fallback) {
+  const error = new Error(String(payload?.error?.message || fallback).slice(0, 300));
+  error.status = 502;
+  error.providerStatus = response?.status || null;
+  error.providerCode = payload?.error?.code || null;
+  return error;
+}
+
+export async function discoverWabaIdFromAccessToken(platform, token, options = {}) {
+  const appAccessToken = `${String(platform?.appId || '')}|${String(platform?.appSecret || '')}`;
+  if (!platform?.appId || !platform?.appSecret || !token) {
+    throw Object.assign(new Error('META_WABA_DISCOVERY_CONFIGURATION_MISSING'), { status: 503 });
+  }
+  const authorizationToken = String(options.authorizationToken || existingMetaDebugToken() || appAccessToken).trim();
+  if (!authorizationToken) {
+    throw Object.assign(new Error('META_WABA_DISCOVERY_CONFIGURATION_MISSING'), { status: 503 });
+  }
+
+  const url = new URL(`https://graph.facebook.com/${encodeURIComponent(platform.graphVersion)}/debug_token`);
+  url.searchParams.set('input_token', String(token));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: { authorization: `Bearer ${authorizationToken}`, accept: 'application/json' },
+      cache: 'no-store',
+      signal: controller.signal,
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || payload?.data?.is_valid === false) {
+      throw metaProviderError(payload, response, 'META_WABA_DISCOVERY_FAILED');
+    }
+
+    const granularScopes = Array.isArray(payload?.data?.granular_scopes) ? payload.data.granular_scopes : [];
+    const targetIds = granularScopes
+      .filter(item => String(item?.scope || '') === 'whatsapp_business_management')
+      .flatMap(item => Array.isArray(item?.target_ids) ? item.target_ids : [])
+      .map(cleanId)
+      .filter(Boolean);
+    const uniqueWabas = [...new Set(targetIds)];
+
+    if (uniqueWabas.length === 1) return uniqueWabas[0];
+    if (uniqueWabas.length > 1) {
+      throw Object.assign(new Error('META_WABA_RESOLUTION_REQUIRED'), { status: 409 });
+    }
+    throw Object.assign(new Error('META_WABA_DISCOVERY_EMPTY'), { status: 409 });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
 async function resolveCoexistencePhoneNumberId(platform, token, wabaId) {
   const url = new URL(`https://graph.facebook.com/${encodeURIComponent(platform.graphVersion)}/${encodeURIComponent(wabaId)}/phone_numbers`);
   url.searchParams.set('fields', 'id,display_phone_number,verified_name,is_on_biz_app,platform_type');
@@ -29,13 +98,7 @@ async function resolveCoexistencePhoneNumberId(platform, token, wabaId) {
       signal: controller.signal,
     });
     const payload = await response.json().catch(() => ({}));
-    if (!response.ok) {
-      const error = new Error(String(payload?.error?.message || 'META_PHONE_RESOLUTION_FAILED').slice(0, 300));
-      error.status = 502;
-      error.providerStatus = response.status;
-      error.providerCode = payload?.error?.code || null;
-      throw error;
-    }
+    if (!response.ok) throw metaProviderError(payload, response, 'META_PHONE_RESOLUTION_FAILED');
 
     const phones = Array.isArray(payload?.data) ? payload.data : [];
     const coexistence = phones.filter(item => item?.is_on_biz_app === true && String(item?.platform_type || '').toUpperCase() === 'CLOUD_API');
@@ -56,19 +119,23 @@ export default async function handler(req, res) {
     const body = await readJsonBody(req, 16 * 1024);
     const businessId = String(body?.business_id || '').trim();
     const code = String(body?.code || '').trim();
-    const wabaId = cleanId(body?.waba_id);
+    let wabaId = cleanId(body?.waba_id);
     let phoneNumberId = cleanId(body?.phone_number_id);
     const onboardingMode = String(body?.onboarding_mode || '').trim();
 
     if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
     if (!code || code.length > 4096) return json(res, 400, { ok: false, error: 'META_AUTHORIZATION_CODE_REQUIRED' });
-    if (!wabaId) return json(res, 400, { ok: false, error: 'META_EMBEDDED_SIGNUP_WABA_REQUIRED' });
 
     const owner = await ownerContext(req, businessId);
     const platform = applyDabbirMetaPublicIdentifiers(await resolveEmbeddedPlatformConfig());
     if (!platform.ready) return json(res, 503, { ok: false, error: 'META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED' });
 
     const exchanged = await exchangeEmbeddedCode(platform, code);
+    if (!wabaId) {
+      wabaId = await discoverWabaIdFromAccessToken(platform, exchanged.accessToken);
+    }
+    if (!wabaId) return json(res, 400, { ok: false, error: 'META_EMBEDDED_SIGNUP_WABA_REQUIRED' });
+
     if (!phoneNumberId && onboardingMode === 'whatsapp_business_app_onboarding') {
       phoneNumberId = await resolveCoexistencePhoneNumberId(platform, exchanged.accessToken, wabaId);
     }
@@ -116,6 +183,7 @@ export default async function handler(req, res) {
       waba_id: stored?.waba_id || wabaId,
       phone_number_id: stored?.phone_number_id || phoneNumberId,
       connected_at: stored?.connected_at || now.toISOString(),
+      waba_source: cleanId(body?.waba_id) ? 'embedded_session' : 'debug_token',
       secrets_exposed: false,
     });
   } catch (error) {

--- a/api/dabbir-whatsapp-embedded-ui.js
+++ b/api/dabbir-whatsapp-embedded-ui.js
@@ -3,6 +3,7 @@ const script = String.raw`(()=>{
   window.__dabbirWhatsAppEmbeddedUiLoaded=true;
 
   const SESSION_TIMEOUT_MS=15*60*1000;
+  const POST_LOGIN_SESSION_GRACE_MS=1800;
   const COEXISTENCE_FEATURE='whatsapp_business_app_onboarding';
   const META_FINISH_EVENTS=new Set([
     'FINISH',
@@ -216,12 +217,13 @@ const script = String.raw`(()=>{
   }
 
   async function completeSignup(code,session){
+    const safeSession=session||{};
     report('complete_start',{
       stage:'server_complete',
       onboarding_mode:COEXISTENCE_FEATURE,
       has_code:Boolean(code),
-      has_waba:Boolean(session?.waba_id),
-      has_phone:Boolean(session?.phone_number_id)
+      has_waba:Boolean(safeSession.waba_id),
+      has_phone:Boolean(safeSession.phone_number_id)
     });
     const response=await fetch('/api/dabbir-whatsapp-embedded-complete',{
       method:'POST',
@@ -230,8 +232,8 @@ const script = String.raw`(()=>{
       body:JSON.stringify({
         business_id:businessId(),
         code,
-        waba_id:session.waba_id,
-        phone_number_id:session.phone_number_id||'',
+        waba_id:safeSession.waba_id||'',
+        phone_number_id:safeSession.phone_number_id||'',
         onboarding_mode:COEXISTENCE_FEATURE
       })
     });
@@ -249,6 +251,8 @@ const script = String.raw`(()=>{
     if(key==='META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED') return ar()?'إعداد ربط WhatsApp Business في Meta غير مكتمل بعد':'Meta WhatsApp Business onboarding is not configured yet';
     if(key==='META_AUTHORIZATION_CODE_MISSING') return ar()?'لم تُرجع Meta رمز التفويض. أغلق نافذة Meta وأعد المحاولة من داخل دبّر.':'Meta did not return an authorization code. Close the Meta window and retry from DABBIR.';
     if(key==='META_EMBEDDED_SIGNUP_SESSION_MISSING') return ar()?'لم يصل تأكيد ربط WhatsApp Business من Meta. لم يتم حفظ أي ربط ناقص.':'Meta did not return the WhatsApp Business connection confirmation. No incomplete connection was saved.';
+    if(key==='META_WABA_DISCOVERY_EMPTY') return ar()?'أكملت Meta تسجيل الدخول، لكن لم تشارك أي حساب WhatsApp Business مع دبّر.':'Meta login completed, but no WhatsApp Business Account was shared with DABBIR.';
+    if(key==='META_WABA_RESOLUTION_REQUIRED') return ar()?'تمت مشاركة أكثر من حساب WhatsApp Business ولا يمكن اختيار أحدها تلقائيًا بأمان.':'More than one WhatsApp Business Account was shared, so DABBIR cannot safely choose one automatically.';
     if(key==='META_COEXISTENCE_PHONE_RESOLUTION_REQUIRED') return ar()?'يوجد أكثر من رقم داخل حساب WhatsApp Business ولم تتمكن Meta من تحديد الرقم المختار تلقائيًا.':'More than one WhatsApp Business number is available and Meta did not identify the selected number.';
     if(key==='META_SDK_NOT_READY'||key==='META_SDK_LOAD_FAILED'||key==='META_SDK_LOAD_TIMEOUT') return ar()?'جاري تجهيز الربط الآمن من Meta. أعد الضغط بعد أن يصبح الزر جاهزًا.':'Meta secure onboarding is still preparing. Retry when the connect button is ready.';
     return ar()?'تعذر ربط WhatsApp Business. لم يتم حفظ أي ربط غير مكتمل.':'WhatsApp Business could not be connected. No incomplete connection was saved.';
@@ -299,8 +303,18 @@ const script = String.raw`(()=>{
       if(!code) throw new Error('META_AUTHORIZATION_CODE_MISSING');
 
       stage='meta_session';
-      const session=await sessionPromise;
-      if(!session?.waba_id) throw new Error('META_EMBEDDED_SIGNUP_SESSION_MISSING');
+      let session=embeddedSession?.waba_id?embeddedSession:null;
+      if(!session){
+        session=await Promise.race([
+          sessionPromise,
+          new Promise(resolve=>setTimeout(()=>resolve(null),POST_LOGIN_SESSION_GRACE_MS))
+        ]);
+      }
+      if(!session?.waba_id){
+        report('session_server_fallback',{stage:'meta_session',has_code:true,has_waba:false,has_phone:false});
+        settleSession(null);
+        session=null;
+      }
 
       stage='server_complete';
       await completeSignup(code,session);

--- a/test/dabbir-whatsapp-server-waba-fallback.test.mjs
+++ b/test/dabbir-whatsapp-server-waba-fallback.test.mjs
@@ -1,0 +1,91 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { discoverWabaIdFromAccessToken } from '../api/dabbir-whatsapp-embedded-complete.js';
+
+const root = new URL('../', import.meta.url);
+const read = path => readFile(new URL(path, root), 'utf8');
+
+const platform = {
+  appId: '123456789012345',
+  appSecret: 'unit-test-app-secret',
+  graphVersion: 'v23.0',
+};
+const debugAuthorizationToken = 'unit-test-system-user-token';
+
+test('server discovers exactly one shared WABA from Meta debug_token granular scopes', async () => {
+  const originalFetch = globalThis.fetch;
+  let seenUrl = null;
+  let seenAuthorization = null;
+  try {
+    globalThis.fetch = async (url, options = {}) => {
+      seenUrl = new URL(String(url));
+      seenAuthorization = options?.headers?.authorization || null;
+      return new Response(JSON.stringify({
+        data: {
+          is_valid: true,
+          granular_scopes: [
+            { scope: 'public_profile', target_ids: [] },
+            { scope: 'whatsapp_business_management', target_ids: ['998877665544332'] },
+          ],
+        },
+      }), { status: 200, headers: { 'content-type': 'application/json' } });
+    };
+
+    const wabaId = await discoverWabaIdFromAccessToken(
+      platform,
+      'oauth-user-token',
+      { authorizationToken: debugAuthorizationToken },
+    );
+    assert.equal(wabaId, '998877665544332');
+    assert.equal(seenUrl.pathname, '/v23.0/debug_token');
+    assert.equal(seenUrl.searchParams.get('input_token'), 'oauth-user-token');
+    assert.equal(seenAuthorization, 'Bearer unit-test-system-user-token');
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('server refuses to guess when Meta shares multiple WABAs', async () => {
+  const originalFetch = globalThis.fetch;
+  try {
+    globalThis.fetch = async () => new Response(JSON.stringify({
+      data: {
+        is_valid: true,
+        granular_scopes: [
+          { scope: 'whatsapp_business_management', target_ids: ['11111111111', '22222222222'] },
+        ],
+      },
+    }), { status: 200, headers: { 'content-type': 'application/json' } });
+
+    await assert.rejects(
+      () => discoverWabaIdFromAccessToken(
+        platform,
+        'oauth-user-token',
+        { authorizationToken: debugAuthorizationToken },
+      ),
+      error => error?.message === 'META_WABA_RESOLUTION_REQUIRED' && error?.status === 409,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test('iPhone Embedded Signup falls back to the server shortly after authorization code returns', async () => {
+  const ui = await read('api/dabbir-whatsapp-embedded-ui.js');
+  const endpoint = await read('api/dabbir-whatsapp-embedded-complete.js');
+
+  assert.match(ui, /POST_LOGIN_SESSION_GRACE_MS=1800/);
+  assert.match(ui, /session_server_fallback/);
+  assert.match(ui, /Promise\.race\(\[/);
+  assert.match(ui, /await completeSignup\(code,session\)/);
+  assert.doesNotMatch(ui, /if\(!session\?\.waba_id\) throw new Error\('META_EMBEDDED_SIGNUP_SESSION_MISSING'\)/);
+
+  assert.match(endpoint, /discoverWabaIdFromAccessToken/);
+  assert.match(endpoint, /debug_token/);
+  assert.match(endpoint, /granular_scopes/);
+  assert.match(endpoint, /whatsapp_business_management/);
+  assert.match(endpoint, /DABBIR_WHATSAPP_ACCESS_TOKEN/);
+  assert.match(endpoint, /authorizationToken \|\| existingMetaDebugToken\(\) \|\| appAccessToken/);
+  assert.match(endpoint, /waba_source: cleanId\(body\?\.waba_id\) \? 'embedded_session' : 'debug_token'/);
+});


### PR DESCRIPTION
Production iPhone evidence shows Meta Embedded Signup repeatedly returns a valid authorization code but no usable WA_EMBEDDED_SIGNUP session message. This PR removes that browser-message dependency after the code callback.

- Preserve normal Meta session handling when WABA/phone arrives.
- After the authorization code returns, wait only 1.8s for late session metadata, then call server completion with the code.
- Server exchanges the code and discovers exactly one shared WABA from Meta debug_token / whatsapp_business_management granular target IDs.
- Prefer an existing server-side WhatsApp/System User token for debug_token authorization, with app access token fallback.
- Resolve the coexistence phone server-side, verify WABA/phone ownership, subscribe the app, encrypt the token and persist the tenant connection exactly as before.
- Multiple WABAs or ambiguous phone numbers fail closed; no guessing.
- No secrets or access tokens are exposed to the browser.

The change is rebased on current main after #186/#188 and is limited to the WhatsApp UI, completion endpoint and executable regression tests.