### PR TITLE
DABBIR: archive superseded Business OS research authority

### DIFF
--- a/docs/archive/business-os-research-2026-08-26/01_GLOBAL_SYSTEM_RESEARCH.md
+++ b/docs/archive/business-os-research-2026-08-26/01_GLOBAL_SYSTEM_RESEARCH.md
@@ -1,0 +1,117 @@
+# 01 — DABBIR Business OS: Global System Research
+
+**Research snapshot:** 2026-08-26  
+**Scope:** Global enterprise/SMB management systems, AI operating layers, workflow, identity, search, finance, supply chain and UAE readiness.  
+**Rule:** This document is research only. It does not authorize any production change.
+
+## Executive conclusion
+
+The market is converging from a classic **system of record** toward a **system of action**: one governed data foundation, role-aware workflows, real-time analytics, and AI agents that can reason and execute inside business controls. DABBIR should not copy an old ERP and add a chatbot. Its target should be a permission-aware operating layer over a canonical company data model.
+
+The strongest patterns discovered are:
+
+1. **Unified transactional core** — SAP, NetSuite, Odoo, Dynamics, Acumatica and Epicor derive value from linking finance, sales, supply chain and operations rather than offering isolated apps.
+2. **AI embedded in the workflow** — Microsoft Dynamics 365, Oracle Fusion/NetSuite, SAP Joule, Salesforce Agentforce, ServiceNow, Bamboo AI and Odoo increasingly place AI inside operational flows rather than in a separate chat window.
+3. **Agent governance is becoming first-class** — Workday Agent System of Record, ServiceNow AI Control Tower/Orchestrator, Salesforce Agentforce observability, n8n governance and Microsoft human-in-the-loop patterns all point to identity, least privilege, approvals and execution traces for AI agents.
+4. **Exception-first management** — modern products increasingly surface what needs attention instead of making managers navigate reports manually.
+5. **Permission-aware enterprise search** — Glean and Atlassian Rovo show the value of one query across many sources while enforcing existing permissions.
+6. **Deterministic automation + AI judgment** — Make, n8n, Zapier and enterprise workflow platforms combine fixed logic for predictable steps with AI only where judgment is useful.
+
+## Benchmark set
+
+| System | Primary benchmark value for DABBIR | Current signal reviewed |
+|---|---|---|
+| SAP S/4HANA Cloud | enterprise transactional integrity, finance/supply-chain integration, Joule | 2026 cloud/Joule releases |
+| SAP Business One | compact ERP breadth for SMB | current SAP B1 10.0 pages |
+| Microsoft Dynamics 365 | composable ERP/CRM + Copilot/agentic execution | 2026 release wave 1 |
+| Oracle Fusion Cloud | deep finance/procurement/HCM + enterprise AI agents | 26A/26B/26C |
+| Oracle NetSuite / NetSuite Next | unified cloud ERP for growth companies + conversational/agentic UX | 2026.2 / NetSuite Next |
+| Odoo 19 | broad modular SMB suite, low-friction UX, integrated automation | Odoo 19 / 19.3 |
+| Salesforce | CRM, customer 360, sales/service agents, AI-human handoff | Agentforce 2026 |
+| HubSpot | approachable SMB CRM and configurable agents | Breeze / custom agents 2026 |
+| Zoho | broad SMB suite and agent catalog | Zia Agents |
+| ServiceNow | enterprise workflow, approvals, orchestration and AI governance | AI Agents / Orchestrator 2026 |
+| Workday | HCM/finance and governed agent identity/control plane | Agent System of Record |
+| Rippling | employee graph across HR/IT/finance and dynamic permissions | 2026 platform |
+| Deel | global HR/payroll/compliance operating model | AI Workforce 2026 |
+| BambooHR | approachable HR lifecycle and connected HR intelligence | Bamboo AI July 2026 |
+| Asana | no-code work orchestration with AI conditions/actions | AI Studio 2026 |
+| monday.com | business work platform + governed agents on live work data | AI agents 2026 |
+| ClickUp | unified work management and teammate-style agents | Super Agents |
+| Atlassian Jira/Rovo | work graph, permission-aware enterprise search and agents | Rovo 2026 |
+| Acumatica | mid-market financials/distribution/manufacturing/project accounting | 2026 R1 |
+| Epicor Kinetic | manufacturing/MRP/APS/project finance + governed extensibility | 2026.100 / Prism |
+| Cin7 | multi-channel inventory and warehouse operations | current 2026 product |
+| Katana | visual manufacturing, planning, BOM, traceability | current 2026 product |
+| Shopify | commerce/order/inventory/POS/B2B benchmark | 2026 B2B/inventory |
+| Stripe | payments, billing, invoicing, tax, revenue recognition, workflows | UAE 2026 product set |
+| Xero / QuickBooks / Sage / FreshBooks | SMB accounting UX, bank reconciliation, invoicing | current product sets |
+| Glean | permission-aware semantic enterprise search/context | current 2026 platform |
+| WorkOS | enterprise SSO, SCIM/directory lifecycle, organizations, audit | current 2026 docs |
+| Zapier | massive app action surface and MCP | MCP August 2026 |
+| Make | transparent visual agent/workflow orchestration | next-gen AI Agents Feb 2026 |
+| n8n | deterministic + agentic workflows, self-hosting and governance | enterprise/agent governance 2026 |
+
+## Best patterns by capability
+
+| Capability | Best pattern observed | DABBIR lesson |
+|---|---|---|
+| ERP transactional core | SAP / NetSuite / Dynamics | canonical records and state machines before UI breadth |
+| Compact SMB ERP | Odoo / SAP Business One / Acumatica | progressive complexity, not consultant-first setup |
+| CRM/customer 360 | Salesforce / HubSpot | one customer timeline across sales, service and communication |
+| Finance | Oracle / SAP / NetSuite | immutable double-entry posting with close/reconciliation discipline |
+| Inventory/WMS | SAP / Acumatica / Cin7 | stock ledger; available/reserved/incoming are derived states |
+| Manufacturing | Epicor / Acumatica / Katana | BOM/MRP/traceability as optional industry capability |
+| Procurement | Oracle / SAP / Dynamics | request → approval → RFQ → PO → receipt → invoice → payment |
+| HR/HCM | Workday / Rippling / BambooHR | employee as shared business principal, not just HR record |
+| Approvals/BPM | ServiceNow / Dynamics / SAP | central approval engine reusable by every module |
+| Automation | Make / n8n / Zapier | deterministic flows + AI only for judgment; observable executions |
+| AI agent governance | Workday / ServiceNow / n8n | agent identity, least privilege, approvals, audit and kill switch |
+| Enterprise search | Glean / Rovo | permission-aware unified and semantic search |
+| Executive command center | ServiceNow / agent observability patterns | prioritize exceptions by impact, urgency, risk and deadline |
+| Identity lifecycle | WorkOS / enterprise IdPs | SSO + SCIM later; one-time invites for SMB now |
+| Observability | OpenTelemetry ecosystem | standard traces, metrics and logs from day one |
+
+## Research implications for DABBIR
+
+### Adopt
+- Canonical company/customer/product/employee/supplier identities.
+- Immutable inventory and finance ledgers.
+- One cross-module approval engine.
+- One event/outbox layer.
+- One permission evaluation service shared by humans, integrations and AI agents.
+- One customer/business timeline.
+- Permission-aware search.
+- AI action receipts: intent, evidence, policy, approval, before/after and result.
+
+### Avoid
+- Feature-per-page architecture.
+- Free-form status strings for financial/operational state.
+- Module-local duplicates of customer/product/supplier.
+- AI with service-role bypass.
+- Microservices before domain boundaries and transaction volume justify them.
+- Payroll or tax-compliance claims without jurisdiction verification.
+
+## Selected official sources
+
+- SAP Business One overview: https://www.sap.com/products/business-one.html
+- SAP Business One features: https://www.sap.com/products/erp/business-one/features.html
+- Microsoft Dynamics 365 release plans: https://learn.microsoft.com/en-us/dynamics365/release-plans/
+- Oracle Fusion Cloud readiness: https://docs.oracle.com/en/cloud/saas/readiness/
+- NetSuite 2026 readiness: https://docs.oracle.com/en/cloud/saas/readiness/netsuite/erp.html
+- NetSuite AI: https://docs.oracle.com/en/cloud/saas/netsuite/ns-online-help/book_5131850092.html
+- Odoo 19 documentation: https://www.odoo.com/documentation/19.0/
+- Salesforce Agentforce: https://www.salesforce.com/agentforce/
+- ServiceNow AI Agents: https://www.servicenow.com/products/ai-agents.html
+- WorkOS SSO: https://workos.com/docs/sso
+- WorkOS Directory Sync: https://workos.com/docs/directory-sync
+- Glean enterprise search: https://www.glean.com/enterprise-search
+- Make AI Agents: https://www.make.com/en/ai-agents
+- n8n AI Agents: https://n8n.io/ai-agents/
+- OpenTelemetry: https://opentelemetry.io/docs/
+- OWASP Agentic AI threats: https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/
+- NIST AI RMF: https://www.nist.gov/itl/ai-risk-management-framework
+
+## Research status
+
+**Baseline accepted for architecture decisions.** Vendor feature/licensing details remain time-sensitive and must be rechecked before commercial commitments or implementation that depends on a specific external product.

--- a/docs/archive/business-os-research-2026-08-26/02_ENTERPRISE_CAPABILITY_MAP.md
+++ b/docs/archive/business-os-research-2026-08-26/02_ENTERPRISE_CAPABILITY_MAP.md
@@ -1,0 +1,56 @@
+# 02 — Enterprise Capability Map
+
+**Snapshot:** 2026-08-26
+
+Priority legend: **P0** foundation, **P1** competitive core, **P2** advanced, **P3** later/industry-specific.
+
+| Domain | Capability set | Priority | Value test | Benchmark | DABBIR decision |
+|---|---|---:|---|---|---|
+| Company Core | tenant, organization, legal entity, company, branch, department, cost center, team, locale, currency, fiscal settings | P0 | control + scale | SAP, NetSuite, Dynamics | BUILD |
+| Identity | user, employee principal, session, one-time invite, permanent membership, MFA-ready, OAuth-ready | P0 | risk + productivity | WorkOS, Workday | BUILD core / INTEGRATE auth primitives |
+| Authorization | role templates, custom roles, RBAC, ABAC, record/field/resource scopes, branch/department scope, temporary elevation | P0 | risk + control | Workday, ServiceNow, Rippling | BUILD policy layer |
+| Audit | immutable write audit, actor/source/session, before/after, reason, approval, AI involvement | P0 | risk + trust | ServiceNow, Workday | BUILD |
+| Approvals | single, sequential, parallel, threshold, conditional, role-based, escalation, delegation, expiry | P0 | risk + control | ServiceNow, SAP, Dynamics | BUILD shared engine |
+| CRM | contacts, leads, source, scoring, opportunity, activities, tasks, pipeline, forecast, customer 360 | P0/P1 | revenue | Salesforce, HubSpot, Odoo | BUILD |
+| Customer Timeline | sales, invoices, messages, tickets, documents, payments, tasks in one chronological view | P0 | service + control | Salesforce | BUILD |
+| Sales | quote, pricing, discount policy, approval, order, fulfillment, invoice state, return, customer history | P0 | revenue + control | SAP, Odoo, NetSuite | BUILD |
+| Product | product, SKU, service, UOM, price lists, tax class, lifecycle | P0 | revenue + control | Odoo, SAP | BUILD |
+| Inventory | warehouse, location, stock ledger, on-hand, available, reserved, incoming, transfer, adjustment | P0 | cost + control | SAP, Cin7, Acumatica | BUILD |
+| Replenishment | reorder point, safety stock, lead time, suggested PO, demand signals | P1 | cost + productivity | Cin7, Katana | BUILD |
+| Traceability | lot/batch, serial, expiry, recall trace | P2 | risk | Katana, Epicor | BUILD as capability pack |
+| Procurement | supplier, purchase request, RFQ, supplier quote, selection, PO, receipt, supplier invoice, performance | P0/P1 | cost + control | Oracle, SAP | BUILD |
+| Finance Core | chart of accounts, journal, double-entry ledger, fiscal periods, posting rules, reversal | P0 | control | Oracle, SAP, NetSuite | BUILD carefully |
+| AR/AP | invoices, credit notes, receivables, payables, aging, allocations | P0/P1 | cash + control | NetSuite, Xero | BUILD |
+| Bank Reconciliation | imported transactions, matching, reconciliation status | P1 | time + control | Xero, NetSuite | BUILD + bank feed integrations |
+| Financial Reporting | trial balance, P&L, balance sheet, cash flow, cost centers | P1 | control | Oracle, SAP | BUILD from ledger |
+| Budget/Forecast | budgets, variance, scenario forecast | P2 | control | Oracle EPM, Dynamics | BUILD later |
+| Tax | tax codes, VAT treatment, tax evidence, returns-support data | P1 | compliance | UAE FTA + ERPs | BUILD rules framework; VERIFY jurisdiction |
+| Payments | payment intents/status/reconciliation, provider adapters | P0/P1 | revenue | Stripe | INTEGRATE rails; BUILD orchestration |
+| eInvoicing | structured invoice model, validation, ASP adapter, status/evidence | P0 architecture / P1 rollout | compliance | UAE MoF | INTEGRATE accredited provider |
+| Projects | project, customer, contract, budget, team, tasks, time, expense, invoice, profitability | P1 | revenue + productivity | Epicor, Dynamics, Asana | BUILD |
+| Tasks/Work | task, owner, due date, dependency, SLA, priority, state | P0 | productivity | Asana, monday, Jira | BUILD |
+| HR Core | employee profile, org chart, employment state, documents, leave, attendance | P1 | productivity + control | Workday, BambooHR, Rippling | BUILD HR core |
+| Payroll | payroll calculation, statutory rules, WPS output/integration | P2 | compliance | local providers/Deel | INTEGRATE first |
+| Recruitment | requisition, candidate, interview, offer, onboarding | P2 | productivity | BambooHR, Workday | DEFER/industry demand |
+| Performance | goals, review cycles, feedback | P2 | productivity | Workday, BambooHR | DEFER |
+| Service | ticket, SLA, queue, priority, resolution, knowledge | P1 | service | ServiceNow, Salesforce | BUILD |
+| Communications | conversation, participant, channel, message, attachments, consent | P1 | service | Salesforce, HubSpot | BUILD hub + adapters |
+| Omnichannel | WhatsApp, email, web, Instagram, SMS, voice adapters | P1/P2 | service | ServiceNow, Salesforce | INTEGRATE channels |
+| Documents | document, version, folder/tag, entity link, access, retention | P1 | control | SharePoint-like DMS patterns | BUILD metadata / INTEGRATE storage/e-sign |
+| E-sign | signature request/status/evidence | P2 | time | specialized providers | INTEGRATE |
+| Search | global lexical + semantic search across authorized entities | P1 | productivity | Glean, Rovo | BUILD permission-aware index |
+| Analytics | operational, sales, inventory, customer, supplier, financial metrics and drill-down | P1 | control | Dynamics, NetSuite | BUILD semantic metric layer |
+| Command Center | exceptions, impact, urgency, risk, deadline, responsible actor | P0/P1 | control | ServiceNow patterns | BUILD differentiated UX |
+| Workflow | trigger, condition, action, wait, branch, approval, retry, compensation | P0 | productivity | Make, n8n | BUILD core |
+| Integration | API, webhooks, connector credentials, sync state, rate limits, idempotency | P0 | scale | Zapier, Workato-style platforms | BUILD framework / INTEGRATE connectors |
+| AI Copilot | ask/explain/summarize across allowed business data | P1 | productivity | Joule, Copilot, Ask Oracle | BUILD |
+| AI Actions | READ, RECOMMEND, DRAFT, EXECUTE with policy checks | P0 architecture / P1 UX | productivity + control | Workday ASOR, ServiceNow | BUILD |
+| AI Agents | domain-scoped agent principals/tools/memory/risk | P2 after policy layer | productivity | ServiceNow, Workday, n8n | BUILD selectively |
+| Agent Control | inventory, identity, permission, approval, execution receipt, cost, trace, kill switch | P0 architecture | risk | Workday, ServiceNow | BUILD |
+| Observability | logs, metrics, traces, jobs, queues, connector health | P0 | reliability | OpenTelemetry | BUILD instrumentation |
+| Self-healing | safe retry, replay, reconciliation, drift detection, quarantine | P1 | reliability | resilient workflow patterns | BUILD bounded |
+| Industry Packs | configuration, forms, workflows, metrics, roles for retail/clinic/etc. | P2 | time-to-value | Odoo/SAP industry patterns | BUILD as metadata, never forks |
+
+## Capability quality gate
+
+A capability may move from map to implementation only when its spec contains: user/problem, measurable business value, priority, benchmark, BUILD/INTEGRATE/DEFER decision, dependencies, security impact, canonical entities, state machine, events, permissions, audit requirements and acceptance tests.

--- a/docs/archive/business-os-research-2026-08-26/03_COMPETITOR_MATRIX.md
+++ b/docs/archive/business-os-research-2026-08-26/03_COMPETITOR_MATRIX.md
@@ -1,0 +1,48 @@
+# 03 — Competitor Matrix
+
+**Snapshot:** 2026-08-26  
+Legend: **5** leading benchmark, **4** strong, **3** capable, **2** limited/secondary focus, **1** not a meaningful benchmark for this capability. Scores are architectural research aids, not procurement rankings.
+
+| Platform | ERP Core | CRM | Finance | Inventory/SCM | HR | Workflow/Approvals | AI/Agents | Search/Knowledge | SMB UX |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
+| SAP S/4HANA Cloud | 5 | 3 | 5 | 5 | 3 | 5 | 5 | 3 | 2 |
+| SAP Business One | 4 | 3 | 4 | 4 | 1 | 3 | 2 | 2 | 3 |
+| Dynamics 365 | 5 | 5 | 5 | 5 | 4 | 5 | 5 | 4 | 3 |
+| Oracle Fusion | 5 | 4 | 5 | 5 | 5 | 5 | 5 | 3 | 2 |
+| NetSuite / Next | 5 | 3 | 5 | 4 | 2 | 4 | 5 | 4 | 3 |
+| Odoo 19 | 4 | 4 | 4 | 4 | 4 | 4 | 4 | 3 | 5 |
+| Salesforce | 2 | 5 | 2 | 2 | 2 | 4 | 5 | 4 | 4 |
+| HubSpot | 1 | 5 | 1 | 1 | 1 | 3 | 4 | 3 | 5 |
+| Zoho | 3 | 4 | 3 | 3 | 3 | 4 | 4 | 3 | 5 |
+| ServiceNow | 2 | 3 | 1 | 2 | 3 | 5 | 5 | 4 | 3 |
+| Workday | 4 | 2 | 5 | 1 | 5 | 4 | 5 | 3 | 2 |
+| Rippling | 2 | 1 | 3 | 1 | 5 | 4 | 4 | 3 | 5 |
+| Deel | 1 | 1 | 3 | 1 | 5 | 3 | 4 | 2 | 5 |
+| BambooHR | 1 | 1 | 2 | 1 | 5 | 3 | 4 | 2 | 5 |
+| Acumatica | 5 | 3 | 5 | 5 | 2 | 4 | 4 | 3 | 4 |
+| Epicor Kinetic | 5 | 2 | 4 | 5 | 2 | 4 | 4 | 3 | 3 |
+| Shopify | 2 | 2 | 2 | 4 | 1 | 3 | 3 | 2 | 5 |
+| Cin7 | 2 | 1 | 1 | 5 | 1 | 3 | 3 | 1 | 4 |
+| Katana | 2 | 1 | 1 | 5 | 1 | 2 | 3 | 1 | 5 |
+| monday.com | 1 | 2 | 1 | 1 | 2 | 4 | 4 | 3 | 5 |
+| Asana | 1 | 1 | 1 | 1 | 2 | 4 | 4 | 3 | 5 |
+| Jira / Rovo | 1 | 2 | 1 | 1 | 1 | 5 | 5 | 5 | 4 |
+| Make | 1 | 1 | 1 | 1 | 1 | 5 | 5 | 2 | 5 |
+| n8n | 1 | 1 | 1 | 1 | 1 | 5 | 5 | 2 | 3 |
+| Glean | 1 | 1 | 1 | 1 | 1 | 2 | 5 | 5 | 4 |
+
+## What DABBIR should learn — not copy
+
+- **SAP/Oracle/Dynamics:** transaction integrity, cross-module state, approvals and financial discipline.
+- **Odoo:** breadth with progressive usability; app-like module activation.
+- **Salesforce/HubSpot:** customer timeline, pipeline clarity and fast task execution.
+- **ServiceNow:** central workflow/approval engine, work queues, governance and exception handling.
+- **Workday/Rippling:** organization + employee graph as an access and automation source.
+- **NetSuite:** unified company data enabling AI across modules.
+- **Acumatica/Epicor/Cin7/Katana:** inventory/manufacturing truth from movements, planning and traceability.
+- **Glean/Rovo:** permission-aware company search and contextual answers.
+- **Make/n8n/Zapier:** visible automation, connectors and deterministic/agentic composition.
+
+## Strategic white space for DABBIR
+
+DABBIR should compete on a combination rather than a single module: **UAE/GCC-native readiness + zero-training bilingual UX + unified SMB ERP core + policy-bound conversational execution + exception-first management.** These are differentiation opportunities, not claims that no competitor can implement them.

--- a/docs/archive/business-os-research-2026-08-26/04_DABBIR_GAP_ANALYSIS.md
+++ b/docs/archive/business-os-research-2026-08-26/04_DABBIR_GAP_ANALYSIS.md
@@ -1,0 +1,67 @@
+# 04 — DABBIR Business OS Gap Analysis
+
+**Snapshot:** 2026-08-26  
+**Evidence base:** isolated branch `dabbir-business-os-v1`; current manifest status is `foundation`. A module name in the manifest is not evidence of an implemented capability.
+
+## Current verified baseline
+
+`business-os/modules.json` declares the intended domains: company-core, CRM, sales, inventory, procurement, operations, finance-lite, hr-lite, communications, automation-engine, dabbir-ai and governance. It also fixes hard rules: separate from current DABBIR, no production mutation, multi-tenant, RLS required, audit every business write and AI permission enforcement.
+
+The current Business OS preview is a **foundation preview**, not proof that ERP transactions, ledgers, permissions or integrations are complete.
+
+## Gap matrix
+
+| Capability | Current | Gap class | Priority | Required outcome |
+|---|---|---|---:|---|
+| Product isolation | separate branch + preview | DABBIR_CURRENT | P0 | separate runtime/database/config target before real data |
+| Tenant/company hierarchy | design intent only | DABBIR_REQUIRED | P0 | tenant→org→company/legal entity→branch→department/cost center |
+| Employee membership | reusable concepts exist in current DABBIR, not Business OS isolated runtime | DABBIR_REQUIRED | P0 | one-time invite→permanent membership in isolated store |
+| Permission model | high-level rule only | DABBIR_MISSING | P0 | RBAC + ABAC scopes + field/resource restrictions |
+| Audit ledger | hard rule only | DABBIR_MISSING | P0 | append-only audit events for every business write |
+| Approval engine | issue/roadmap intent | DABBIR_MISSING | P0 | central reusable approval definitions + instances |
+| Canonical master data | not implemented | DABBIR_MISSING | P0 | party/customer/supplier/product/employee identities |
+| CRM | module declared | DABBIR_MISSING | P0 | lead/opportunity/activity/customer timeline |
+| Sales lifecycle | module declared | DABBIR_MISSING | P0 | quote→approval→order→fulfillment→invoice→payment state |
+| Inventory ledger | module declared | DABBIR_MISSING | P0 | immutable stock movements + reservations |
+| Procurement lifecycle | module declared | DABBIR_MISSING | P0 | request/RFQ/PO/receipt/invoice/payment linkage |
+| Finance double-entry | only `finance-lite` label | DABBIR_WEAK | P0 | real journal/posting model before financial claims |
+| AR/AP | absent | DABBIR_MISSING | P1 | receivable/payable subledger and aging |
+| Bank reconciliation | absent | DABBIR_MISSING | P1 | provider-neutral imported transaction matching |
+| UAE eInvoice | absent | DABBIR_REQUIRED | P0 architecture | structured invoice + Accredited Service Provider adapter |
+| Tax framework | absent | DABBIR_REQUIRED | P1 | versioned jurisdiction rules and evidence |
+| Projects/PSA | absent from initial manifest | DABBIR_REQUIRED | P1 | project/customer/budget/team/time/expense/invoice/profitability |
+| HR core | `hr-lite` only | DABBIR_WEAK | P1 | employee lifecycle/org/leave/attendance/docs |
+| Payroll/WPS | absent | DABBIR_ADVANCED | P2 | integration-first, UAE legal verification required |
+| Service/helpdesk | absent | DABBIR_REQUIRED | P1 | ticket/SLA/queue/knowledge/customer timeline |
+| Omnichannel | communications module only | DABBIR_WEAK | P1 | channel adapters + unified conversation identity |
+| DMS | absent | DABBIR_REQUIRED | P1 | versioned docs, entity links, retention/access metadata |
+| Global search | absent | DABBIR_REQUIRED | P1 | permission-aware lexical + semantic retrieval |
+| Analytics semantic layer | preview metrics are not business analytics | DABBIR_MISSING | P1 | defined metrics with source-of-truth and drill-down |
+| Command Center | concept only | DABBIR_DIFFERENTIATOR | P0/P1 | exception queue ranked by business impact |
+| Workflow engine | module declared | DABBIR_MISSING | P0 | durable WHEN/IF/THEN with retries/idempotency/approvals |
+| Event bus/outbox | absent | DABBIR_MISSING | P0 | transactional outbox + versioned domain events |
+| API platform | absent as Business OS contract | DABBIR_REQUIRED | P0 | versioned API, idempotency, webhooks, rate controls |
+| AI read/explain | module declared | DABBIR_WEAK | P1 | permission-filtered context retrieval |
+| AI actions | policy rule only | DABBIR_REQUIRED | P0 architecture | READ/RECOMMEND/DRAFT/EXECUTE gates |
+| AI agent identity | absent | DABBIR_DIFFERENTIATOR | P0 architecture | explicit agent principal, scope, execution mode and trace |
+| Observability | absent in isolated runtime | DABBIR_MISSING | P0 | traces, metrics, logs, jobs, integration health |
+| Self-healing | absent | DABBIR_ADVANCED | P1/P2 | bounded retries/reconciliation/quarantine; no sensitive bypass |
+| SSO/SCIM | absent | DABBIR_ADVANCED | P2 | enterprise identity integration after SMB auth core |
+| Industry packs | absent | DABBIR_ADVANCED | P2 | metadata/config packs, never code forks |
+
+## Immediate P0 gaps that block feature building
+
+1. Separate data/runtime boundary.
+2. Canonical identity/company hierarchy.
+3. Permission/policy engine.
+4. Immutable audit.
+5. Central approval engine.
+6. Transactional event/outbox layer.
+7. Canonical customer/product/supplier/employee masters.
+8. Finance and inventory ledger invariants.
+9. API/idempotency contract.
+10. AI action governance.
+
+## Gate
+
+No module can be marked complete because a page exists. Completion requires persisted canonical data, permissions, audit event, state transition rules, API contract, failure handling and an end-to-end acceptance test.

--- a/docs/archive/business-os-research-2026-08-26/05_DABBIR_TARGET_ARCHITECTURE.md
+++ b/docs/archive/business-os-research-2026-08-26/05_DABBIR_TARGET_ARCHITECTURE.md
@@ -1,0 +1,221 @@
+# 05 — DABBIR Business OS Target Architecture
+
+**Architecture decision baseline:** 2026-08-26
+
+## 1. Architecture style
+
+Start as a **modular monolith with explicit domain boundaries**, not microservices.
+
+Why:
+- DABBIR needs cross-module transactional integrity before independent service scaling.
+- Sales, inventory, finance and approvals frequently need one reliable transaction boundary.
+- A modular monolith is simpler to operate for an early product while still allowing extraction later.
+- Domain events and API contracts should be designed now so high-load modules can be separated without rewriting the business model.
+
+## 2. Logical layers
+
+```text
+Web / Mobile / API Clients
+        ↓
+API Gateway / Session / Rate Limits / Idempotency
+        ↓
+Authorization Policy + Approval Check
+        ↓
+Application Commands / Queries
+        ↓
+Domain Modules
+        ↓
+PostgreSQL Canonical Store
+        ↓
+Transactional Outbox → Workers / Webhooks / Search / Analytics
+```
+
+AI does **not** bypass this stack:
+
+```text
+User Intent
+  → AI Planner
+  → Tool Proposal
+  → Policy Evaluation
+  → Approval if needed
+  → Same Application Command used by human/API
+  → Transaction
+  → Audit + AI Execution Receipt
+```
+
+## 3. Domain modules
+
+### Foundation
+- tenancy
+- organization/company hierarchy
+- identity/membership
+- authorization/policy
+- audit
+- approvals
+- workflows
+- events/outbox
+- integrations
+- notifications
+
+### Commercial
+- parties/customer/contact
+- CRM/lead/opportunity
+- product/catalog/pricing
+- sales/quotes/orders
+- fulfillment/returns
+- service/tickets
+
+### Supply
+- suppliers
+- procurement
+- inventory/warehouses/locations
+- receiving
+- replenishment
+- optional manufacturing/traceability pack
+
+### Finance
+- chart of accounts
+- journal/posting
+- AR/AP
+- invoice/credit note/payment allocation
+- tax framework
+- bank reconciliation
+- financial reporting
+- eInvoice adapter
+
+### People & Work
+- employee/org
+- tasks/projects
+- leave/attendance
+- documents
+- payroll integration adapter
+
+### Intelligence
+- metric definitions
+- analytics read models
+- enterprise search
+- command center
+- AI context/tools/policies
+- agent registry/control
+
+## 4. Database principles
+
+Use PostgreSQL with:
+- UUID/ULID-style stable IDs.
+- explicit `tenant_id` on every tenant-scoped business row.
+- foreign keys and unique constraints.
+- money stored as decimal/numeric with explicit currency.
+- timestamps stored in UTC; business timezone stored separately.
+- state-machine enums/reference tables for critical lifecycle state.
+- soft deletion only for mutable master records where legally/business appropriate.
+- no deletion/update of posted finance or stock ledger entries; use reversal/compensating records.
+- row-level isolation as defense in depth, not the only authorization layer.
+
+## 5. Event architecture
+
+Use a **transactional outbox** in the same DB transaction as the business write.
+
+Event envelope:
+
+```json
+{
+  "event_id": "...",
+  "event_type": "sales_order.confirmed.v1",
+  "tenant_id": "...",
+  "entity_type": "sales_order",
+  "entity_id": "...",
+  "actor_type": "user|agent|integration|system",
+  "actor_id": "...",
+  "occurred_at": "...",
+  "correlation_id": "...",
+  "causation_id": "...",
+  "schema_version": 1,
+  "payload": {}
+}
+```
+
+Consumers must be idempotent. Failed deliveries move to retry/dead-letter state with observable reason.
+
+## 6. API-first contract
+
+- `/api/v1/...` versioning.
+- authorization enforced server-side on every operation.
+- idempotency keys required for create/payment/posting/external action APIs.
+- optimistic version or `updated_at` checks for collision-sensitive edits.
+- cursor pagination.
+- structured errors with stable error codes.
+- signed outbound webhooks with replay protection.
+- OAuth/client credentials only for approved integration principals.
+- OpenAPI schema generated/tested as a release artifact.
+
+## 7. Search architecture
+
+V1:
+- PostgreSQL full-text/trigram for deterministic search.
+- vector embeddings only for approved semantic fields/documents.
+- search index rows carry tenant + ACL/scope metadata.
+- authorization is evaluated before result disclosure.
+
+Later, external search infrastructure may replace the index, but the **permission contract remains DABBIR-owned**.
+
+## 8. Workflow runtime
+
+A workflow definition is metadata, not executable arbitrary code by default.
+
+Nodes:
+- trigger
+- condition
+- deterministic action
+- AI judgment step
+- approval
+- wait/timer
+- branch
+- webhook/integration
+- notification
+- compensation
+
+Execution requires durable state, retry count, idempotency key, correlation ID, actor and audit linkage.
+
+## 9. Observability
+
+Adopt OpenTelemetry-compatible instrumentation for:
+- traces
+- metrics
+- logs
+
+Business-specific telemetry:
+- command latency/error rate
+- outbox backlog
+- job retry/dead-letter count
+- webhook failure rate
+- integration health
+- approval aging
+- AI tool failure/approval/rejection rates
+- token/model cost by tenant and feature
+
+Owner UI exposes only `Operational`, `Degraded`, `Action required`; engineering retains detail.
+
+## 10. Deployment boundaries
+
+Business OS must have its own:
+- environment variables
+- database/schema boundary
+- auth redirect configuration
+- queues/jobs
+- storage namespace
+- encryption/secrets scope
+- observability service/environment tags
+- preview and production deployment targets
+
+No Business OS migration may run against the current DABBIR production database.
+
+## 11. Extraction criteria for future microservices
+
+Only extract a module when there is evidence of one or more:
+- independent scale profile
+- independent security boundary
+- high deployment frequency conflict
+- specialized persistence/runtime need
+- operational blast-radius benefit
+
+Likely future candidates: communications delivery, document processing, search indexing, AI execution workers, analytics pipelines. Finance and inventory transaction cores should remain strongly consistent unless a proven architecture preserves their invariants.

--- a/docs/archive/business-os-research-2026-08-26/06_DABBIR_CANONICAL_DATA_MODEL.md
+++ b/docs/archive/business-os-research-2026-08-26/06_DABBIR_CANONICAL_DATA_MODEL.md
@@ -1,0 +1,286 @@
+# 06 — DABBIR Canonical Enterprise Data Model
+
+**Snapshot:** 2026-08-26
+
+## Core rule
+
+There is one canonical identity for a business concept. Modules reference it; they do not clone it.
+
+Example: one `party/customer` identity is referenced by CRM, sales, finance, support, projects, communications and AI context.
+
+## A. Organization graph
+
+```text
+Tenant
+ └─ Organization
+     ├─ LegalEntity / Company
+     │   ├─ Branch
+     │   ├─ Department
+     │   ├─ CostCenter
+     │   └─ Warehouse
+     └─ Team
+```
+
+### Entities
+- `tenant`
+- `organization`
+- `legal_entity`
+- `branch`
+- `department`
+- `cost_center`
+- `team`
+- `business_calendar`
+- `fiscal_period`
+- `currency`
+- `exchange_rate`
+
+## B. Identity and people
+
+- `user` — authentication identity.
+- `employee` — employment/business-person record; may link to one user.
+- `membership` — user/employee access to tenant/company scope.
+- `role`
+- `permission`
+- `role_permission`
+- `policy_rule`
+- `scope_binding`
+- `employee_invitation`
+- `delegation`
+- `approval_authority`
+- `agent_principal`
+- `integration_principal`
+
+**Invariant:** invitation token is one-time and never becomes the permanent credential. Acceptance creates/activates membership; later login uses normal authentication.
+
+## C. Party master
+
+Use a shared `party` concept to reduce duplicate identities.
+
+- `party` — person or organization.
+- `party_person`
+- `party_organization`
+- `party_contact_point` — email/phone/address/channel handle.
+- `customer_account`
+- `supplier_account`
+- `contact_relationship`
+- `party_tag`
+
+A party may be both customer and supplier without duplication.
+
+## D. CRM
+
+- `lead`
+- `lead_source`
+- `opportunity`
+- `opportunity_stage`
+- `activity`
+- `note`
+- `sales_pipeline`
+- `sales_forecast_snapshot`
+
+**Conversion:** lead conversion creates/links canonical party/customer and opportunity; it does not copy contact data into a second customer universe.
+
+## E. Product/catalog
+
+- `product`
+- `sku`
+- `service_item`
+- `unit_of_measure`
+- `price_list`
+- `price_list_item`
+- `tax_class`
+- `product_category`
+- `barcode`
+
+## F. Sales and fulfillment
+
+- `quote`
+- `quote_line`
+- `sales_order`
+- `sales_order_line`
+- `sales_order_reservation`
+- `delivery`
+- `delivery_line`
+- `return_authorization`
+- `return_receipt`
+
+State examples:
+
+```text
+Quote: DRAFT → SENT → ACCEPTED | REJECTED | EXPIRED
+Order: DRAFT → PENDING_APPROVAL → CONFIRMED → FULFILLING → FULFILLED → CLOSED
+      ↘ CANCELLED
+```
+
+Transitions must be explicit and audited.
+
+## G. Inventory
+
+- `warehouse`
+- `storage_location`
+- `stock_ledger_entry`
+- `stock_reservation`
+- `stock_transfer`
+- `stock_adjustment_request`
+- `inventory_count`
+- `lot_batch`
+- `serial_number`
+- `expiry_record`
+- `replenishment_policy`
+
+**Critical invariant:** on-hand/available/reserved/incoming values are derived from ledgers/reservations/open receipts; no privileged UI may silently overwrite stock truth.
+
+## H. Procurement
+
+- `supplier_account`
+- `purchase_request`
+- `purchase_request_line`
+- `rfq`
+- `supplier_quote`
+- `supplier_quote_line`
+- `purchase_order`
+- `purchase_order_line`
+- `goods_receipt`
+- `goods_receipt_line`
+- `supplier_performance_snapshot`
+
+Lifecycle:
+
+```text
+Purchase Request → Approval → RFQ → Supplier Quote → Selection → PO → Goods Receipt → Supplier Invoice → Payment
+```
+
+## I. Finance
+
+- `chart_of_accounts`
+- `account`
+- `journal`
+- `journal_entry`
+- `journal_line`
+- `posting_batch`
+- `invoice`
+- `invoice_line`
+- `credit_note`
+- `payment`
+- `payment_allocation`
+- `expense`
+- `bank_account`
+- `bank_transaction`
+- `reconciliation`
+- `tax_transaction`
+- `budget`
+
+**Double-entry invariant:** every posted journal entry is balanced per currency/posting rules. Posted entries are immutable; errors are corrected through reversal/correction entries.
+
+## J. Projects/work
+
+- `project`
+- `project_milestone`
+- `task`
+- `task_dependency`
+- `time_entry`
+- `project_expense`
+- `resource_assignment`
+- `contract`
+
+Project can link customer, contract, budget, cost center, sales order and invoices, enabling actual profitability.
+
+## K. HR
+
+- `employee`
+- `employment`
+- `position`
+- `org_assignment`
+- `leave_request`
+- `attendance_record`
+- `shift`
+- `performance_cycle`
+- `employee_document`
+- `offboarding_case`
+
+Payroll is initially an integration boundary; DABBIR may store payroll run status/evidence without claiming to be a statutory payroll engine.
+
+## L. Service and communications
+
+- `ticket`
+- `sla_policy`
+- `conversation`
+- `conversation_participant`
+- `message`
+- `channel_account`
+- `consent_record`
+- `handoff`
+- `followup`
+
+All customer-facing events can appear in `customer_timeline_event`, preferably as a read model built from authoritative entities/events.
+
+## M. Documents
+
+- `document`
+- `document_version`
+- `document_link` — entity-to-document relationship.
+- `document_acl`
+- `retention_policy`
+- `signature_request`
+
+Blob storage is external/object storage; metadata/access/audit remain canonical in DABBIR.
+
+## N. Workflow/approval/integration
+
+- `workflow_definition`
+- `workflow_version`
+- `workflow_execution`
+- `workflow_step_execution`
+- `approval_policy`
+- `approval_request`
+- `approval_step`
+- `approval_decision`
+- `integration_connection`
+- `webhook_endpoint`
+- `webhook_delivery`
+- `outbox_event`
+- `dead_letter_event`
+
+## O. AI governance
+
+- `ai_agent_definition`
+- `agent_principal`
+- `ai_tool_definition`
+- `ai_policy_binding`
+- `ai_execution`
+- `ai_tool_call`
+- `ai_approval_link`
+- `ai_execution_receipt`
+- `ai_cost_record`
+
+## P. Audit
+
+`audit_event` minimum fields:
+- event_id
+- tenant_id
+- actor_type / actor_id
+- session_or_execution_id
+- action
+- entity_type / entity_id
+- occurred_at
+- source
+- reason
+- before_hash / before_json where permitted
+- after_hash / after_json where permitted
+- approval_request_id
+- ai_execution_id
+- correlation_id
+- request_id
+
+Sensitive fields must be redacted/tokenized in audit payloads; auditability does not justify duplicating secrets.
+
+## Cross-domain invariants
+
+1. Every tenant-scoped row carries tenant ownership.
+2. Every business write emits an audit event.
+3. Every externally retryable mutation has an idempotency key.
+4. Posted finance and stock entries are immutable.
+5. Critical state changes use explicit state machines.
+6. Money always has amount + currency; no floating-point money.
+7. AI/integrations are principals, never invisible superusers.
+8. Deleting a master record cannot orphan historical transactional evidence.

--- a/docs/archive/business-os-research-2026-08-26/07_DABBIR_PERMISSION_MODEL.md
+++ b/docs/archive/business-os-research-2026-08-26/07_DABBIR_PERMISSION_MODEL.md
@@ -1,0 +1,234 @@
+# 07 — DABBIR Permission Model
+
+**Snapshot:** 2026-08-26
+
+## Principle
+
+DABBIR must authorize **the action on the resource in its business context**, not merely check whether the user has a role name.
+
+Use:
+
+**RBAC templates + ABAC conditions + resource/field scopes + approval authority.**
+
+## Principal types
+
+- `user`
+- `employee`
+- `agent_principal`
+- `integration_principal`
+- `system_worker`
+
+Every principal has an ID, tenant, status, authentication method, role/policy bindings and audit identity.
+
+## Default role templates
+
+- Owner
+- Super Admin
+- Admin
+- Manager
+- Supervisor
+- Employee
+- Accountant
+- Sales
+- Customer Service
+- Warehouse
+- Procurement
+- HR
+- Auditor
+- Custom Role
+
+Templates are onboarding conveniences, not hard-coded authorization logic.
+
+## Permission grammar
+
+Use stable permissions such as:
+
+```text
+crm.customer.read
+crm.customer.write
+sales.quote.create
+sales.discount.apply
+sales.order.confirm
+inventory.stock.read
+inventory.adjustment.request
+inventory.adjustment.approve
+procurement.po.create
+procurement.po.approve
+finance.invoice.issue
+finance.journal.post
+finance.payment.approve
+hr.employee.read
+hr.compensation.read
+workflow.manage
+audit.read
+ai.execute
+```
+
+## Scope dimensions
+
+A permission can be narrowed by:
+- tenant
+- company/legal entity
+- branch
+- department
+- cost center
+- team
+- record ownership
+- customer/account portfolio
+- warehouse
+- project
+- data classification
+- amount threshold
+- time window
+- temporary elevation expiry
+
+Example:
+
+```text
+permission = finance.invoice.read
+company_id = COMPANY_A
+branch_id = ABU_DHABI
+amount_max = null
+```
+
+A Dubai employee does not inherit Abu Dhabi visibility simply because both hold `Sales`.
+
+## Field-level controls
+
+Sensitive fields can have separate policy checks:
+- salary/compensation
+- bank account
+- national identifiers
+- cost/margin
+- customer credit limit
+- private HR notes
+- secrets/tokens
+
+Example: Sales may read product sell price but not supplier landed cost unless granted.
+
+## Record ownership
+
+Support policies such as:
+- own records
+- team records
+- department records
+- branch records
+- all company records
+
+Ownership is one attribute in policy evaluation; it does not replace roles.
+
+## Employee access lifecycle
+
+```text
+OWNER/ADMIN CREATES INVITE
+  → random one-time token hash stored
+  → email/link/optional QR delivered
+  → invite expires or is revoked if unused
+  → employee authenticates/verifies identity
+  → invite accepted exactly once
+  → permanent membership activated
+  → invite token invalidated
+  → normal secure login thereafter
+```
+
+Invitation status:
+`PENDING → ACCEPTED | EXPIRED | REVOKED`
+
+Membership status:
+`ACTIVE → SUSPENDED → ACTIVE | TERMINATED`
+
+Resending creates a new token and invalidates the prior token where security policy requires.
+
+## Enterprise identity path
+
+SMB V1: password + verified email; OAuth/social providers can be integrated.  
+Enterprise later: SAML/OIDC SSO + SCIM/Directory Sync.
+
+WorkOS research reinforces that enterprise customers expect automatic provisioning/deprovisioning and group sync. DABBIR should preserve an identity-provider-neutral internal membership model so an enterprise directory can become a lifecycle source without replacing DABBIR authorization.
+
+## Approval authority
+
+Permission to **request** an action differs from authority to **approve** it.
+
+An authority rule can depend on:
+- action/resource type
+- company/branch
+- amount/currency
+- department/cost center
+- risk class
+- requester role
+- segregation-of-duties rule
+
+Example:
+
+```text
+Purchase order <= 5,000 AED → Procurement Manager
+5,000–50,000 AED → Procurement Manager + Finance Manager
+> 50,000 AED → Finance Manager + Owner/CFO
+```
+
+Threshold values are tenant configuration, not product constants.
+
+## Approval modes
+
+- single
+- sequential
+- parallel
+- threshold-based
+- conditional
+- role/group-based
+- named approver
+- escalation
+- delegation
+- expiry
+
+Approval instance must snapshot the policy/version used so later policy edits cannot rewrite history.
+
+## Segregation of duties
+
+P0 controls:
+- requester should not approve own sensitive request unless explicit exceptional policy.
+- journal preparer vs poster can be separated.
+- payment creator vs approver can be separated.
+- stock adjustment requester vs approver can be separated.
+- employee compensation editor vs payroll approver can be separated.
+
+## AI permissions
+
+An AI agent never receives blanket service-role access.
+
+Two execution modes:
+
+### Delegate mode
+Effective permission = intersection of:
+`agent tool scope ∩ initiating user's effective permission ∩ current resource policy`.
+
+### Service mode
+Agent uses its own tightly-scoped principal and can operate only inside explicitly assigned domains/tools. High-risk actions still enter the approval engine.
+
+Every AI action records:
+- initiating human/system
+- agent principal
+- permission decision
+- tool called
+- proposed vs executed action
+- approval
+- before/after
+- result
+
+## Policy evaluation order
+
+1. Principal active?
+2. Tenant/resource relationship valid?
+3. Permission granted by role/custom policy?
+4. Scope/ABAC conditions pass?
+5. Field restrictions pass?
+6. Segregation-of-duties constraints pass?
+7. Does action require approval?
+8. If approved, is approval valid/current/unspent?
+9. Execute command.
+10. Audit decision + outcome.
+
+## Fail-closed rule
+
+Unknown principal, missing scope, stale approval, ambiguous company or failed policy evaluation must deny the mutation. The UI may explain the next allowed step; backend authorization cannot guess.

--- a/docs/archive/business-os-research-2026-08-26/08_DABBIR_MODULE_ROADMAP.md
+++ b/docs/archive/business-os-research-2026-08-26/08_DABBIR_MODULE_ROADMAP.md
@@ -1,0 +1,151 @@
+# 08 — DABBIR Business OS Module Roadmap
+
+**Snapshot:** 2026-08-26
+
+The roadmap prioritizes cross-cutting foundations before visible feature breadth.
+
+## P0 — Business OS Foundation
+
+### Platform boundary
+- separate Business OS runtime/environment
+- isolated database/schema/storage/secrets
+- production protection guard
+- bilingual Arabic RTL / English LTR design system
+
+### Company Core
+- tenant / organization / legal entity / company
+- branch / department / cost center / team
+- currency / timezone / locale / business calendar
+
+### Identity & Governance
+- user/employee/member separation
+- one-time invite → permanent membership
+- RBAC + ABAC policy service
+- resource/field/branch/department scopes
+- immutable audit
+- approval engine
+- agent/integration principals
+
+### Platform mechanics
+- versioned API
+- idempotency
+- transactional outbox/events
+- durable jobs/retries/dead letters
+- notifications
+- OpenTelemetry-compatible observability
+
+### Canonical commercial core
+- party/customer/contact
+- supplier
+- product/SKU/service/UOM
+- CRM lead/opportunity/activity
+- quote
+- sales order
+- warehouse/location
+- stock ledger/reservation
+- purchase request/PO/receipt
+
+### Finance foundation
+- chart of accounts
+- journal/journal lines
+- double-entry posting/reversal
+- invoice/payment/credit-note canonical states
+- fiscal period primitives
+- UAE eInvoice-compatible invoice data shape and provider adapter boundary
+
+### AI governance foundation
+- READ / RECOMMEND / DRAFT / EXECUTE classes
+- policy-gated tool calls
+- approval handoff
+- execution receipts
+- model/provider abstraction
+- no AI superuser
+
+### P0 acceptance journey
+
+```text
+Create company
+→ create branch + roles
+→ invite employee once
+→ employee accepts and logs in normally
+→ create customer
+→ create product
+→ create quote
+→ approve discount if policy requires
+→ convert to sales order
+→ reserve stock
+→ fulfill
+→ issue invoice
+→ record payment state
+→ finance/inventory/audit reflect the full chain
+→ owner asks AI what happened and receives source-linked explanation
+```
+
+## P1 — Competitive Operating Suite
+
+- AR/AP and aging
+- bank transaction import/reconciliation
+- supplier RFQ and supplier performance
+- reorder/safety stock/replenishment suggestions
+- returns/refunds
+- tasks/projects/time/expense/profitability
+- helpdesk/SLA/knowledge
+- unified communication hub
+- document metadata/versioning/access
+- global permission-aware search
+- semantic metric layer and drill-down analytics
+- DABBIR Command Center
+- workflow visual builder
+- integration management UI/webhooks
+- safe self-healing for retry/reconciliation/quarantine
+- AI executive briefings and grounded cross-module analysis
+
+## P2 — Advanced / Growth Company
+
+- multi-company consolidation support
+- advanced budgeting/forecasting
+- advanced treasury/cash planning
+- lot/batch/serial/expiry traceability
+- manufacturing/BOM/MRP/APS pack where demanded
+- asset management
+- contract lifecycle
+- recruitment/performance/compensation
+- payroll/WPS integrations
+- SSO/SAML/OIDC
+- SCIM/Directory Sync
+- e-sign integration
+- advanced AI domain agents
+- industry packs: retail, clinic, salon, real estate, services, maintenance, e-commerce
+
+## P3 — Enterprise Expansion
+
+- advanced consolidation/EPM
+- sophisticated GRC/risk controls
+- global payroll engines or deeper country packs where justified
+- advanced workforce planning
+- supply planning/network optimization
+- advanced manufacturing/quality/PLM
+- marketplace/SDK ecosystem
+- multi-region data residency options
+- complex intercompany automation
+- enterprise master-data governance workflows
+
+## Release gating
+
+A module is not “done” until it has:
+1. canonical schema and state machine
+2. server-side authorization
+3. approval integration if sensitive
+4. audit events
+5. API contract
+6. idempotent external mutation handling
+7. observability
+8. failure/retry behavior
+9. Arabic/English UX
+10. automated acceptance tests
+11. source-of-truth mapping for analytics
+12. no fake/demo operational data in production
+
+## No-bloat rule
+
+Any requested feature that does not measurably save time, reduce cost, increase revenue, reduce risk, improve control, improve customer service or improve employee productivity is deferred.

--- a/docs/archive/business-os-research-2026-08-26/09_DABBIR_AI_ARCHITECTURE.md
+++ b/docs/archive/business-os-research-2026-08-26/09_DABBIR_AI_ARCHITECTURE.md
@@ -1,0 +1,229 @@
+# 09 — DABBIR AI Architecture
+
+**Snapshot:** 2026-08-26
+
+## Position
+
+DABBIR AI is an **operating layer over governed business capabilities**, not a chatbot bolted onto an ERP.
+
+The same business command must be used whether triggered by a button, API integration or AI. AI never writes tables directly.
+
+## Action classes
+
+### READ
+Retrieve authorized data and explain it.
+
+Examples:
+- Which invoices are overdue?
+- What stock is available in Abu Dhabi?
+
+### RECOMMEND
+Analyze data and propose a next action without creating business state.
+
+Examples:
+- Recommend replenishment quantities.
+- Rank late accounts by collection priority.
+
+### DRAFT
+Create a reversible draft that a human may review/edit.
+
+Examples:
+- draft quote
+- draft purchase request
+- draft customer reply
+
+### EXECUTE
+Commit a real business action through the normal application command path.
+
+Examples:
+- assign task
+- approve a permitted routine item
+- issue an approved purchase order
+
+`EXECUTE` is never implied by conversational fluency. It requires explicit tool permission and, where policy says so, approval.
+
+## Agent principal model
+
+Each operational agent has:
+- `agent_principal_id`
+- domain
+- allowed tools
+- tenant/company scopes
+- data classifications
+- execution mode
+- model/provider policy
+- cost budget
+- risk tier
+- kill switch
+- owner
+- version
+
+### Delegate mode
+The agent acts for an initiating user. Effective access is the intersection of user access, agent tool scope and resource policy.
+
+### Service mode
+The agent has its own narrow permissions for scheduled/background work. It does not inherit owner/admin power.
+
+This follows the market direction seen in Workday agent identity, ServiceNow AI governance, n8n workflow-level guardrails and Microsoft/Oracle human-in-the-loop execution.
+
+## AI request pipeline
+
+```text
+Intent
+→ classify domain/risk
+→ retrieve authorized context
+→ create plan
+→ select typed tool
+→ validate tool arguments
+→ policy evaluation
+→ approval checkpoint if required
+→ execute normal command
+→ verify outcome
+→ produce execution receipt
+→ audit + telemetry
+```
+
+## Tool design
+
+Tools must be narrow and typed. Prefer:
+- `get_customer_balance(customer_id)`
+- `draft_purchase_request(items, warehouse_id)`
+- `submit_purchase_request(request_id)`
+
+Avoid:
+- `run_sql`
+- `admin_action`
+- unrestricted HTTP
+- generic mutation tools
+
+Every tool defines:
+- purpose
+- input schema
+- output schema
+- permission required
+- risk class
+- whether approval may be required
+- idempotency behavior
+- data classification
+- timeout/retry policy
+
+## Agent separation rule
+
+Do not create one agent per menu page.
+
+Create a separate agent only when **domain, permissions, tools, context or risk** are materially different.
+
+Candidate later-stage agents:
+- Executive Agent
+- Finance Agent
+- Sales Agent
+- Inventory/Procurement Agent
+- Customer Service Agent
+- People/HR Agent
+
+P0 can use one orchestrator with domain-specific tool bundles and policies; specialization comes when there is operational evidence for it.
+
+## DABBIR Executive AI
+
+Question: `ماذا يحدث في شركتي؟`
+
+Response contract:
+- What happened
+- Why it matters
+- Evidence/source records
+- Business impact
+- Risk/confidence
+- Recommended action
+- Responsible person/team
+- Suggested deadline
+- Action buttons only for permitted actions
+
+Inputs may include sales, cash, inventory, supplier, customer, project, people and system-health signals, always filtered by the viewer's access.
+
+## Grounding
+
+Priority order:
+1. canonical transactional data
+2. approved business definitions/metric layer
+3. authorized documents/knowledge
+4. approved connected sources
+5. web/external research only when task explicitly permits it
+
+Business answers should cite internal record IDs/links where useful. Search retrieval must enforce tenant and ACL filters before prompt construction.
+
+## Memory
+
+Separate:
+- short conversation context
+- user preferences
+- business knowledge
+- agent execution state
+
+Never let conversational memory become authoritative financial/stock/customer state. Authoritative state is always the canonical store.
+
+## High-risk actions
+
+Always policy/approval gated by default:
+- money movement/payment approval
+- journal posting/period close
+- refunds above configured threshold
+- supplier banking changes
+- payroll/compensation changes
+- employee termination/access elevation
+- bulk deletion/export
+- legal/compliance submissions
+- credential/security changes
+
+## AI execution receipt
+
+For each consequential AI run store:
+
+```text
+intent
+agent/version/model
+initiator
+retrieved source references
+plan summary
+proposed tools
+policy decisions
+approval IDs
+executed tools
+before/after entity versions
+result
+failure/retry state
+latency
+cost/tokens
+correlation ID
+```
+
+Do not store private model chain-of-thought. Store concise decision/execution evidence required for audit and debugging.
+
+## Prompt injection and untrusted data
+
+Treat customer messages, emails, uploaded documents and web text as untrusted data.
+
+Controls:
+- distinguish system policy from retrieved content
+- tool allowlists
+- typed inputs
+- no secret exposure to model unless strictly needed
+- output validation
+- external URL restrictions
+- confirmation/approval gates
+- sandbox file processing
+- rate and budget limits
+
+Reference security baselines: OWASP Agentic AI Threats and Mitigations and NIST AI RMF Generative AI Profile.
+
+## Model/provider strategy
+
+Provider abstraction is required. Route by task:
+- cheap deterministic classification → small model
+- complex cross-module reasoning → capable model
+- sensitive local processing → approved provider/deployment policy
+
+Track quality, latency and cost by feature. A model upgrade must not change permissions or business invariants.
+
+## Success metric
+
+DABBIR AI is successful when it reduces navigation and manual coordination **without reducing control**. The target is intent → trusted evidence → governed action → verified result.

--- a/docs/archive/business-os-research-2026-08-26/10_DABBIR_UAE_READINESS.md
+++ b/docs/archive/business-os-research-2026-08-26/10_DABBIR_UAE_READINESS.md
@@ -1,0 +1,173 @@
+# 10 — DABBIR UAE Readiness
+
+**Legal/research snapshot:** 2026-08-26  
+**Important:** This is product/compliance engineering research, not legal or tax advice. Any rule that has not been mapped to the exact current legislation and business scope remains `LEGAL_REVIEW_REQUIRED`.
+
+Status legend:
+- `LEGAL_VERIFIED` — supported by current UAE official source for the stated narrow claim.
+- `LEGAL_REVIEW_REQUIRED` — relevant but detailed implementation/legal interpretation must be reviewed.
+- `NOT_APPLICABLE` — not applicable to current planned product scope.
+
+## 1. UAE eInvoicing — P0 architecture
+
+### Verified current facts
+
+**LEGAL_VERIFIED** — The UAE Ministry of Finance states that an eInvoice is **structured invoice data issued/exchanged electronically and reported electronically to the FTA**. PDF, Word, image, scan or email formats are not eInvoices.
+
+**LEGAL_VERIFIED** — The official programme is based on OpenPeppol and uses Accredited Service Providers (ASPs).
+
+**LEGAL_VERIFIED** — Mandatory implementation schedule currently includes:
+- annual revenue ≥ AED 50 million: implement by **1 January 2027**.
+- annual revenue < AED 50 million: implement by **1 July 2027**.
+- in-scope government entities: implement by **1 October 2027**.
+
+**LEGAL_VERIFIED** — For persons above AED 50 million revenue, the deadline to appoint an ASP was amended from 31 July 2026 to **30 October 2026**. The implementation date remains 1 January 2027.
+
+**LEGAL_VERIFIED** — Current official guidance states B2C transactions are outside the mandatory scope until determined otherwise; detailed scope must still be evaluated for each customer/use case.
+
+### DABBIR engineering decision
+
+Do **not** attempt to become an Accredited Service Provider in V1.
+
+Build:
+- canonical structured invoice data model
+- mandatory-field validation layer
+- eInvoice status/evidence model
+- `EinvoiceProviderAdapter` interface
+- outbound/inbound document IDs and correlation
+- retry/reconciliation/webhook evidence
+- provider-specific mapping outside finance core
+
+Integrate with an accredited ASP after commercial/technical review.
+
+Sources:
+- https://mof.gov.ae/en/about-us/initiatives/einvoicing/
+- https://mof.gov.ae/en/news/ministry-of-finance-announces-targeted-amendments-to-einvoicing-system-decisions/
+- https://mof.gov.ae/en/news/ministry-of-finance-announces-the-issuance-of-two-ministerial-decisions-on-the-scope-of-obligations-and-the-timelines-for-implementing-the-electronic-invoicing-system-2/
+
+## 2. VAT / accounting records
+
+**LEGAL_VERIFIED** — UAE VAT legislation and FTA guidance must be treated as the source of truth for tax behavior; DABBIR must use configurable tax codes rather than hard-coded assumptions.
+
+**LEGAL_VERIFIED** — On 20 August 2026, the FTA published **Decision No. 4 of 2026 on the Rules and Requirements for Maintaining the Information Contained in Accounting Records and Commercial Books**.
+
+**LEGAL_REVIEW_REQUIRED** — Before DABBIR defines retention periods, storage format, deletion policies or archival guarantees, the full Decision No. 4/2026 and all applicable tax legislation must be mapped field-by-field. Do not encode legacy retention assumptions from older FAQs without this review.
+
+Engineering requirements:
+- tax registration/profile per legal entity
+- VAT/tax code versioning
+- evidence of tax calculation source/version
+- tax period and reporting extracts
+- credit note/correction linkage
+- immutable posting history
+- configurable document numbering
+- retention-policy engine driven by verified jurisdiction rules
+
+Sources:
+- https://tax.gov.ae/en/Legislation.aspx
+- https://tax.gov.ae/en/content/fta.decision.no.4.of.2026.on.the.rules.and.requirements.for.maintaining.the.information.contained.in.accounting.records.and.commercial.books.aspx
+
+## 3. Wages Protection System / payroll
+
+**LEGAL_VERIFIED** — The UAE official government portal states that establishments registered with MoHRE must pay relevant employee wages through WPS, subject to the current rules/exclusions, and identifies **Ministerial Resolution No. 340 of 2026** as the current WPS basis on the updated page.
+
+**LEGAL_VERIFIED** — The same current page states salaries for the previous month are due on the first day of each Gregorian month under that resolution.
+
+**LEGAL_REVIEW_REQUIRED** — Payroll calculation, employee categories, exclusions, end-of-service, pension/social security, Emiratisation and free-zone/special-jurisdiction treatment require separate legal/product mapping.
+
+DABBIR V1 decision:
+- HR core: BUILD.
+- payroll statutory engine: **DEFER / INTEGRATE** first.
+- payroll run metadata, approvals and accounting interface: BUILD.
+- WPS file/payment-provider integration: design adapter after provider + legal format verification.
+
+Sources:
+- https://u.ae/en/information-and-services/jobs/employment-in-the-private-sector/payment-of-wages
+- https://www.mohre.gov.ae/en/guidance-and-awareness-portal-new/wages-protection-system
+
+## 4. Personal data protection
+
+**LEGAL_VERIFIED** — UAE Federal Decree-Law No. 45 of 2021 on Personal Data Protection applies to electronic processing within its stated scope, includes processing controls, data-subject rights and cross-border transfer requirements.
+
+DABBIR requirements:
+- data inventory and classification
+- tenant isolation
+- purpose/processing records where required
+- consent/evidence where consent is the applicable legal basis
+- correction/restriction/deletion request workflow where legally applicable
+- export/data-subject request workflow
+- processor/subprocessor register
+- configurable data residency/transfer documentation
+- secure deletion and retention conflict handling
+- audit of sensitive-data access
+
+**LEGAL_REVIEW_REQUIRED** — Exact legal basis, controller/processor roles, data residency and transfer rules must be assessed per customer, industry and deployment location.
+
+Source:
+- https://u.ae/en/about-the-uae/digital-uae/data/data-protection-laws.
+
+## 5. Electronic transactions and trust services
+
+**LEGAL_VERIFIED** — Federal Decree-Law No. 46 of 2021 governs Electronic Transactions and Trust Services in the UAE.
+
+DABBIR implications:
+- maintain document integrity/evidence metadata
+- do not claim an internal click is a legally qualified signature
+- integrate specialized e-sign/trust provider where legal assurance is required
+- preserve signer/actor/timestamp/document-version evidence
+
+**LEGAL_REVIEW_REQUIRED** — Signature level, trust service and evidentiary requirements for each document/use case.
+
+Official law source:
+- https://assets.u.ae/api/public/content/83039e37384242afaf63c2e4bc05d7a1?v=3ce37943
+
+## 6. Payments and financial services boundary
+
+DABBIR should orchestrate payment states through licensed/supported payment providers rather than hold customer funds as a wallet or represent itself as a bank/payment institution.
+
+`LEGAL_REVIEW_REQUIRED` for any future feature involving:
+- stored monetary value
+- customer fund custody
+- transfers/P2P
+- lending/credit
+- regulated payment initiation beyond provider APIs
+
+## 7. Arabic and business documents
+
+Product requirement (not a blanket legal claim):
+- Arabic-first capability + English parity
+- RTL/LTR
+- Arabic customer/supplier/company names
+- bilingual invoice/quote templates where customer needs them
+- UAE date/time/currency formatting
+- AED support plus multi-currency ledger architecture
+
+## 8. Jurisdiction architecture for GCC growth
+
+Never put UAE rules directly inside generic finance code.
+
+Use:
+
+```text
+Core Finance / HR / Documents
+        +
+Jurisdiction Pack (AE)
+        +
+Provider Adapters (ASP/WPS/payments/etc.)
+```
+
+Future GCC expansion gets separate verified jurisdiction packs rather than conditionals scattered through core.
+
+## 9. Release gates for UAE-facing modules
+
+Before enabling a compliance-sensitive capability:
+1. identify current official legislation/guidance and effective date
+2. identify customer/business scope
+3. map every required field/state
+4. legal/tax review where interpretation exists
+5. test positive/negative examples
+6. record rule version/effective date
+7. establish update monitoring
+8. preserve evidence and audit history
+
+No screen or report may use the label “UAE compliant” unless the scoped compliance claim has passed this gate.

--- a/docs/archive/business-os-research-2026-08-26/11_DABBIR_SECURITY_MODEL.md
+++ b/docs/archive/business-os-research-2026-08-26/11_DABBIR_SECURITY_MODEL.md
@@ -1,0 +1,187 @@
+# 11 — DABBIR Business OS Security Model
+
+**Snapshot:** 2026-08-26
+
+## Security objective
+
+Protect tenant data and business authority while allowing humans, integrations and AI to act through the same governed command system.
+
+## P0 threat/control matrix
+
+| Threat | P | Required control |
+|---|---:|---|
+| Cross-tenant data disclosure | P0 | tenant ID on all rows, server policy checks, RLS defense-in-depth, tenant-scoped caches/search/storage |
+| Broken object-level authorization | P0 | resource authorization on every read/write; never trust client-provided role/company |
+| Privilege escalation | P0 | RBAC+ABAC, admin-action controls, short-lived elevation, audit, separation of duties |
+| Session theft/fixation | P0 | secure HttpOnly cookies/tokens, rotation, expiry, CSRF/same-origin controls, MFA-ready auth |
+| Secret leakage | P0 | managed secrets, no secrets in frontend/logs/audit/model prompts, rotation and access logging |
+| SQL/injection | P0 | parameterized queries/typed data access; schema validation; no generic AI SQL execution |
+| Mass assignment | P0 | explicit command DTO allowlists and server-owned fields |
+| Business state tampering | P0 | state machines, immutable posted ledgers, approvals, optimistic concurrency |
+| Duplicate external mutations | P0 | idempotency keys, provider correlation IDs, transaction/outbox pattern |
+| Audit manipulation | P0 | append-only audit store, restricted write API, hashes/sequence where useful, independent retention |
+| AI prompt injection | P0 | untrusted-content separation, tool allowlists, typed args, retrieval ACLs, approvals, output validation |
+| AI excessive agency | P0 | agent principals, least privilege, READ/RECOMMEND/DRAFT/EXECUTE, risk tiers, kill switch |
+| Integration compromise | P0 | per-connection credentials, narrow scopes, encrypted tokens, webhook signatures, revoke/rotate |
+| Malicious file/upload | P0 | type/size limits, isolated processing, malware/content scanning path, no active execution |
+| Data export abuse | P0 | export permission, limits, async jobs, watermark/evidence where appropriate, audit |
+| Account recovery takeover | P0 | secure one-time recovery, allowlisted HTTPS redirects, token expiry, no account enumeration |
+
+## Tenant isolation
+
+Defense layers:
+1. authenticated principal bound to tenant memberships
+2. application policy evaluation
+3. database RLS/tenant predicates
+4. tenant namespacing in storage/search/cache/jobs
+5. tenant ID included in audit/events
+6. automated negative tests proving Tenant A cannot access Tenant B IDs
+
+Never use “hidden UI” as authorization.
+
+## Authentication roadmap
+
+P0/P1:
+- verified email/password
+- secure recovery
+- Google/Apple where configured
+- MFA/passkeys readiness
+- session/device management
+
+P2 enterprise:
+- SAML/OIDC SSO
+- SCIM/directory lifecycle
+- enforced corporate domain/IdP policy
+- enterprise admin portal
+
+## Authorization
+
+- central permission service
+- role templates + custom roles
+- ABAC scopes
+- field-level restrictions
+- separation of duties
+- approval authority distinct from CRUD permission
+- deny by default
+
+## Data protection
+
+- TLS in transit
+- managed encryption at rest by infrastructure provider
+- application-level encryption/tokenization for selected high-risk fields if threat model requires
+- classification labels: public/internal/confidential/restricted
+- PII minimization
+- tenant-configurable retention within legal constraints
+- backup encryption + restore testing
+- no production data in developer previews by default
+
+## Financial and inventory integrity
+
+- posted journal/stock ledger entries immutable
+- corrections by reversal/compensation
+- posting periods and close controls
+- double-entry validation
+- source document linkage
+- inventory reservation/fulfillment concurrency protection
+- high-risk changes use approvals
+
+## AI/agent security
+
+Reference baselines:
+- OWASP Agentic AI Threats and Mitigations: https://genai.owasp.org/resource/agentic-ai-threats-and-mitigations/
+- OWASP Agentic AI security landscape 2026: https://genai.owasp.org/resource/ai-security-solutions-landscape-for-agentic-ai-q2-2026/
+- NIST AI RMF GenAI Profile: https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence
+
+Controls:
+- agent is a principal
+- allowlisted typed tools
+- separate deterministic policy layer from model reasoning
+- retrieved messages/docs/web are untrusted
+- least data sent to model
+- high-risk actions approval-gated
+- result validation and postcondition checks
+- budget/rate limits
+- model/provider allowlist
+- execution receipt without private chain-of-thought
+- emergency disable per agent/tool/provider
+
+## API security
+
+- OpenAPI-defined contracts
+- schema validation
+- rate limits by user/integration/tenant
+- idempotency for mutations
+- replay-protected signed webhooks
+- short-lived OAuth tokens where applicable
+- webhook egress allowlist controls for sensitive environments
+- correlation/request IDs
+- structured error codes without secret/internal leakage
+
+## Supply chain
+
+- lock dependencies
+- automated dependency/security scanning
+- provenance/SBOM capability before enterprise launch
+- minimal runtime dependencies
+- branch protection/CI gates
+- no direct production deploy from unreviewed experimental branches
+
+## Observability/security operations
+
+Use vendor-neutral OpenTelemetry conventions for logs/metrics/traces where possible.
+
+Security telemetry:
+- auth failures and suspicious recovery
+- privilege/role changes
+- bulk exports
+- approval bypass attempts
+- integration credential failures
+- webhook signature failures
+- agent denied actions
+- unusual tool-call rates
+- tenant-boundary test failures
+
+Alerts must be actionable and severity-ranked.
+
+## Backup / DR
+
+P0:
+- automated encrypted backups
+- documented restore process
+- periodic restore verification
+- RPO/RTO targets defined before paid production
+- migration rollback strategy
+
+P1/P2:
+- regional resilience based on customer/SLA needs
+- tested disaster recovery exercise
+
+## Incident response
+
+Every incident record should preserve:
+- detection time/source
+- affected tenants/entities
+- severity
+- containment action
+- evidence/correlation IDs
+- customer notification decision
+- recovery steps
+- root cause
+- prevention task
+
+## Security acceptance gates
+
+Before launch:
+- tenant escape tests
+- authorization matrix tests
+- recovery/login abuse tests
+- API schema/fuzz negative tests
+- financial and stock invariant tests
+- webhook replay/idempotency tests
+- agent prompt-injection/tool-abuse tests
+- secret scanning
+- dependency scanning
+- backup restore test
+- audit completeness test
+
+No `P0` security finding may be waived by hiding a feature from the UI.

--- a/docs/archive/business-os-research-2026-08-26/12_DABBIR_BUILD_VS_BUY.md
+++ b/docs/archive/business-os-research-2026-08-26/12_DABBIR_BUILD_VS_BUY.md
@@ -1,0 +1,94 @@
+# 12 — DABBIR Build vs Buy / Integrate
+
+**Snapshot:** 2026-08-26
+
+Rule: DABBIR owns business semantics, authority and canonical state. Specialized regulated/infrastructure functions should usually be integrated unless owning them creates clear strategic value.
+
+| Capability | Decision | Reason |
+|---|---|---|
+| Tenant/company hierarchy | BUILD | core product semantics |
+| Canonical customer/supplier/product/employee model | BUILD | source of truth and differentiation |
+| Membership/roles/policies | BUILD policy model | company authority is core |
+| Authentication primitives | INTEGRATE / managed provider | password/OAuth/MFA security benefits from specialized auth |
+| Google/Apple login | INTEGRATE | use standards/provider OAuth |
+| Enterprise SSO | INTEGRATE | SAML/OIDC complexity; WorkOS/Auth0-class provider is more efficient |
+| SCIM/Directory Sync | INTEGRATE | enterprise IdP variability is costly and security-sensitive |
+| Approval engine | BUILD | must apply consistently to all business modules and AI |
+| Audit ledger | BUILD | authoritative evidence across modules |
+| Workflow engine | BUILD compact core | central differentiator; can integrate external actions |
+| Generic long-tail app connectors | INTEGRATE | Zapier/Make/n8n-style ecosystems are wider than DABBIR can reproduce |
+| Strategic connectors | BUILD adapters | e.g. payments, commerce, WhatsApp, eInvoice, key accounting/banks |
+| CRM | BUILD | part of unified customer truth |
+| Sales/order management | BUILD | transaction core |
+| Inventory ledger/reservations | BUILD | transaction core/invariants |
+| Procurement | BUILD | transaction core and approvals |
+| Finance double-entry ledger | BUILD carefully | one source of financial truth; cannot outsource business posting semantics |
+| Tax calculation framework | BUILD framework + INTEGRATE data/services as needed | rules are jurisdiction-specific and versioned |
+| Payment rails | INTEGRATE | use licensed providers such as Stripe/approved local providers |
+| Billing orchestration | BUILD around provider | DABBIR controls plans/business state; provider controls money rails |
+| UAE eInvoicing transport | INTEGRATE accredited ASP | regulatory accreditation and network transport should not be recreated |
+| eInvoice canonical data/validation/status | BUILD | DABBIR must create correct structured business data and evidence |
+| Payroll statutory engine | INTEGRATE first | high legal/local complexity |
+| WPS delivery/payment channel | INTEGRATE | provider/government/bank interfaces |
+| HR core | BUILD | employee/company graph is core |
+| Recruitment | DEFER then BUILD/INTEGRATE based demand | not P0 |
+| E-signature/trust service | INTEGRATE | specialized legal evidence/trust providers |
+| Object/file storage | INTEGRATE infrastructure | commodity infrastructure; DABBIR owns metadata/ACL |
+| Document management metadata/version links | BUILD | needed for entity-level governance |
+| Email delivery | INTEGRATE | deliverability/reputation infrastructure |
+| SMS | INTEGRATE | telecom provider network |
+| WhatsApp/Meta | INTEGRATE official APIs | external regulated/platform channel |
+| Enterprise search index | BUILD V1 | permission-aware canonical search is strategic and manageable in Postgres |
+| External enterprise knowledge connectors | INTEGRATE later | use connectors/search providers if customer demand justifies |
+| Vector embeddings/LLMs | INTEGRATE models | model layer changes quickly; remain provider-agnostic |
+| AI tool/policy/orchestration | BUILD | critical differentiator and authority boundary |
+| AI observability/receipts | BUILD | trust and audit requirement |
+| Generic workflow/agent sandbox | BUILD only what DABBIR needs | avoid becoming a generic automation IDE |
+| Observability instrumentation | BUILD using OpenTelemetry | standard instrumentation, vendor-neutral backend |
+| Error monitoring backend | INTEGRATE | specialized observability products |
+| Backups/database | INTEGRATE managed infra + BUILD verification | provider handles storage; DABBIR owns restore tests/RPO/RTO |
+| WAF/DDoS/CDN | INTEGRATE platform | infrastructure/security commodity |
+| Fraud/risk engines | INTEGRATE where needed | specialized data/models |
+| Maps/geocoding | INTEGRATE | commodity provider |
+| Analytics metric definitions | BUILD | business semantics/source-of-truth |
+| BI visualization | BUILD core UI; INTEGRATE advanced export/BI later | owner experience is product; advanced BI can be ecosystem |
+
+## Decision filters
+
+Choose **BUILD** when:
+- it defines DABBIR's source of truth or authority
+- it must coordinate multiple modules
+- it is required for differentiation
+- vendor lock-in would compromise canonical state
+
+Choose **INTEGRATE** when:
+- regulated/accredited provider is needed
+- infrastructure has mature specialized providers
+- long-tail connector breadth outweighs product value
+- security/deliverability/network effects are hard to reproduce
+
+Choose **DEFER** when:
+- no P0/P1 customer value is proven
+- implementation would force premature jurisdiction complexity
+- a feature adds screens but not measurable business outcome
+
+## Provider abstraction requirement
+
+Integrations must use DABBIR-owned interfaces and canonical states. Example:
+
+```text
+PaymentProvider
+- createIntent()
+- capture()
+- refund()
+- getStatus()
+- verifyWebhook()
+
+EinvoiceProvider
+- validate()
+- submit()
+- receiveStatus()
+- reconcile()
+```
+
+Provider payloads stay at the adapter boundary; core modules do not become coupled to a vendor schema.

--- a/docs/archive/business-os-research-2026-08-26/13_DABBIR_DIFFERENTIATION.md
+++ b/docs/archive/business-os-research-2026-08-26/13_DABBIR_DIFFERENTIATION.md
@@ -1,0 +1,190 @@
+# 13 — DABBIR Differentiation Thesis
+
+**Snapshot:** 2026-08-26
+
+These are **differentiation opportunities to build and validate**, not unsupported claims of global uniqueness.
+
+## 1. Intent-to-execution ERP
+
+Traditional ERP navigation starts with modules and screens. DABBIR should let an authorized user start with intent:
+
+> "الطلبات المتأخرة فوق 10,000 درهم — حدد السبب وأنشئ المتابعات للمسؤولين."
+
+DABBIR resolves data, explains evidence, proposes actions and executes only what the user's authority allows.
+
+**Moat:** AI is wired to canonical commands, policy, approvals and audit—not a generic chatbot.
+
+## 2. Same authority system for humans and AI
+
+Every human, integration and agent is a principal under the same business authority model.
+
+This enables a strong trust statement:
+
+> AI cannot do something merely because the model knows how; it can do only what DABBIR policy authorizes.
+
+Deliverables:
+- agent identity
+- tool scopes
+- delegated vs service execution
+- approval gates
+- execution receipts
+- kill switch
+
+## 3. One business timeline
+
+Customer, supplier, employee, project and transaction history should become explainable timelines sourced from canonical records.
+
+For a customer, one view can contain:
+- lead/opportunity
+- quotes/orders
+- deliveries/returns
+- invoices/payments
+- messages/tickets
+- documents
+- tasks/follow-ups
+
+This removes the fragmentation common when SMBs stitch together CRM, accounting, WhatsApp and task apps.
+
+## 4. Exception-first Command Center
+
+Do not make the owner inspect dashboards to discover problems.
+
+DABBIR calculates an attention queue:
+- pending approvals
+- overdue receivables
+- stock-out risk
+- delayed fulfillment
+- supplier failures
+- project slippage
+- employee exceptions
+- failed integrations
+
+Rank by:
+`business impact × urgency × risk × deadline confidence`.
+
+The goal is **what requires action now**, with drill-down to evidence.
+
+## 5. Progressive ERP / zero-training UX
+
+The architecture supports multi-company, branches, cost centers and advanced controls, but a five-person company should not see enterprise complexity on day one.
+
+Use:
+- smart defaults
+- role-based navigation
+- templates
+- progressive disclosure
+- natural language commands
+- contextual actions
+- automatic linking from business events
+
+Complexity appears when the company needs it, not because the database supports it.
+
+## 6. Arabic-first, bilingual enterprise UX
+
+Arabic is not a translation afterthought.
+
+Requirements:
+- true RTL layout
+- Arabic search and entity names
+- bilingual documents/templates
+- Arabic-first AI understanding with English parity
+- UAE locale/currency/date formatting
+- mixed Arabic/English business vocabulary
+
+This is particularly important for UAE/GCC SMB operations where employees and customers may switch language within the same workflow.
+
+## 7. UAE regulatory adaptation layer
+
+Build generic core + jurisdiction packs.
+
+For UAE, priority examples:
+- eInvoice-ready structured invoice model + accredited provider adapter
+- versioned tax rule framework
+- accounting record/retention rule mapping
+- WPS/payroll integration boundary
+- UAE data-protection workflows
+
+This should make regulatory updates a **versioned configuration/integration problem**, not a product rewrite.
+
+## 8. Business health graph
+
+DABBIR can use the cross-module graph to explain relationships that individual apps miss.
+
+Example:
+
+```text
+Sales growth ↑
+→ SKU demand ↑
+→ supplier lead time worsened
+→ available stock ↓
+→ late orders ↑
+→ customer tickets ↑
+→ cash collection delayed
+```
+
+Executive AI should surface the causal chain with source records, not merely a generic KPI alert.
+
+## 9. AI execution receipts
+
+For consequential AI actions, show the user a concise receipt:
+
+- what was requested
+- what evidence was used
+- what DABBIR proposed
+- which policy/approval applied
+- what was actually changed
+- who/what executed it
+- whether it succeeded
+
+This turns AI trust from “believe the answer” into **inspect the operation**.
+
+## 10. Industry packs without forks
+
+Retail, clinic, salon, real estate, maintenance, trading and services should share the same platform.
+
+Industry pack contains metadata/config:
+- terminology
+- enabled modules
+- roles
+- forms
+- workflows
+- metrics
+- templates
+- integrations
+
+Do not fork databases/applications per industry.
+
+## Why a customer could choose DABBIR instead of five apps
+
+Target value proposition:
+
+> **Run the company from one source of truth, and tell DABBIR what outcome you want.**
+
+Compared with a patchwork of CRM + accounting + inventory + tasks + WhatsApp:
+- less duplicate data
+- fewer integration gaps
+- one permission system
+- one audit history
+- one automation engine
+- cross-module AI context
+
+Compared with heavyweight ERP:
+- simpler onboarding
+- smaller visible surface per role
+- conversational execution
+- UAE/GCC-first experience
+
+## Validation metrics
+
+A differentiator is proven only if customer testing shows measurable improvement such as:
+- time to first company setup
+- time to invite first employee
+- time from lead to quote/order
+- clicks/time to resolve exception
+- percentage of owner questions answered with source evidence
+- manual reconciliations avoided
+- automation success/error rate
+- hours of training required
+- permission/security incidents
+
+No marketing claim should be promoted from this thesis until measured.

--- a/docs/archive/business-os-research-2026-08-26/14_DABBIR_IMPLEMENTATION_PLAN.md
+++ b/docs/archive/business-os-research-2026-08-26/14_DABBIR_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,282 @@
+# 14 — DABBIR Business OS Implementation Plan
+
+**Plan baseline:** 2026-08-26  
+**Execution rule:** Research and architecture precede P0 implementation. Existing DABBIR production is out of scope.
+
+## Phase R0 — Research baseline — COMPLETE v1
+
+Deliverables:
+- global system research
+- enterprise capability map
+- competitor matrix
+- gap analysis
+- target architecture
+- canonical data model
+- permission model
+- module roadmap
+- AI architecture
+- UAE readiness
+- security model
+- build-vs-buy
+- differentiation thesis
+- implementation plan
+
+Exit criteria:
+- architecture direction is explicit
+- P0 dependencies identified
+- legal/compliance unknowns labeled rather than guessed
+- no production code/database mutated
+
+## Phase 0A — Isolated Platform Boundary
+
+Build:
+- dedicated Business OS runtime/deployment target
+- dedicated database project/schema/storage namespace
+- separate secrets and auth configuration
+- environment guard that refuses current DABBIR production resources
+- migration runner scoped to Business OS only
+- health endpoint and observability tags
+
+Acceptance:
+- Business OS can deploy without touching current DABBIR
+- test migration changes only isolated database
+- production DABBIR baseline remains byte/data unaffected by Business OS release
+
+## Phase 0B — Company + Identity + Authority Core
+
+Build:
+- tenant, organization, company/legal entity
+- branch, department, cost center, team
+- user, employee, membership
+- one-time employee invites
+- role templates/custom roles
+- ABAC scope bindings
+- field/resource policies
+- agent/integration principals
+
+Acceptance:
+- owner creates company and branches
+- owner invites employee once
+- employee accepts once and uses normal login afterward
+- employee sees only assigned company/branch/resource scope
+- tenant-crossing requests fail server-side
+
+## Phase 0C — Audit + Approval + Event Backbone
+
+Build:
+- append-only audit event service
+- approval policy/version/instance engine
+- single/sequential/parallel/threshold/conditional approval
+- delegation/escalation/expiry
+- transactional outbox
+- worker retry/dead-letter
+- event schema/versioning
+
+Acceptance:
+- every canonical write has audit correlation
+- sensitive action can stop at approval then resume exactly once
+- retry cannot duplicate completed business mutation
+- event consumer replay is idempotent
+
+## Phase 0D — Master Data + CRM
+
+Build:
+- party/person/organization
+- customer/supplier account
+- contacts/addresses
+- product/SKU/service/UOM
+- lead/opportunity/activity
+- customer timeline read model
+
+Acceptance:
+- lead conversion links canonical party/customer; no duplicates
+- same customer ID is used by CRM and future sales/finance
+- search respects tenant/permission scope
+
+## Phase 0E — Sales + Inventory Transaction Core
+
+Build:
+- quote/line
+- discount policy/approval
+- sales order/line
+- stock ledger
+- reservation
+- warehouse/location
+- fulfillment/delivery
+- return primitives
+
+Acceptance:
+- accepted quote can create order
+- confirmation reserves stock atomically
+- overselling race is prevented according to policy
+- fulfillment writes stock movement and audit
+- stock balance can be reconstructed from ledger
+
+## Phase 0F — Procurement
+
+Build:
+- purchase request
+- purchase approval
+- RFQ/supplier quote
+- PO
+- goods receipt
+- supplier performance base
+
+Acceptance:
+- receipt creates inventory movement
+- PO amount/branch can drive approval policy
+- supplier invoice linkage is ready for finance phase
+
+## Phase 0G — Finance Core
+
+Build behind strict verification:
+- chart of accounts
+- journals/lines
+- balanced double-entry posting
+- fiscal periods
+- invoice/credit note
+- payment/payment allocation state
+- AR/AP base
+- posting integration from sales/procurement
+
+Acceptance:
+- every posted entry balances
+- posted journal cannot be edited/deleted
+- reversal creates compensating entry
+- sales invoice posts according to configured mapping
+- supplier invoice posts according to configured mapping
+- accounting reports trace to journal lines
+
+No “accounting compliant” marketing claim is allowed at this phase.
+
+## Phase 0H — UAE Invoice Readiness Boundary
+
+Build:
+- structured invoice canonical fields
+- versioned validation profile
+- ASP adapter contract
+- provider delivery/status/evidence store
+
+Do not select/activate a provider until current commercial, technical and legal verification.
+
+Acceptance:
+- DABBIR can generate a structured invoice object independent of a PDF
+- provider mapping is adapter-only
+- retry/reconcile does not duplicate official submission
+
+## Phase 0I — AI Operating Layer v1
+
+Build:
+- permission-filtered context retrieval
+- typed tool registry
+- READ/RECOMMEND/DRAFT/EXECUTE classes
+- risk classifier
+- policy and approval interception
+- execution receipt
+- model/provider abstraction
+- cost/latency telemetry
+
+Acceptance:
+- AI can answer sourced business questions
+- AI cannot read cross-scope data
+- AI cannot execute a denied action
+- high-risk action enters approval
+- approved action executes same server command as UI
+- action receipt proves outcome
+
+## Phase 0J — Command Center + Zero-Training UX
+
+Build:
+- exception event/read model
+- severity/impact/urgency/deadline scoring
+- role-based owner/manager/employee home
+- global command/search entry
+- progressive onboarding checklist
+- Arabic/English full parity
+
+Acceptance:
+- new owner reaches first customer/product/order without training document
+- manager can resolve a top exception from command center
+- no KPI is displayed without a traceable source definition
+
+## Phase 1 — Competitive suite
+
+After P0 E2E passes:
+- bank reconciliation
+- advanced AR/AP
+- replenishment
+- projects/time/expense/profitability
+- helpdesk/SLA
+- document/version system
+- unified communications
+- semantic search
+- workflow visual builder
+- integration management
+- safe self-healing
+
+## Phase 2 — Advanced growth
+
+- SSO/SCIM
+- payroll/WPS integration
+- lot/serial/expiry
+- manufacturing pack where demanded
+- asset/contract management
+- budgeting/forecasting
+- industry packs
+- specialized AI agents
+
+## Mandatory acceptance suite
+
+### Customer journey
+`signup/login → company → employees → customer → quote → order → inventory → invoice → payment → audit → AI explanation`
+
+### Procurement journey
+`request → approval → RFQ → supplier selection → PO → receipt → supplier invoice → payment state`
+
+### Security
+- cross-tenant negative tests
+- cross-branch policy tests
+- privilege escalation tests
+- invite replay/expiry/revoke tests
+- CSRF/session/recovery tests
+- prompt-injection/tool-abuse tests
+
+### Integrity
+- double-entry balance property tests
+- inventory reconstruction tests
+- concurrent reservation tests
+- idempotency/replay tests
+- approval one-time-consumption tests
+
+### Reliability
+- worker retry/dead letter
+- provider outage/recovery
+- webhook replay/signature
+- backup/restore
+- observability correlation
+
+## Implementation quality gate per capability
+
+Before code:
+- problem/user/value
+- benchmark
+- P0/P1/P2/P3
+- BUILD/INTEGRATE/DEFER
+- canonical entities/state machine
+- permissions/approvals
+- events/API
+- security/legal impact
+- observability/failure behavior
+- acceptance test
+
+After code:
+- persisted behavior verified
+- negative tests pass
+- audit present
+- no production leakage
+- bilingual UX
+- evidence linked to issue/commit/deployment
+
+## Final P0 exit verdict
+
+P0 is complete only when a real isolated Business OS environment passes the full lead/customer/quote/order/stock/invoice/payment/audit journey with role-scoped employee access and policy-bound AI. A dashboard or static preview is not an acceptance substitute.

--- a/docs/archive/business-os-research-2026-08-26/LEGACY_DABBIR_BUSINESS_OS_V1.md
+++ b/docs/archive/business-os-research-2026-08-26/LEGACY_DABBIR_BUSINESS_OS_V1.md
@@ -1,0 +1,178 @@
+# DABBIR Business OS v1
+
+## Product decision
+
+DABBIR Business OS is a separate product line from the current DABBIR operational assistant. It is a compact ERP / Business OS for small and medium businesses, inspired by the integration principles of SAP without copying SAP complexity.
+
+## Isolation rules
+
+- Branch: `dabbir-business-os-v1`
+- Do not modify or deploy the current DABBIR production baseline from this branch.
+- No production data migrations until the Business OS schema passes review and migration dry-runs.
+- No reuse of current production secrets by default.
+- Separate deployment target and separate runtime configuration are required before public testing.
+- Shared code may be copied only when it is generic, audited, and does not couple the two products.
+
+## v1 core modules
+
+1. Company Core
+   - companies
+   - branches
+   - departments
+   - users
+   - memberships
+   - roles
+   - granular permissions
+   - approval policies
+
+2. CRM
+   - customers
+   - leads
+   - contacts
+   - pipelines
+   - activities
+   - notes
+
+3. Sales
+   - quotations
+   - sales orders
+   - invoices
+   - returns
+   - payment status
+
+4. Inventory
+   - products
+   - variants
+   - warehouses
+   - stock balances
+   - stock movements
+   - transfers
+   - reorder rules
+
+5. Procurement
+   - suppliers
+   - purchase requisitions
+   - purchase orders
+   - receipts
+   - supplier invoices
+
+6. Operations
+   - tasks
+   - projects
+   - appointments
+   - service requests
+   - approvals
+   - SLA tracking
+
+7. Finance Lite
+   - chart of accounts
+   - journals
+   - receivables
+   - payables
+   - expenses
+   - cash flow
+   - profit and loss summary
+
+8. HR Lite
+   - employees
+   - attendance
+   - leave
+   - departments
+   - manager hierarchy
+
+9. Communications
+   - WhatsApp
+   - email
+   - internal comments
+   - notifications
+
+10. Automation Engine
+   - triggers
+   - conditions
+   - actions
+   - approval gates
+   - scheduled jobs
+
+11. DABBIR AI
+   - read authorized business context
+   - generate summaries and recommendations
+   - create drafts
+   - execute approved actions
+   - never bypass role permissions or approval gates
+
+12. Governance
+   - immutable audit log
+   - action history
+   - data ownership
+   - soft delete / archival rules
+   - export controls
+
+## Core design principle
+
+Every module must operate on one canonical company graph. A customer, product, supplier, invoice, employee, warehouse, and order must not be duplicated across modules. Events from one module must update dependent modules through explicit domain events.
+
+Example:
+
+Sales Order confirmed -> reserve inventory -> create fulfillment task -> update customer timeline -> create receivable -> generate audit event -> notify permitted users.
+
+## Security model
+
+- Multi-tenant by company.
+- Row-level security by company membership.
+- Fine-grained permissions by module and action.
+- Owner/Admin approval required for sensitive actions.
+- Employees use one-time invitation -> permanent membership -> normal secure login.
+- Audit every write that changes business state.
+- No client-side trust for authorization.
+
+## AI execution model
+
+AI is a controlled operator, not a bypass layer.
+
+Every AI action must pass:
+
+intent -> permission check -> business rule validation -> approval gate if required -> execution -> audit event -> outcome verification.
+
+## v1 delivery order
+
+Phase 0 — Platform Core
+- tenant model
+- auth
+- roles and permissions
+- audit log
+- company/branch/department model
+- navigation and design system
+
+Phase 1 — CRM + Sales
+- customers
+- leads
+- quotes
+- sales orders
+- invoices
+
+Phase 2 — Inventory + Procurement
+- catalog
+- warehouses
+- stock ledger
+- suppliers
+- purchase orders
+- receiving
+
+Phase 3 — Finance Lite + Operations
+- receivables/payables
+- expenses
+- cash flow
+- tasks
+- approvals
+
+Phase 4 — AI + Automations + Channels
+- AI command center
+- automation rules
+- WhatsApp/email integrations
+- notifications
+
+## Launch criterion
+
+DABBIR Business OS v1 is not considered production-ready until an end-to-end scenario succeeds:
+
+lead -> customer -> quote -> approved sales order -> stock reservation -> invoice -> payment state -> fulfillment -> audit trail -> management dashboard.

--- a/docs/archive/business-os-research-2026-08-26/ORIGINAL_RESEARCH_INDEX.md
+++ b/docs/archive/business-os-research-2026-08-26/ORIGINAL_RESEARCH_INDEX.md
@@ -1,0 +1,29 @@
+# DABBIR Business OS — Research Baseline
+
+Research snapshot: **2026-08-26**
+
+Phase `R0 — GLOBAL DISCOVERY → CAPABILITY MAP → GAP ANALYSIS` is complete as a versioned baseline.
+
+Documents:
+1. `01_GLOBAL_SYSTEM_RESEARCH.md`
+2. `02_ENTERPRISE_CAPABILITY_MAP.md`
+3. `03_COMPETITOR_MATRIX.md`
+4. `04_DABBIR_GAP_ANALYSIS.md`
+5. `05_DABBIR_TARGET_ARCHITECTURE.md`
+6. `06_DABBIR_CANONICAL_DATA_MODEL.md`
+7. `07_DABBIR_PERMISSION_MODEL.md`
+8. `08_DABBIR_MODULE_ROADMAP.md`
+9. `09_DABBIR_AI_ARCHITECTURE.md`
+10. `10_DABBIR_UAE_READINESS.md`
+11. `11_DABBIR_SECURITY_MODEL.md`
+12. `12_DABBIR_BUILD_VS_BUY.md`
+13. `13_DABBIR_DIFFERENTIATION.md`
+14. `14_DABBIR_IMPLEMENTATION_PLAN.md`
+
+## Architecture decision
+
+P0 is unlocked only in the isolated Business OS line. The next executable phase is **0A — isolated platform boundary**. No database migration or production release may target the current DABBIR production environment.
+
+## Research refresh
+
+Time-sensitive vendor capabilities, pricing and UAE legal/tax requirements must be re-verified immediately before a commercial commitment or compliance-sensitive implementation.

--- a/docs/archive/business-os-research-2026-08-26/README.md
+++ b/docs/archive/business-os-research-2026-08-26/README.md
@@ -1,0 +1,28 @@
+# DABBIR Business OS research archive — 2026-08-26
+
+Status: **HISTORICAL / NON-AUTHORITATIVE**
+
+This directory preserves architecture and market research created on the retired experimental branch `dabbir-business-os-v1` at commit `d9d26cb57f40c819c9cd6e593f81a5b141bfc1a4`.
+
+## Authority
+
+The authoritative DABBIR product, runtime, database contract, UI, release evidence, and implementation source is the repository default branch `main`. Nothing in this archive overrides current code, migrations, security controls, release gates, product state, or verified production evidence.
+
+The old branch assumption that “DABBIR Business OS” must remain a separate product/environment is **superseded**. Useful research principles are retained here as design inputs only.
+
+## Intentionally not archived
+
+The old `business-os.html` foundation preview and `business-os/modules.json` manifest are intentionally excluded because they can be mistaken for an executable/product source of truth. They remain discoverable in Git history at the source commit above.
+
+## Retained design principles
+
+- one canonical data model and explicit state machines;
+- permission before action, fail-closed authorization, immutable/auditable business writes;
+- AI and integrations are governed principals, never hidden superusers;
+- provider-specific payloads stay behind adapters while DABBIR owns business semantics and canonical state;
+- externally retryable mutations require idempotency and verifiable postconditions;
+- UAE/GCC compliance claims require scoped, current legal verification rather than marketing assumptions;
+- features must measurably improve time, cost, revenue, risk, control, service, or productivity;
+- no dashboard, preview, or mock state counts as operational proof.
+
+These principles may inform future implementation, but current behavior is determined only by authoritative `main` plus exact deployed-artifact verification.


### PR DESCRIPTION
Archives the useful research/architecture material from the obsolete isolated `dabbir-business-os-v1` branch under `docs/archive/business-os-research-2026-08-26/` while explicitly marking it historical and non-authoritative. No legacy preview/manifest is promoted. `main` remains the only product/runtime/database/UI/release authority.

The branch is being rebased to latest `main` before review/merge.