### PR TITLE
DABBIR: retire unused PILOT API aliases

### DIFF
--- a/api/pilot-ai.js
+++ b/api/pilot-ai.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-ai.js';
-export * from './dabbir-ai.js';

--- a/api/pilot-runtime.js
+++ b/api/pilot-runtime.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-runtime.js';
-export * from './dabbir-runtime.js';

--- a/api/pilot-whatsapp-webhook.js
+++ b/api/pilot-whatsapp-webhook.js
@@ -1,2 +1,0 @@
-export { default } from './dabbir-whatsapp-webhook.js';
-export * from './dabbir-whatsapp-webhook.js';

--- a/config/dabbir-architecture-ownership.json
+++ b/config/dabbir-architecture-ownership.json
@@ -1,5 +1,5 @@
 {
-  "version": 6,
+  "version": 7,
   "purpose": "Prevent recurring DABBIR failures by giving each critical truth and UI surface one authoritative owner.",
   "authorities": {
     "root_shell": "api/app-recovery.js",
@@ -28,6 +28,18 @@
       "/api/dabbir-mobile-shell-v3",
       "/api/dabbir-logo-placement-ui"
     ]
+  },
+  "legacy_api": {
+    "retired_aliases_forbidden": [
+      "/api/pilot-runtime",
+      "/api/pilot-ai",
+      "/api/pilot-whatsapp-webhook"
+    ],
+    "canonical_replacements": {
+      "/api/pilot-runtime": "/api/dabbir-runtime",
+      "/api/pilot-ai": "/api/dabbir-ai",
+      "/api/pilot-whatsapp-webhook": "/api/dabbir-whatsapp-webhook"
+    }
   },
   "primary_navigation": {
     "desktop_and_mobile_destinations": [

--- a/test/dabbir-architecture-invariants-v1.test.mjs
+++ b/test/dabbir-architecture-invariants-v1.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 const root = new URL('../', import.meta.url);
 const read = path => fs.readFileSync(new URL(path, root), 'utf8');
 const ownership = JSON.parse(read('config/dabbir-architecture-ownership.json'));
+const runtimeRegistry = JSON.parse(read('config/runtime-registry.json'));
 const shell = read('api/app-recovery.js');
 const index = read('index.html');
 const ownerOperations = read('api/owner-operations-ui.js');
@@ -117,4 +118,22 @@ test('tenant WhatsApp truth remains fail-closed and cannot inherit global identi
   assert.match(whatsappStatus, /TENANT_WHATSAPP_NOT_LINKED/);
   assert.match(whatsappStatus, /BUSINESS_CONTEXT_REQUIRED/);
   assert.match(whatsappStatus, /must never inherit a global\/server WhatsApp/i);
+});
+
+test('retired PILOT API aliases cannot return as competing runtime surfaces', () => {
+  assert.equal(runtimeRegistry.authority, 'DABBIR');
+  assert.equal(runtimeRegistry.runtime, 'api/dabbir-runtime.js');
+
+  const retired = ownership.legacy_api.retired_aliases_forbidden;
+  assert.deepEqual(retired, [
+    '/api/pilot-runtime',
+    '/api/pilot-ai',
+    '/api/pilot-whatsapp-webhook'
+  ]);
+
+  for (const route of retired) {
+    const legacyFile = `${route.slice(1)}.js`;
+    assert.equal(fs.existsSync(new URL(legacyFile, root)), false, `retired legacy API returned: ${legacyFile}`);
+    assert.match(ownership.legacy_api.canonical_replacements[route], /^\/api\/dabbir-/);
+  }
 });


### PR DESCRIPTION
Root cause cleanup for legacy product-name API surfaces.

Evidence before removal:
- `config/runtime-registry.json` names DABBIR and `api/dabbir-runtime.js` as the authoritative runtime.
- `api/pilot-runtime.js`, `api/pilot-ai.js`, and `api/pilot-whatsapp-webhook.js` only re-exported DABBIR handlers; they contained no unique logic.
- repository code search found no references to these legacy aliases.
- Vercel Production logs on the latest production deployment and the previous verified production deployment showed no `/api/pilot*` traffic.

Change:
- remove the three unused legacy HTTP aliases
- record them as retired/forbidden in the architecture ownership contract with canonical DABBIR replacements
- add a regression test that fails if any alias returns as a file or if runtime authority drifts from DABBIR

No secret/environment compatibility names are changed in this PR.