### PR TITLE
DABBIR release: fix BAR-12 runtime-equivalence deadlock

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - 'package.json'
       - 'package-lock.json'
+      - 'vercel-ignore-if-unaffected.sh'
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/dabbir-cross-tenant-isolation.mjs'
       - 'test/dabbir-protected-full-journey-preload.mjs'

--- a/test/vercel-ignore.test.mjs
+++ b/test/vercel-ignore.test.mjs
@@ -6,6 +6,7 @@ import path from 'node:path';
 import { execFileSync, spawnSync } from 'node:child_process';
 
 const sourceScript = path.resolve('vercel-ignore-if-unaffected.sh');
+const journeyWorkflow = fs.readFileSync(path.resolve('.github/workflows/dabbir-ai-customer-journey.yml'), 'utf8');
 
 function git(cwd, ...args) {
   return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
@@ -64,6 +65,35 @@ test('test-only changes on main skip Vercel deployment when no runtime drift exi
   git(dir, 'add', '.'); git(dir, 'commit', '-qm', 'test only');
   const head = git(dir, 'rev-parse', 'HEAD');
   assert.equal(runGuard(dir, head, lastSuccessfulDeployment).status, 0);
+});
+
+test('native mobile and App Store preflight changes on main reuse the last verified web runtime', () => {
+  const paths = [
+    'mobile/src/SubscriptionCard.tsx',
+    'mobile/app.json',
+    'scripts/dabbir-app-store-preflight.mjs',
+  ];
+  for (const relativePath of paths) {
+    const dir = setupRepo();
+    const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+    const head = commitPath(dir, relativePath, 'native-only\n');
+    const result = runGuard(dir, head, lastSuccessfulDeployment);
+    assert.equal(result.status, 0, `${relativePath}: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /Only explicitly non-runtime DABBIR paths changed/);
+  }
+});
+
+test('unlisted scripts remain fail-safe and force a web deployment', () => {
+  const dir = setupRepo();
+  const lastSuccessfulDeployment = git(dir, 'rev-parse', 'HEAD');
+  const head = commitPath(dir, 'scripts/unknown-release-hook.mjs', 'export {};\n');
+  const result = runGuard(dir, head, lastSuccessfulDeployment);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /Runtime or unknown path changed/);
+});
+
+test('customer journey tracks changes to the web-runtime classification contract', () => {
+  assert.match(journeyWorkflow, /- 'vercel-ignore-if-unaffected\.sh'/);
 });
 
 test('protected Production smoke runner changes on main force exact-SHA Vercel deployment', () => {

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -17,7 +17,10 @@ set -u
 #    when their source files live under .github/ or test/. If one of those files
 #    changes, Production must advance to the same commit before the verification
 #    workflow can truthfully claim exact-artifact evidence.
-# 4) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
+# 4) Native iOS/App Store-only files are explicitly outside the Vercel web runtime.
+#    They may reuse the last web-runtime journey only when no web/database/runtime
+#    path changed in the same comparison range.
+# 5) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 ref="${VERCEL_GIT_COMMIT_REF:-}"
 previous_success="${VERCEL_GIT_PREVIOUS_SHA:-}"
@@ -74,6 +77,9 @@ while IFS= read -r path; do
     test/dabbir-activity-regression.test.mjs)
       echo "Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence: $path"
       exit 1
+      ;;
+    mobile/*|scripts/dabbir-app-store-preflight.mjs)
+      echo "Native/App Store-only path does not change the Vercel web runtime: $path"
       ;;
     .github/*|docs/*|test/*|README.md|.gitignore)
       ;;


### PR DESCRIPTION
Root cause exposed by BAR-12 after App Store preflight merge:
- Native/App Store-only changes under `mobile/**` and `scripts/dabbir-app-store-preflight.mjs` were treated as unknown Vercel web-runtime changes.
- Vercel therefore advanced Production SHA, but the canonical Full Customer Journey did not trigger for those native-only paths.
- BAR-12 then waited for an exact/runtime-equivalent journey artifact that could not exist.

Fix:
- Explicitly classify `mobile/**` and the App Store preflight script as outside the Vercel web runtime.
- Keep every unlisted script/path fail-closed and deployment-affecting.
- Make changes to `vercel-ignore-if-unaffected.sh` trigger the canonical Full Customer Journey, since changing runtime classification is itself a release-integrity contract change.
- Add regressions proving native/App Store-only changes may reuse the last verified web runtime, unknown scripts still force deployment, and the journey tracks classification-contract changes.

No auth, database, customer data, payment, Meta, Apple credential, or release-readiness threshold is weakened.