### PR TITLE
DABBIR: reconcile UI patch-growth root cause status

### DIFF
--- a/docs/root-cause-registry.md
+++ b/docs/root-cause-registry.md
@@ -10,7 +10,7 @@
 | QA false green | Protected browser journey could be skipped while workflow ended green | Blocked execution was not a failing evidence state | QA_FALSE_GREEN | Blocked/skipped journey exits non-zero and cannot count as PASS | CONTROLLED |
 | Deployment comparison drift | A failed runtime commit could be followed by a test/docs commit that Vercel ignored, leaving the combined candidate unverified | Ignored Build Step treated incremental Git history as sufficient release evidence; ignored commits could advance the comparison baseline | ARTIFACT_DRIFT + QA_FALSE_GREEN | Every non-main branch runs the full Vercel build gate; main compares from the last successful baseline and any uncertainty/runtime drift builds fail-safe | CONTROLLED |
 | Runtime engine drift | Vercel/Control Plane required Node 24.x while package.json forced Node 22.x and its test encoded the stale value | Runtime version had multiple unsynchronized sources of truth | CONFIG_SOURCE_DRIFT | package.json and package-lock.json must both equal the authoritative Node 24.x line; regression test locks equality | CONTROLLED |
-| UI patch growth | Fixes repeatedly added guards/overlays that depended on load order | Shell had no hard complexity ceiling or ownership contract | PATCH_ON_PATCH | Explicit shell allowlist, unique modules, max module ceiling, retired-module denylist | ACTIVE |
+| UI patch growth | Fixes repeatedly added guards/overlays that depended on load order | Shell had no hard complexity ceiling or ownership contract | PATCH_ON_PATCH | Explicit shell allowlist, unique modules, maximum 25-module ceiling, last-loaded auth observer, and retired-module denylist enforced by `test/dabbir-architecture-invariants-v1.test.mjs` | CONTROLLED |
 
 ## Closure rule
 


### PR DESCRIPTION
Second-pass audit reconciliation only. The UI patch-growth row remained marked ACTIVE even though the permanent control already exists and is enforced in `test/dabbir-architecture-invariants-v1.test.mjs`: explicit shell allowlist, unique modules, 25-module ceiling, last-loaded auth observer, and retired-module denylist.

This PR changes the registry status to CONTROLLED and names the executable invariant. It intentionally does not claim broader shell consolidation is complete.

Evidence:
- architecture recurrence prevention landed in `f1df58883229d41b6f7899a67d20433b27dad82f`;
- current main CI passes the architecture invariant;
- later exact-production customer journeys passed after the control landed.

Docs-only; no runtime/database/auth/security behavior changes.