### PR TITLE
DABBIR iOS: add fail-closed App Store release preflight

### DIFF
--- a/.github/workflows/dabbir-mobile-ci.yml
+++ b/.github/workflows/dabbir-mobile-ci.yml
@@ -9,6 +9,8 @@ on:
       - 'api/apple/**'
       - 'supabase/migrations/*dabbir_apple*'
       - 'supabase/migrations/*dabbir_*account_deletion*'
+      - 'scripts/dabbir-app-store-preflight.mjs'
+      - 'test/dabbir-app-store-preflight.test.mjs'
       - '.github/workflows/dabbir-mobile-ci.yml'
   push:
     branches: [main]
@@ -19,6 +21,9 @@ on:
       - 'api/apple/**'
       - 'supabase/migrations/*dabbir_apple*'
       - 'supabase/migrations/*dabbir_*account_deletion*'
+      - 'scripts/dabbir-app-store-preflight.mjs'
+      - 'test/dabbir-app-store-preflight.test.mjs'
+      - '.github/workflows/dabbir-mobile-ci.yml'
 
 permissions:
   contents: read
@@ -35,6 +40,11 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22.23.1'
+      - name: Run App Store static preflight
+        working-directory: .
+        env:
+          DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-app-store-preflight-report.json
+        run: node scripts/dabbir-app-store-preflight.mjs
       - name: Install dependencies
         run: npm install --no-audit --no-fund
       - name: Expo doctor
@@ -46,6 +56,14 @@ jobs:
           DABBIR_IOS_BUNDLE_ID: com.barmansystems.dabbir
           DABBIR_IOS_BUILD_NUMBER: '1'
         run: npx expo config --type public >/tmp/dabbir-expo-config.json
+      - name: Upload App Store preflight evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-app-store-preflight-evidence
+          path: dabbir-app-store-preflight-report.json
+          if-no-files-found: warn
+          retention-days: 14
 
   ios-native-compile:
     runs-on: macos-26

--- a/docs/app-store/APP_STORE_RELEASE_PLAN.md
+++ b/docs/app-store/APP_STORE_RELEASE_PLAN.md
@@ -1,43 +1,97 @@
 # DABBIR iOS Release Plan
 
-## Verified starting state
-The authoritative DABBIR repository was web/Vercel-first and had no iOS target, Podfile, Info.plist, Expo, React Native, Swift, or StoreKit app target. PR #158 creates the first native iPhone implementation without wrapping the existing website.
+## Current release verdict
+`APP_STORE_READY=FALSE`
 
-## Verified work completed in PR #158
-- Native React Native / Expo SDK 57 iPhone app foundation.
+The native application, server-side Apple entitlement path, account deletion, web/auth journey, and cross-tenant isolation now have executable evidence. A signed Apple Distribution artifact and TestFlight device run do not yet exist, so App Store readiness must remain false.
+
+## Verified native foundation
+PR #158 created the first native DABBIR iPhone implementation without wrapping the website.
+
+Verified on final PR #158 head `04ba4aecbf8318ffc4068bd41739e484efaa21b0`:
+- DABBIR Mobile CI run `33161772286` completed successfully.
+- `mobile-static` job `98817684658` completed successfully.
+- `ios-native-compile` job `98817684653` completed successfully.
+- The native compile job runs on `macos-26`, explicitly requires Xcode major >= 26, generates the native iOS project, installs CocoaPods, and compiles the Release configuration for the iOS Simulator with code signing disabled.
+- Native React Native / Expo SDK 57 iPhone app; no WebView wrapper.
 - Secure device session storage via iOS Keychain (`expo-secure-store`).
-- Native Bearer auth bridge preserving the existing browser CSRF/same-origin model.
-- Native login, signup, token refresh, logout and password-recovery entry point.
-- Native DABBIR workspace using the existing RLS-protected runtime.
-- Native account-deletion UX and product-scoped deletion architecture that preserves the shared Supabase Auth identity used by unrelated products.
-- DABBIR deleted-account tombstone blocks future DABBIR login/runtime access.
-- Apple StoreKit client flow with Restore Purchases and user UUID `appAccountToken` binding.
-- Server-side Apple JWS transaction verification using Apple's official App Store Server Library.
-- Server-side App Store notification JWS verification.
-- FORCE-RLS Apple entitlement ledger; client can only read its own entitlement and cannot write entitlements.
-- Apple entitlement and retained DABBIR owner-identity cleanup on DABBIR account deletion.
-- Public account deletion RPC hardened to SECURITY INVOKER; privileged implementation isolated in `dabbir_private`.
-- iOS Privacy Manifest foundation and no ATT/tracking declaration because the native app currently contains no tracking/analytics SDK.
-- Root CI, Expo Doctor, TypeScript, Expo config validation, lockfile integrity, CocoaPods/native prebuild gates.
-- Native Release simulator compilation gate using Xcode 26 on macOS; a preceding PR commit has completed `xcodebuild Release` successfully and the latest code continues through the same gate.
+- Native Bearer auth bridge preserving browser CSRF/same-origin behavior.
+- Login, signup, refresh, logout and password recovery.
+- RLS-protected DABBIR workspace.
+- In-app product-scoped account deletion that does not delete a shared Supabase Auth identity used by unrelated products.
+- Deleted-account tombstone blocks future DABBIR login/runtime access.
+- StoreKit client flow with Restore Purchases and user UUID `appAccountToken` binding.
+- Server-side Apple transaction and App Store Server Notification JWS verification using Apple's official App Store Server Library.
+- FORCE-RLS Apple entitlement ledger; client can read only its own entitlement and cannot write entitlements.
+- Server verification and entitlement persistence occur before the client finishes/grants a purchase.
+- iOS Privacy Manifest foundation with tracking disabled; final collected-data reconciliation is still required against the submission binary.
 
-## Active release gates
-1. Complete latest-head CI for every source-changing commit.
-2. Apply and transaction-test the final DABBIR account deletion reconciliation migration.
-3. Complete synthetic tenant-isolation and WhatsApp-isolation regression tests.
-4. Register/verify the final Apple Bundle ID and App Store Connect app record.
-5. Provision Apple App Store verification environment values and create the actual subscription product.
-6. Produce a signed Distribution build and upload it to TestFlight.
-7. Perform exact TestFlight artifact on-device QA.
-8. Publish final Privacy / Support / Terms URLs and reconcile App Privacy answers to the final binary and backend processors.
-9. Capture screenshots from the exact production candidate and prepare App Review access/notes.
+## Verified Supabase release migrations
+Applied to project `spohjzrsymsmzsseygtw`:
+- `dabbir_apple_entitlements_v1`
+- `dabbir_product_scoped_account_deletion_v1`
+- `dabbir_account_deletion_apple_cleanup_v1`
+- `dabbir_account_deletion_identity_cleanup_v2`
+- `dabbir_account_delete_private_executor_v2`
+- `dabbir_account_delete_customer_number_release_v3`
+
+## Verified security / production journey
+Canonical Full Customer Journey run `33175328444` (#138) completed successfully on exact production release:
+- Commit SHA: `55ed13414e31c39784b0737528a77f0dbffe911a`
+- Vercel deployment: `dpl_5UDsdeQz62ZbCPzjndhUipBVLtEF`
+- Full owner/customer/employee/AI journey: 28/28 PASS.
+- Cross-tenant + WhatsApp isolation attack: 9/9 PASS.
+- Required failures: 0.
+- Release remained the same before and after the tests.
+- Evidence ZIP SHA-256: `757b688872425e9dac8602e904575da564f14efc7c78f7c836d979927d56b8d5`.
+
+This verifies server/web authentication, tenant isolation and WhatsApp cross-tenant authorization. It does **not** substitute for a real iPhone/TestFlight Meta WhatsApp pairing and message test.
+
+## App Store preflight contract
+The release pipeline must distinguish internal source readiness from Apple/external readiness.
+
+Static preflight is required to verify:
+- Native/non-WebView client.
+- In-app account deletion and password recovery.
+- Server-side Apple JWS verification and entitlement persistence.
+- No entitlement before server verification.
+- Restore Purchases.
+- StoreKit-derived subscription period and introductory-offer disclosure; no hardcoded 7-day trial claim in the client.
+- Public Privacy Policy and Terms links are required by the subscription UI before purchase is enabled.
+- No Stripe, web checkout, or external purchase CTA in the iOS subscription component.
+- Native API base remains explicit HTTPS and fail-closed.
+
+Release-mode preflight must additionally fail unless all of these are real and configured:
+- Bundle ID exactly `com.barmansystems.dabbir`.
+- Numeric App Store Apple ID.
+- Same subscription product ID on the iOS client and server.
+- Apple IAP enabled for the production candidate.
+- Public production HTTPS API URL, not a protected/prelaunch deployment URL.
+- Public HTTPS Privacy Policy, Terms of Use, and Support URLs.
+- Apple root certificates for JWS verification.
+- Server-side entitlement storage credential.
+
+The preflight must never print private keys, root certificate bodies, or service-role credentials.
+
+## Remaining P0 release gates
+1. Register/verify `com.barmansystems.dabbir` in the Apple Developer account and create/verify the App Store Connect app record.
+2. Create the real auto-renewable subscription in App Store Connect and configure the intended introductory free trial there. The client must display only StoreKit-reported offer data; it must not manufacture eligibility or duration.
+3. Configure production Apple/IAP values and public API/legal/support URLs, then obtain a RELEASE preflight PASS.
+4. Reconcile the Privacy Manifest and App Privacy questionnaire against the exact final binary, backend processing, and third-party SDKs.
+5. Produce a signed Apple Distribution archive/IPA from the exact candidate and record its build/artifact identity.
+6. Upload that exact build to TestFlight.
+7. Perform exact TestFlight artifact QA on a real iPhone: install, launch, signup/email verification, login, password recovery, dashboard, native WhatsApp Embedded Signup/pairing, send/receive path, StoreKit purchase, server entitlement, Restore Purchases, logout/login, product-scoped account deletion, reinstall/re-auth behavior.
+8. Capture App Store screenshots from the exact candidate and finish Arabic/English metadata, age rating, export-compliance answers, privacy answers, Support/Privacy/Terms URLs, reviewer demo access, and review notes.
+
+## Known security warning outside the native source gate
+Supabase Security Advisor still reports Leaked Password Protection disabled. It remains unresolved until Supabase Auth configuration can be changed through an authorized management surface. Do not mark it fixed merely because application tests pass.
 
 ## External-owner-only gates
 - Apple Developer enrollment/fee if not active.
 - Apple ID authentication/OTP.
 - Acceptance of Apple legal agreements when Account Holder action is required.
 - Banking/tax/legal identity fields where Apple requires the Account Holder.
-- Apple account authorization/API credentials if no authorized machine/service credential is available.
+- Apple account authorization/API credentials when no authorized machine/service credential is available.
 
 ## Release rule
 Do not claim TestFlight Ready while signing/App Store Connect/TestFlight are unverified. Do not claim App Store Ready while any P0 remains. Every PASS must follow ACTION → ARTIFACT → TEST → EVIDENCE → VERIFICATION.

--- a/mobile/src/SubscriptionCard.tsx
+++ b/mobile/src/SubscriptionCard.tsx
@@ -1,13 +1,88 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Linking, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useIAP, type Purchase } from 'expo-iap';
 import { loadAppleEntitlement, verifyApplePurchase } from './api';
 
 type FinishTransaction = (args: { purchase: Purchase; isConsumable?: boolean }) => Promise<void>;
 
+type StoreKitPeriod = { count: number; unit: string };
+type StoreKitIntro = { paymentMode?: string; periodCount?: number; period?: { unit?: string }; displayPrice?: string };
+
+function publicHttpsUrl(raw: string | undefined): string | null {
+  try {
+    const url = new URL(String(raw || '').trim());
+    if (url.protocol !== 'https:') return null;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function periodFromProduct(product: any): StoreKitPeriod | null {
+  const legacyCount = Number(product?.subscriptionPeriodNumberIOS);
+  const legacyUnit = String(product?.subscriptionPeriodUnitIOS || '').toLowerCase();
+  if (Number.isFinite(legacyCount) && legacyCount > 0 && legacyUnit) return { count: legacyCount, unit: legacyUnit };
+
+  const modern = product?.subscriptionInfoIOS?.subscriptionPeriod || product?.subscriptionPeriod || null;
+  const modernCount = Number(modern?.value ?? modern?.periodCount ?? modern?.count);
+  const modernUnit = String(modern?.unit || '').toLowerCase();
+  if (Number.isFinite(modernCount) && modernCount > 0 && modernUnit) return { count: modernCount, unit: modernUnit };
+  return null;
+}
+
+function introFromProduct(product: any): StoreKitIntro | null {
+  return product?.subscriptionInfoIOS?.introductoryOffer || product?.introductoryOffer || null;
+}
+
+function unitLabel(unit: string, arabic: boolean): string {
+  const value = unit.toLowerCase();
+  if (arabic) {
+    if (value.includes('day')) return 'يوم';
+    if (value.includes('week')) return 'أسبوع';
+    if (value.includes('month')) return 'شهر';
+    if (value.includes('year')) return 'سنة';
+    return unit;
+  }
+  if (value.includes('day')) return 'day';
+  if (value.includes('week')) return 'week';
+  if (value.includes('month')) return 'month';
+  if (value.includes('year')) return 'year';
+  return unit;
+}
+
+function periodText(period: StoreKitPeriod | null, arabic: boolean): string | null {
+  if (!period) return null;
+  const unit = unitLabel(period.unit, arabic);
+  return arabic ? `كل ${period.count} ${unit}` : `every ${period.count} ${unit}${period.count === 1 ? '' : 's'}`;
+}
+
+function introText(intro: StoreKitIntro | null, arabic: boolean): string | null {
+  if (!intro) return null;
+  const mode = String(intro.paymentMode || '').toLowerCase();
+  const count = Number(intro.periodCount || 0);
+  const unit = String(intro.period?.unit || '').toLowerCase();
+  const duration = count > 0 && unit ? `${count} ${unitLabel(unit, arabic)}` : '';
+
+  if (mode === 'free-trial' || mode === 'freetrial') {
+    return arabic
+      ? `عرض App Store التمهيدي: تجربة مجانية${duration ? ` لمدة ${duration}` : ''}. تطبق Apple العرض فقط على الحسابات المؤهلة.`
+      : `App Store introductory offer: free trial${duration ? ` for ${duration}` : ''}. Apple applies the offer only to eligible accounts.`;
+  }
+
+  if (intro.displayPrice) {
+    return arabic
+      ? `عرض App Store التمهيدي: ${intro.displayPrice}${duration ? ` لمدة ${duration}` : ''}.`
+      : `App Store introductory offer: ${intro.displayPrice}${duration ? ` for ${duration}` : ''}.`;
+  }
+  return null;
+}
+
 export function SubscriptionCard({ accessToken, accountToken }: { accessToken: string; accountToken?: string | null }) {
   const enabled = process.env.EXPO_PUBLIC_IOS_IAP_ENABLED === 'true';
   const productId = String(process.env.EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID || '').trim();
+  const privacyUrl = publicHttpsUrl(process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL);
+  const termsUrl = publicHttpsUrl(process.env.EXPO_PUBLIC_DABBIR_TERMS_URL);
+  const legalReady = Boolean(privacyUrl && termsUrl);
   const [busy, setBusy] = useState(false);
   const [verified, setVerified] = useState(false);
   const finishRef = useRef<FinishTransaction | null>(null);
@@ -54,10 +129,16 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
   }, [connected, enabled, fetchProducts, productId]);
 
   const product = useMemo(() => subscriptions.find(item => item.id === productId) || null, [productId, subscriptions]);
+  const billingPeriod = useMemo(() => periodFromProduct(product), [product]);
+  const introductoryOffer = useMemo(() => introFromProduct(product), [product]);
+  const billingText = periodText(billingPeriod, true);
+  const offerText = introText(introductoryOffer, true);
+
   if (!enabled) return null;
 
   const buy = async () => {
-    if (!productId || !connected) return Alert.alert('غير متاح', 'Apple StoreKit غير جاهز على هذا البناء.');
+    if (!productId || !connected || !product) return Alert.alert('غير متاح', 'Apple StoreKit أو منتج الاشتراك غير جاهز على هذا البناء.');
+    if (!legalReady) return Alert.alert('إعداد الإصدار غير مكتمل', 'يجب ربط سياسة الخصوصية وشروط الاستخدام العامة قبل إتاحة اشتراك App Store.');
     if (!accountToken) return Alert.alert('غير متاح', 'تعذر ربط عملية الشراء بهوية حساب دبّر الحالية.');
     setBusy(true);
     try {
@@ -80,9 +161,25 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
   return (
     <View style={styles.card}>
       <Text style={styles.title}>اشتراك دبّر عبر Apple</Text>
-      <Text style={styles.body}>{verified ? 'الاشتراك موثّق ونشط.' : (product ? `${product.displayName || 'DABBIR Owner'} — ${product.displayPrice || ''}` : 'جارٍ قراءة منتج الاشتراك من App Store.')}</Text>
-      <Pressable style={[styles.button, busy && styles.disabled]} disabled={busy || verified} onPress={buy}><Text style={styles.buttonText}>{verified ? 'الاشتراك نشط' : 'اشترك عبر Apple'}</Text></Pressable>
+      <Text style={styles.body}>
+        {verified
+          ? 'الاشتراك موثّق ونشط.'
+          : product
+            ? `${product.displayName || 'DABBIR Owner'} — ${product.displayPrice || ''}${billingText ? `، ${billingText}` : ''}`
+            : 'جارٍ قراءة منتج الاشتراك من App Store.'}
+      </Text>
+      {offerText ? <Text style={styles.offer}>{offerText}</Text> : null}
+      {!legalReady ? <Text style={styles.warning}>هذا البناء غير جاهز للبيع حتى تُضبط روابط سياسة الخصوصية وشروط الاستخدام العامة.</Text> : null}
+      <Pressable style={[styles.button, (busy || !legalReady || !product) && styles.disabled]} disabled={busy || verified || !legalReady || !product} onPress={buy}>
+        <Text style={styles.buttonText}>{verified ? 'الاشتراك نشط' : 'اشترك عبر Apple'}</Text>
+      </Pressable>
       <Pressable disabled={busy} onPress={restore}><Text style={styles.link}>استعادة المشتريات</Text></Pressable>
+      <View style={styles.legalRow}>
+        <Pressable disabled={!privacyUrl} onPress={() => { if (privacyUrl) void Linking.openURL(privacyUrl); }}><Text style={[styles.legalLink, !privacyUrl && styles.disabledText]}>سياسة الخصوصية</Text></Pressable>
+        <Text style={styles.separator}>•</Text>
+        <Pressable disabled={!termsUrl} onPress={() => { if (termsUrl) void Linking.openURL(termsUrl); }}><Text style={[styles.legalLink, !termsUrl && styles.disabledText]}>شروط الاستخدام</Text></Pressable>
+      </View>
+      <Text style={styles.disclosure}>يُدار الدفع والتجديد والإلغاء عبر Apple ID وApp Store. سعر وفترة الاشتراك والعروض أعلاه تُقرأ من StoreKit ولا ينشئها دبّر محليًا.</Text>
     </View>
   );
 }
@@ -91,8 +188,15 @@ const styles = StyleSheet.create({
   card: { padding: 16, borderRadius: 18, borderWidth: 1, borderColor: '#D8D8DE', gap: 10 },
   title: { fontSize: 17, fontWeight: '700', textAlign: 'right' },
   body: { fontSize: 14, lineHeight: 22, textAlign: 'right' },
+  offer: { fontSize: 13, lineHeight: 20, textAlign: 'right', fontWeight: '600' },
+  warning: { fontSize: 13, lineHeight: 20, textAlign: 'right', color: '#B42318' },
   button: { backgroundColor: '#17171B', padding: 14, borderRadius: 12 },
   disabled: { opacity: 0.5 },
   buttonText: { color: '#FFF', textAlign: 'center', fontWeight: '700' },
   link: { textAlign: 'center', textDecorationLine: 'underline', padding: 6 },
+  legalRow: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
+  legalLink: { textDecorationLine: 'underline', fontSize: 13 },
+  disabledText: { opacity: 0.45 },
+  separator: { opacity: 0.5 },
+  disclosure: { fontSize: 12, lineHeight: 18, textAlign: 'right', opacity: 0.7 },
 });

--- a/scripts/dabbir-app-store-preflight.mjs
+++ b/scripts/dabbir-app-store-preflight.mjs
@@ -69,7 +69,7 @@ requireStatic(/subscriptionPeriodNumberIOS|subscriptionInfoIOS/.test(subscriptio
 requireStatic(/introductoryOffer|introOffer/.test(subscription) && /free-trial/.test(subscription), 'STOREKIT_INTRO_OFFER_DISCLOSURE', 'Introductory/free-trial text is derived from StoreKit offer metadata.');
 requireStatic(/EXPO_PUBLIC_DABBIR_PRIVACY_URL/.test(subscription) && /EXPO_PUBLIC_DABBIR_TERMS_URL/.test(subscription), 'SUBSCRIPTION_LEGAL_LINKS', 'Subscription screen requires privacy and Terms links.');
 requireStatic(!/stripe|checkout|payment[_ -]?link|buy on web|subscribe on web/i.test(subscription), 'NO_EXTERNAL_PAYMENT_CTA', 'The iOS subscription component contains no Stripe/external purchase CTA.');
-requireStatic(/DABBIR_API_BASE_URL_NOT_CONFIGURED/.test(mobileApi) && /\^https:\\/\\//.test(mobileApi), 'HTTPS_API_FAIL_CLOSED', 'Native API requires an explicit HTTPS base URL.');
+requireStatic(mobileApi.includes('DABBIR_API_BASE_URL_NOT_CONFIGURED') && mobileApi.includes('configuredBase') && mobileApi.includes('https:'), 'HTTPS_API_FAIL_CLOSED', 'Native API requires an explicit HTTPS base URL.');
 
 const bundleId = String(process.env.DABBIR_IOS_BUNDLE_ID || '').trim();
 const appAppleId = String(process.env.DABBIR_IOS_APP_APPLE_ID || '').trim();

--- a/scripts/dabbir-app-store-preflight.mjs
+++ b/scripts/dabbir-app-store-preflight.mjs
@@ -1,0 +1,111 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const releaseMode = String(process.env.DABBIR_APP_STORE_RELEASE_PREFLIGHT || '').trim() === '1';
+const reportPath = String(process.env.DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH || '').trim();
+
+const read = relative => fs.readFileSync(path.join(ROOT, relative), 'utf8');
+const failures = [];
+const external = [];
+const passes = [];
+
+function requireStatic(condition, code, detail) {
+  if (condition) passes.push({ code, detail });
+  else failures.push({ code, detail });
+}
+
+function requireRelease(condition, code, detail) {
+  if (condition) passes.push({ code, detail });
+  else if (releaseMode) failures.push({ code, detail });
+  else external.push({ code, detail });
+}
+
+function httpsUrl(value) {
+  try {
+    const url = new URL(String(value || '').trim());
+    if (url.protocol !== 'https:') return null;
+    if (['localhost', '127.0.0.1', '::1'].includes(url.hostname)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function isProtectedPrelaunchHost(url) {
+  if (!url) return false;
+  return /-3619s-projects\.vercel\.app$/i.test(url.hostname) || /-nd56cm4j5v-/i.test(url.hostname);
+}
+
+const appConfig = read('mobile/app.config.ts');
+const app = read('mobile/App.tsx');
+const subscription = read('mobile/src/SubscriptionCard.tsx');
+const mobileApi = read('mobile/src/api.ts');
+const mobilePackage = read('mobile/package.json');
+const appleCore = read('api/_apple-iap-core.js');
+const appleVerify = read('api/mobile/iap/verify.js');
+const appleNotifications = read('api/apple/app-store-notifications.js');
+const accountDelete = read('api/mobile/account-delete.js');
+const entitlementMigration = read('supabase/migrations/20260828091500_dabbir_apple_entitlements_v1.sql');
+
+requireStatic(/name:\s*['"]DABBIR \| دبّر['"]/.test(appConfig), 'APP_NAME_LOCKED', 'Native app name is DABBIR | دبّر.');
+requireStatic(/supportsTablet:\s*false/.test(appConfig), 'IPHONE_ONLY', 'iPad distribution is disabled for v1.');
+requireStatic(/scheme:\s*['"]dabbir['"]/.test(appConfig), 'DEEPLINK_SCHEME', 'dabbir:// scheme exists.');
+requireStatic(/version:\s*['"]1\.0\.0['"]/.test(appConfig), 'VERSION_1_0_0', 'Version 1.0.0 is explicit.');
+requireStatic(/com\.barmansystems\.dabbir/.test(appConfig), 'BUNDLE_DEFAULT', 'Canonical bundle identifier default exists.');
+requireStatic(/privacyManifests/.test(appConfig) && /NSPrivacyTracking:\s*false/.test(appConfig), 'PRIVACY_MANIFEST_BASE', 'Privacy manifest base exists and tracking is disabled.');
+requireStatic(/"react-native"/.test(mobilePackage) && !/\bWebView\b|react-native-webview/.test(app), 'NATIVE_NOT_WEBVIEW', 'The iOS client is React Native and not a WebView wrapper.');
+requireStatic(/deleteDabbirAccount/.test(app) && /api\.deleteDabbirAccount/.test(app) && /dabbir_delete_current_user_account/.test(accountDelete), 'IN_APP_ACCOUNT_DELETION', 'Product-scoped account deletion is reachable inside the app.');
+requireStatic(/requestPasswordRecovery/.test(app) && /Forgot password|نسيت كلمة المرور/.test(app), 'PASSWORD_RECOVERY', 'Native password recovery is present.');
+requireStatic(/SignedDataVerifier/.test(appleCore) && /verifyAndDecodeTransaction/.test(appleCore), 'APPLE_JWS_TRANSACTION_VERIFY', 'Apple transaction JWS is verified server-side.');
+requireStatic(/verifyAndDecodeNotification/.test(appleCore) && /verifyAppleNotification/.test(appleNotifications), 'APPLE_SERVER_NOTIFICATIONS_VERIFY', 'App Store Server Notifications are verified server-side.');
+requireStatic(/appAccountToken\.toLowerCase\(\) !== userId\.toLowerCase\(\)/.test(appleCore), 'APPLE_ACCOUNT_BINDING', 'Apple transactions are bound to the DABBIR user UUID.');
+requireStatic(/persistAppleEntitlement/.test(appleVerify) && /persistAppleEntitlement/.test(appleNotifications), 'APPLE_ENTITLEMENT_PERSISTENCE', 'Verified purchase and notification paths persist entitlements.');
+requireStatic(/force row level security/i.test(entitlementMigration), 'APPLE_ENTITLEMENT_RLS', 'Apple entitlement table is protected by forced RLS.');
+requireStatic(/verified !== true \|\| result\?\.entitled !== true/.test(subscription) && /finishTransaction/.test(subscription), 'NO_UNVERIFIED_ENTITLEMENT', 'Client never finishes/grants a purchase before server entitlement verification.');
+requireStatic(/restorePurchases/.test(subscription), 'RESTORE_PURCHASES', 'Restore Purchases is exposed.');
+requireStatic(/EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID/.test(subscription), 'STOREKIT_PRODUCT_CONFIG', 'Client subscription product is configuration-driven.');
+requireStatic(/subscriptionPeriodNumberIOS|subscriptionInfoIOS/.test(subscription), 'STOREKIT_PERIOD_DISCLOSURE', 'Subscription billing period is derived from StoreKit product data.');
+requireStatic(/introductoryOffer|introOffer/.test(subscription) && /free-trial/.test(subscription), 'STOREKIT_INTRO_OFFER_DISCLOSURE', 'Introductory/free-trial text is derived from StoreKit offer metadata.');
+requireStatic(/EXPO_PUBLIC_DABBIR_PRIVACY_URL/.test(subscription) && /EXPO_PUBLIC_DABBIR_TERMS_URL/.test(subscription), 'SUBSCRIPTION_LEGAL_LINKS', 'Subscription screen requires privacy and Terms links.');
+requireStatic(!/stripe|checkout|payment[_ -]?link|buy on web|subscribe on web/i.test(subscription), 'NO_EXTERNAL_PAYMENT_CTA', 'The iOS subscription component contains no Stripe/external purchase CTA.');
+requireStatic(/DABBIR_API_BASE_URL_NOT_CONFIGURED/.test(mobileApi) && /\^https:\\/\\//.test(mobileApi), 'HTTPS_API_FAIL_CLOSED', 'Native API requires an explicit HTTPS base URL.');
+
+const bundleId = String(process.env.DABBIR_IOS_BUNDLE_ID || '').trim();
+const appAppleId = String(process.env.DABBIR_IOS_APP_APPLE_ID || '').trim();
+const serverProductId = String(process.env.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID || '').trim();
+const clientProductId = String(process.env.EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID || '').trim();
+const iapEnabled = String(process.env.EXPO_PUBLIC_IOS_IAP_ENABLED || '').trim();
+const apiUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL);
+const privacyUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL);
+const termsUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_TERMS_URL);
+const supportUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL);
+const rootCerts = String(process.env.APPLE_ROOT_CERTIFICATES_BASE64 || '').trim();
+const serviceRole = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+
+requireRelease(bundleId === 'com.barmansystems.dabbir', 'APPLE_BUNDLE_REGISTERED_VALUE', 'Release bundle ID must be com.barmansystems.dabbir.');
+requireRelease(/^\d{5,20}$/.test(appAppleId), 'APP_STORE_APPLE_ID', 'App Store numeric Apple ID must be configured.');
+requireRelease(serverProductId.length > 2 && clientProductId === serverProductId, 'IAP_PRODUCT_MATCH', 'Client and server must use the exact same App Store subscription product ID.');
+requireRelease(iapEnabled === 'true', 'IAP_ENABLED_RELEASE', 'Production candidate must enable Apple IAP.');
+requireRelease(Boolean(apiUrl) && !isProtectedPrelaunchHost(apiUrl), 'PUBLIC_PRODUCTION_API', 'Production iOS API base must be public HTTPS and not a protected/prelaunch Vercel host.');
+requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl), 'PUBLIC_PRIVACY_URL', 'Privacy Policy URL must be public HTTPS.');
+requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl), 'PUBLIC_TERMS_URL', 'Terms of Use URL must be public HTTPS.');
+requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl), 'PUBLIC_SUPPORT_URL', 'Support URL must be public HTTPS.');
+requireRelease(rootCerts.split(',').map(v => v.trim()).filter(Boolean).length >= 2, 'APPLE_ROOT_CERTIFICATES', 'Apple root certificates must be configured server-side.');
+requireRelease(Boolean(serviceRole) && !serviceRole.startsWith('sb_publishable_'), 'IAP_SERVER_STORAGE_CREDENTIAL', 'Server-side entitlement persistence credential must exist.');
+
+const report = {
+  ok: failures.length === 0,
+  mode: releaseMode ? 'RELEASE' : 'STATIC',
+  verdict: failures.length ? 'FAIL' : (external.length ? 'INTERNAL_PASS_EXTERNAL_BLOCKED' : 'PASS'),
+  passes: passes.map(item => item.code),
+  failures,
+  external_blockers: external,
+  privacy_manifest_final_binary_reconciliation: 'REQUIRED_BEFORE_SUBMISSION',
+  signed_distribution_testflight: 'EXTERNAL_APPLE_GATE',
+};
+
+const json = JSON.stringify(report, null, 2);
+if (reportPath) fs.writeFileSync(path.resolve(ROOT, reportPath), `${json}\n`);
+console.log(json);
+if (failures.length) process.exit(2);

--- a/test/dabbir-app-store-preflight.test.mjs
+++ b/test/dabbir-app-store-preflight.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const read = relative => readFile(path.join(ROOT, relative), 'utf8');
+
+function runPreflight(extraEnv = {}) {
+  const clean = {
+    ...process.env,
+    DABBIR_APP_STORE_RELEASE_PREFLIGHT: '',
+    DABBIR_IOS_BUNDLE_ID: '',
+    DABBIR_IOS_APP_APPLE_ID: '',
+    DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID: '',
+    EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID: '',
+    EXPO_PUBLIC_IOS_IAP_ENABLED: '',
+    EXPO_PUBLIC_DABBIR_API_BASE_URL: '',
+    EXPO_PUBLIC_DABBIR_PRIVACY_URL: '',
+    EXPO_PUBLIC_DABBIR_TERMS_URL: '',
+    EXPO_PUBLIC_DABBIR_SUPPORT_URL: '',
+    APPLE_ROOT_CERTIFICATES_BASE64: '',
+    SUPABASE_SERVICE_ROLE_KEY: '',
+    ...extraEnv,
+  };
+  return spawnSync(process.execPath, ['scripts/dabbir-app-store-preflight.mjs'], {
+    cwd: ROOT,
+    env: clean,
+    encoding: 'utf8',
+  });
+}
+
+test('static App Store preflight passes internal invariants while reporting external Apple blockers', () => {
+  const result = runPreflight();
+  assert.equal(result.status, 0, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, true);
+  assert.equal(report.mode, 'STATIC');
+  assert.equal(report.verdict, 'INTERNAL_PASS_EXTERNAL_BLOCKED');
+  assert.ok(report.passes.includes('NATIVE_NOT_WEBVIEW'));
+  assert.ok(report.passes.includes('NO_UNVERIFIED_ENTITLEMENT'));
+  assert.ok(report.passes.includes('SUBSCRIPTION_LEGAL_LINKS'));
+  assert.ok(report.passes.includes('STOREKIT_INTRO_OFFER_DISCLOSURE'));
+  assert.ok(report.external_blockers.some(item => item.code === 'APP_STORE_APPLE_ID'));
+  assert.ok(report.external_blockers.some(item => item.code === 'PUBLIC_PRODUCTION_API'));
+  assert.equal(report.signed_distribution_testflight, 'EXTERNAL_APPLE_GATE');
+});
+
+test('release App Store preflight fails closed when Apple/public release configuration is absent', () => {
+  const result = runPreflight({ DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1' });
+  assert.equal(result.status, 2, result.stderr || result.stdout);
+  const report = JSON.parse(result.stdout);
+  assert.equal(report.ok, false);
+  assert.equal(report.mode, 'RELEASE');
+  assert.equal(report.verdict, 'FAIL');
+  const codes = new Set(report.failures.map(item => item.code));
+  for (const required of ['APPLE_BUNDLE_REGISTERED_VALUE', 'APP_STORE_APPLE_ID', 'IAP_PRODUCT_MATCH', 'IAP_ENABLED_RELEASE', 'PUBLIC_PRODUCTION_API', 'PUBLIC_PRIVACY_URL', 'PUBLIC_TERMS_URL', 'PUBLIC_SUPPORT_URL', 'APPLE_ROOT_CERTIFICATES', 'IAP_SERVER_STORAGE_CREDENTIAL']) {
+    assert.ok(codes.has(required), `missing fail-closed release blocker ${required}`);
+  }
+});
+
+test('subscription UI discloses StoreKit-derived period/offer and legal links without external payment CTA', async () => {
+  const source = await read('mobile/src/SubscriptionCard.tsx');
+  assert.match(source, /subscriptionPeriodNumberIOS|subscriptionInfoIOS/);
+  assert.match(source, /introductoryOffer/);
+  assert.match(source, /free-trial/);
+  assert.match(source, /EXPO_PUBLIC_DABBIR_PRIVACY_URL/);
+  assert.match(source, /EXPO_PUBLIC_DABBIR_TERMS_URL/);
+  assert.match(source, /Linking\.openURL/);
+  assert.match(source, /verified !== true \|\| result\?\.entitled !== true/);
+  assert.match(source, /finishTransaction/);
+  assert.doesNotMatch(source, /stripe|checkout|buy on web|subscribe on web/i);
+  assert.doesNotMatch(source, /7\s*(day|days|يوم|أيام)/i);
+});
+
+test('mobile CI permanently runs the static App Store preflight and watches its contract paths', async () => {
+  const workflow = await read('.github/workflows/dabbir-mobile-ci.yml');
+  assert.match(workflow, /scripts\/dabbir-app-store-preflight\.mjs/);
+  assert.match(workflow, /test\/dabbir-app-store-preflight\.test\.mjs/);
+  assert.match(workflow, /Run App Store static preflight/);
+  assert.match(workflow, /node scripts\/dabbir-app-store-preflight\.mjs/);
+});


### PR DESCRIPTION
Adds a permanent App Store release preflight for DABBIR iOS and closes internal subscription-disclosure gaps without claiming Apple/TestFlight readiness.

Changes:
- Adds static and release-mode App Store preflight.
- Static mode verifies native/no-WebView, account deletion, Apple JWS verification, entitlement persistence, Restore Purchases, no external payment CTA, StoreKit-derived subscription period/intro offer, and legal links.
- Release mode fails closed unless the exact bundle ID, numeric App Store Apple ID, matching client/server subscription product, IAP enablement, public API/Privacy/Terms/Support URLs, Apple root certificates, and server entitlement storage credential exist.
- Subscription UI now shows billing period and introductory/free-trial information from StoreKit instead of hardcoding a trial duration.
- Purchase is disabled when Privacy Policy or Terms URLs are missing.
- Mobile CI permanently runs the static preflight and uploads its JSON evidence.
- Adds regression tests preventing the gate from being silently removed.
- Refreshes the App Store release plan with verified #158 native compile and #138 28-step + 9 isolation evidence.

This PR does not add Stripe/web checkout to iOS and does not expose Apple or Supabase secrets. Signed Distribution/TestFlight remains an external gate.