### PR TITLE
DABBIR: add public App Store Privacy, Terms and Support pages

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -1,0 +1,100 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="robots" content="index,follow">
+<title>سياسة الخصوصية | DABBIR</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#121416;--line:#2a2e33;--text:#f7f8f9;--muted:#a8adb4;--accent:#d7ff5f}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif;line-height:1.8}.wrap{width:min(920px,calc(100% - 32px));margin:0 auto;padding:40px 0 64px}.brand{font-weight:900;color:var(--accent);letter-spacing:.02em}.card{margin-top:18px;padding:24px;border:1px solid var(--line);border-radius:20px;background:var(--panel)}h1{margin:.2em 0;font-size:clamp(28px,5vw,44px)}h2{margin-top:1.7em;font-size:20px}p,li{color:#e4e7ea}small,.muted{color:var(--muted)}a{color:var(--accent)}hr{border:0;border-top:1px solid var(--line);margin:34px 0}.en{direction:ltr;text-align:left}.nav{display:flex;gap:14px;flex-wrap:wrap;margin-top:22px}.nav a{min-height:44px;display:inline-flex;align-items:center}.notice{border-inline-start:3px solid var(--accent);padding-inline-start:14px;color:var(--muted)}
+</style>
+</head>
+<body><main class="wrap">
+<div class="brand">DABBIR | دبّر</div>
+<section class="card">
+<h1>سياسة الخصوصية</h1>
+<p class="muted">آخر تحديث: 28 أغسطس 2026</p>
+<p>توضح هذه السياسة كيفية تعامل DABBIR | دبّر مع البيانات عند استخدام التطبيق والخدمة. صيغت هذه الصفحة لتصف السلوك التشغيلي الحالي للمنتج، ولا تغيّر حقوقك التي يمنحها القانون المعمول به.</p>
+
+<h2>1. البيانات التي نعالجها</h2>
+<ul>
+<li><b>بيانات الحساب:</b> مثل البريد الإلكتروني، معرّف المستخدم، وحالة الجلسة اللازمة لتسجيل الدخول وتأمين الحساب.</li>
+<li><b>بيانات النشاط:</b> اسم النشاط ونوعه والإعدادات وعضويات مساحة العمل.</li>
+<li><b>بيانات التشغيل:</b> العملاء، المحادثات، المواعيد، المتابعات، والتحويلات أو المهام التي ينشئها المستخدم داخل DABBIR.</li>
+<li><b>بيانات التكاملات:</b> معلومات الربط والحالة اللازمة لتشغيل خدمة يختار المستخدم ربطها، مثل WhatsApp عبر Meta. لا تُعرض القناة على أنها متصلة قبل تحقق الربط الفعلي.</li>
+<li><b>بيانات اشتراك Apple:</b> عند الشراء داخل iOS، نعالج بيانات المعاملة والصلاحية اللازمة للتحقق الخادمي من الاشتراك وربطه بحساب DABBIR. لا نخزن بيانات بطاقة الدفع الخاصة بك.</li>
+<li><b>بيانات الأمان والتشغيل:</b> سجلات فنية وأحداث تدقيق ضرورية لمنع الإساءة، اكتشاف الأخطاء، وحماية العزل بين الأنشطة.</li>
+</ul>
+
+<h2>2. لماذا نستخدم البيانات</h2>
+<p>نستخدم البيانات لتسجيل الدخول، تشغيل مساحة نشاطك، تنفيذ الميزات التي تطلبها، تشغيل المساعد الذكي ضمن الصلاحيات المسموح بها، ربط القنوات التي تفوضها، التحقق من الاشتراكات، تقديم الدعم، منع الاحتيال والإساءة، وتحسين موثوقية وأمان الخدمة.</p>
+
+<h2>3. الخدمات الخارجية</h2>
+<p>قد تُعالج البيانات بواسطة مزودي البنية والخدمات اللازمة لتقديم DABBIR، بما في ذلك خدمات الاستضافة وقاعدة البيانات والمصادقة، ومزودي ميزات الذكاء الاصطناعي المطلوبة، وApple عند استخدام اشتراك App Store، وMeta عند ربط WhatsApp. لا نرسل بيانات إلى تكامل اختياري قبل أن يختار المستخدم ربطه أو استخدامه.</p>
+
+<h2>4. التتبع والإعلانات</h2>
+<p>تطبيق iOS لا يعلن استخدام بياناتك للتتبع الإعلاني عبر تطبيقات أو مواقع شركات أخرى، وملف Privacy Manifest الحالي يحدد <b>NSPrivacyTracking = false</b>. لا يعني ذلك أن البيانات التشغيلية لا تُستخدم للأمان أو لتقديم الخدمة نفسها.</p>
+
+<h2>5. الأمان والعزل</h2>
+<p>DABBIR يطبق عزلًا على مستوى النشاط وصلاحيات وصول إلى البيانات. بيانات الجلسة الحساسة في تطبيق iOS تحفظ في Keychain عبر التخزين الآمن للجهاز، وتُستخدم الاتصالات المشفرة HTTPS عند الوصول إلى واجهات الخدمة.</p>
+
+<h2>6. الاحتفاظ والحذف</h2>
+<p>يوفر تطبيق iOS مسار حذف حساب DABBIR من داخل التطبيق. الحذف مخصص لبيانات منتج DABBIR ولا يفترض حذف هوية مصادقة مشتركة قد تُستخدم في منتج مستقل آخر. عند تنفيذ الحذف، تُزال بيانات DABBIR التشغيلية المرتبطة بالحساب وفق تصميم الحذف، مع إمكانية الاحتفاظ بسجلات محدودة عندما تكون لازمة لأسباب قانونية أو أمنية أو محاسبية أو لتنفيذ التزامات الاحتفاظ المشروعة.</p>
+<p class="notice">حذف حساب DABBIR لا يلغي تلقائيًا اشتراك App Store. إدارة أو إلغاء اشتراك Apple تتم من إعدادات الاشتراكات لدى Apple.</p>
+
+<h2>7. الوصول والتصحيح والطلبات</h2>
+<p>يمكنك تحديث بيانات نشاطك من داخل الخدمة، واستخدام خيارات الخصوصية أو حذف الحساب المتاحة في التطبيق. للطلبات المتعلقة بالحساب، استخدم شاشة <b>المساعدة</b> داخل DABBIR بعد تسجيل الدخول.</p>
+
+<h2>8. الأطفال والبيانات غير المطلوبة</h2>
+<p>DABBIR منتج لإدارة الأعمال. لا تطلب الخدمة من المستخدم إدخال بيانات حساسة لا تحتاجها الميزة التي يستخدمها. تقع على مستخدم النشاط مسؤولية عدم إدخال بيانات غير لازمة أو غير مصرح له بمعالجتها.</p>
+
+<h2>9. تحديثات السياسة</h2>
+<p>قد تتغير هذه السياسة إذا تغيرت ميزات DABBIR أو مزودو الخدمة أو المتطلبات النظامية. سيظهر تاريخ آخر تحديث في أعلى الصفحة.</p>
+
+<div class="nav"><a href="/terms">شروط الاستخدام</a><a href="/support">الدعم</a><a href="/">DABBIR</a></div>
+</section>
+
+<hr>
+<section class="card en" lang="en">
+<h1>Privacy Policy</h1>
+<p class="muted">Last updated: August 28, 2026</p>
+<p>This policy explains how DABBIR handles data when you use the app and service. It describes the product's current operational behavior and does not reduce rights available under applicable law.</p>
+
+<h2>1. Data we process</h2>
+<ul>
+<li><b>Account data:</b> email address, user identifier, and session state needed to sign in and secure the account.</li>
+<li><b>Business data:</b> business name, type, settings, and workspace memberships.</li>
+<li><b>Operational data:</b> customers, conversations, appointments, follow-ups, handoffs, and tasks created in DABBIR.</li>
+<li><b>Integration data:</b> connection information and status needed for a service you choose to connect, such as WhatsApp through Meta. A channel is not represented as connected before the real connection is verified.</li>
+<li><b>Apple subscription data:</b> for iOS purchases, transaction and entitlement information required to verify the subscription server-side and bind it to the DABBIR account. DABBIR does not store your payment-card details.</li>
+<li><b>Security and operational data:</b> technical logs and audit events needed to prevent abuse, diagnose failures, and protect tenant isolation.</li>
+</ul>
+
+<h2>2. Why we use data</h2>
+<p>We use data to authenticate you, operate your business workspace, provide features you request, run AI assistance within permitted scope, connect channels you authorize, verify subscriptions, provide support, prevent fraud and abuse, and improve service reliability and security.</p>
+
+<h2>3. External services</h2>
+<p>Data may be processed by infrastructure and service providers needed to operate DABBIR, including hosting, database and authentication services, providers used for requested AI functionality, Apple for App Store subscriptions, and Meta when you connect WhatsApp. We do not send data to an optional integration merely because the integration is available; the user must connect or use it.</p>
+
+<h2>4. Tracking and advertising</h2>
+<p>The iOS app does not declare use of your data for advertising tracking across other companies' apps or websites, and its current Privacy Manifest sets <b>NSPrivacyTracking = false</b>. This does not prevent operational data from being used to secure and provide DABBIR itself.</p>
+
+<h2>5. Security and tenant isolation</h2>
+<p>DABBIR applies business-level data isolation and access controls. Sensitive iOS session material is stored in the device Keychain through secure storage, and service APIs require encrypted HTTPS connections.</p>
+
+<h2>6. Retention and deletion</h2>
+<p>The iOS app provides an in-app path to delete the DABBIR product account. Deletion is scoped to DABBIR data and does not assume that a shared authentication identity used by a separate product should be destroyed. DABBIR operational data associated with the account is removed according to the deletion design, while limited records may be retained where necessary for lawful legal, security, accounting, or retention obligations.</p>
+<p class="notice">Deleting a DABBIR account does not automatically cancel an App Store subscription. Apple subscriptions are managed or cancelled through Apple's subscription settings.</p>
+
+<h2>7. Access, correction, and requests</h2>
+<p>You can update business information through the service and use available privacy or account-deletion controls in the app. For account-specific requests, use the <b>Help</b> screen inside DABBIR after signing in.</p>
+
+<h2>8. Children and unnecessary data</h2>
+<p>DABBIR is a business-management product. The service does not ask users to provide sensitive information unrelated to a feature they are using. Business users are responsible for avoiding unnecessary data or data they are not authorized to process.</p>
+
+<h2>9. Policy updates</h2>
+<p>This policy may change when DABBIR features, service providers, or legal requirements change. The latest update date will appear at the top of this page.</p>
+
+<div class="nav"><a href="/terms">Terms of Use</a><a href="/support">Support</a><a href="/">DABBIR</a></div>
+</section>
+</main></body></html>

--- a/support.html
+++ b/support.html
@@ -1,0 +1,80 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="robots" content="index,follow">
+<title>الدعم | DABBIR</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#121416;--line:#2a2e33;--text:#f7f8f9;--muted:#a8adb4;--accent:#d7ff5f;--green:#8ce6a1}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif;line-height:1.8}.wrap{width:min(920px,calc(100% - 32px));margin:0 auto;padding:40px 0 64px}.brand{font-weight:900;color:var(--accent)}.card{margin-top:18px;padding:24px;border:1px solid var(--line);border-radius:20px;background:var(--panel)}h1{font-size:clamp(28px,5vw,44px);margin:.2em 0}h2{margin-top:1.6em;font-size:20px}p,li{color:#e4e7ea}.muted{color:var(--muted)}a{color:var(--accent)}hr{border:0;border-top:1px solid var(--line);margin:34px 0}.en{direction:ltr;text-align:left}.nav{display:flex;gap:14px;flex-wrap:wrap;margin-top:22px}.nav a{min-height:44px;display:inline-flex;align-items:center}.status{display:inline-flex;padding:5px 9px;border:1px solid #31503b;border-radius:999px;color:var(--green);font-size:12px}.step{padding:14px 0;border-bottom:1px solid var(--line)}.step:last-child{border-bottom:0}.notice{border-inline-start:3px solid var(--accent);padding-inline-start:14px;color:var(--muted)}
+</style>
+</head>
+<body><main class="wrap">
+<div class="brand">DABBIR | دبّر</div>
+<section class="card">
+<h1>الدعم</h1>
+<p class="muted">مساعدة استخدام DABBIR وإدارة الحساب والاشتراك والتكاملات.</p>
+<span class="status">صفحة دعم عامة</span>
+
+<h2>المساعدة المرتبطة بحسابك</h2>
+<p>بعد تسجيل الدخول إلى DABBIR افتح <b>المزيد ← المساعدة</b>. هذا هو المسار المفضل للمشكلات المرتبطة بحساب أو نشاط محدد لأنه يبقي الطلب داخل سياق مساحة العمل الصحيحة.</p>
+
+<h2>تسجيل الدخول وكلمة المرور</h2>
+<div class="step"><b>نسيت كلمة المرور</b><br><span class="muted">استخدم خيار «نسيت كلمة المرور» من شاشة الدخول واتبع رابط الاستعادة المرسل إلى بريد الحساب.</span></div>
+<div class="step"><b>الحساب المحذوف</b><br><span class="muted">إذا حذفت حساب DABBIR، يمنع المنتج إعادة الدخول التلقائي إلى مساحة DABBIR المحذوفة. هوية مصادقة مشتركة قد تبقى إذا كانت مستخدمة في منتج مستقل آخر.</span></div>
+
+<h2>WhatsApp</h2>
+<p>ربط WhatsApp يتطلب تفويض Meta الحقيقي للحساب الصحيح. لا يعتبر DABBIR القناة متصلة لمجرد بدء نافذة الربط. عند ظهور حالة غير مؤكدة، لا يعيد النظام الإرسال تلقائيًا إذا كان ذلك قد يؤدي إلى رسالة مكررة.</p>
+
+<h2>اشتراك iPhone</h2>
+<ul>
+<li>عمليات الشراء داخل تطبيق iOS تستخدم Apple In-App Purchase عندما يكون الاشتراك مفعّلًا.</li>
+<li>استخدم <b>استعادة المشتريات</b> داخل التطبيق إذا كان لديك اشتراك Apple صالح ولا تظهر الصلاحية.</li>
+<li>تتم إدارة التجديد أو الإلغاء من إعدادات اشتراكات Apple.</li>
+<li>حذف حساب DABBIR لا يلغي اشتراك Apple تلقائيًا.</li>
+</ul>
+
+<h2>حذف حساب DABBIR</h2>
+<p>يتوفر حذف الحساب من داخل تطبيق iOS. الحذف مخصص لمنتج DABBIR ويزيل بيانات التشغيل المرتبطة به وفق سياسة الاحتفاظ، مع إمكانية بقاء سجلات محدودة مطلوبة قانونيًا أو أمنيًا أو محاسبيًا.</p>
+
+<h2>قبل طلب المساعدة</h2>
+<p>دوّن وقت المشكلة والخطوة التي كنت تنفذها وما إذا كانت الحالة ظهرت كـ«موثقة» أو «تحتاج تحقق». لا ترسل كلمات المرور أو مفاتيح API أو رموز OTP أو مفاتيح Apple/Meta السرية ضمن وصف المشكلة.</p>
+
+<p class="notice">لا يوجد على هذه الصفحة مسار دفع خارجي لاشتراك iOS.</p>
+<div class="nav"><a href="/privacy">سياسة الخصوصية</a><a href="/terms">شروط الاستخدام</a><a href="/">DABBIR</a></div>
+</section>
+
+<hr>
+<section class="card en" lang="en">
+<h1>Support</h1>
+<p class="muted">Help with DABBIR usage, accounts, subscriptions, and integrations.</p>
+<span class="status">Public support page</span>
+
+<h2>Account-specific help</h2>
+<p>After signing in to DABBIR, open <b>More → Help</b>. This is the preferred path for issues tied to a specific account or business because it keeps the request in the correct workspace context.</p>
+
+<h2>Sign-in and password</h2>
+<div class="step"><b>Forgot password</b><br><span class="muted">Use “Forgot password” on the sign-in screen and follow the recovery link sent to the account email address.</span></div>
+<div class="step"><b>Deleted account</b><br><span class="muted">If you delete the DABBIR product account, the product blocks automatic re-entry to the deleted DABBIR workspace. A shared authentication identity may remain if it is also used by a separate product.</span></div>
+
+<h2>WhatsApp</h2>
+<p>WhatsApp connection requires real Meta authorization for the correct account. DABBIR does not treat the channel as connected merely because the connection window was opened. If an outbound state is ambiguous, automatic resend can be blocked to prevent duplicate messages.</p>
+
+<h2>iPhone subscription</h2>
+<ul>
+<li>In-app purchases in the iOS app use Apple In-App Purchase when the subscription is enabled.</li>
+<li>Use <b>Restore Purchases</b> in the app if a valid Apple subscription is not reflected in your entitlement.</li>
+<li>Renewal and cancellation are managed through Apple's subscription settings.</li>
+<li>Deleting a DABBIR account does not automatically cancel the Apple subscription.</li>
+</ul>
+
+<h2>Delete the DABBIR account</h2>
+<p>Account deletion is available from inside the iOS app. Deletion is scoped to the DABBIR product and removes associated operational data according to retention rules, while limited records may remain where legally, securely, or financially necessary.</p>
+
+<h2>Before requesting help</h2>
+<p>Record the time of the problem, the action you were performing, and whether the state was shown as verified or needing verification. Do not send passwords, API secrets, OTP codes, or private Apple/Meta keys in a support description.</p>
+
+<p class="notice">This page contains no external payment path for an iOS subscription.</p>
+<div class="nav"><a href="/privacy">Privacy Policy</a><a href="/terms">Terms of Use</a><a href="/">DABBIR</a></div>
+</section>
+</main></body></html>

--- a/terms.html
+++ b/terms.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="robots" content="index,follow">
+<title>شروط الاستخدام | DABBIR</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#121416;--line:#2a2e33;--text:#f7f8f9;--muted:#a8adb4;--accent:#d7ff5f}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif;line-height:1.8}.wrap{width:min(920px,calc(100% - 32px));margin:0 auto;padding:40px 0 64px}.brand{font-weight:900;color:var(--accent)}.card{margin-top:18px;padding:24px;border:1px solid var(--line);border-radius:20px;background:var(--panel)}h1{font-size:clamp(28px,5vw,44px);margin:.2em 0}h2{margin-top:1.7em;font-size:20px}p,li{color:#e4e7ea}.muted{color:var(--muted)}a{color:var(--accent)}hr{border:0;border-top:1px solid var(--line);margin:34px 0}.en{direction:ltr;text-align:left}.nav{display:flex;gap:14px;flex-wrap:wrap;margin-top:22px}.nav a{min-height:44px;display:inline-flex;align-items:center}.notice{border-inline-start:3px solid var(--accent);padding-inline-start:14px;color:var(--muted)}
+</style>
+</head>
+<body><main class="wrap">
+<div class="brand">DABBIR | دبّر</div>
+<section class="card">
+<h1>شروط الاستخدام</h1>
+<p class="muted">آخر تحديث: 28 أغسطس 2026</p>
+<p>تحكم هذه الشروط استخدامك لخدمة DABBIR | دبّر. باستخدام الخدمة، فإنك توافق على استخدامها بصورة مشروعة وضمن الصلاحيات التي تملكها لإدارة نشاطك وبياناته.</p>
+
+<h2>1. الخدمة</h2>
+<p>DABBIR أداة لإدارة أعمال ومحادثات ومواعيد وعملاء ومتابعات وتكاملات اختيارية. قد تتغير الميزات مع تطوير المنتج، ولا تُعد أي قناة خارجية متصلة أو أي عملية خارجية مكتملة إلا عندما تعرض الخدمة حالة تحقق فعلية.</p>
+
+<h2>2. الحساب والأمان</h2>
+<p>أنت مسؤول عن المحافظة على سرية بيانات الدخول وعن استخدام الحساب للأغراض المصرح بها. قد توقف DABBIR جلسة أو إجراءً عندما تكون الهوية أو الصلاحية أو نتيجة التنفيذ غير قابلة للتحقق بأمان.</p>
+
+<h2>3. بيانات نشاطك</h2>
+<p>تظل مسؤولًا عن قانونية البيانات التي تدخلها أو تربطها بالخدمة وعن امتلاك الصلاحية اللازمة لمعالجة بيانات العملاء والموظفين والجهات الأخرى. لا يجوز استخدام DABBIR لانتهاك الخصوصية أو إرسال رسائل غير مصرح بها أو التحايل على أنظمة مزودي القنوات.</p>
+
+<h2>4. التكاملات الخارجية</h2>
+<p>عند ربط خدمة خارجية مثل WhatsApp عبر Meta، تخضع بعض الوظائف أيضًا لشروط وسياسات مزود تلك الخدمة. يجب أن تمنح التفويض الصحيح للحساب الذي تريد ربطه. DABBIR لا يفترض نجاح الربط أو التسليم قبل التحقق من النتيجة.</p>
+
+<h2>5. الذكاء الاصطناعي والأتمتة</h2>
+<p>قد يستخدم DABBIR الذكاء الاصطناعي للمساعدة في الردود أو التنظيم أو المتابعة. المخرجات قد تحتاج مراجعة عندما تكون غير مؤكدة أو عندما تتطلب قرارًا بشريًا أو التزامًا قانونيًا أو ماليًا. لا يجوز الاعتماد على المخرجات الآلية كبديل عن المشورة المهنية المنظمة عندما تكون مطلوبة.</p>
+
+<h2>6. اشتراكات iOS</h2>
+<p>عندما يتوفر اشتراك DABBIR داخل تطبيق iOS ويتم شراؤه من التطبيق، تتم عملية الشراء عبر نظام Apple In-App Purchase. السعر، مدة الفوترة، وأي عرض تمهيدي أو تجربة مجانية معروضة داخل التطبيق تُقرأ من معلومات App Store المتاحة للجهاز ولا يصنع DABBIR مدة عرض غير صادرة من StoreKit.</p>
+<p>اشتراكات Apple قد تتجدد تلقائيًا وفق شروط App Store ما لم يتم إلغاؤها من إدارة اشتراكات Apple. طلبات الاسترداد للشراء الذي عالجته Apple تخضع لمسار Apple المطبق.</p>
+<p class="notice">حذف حساب DABBIR لا يلغي تلقائيًا اشتراك App Store؛ إدارة الاشتراك منفصلة لدى Apple.</p>
+
+<h2>7. الاستخدام المقبول</h2>
+<ul>
+<li>لا تستخدم الخدمة للوصول إلى بيانات نشاط أو مستخدم آخر دون صلاحية.</li>
+<li>لا تحاول تجاوز العزل أو المصادقة أو حدود الأمان أو القيود التي يفرضها مزود تكامل خارجي.</li>
+<li>لا تستخدم الخدمة لإرسال محتوى غير قانوني أو احتيالي أو ضار أو رسائل غير مرغوب بها.</li>
+<li>لا تُدخل أسرارًا أو بيانات شديدة الحساسية لا تحتاجها الميزة التي تستخدمها.</li>
+</ul>
+
+<h2>8. الإتاحة والتغييرات</h2>
+<p>نسعى إلى تشغيل DABBIR بصورة موثوقة، لكن قد تحدث صيانة أو أعطال أو قيود من خدمات خارجية. عندما تكون نتيجة إجراء خارجي غير مؤكدة، قد يوقف DABBIR إعادة المحاولة التلقائية لمنع التكرار أو الضرر حتى يتم التحقق.</p>
+
+<h2>9. إنهاء الاستخدام وحذف الحساب</h2>
+<p>يمكنك التوقف عن استخدام الخدمة، ويوفر تطبيق iOS مسارًا داخل التطبيق لحذف حساب DABBIR. قد تبقى سجلات محدودة عندما يلزم الاحتفاظ بها قانونيًا أو أمنيًا أو محاسبيًا. راجع <a href="/privacy">سياسة الخصوصية</a> لمزيد من التفاصيل.</p>
+
+<h2>10. الدعم</h2>
+<p>للمساعدة في الحساب أو التكاملات أو الاشتراك، راجع <a href="/support">صفحة الدعم</a> واستخدم شاشة المساعدة داخل DABBIR للحالات المرتبطة بحسابك.</p>
+
+<div class="nav"><a href="/privacy">سياسة الخصوصية</a><a href="/support">الدعم</a><a href="/">DABBIR</a></div>
+</section>
+
+<hr>
+<section class="card en" lang="en">
+<h1>Terms of Use</h1>
+<p class="muted">Last updated: August 28, 2026</p>
+<p>These terms govern your use of DABBIR. By using the service, you agree to use it lawfully and within the authority you hold to manage your business and its data.</p>
+
+<h2>1. The service</h2>
+<p>DABBIR is a business-management tool for conversations, appointments, customers, follow-ups, and optional integrations. Features may change as the product develops. An external channel is not treated as connected, and an external action is not treated as completed, unless the service has verified the relevant state.</p>
+
+<h2>2. Account and security</h2>
+<p>You are responsible for protecting your sign-in credentials and using the account only for authorized purposes. DABBIR may stop a session or action when identity, authorization, or execution outcome cannot be safely verified.</p>
+
+<h2>3. Your business data</h2>
+<p>You are responsible for the legality of data you enter or connect and for having authority to process customer, employee, and third-party data. You may not use DABBIR to violate privacy, send unauthorized messages, or evade external channel-provider rules.</p>
+
+<h2>4. External integrations</h2>
+<p>If you connect an external service such as WhatsApp through Meta, parts of the functionality are also subject to that provider's terms and policies. You must authorize the correct account you intend to connect. DABBIR does not assume a connection or delivery succeeded before the result is verified.</p>
+
+<h2>5. AI and automation</h2>
+<p>DABBIR may use AI to assist with replies, organization, and follow-up. Outputs may require review when uncertain or when a human, legal, or financial decision is required. Automated output is not a substitute for regulated professional advice where such advice is required.</p>
+
+<h2>6. iOS subscriptions</h2>
+<p>When a DABBIR subscription is offered and purchased inside the iOS app, the transaction uses Apple In-App Purchase. Price, billing period, and any introductory offer or free trial displayed in the app are derived from App Store information available through StoreKit; DABBIR does not manufacture an offer duration that StoreKit did not report.</p>
+<p>Apple subscriptions may renew automatically under App Store terms unless cancelled through Apple's subscription management. Refund requests for purchases processed by Apple follow Apple's applicable process.</p>
+<p class="notice">Deleting a DABBIR account does not automatically cancel an App Store subscription; Apple subscription management is separate.</p>
+
+<h2>7. Acceptable use</h2>
+<ul>
+<li>Do not access another business's or user's data without authorization.</li>
+<li>Do not bypass tenant isolation, authentication, security controls, or external-provider restrictions.</li>
+<li>Do not use the service for unlawful, fraudulent, harmful, or unsolicited content.</li>
+<li>Do not enter secrets or highly sensitive data that the feature does not need.</li>
+</ul>
+
+<h2>8. Availability and changes</h2>
+<p>We aim to operate DABBIR reliably, but maintenance, outages, and third-party restrictions may occur. If the result of an external action is ambiguous, DABBIR may block automatic retries to prevent duplication or harm until the attempt is reconciled.</p>
+
+<h2>9. Ending use and deleting the account</h2>
+<p>You may stop using the service, and the iOS app provides an in-app path to delete the DABBIR product account. Limited records may remain when lawful legal, security, or accounting retention is required. See the <a href="/privacy">Privacy Policy</a> for more information.</p>
+
+<h2>10. Support</h2>
+<p>For account, integration, or subscription help, see the <a href="/support">Support page</a> and use DABBIR's in-app Help screen for account-specific issues.</p>
+
+<div class="nav"><a href="/privacy">Privacy Policy</a><a href="/support">Support</a><a href="/">DABBIR</a></div>
+</section>
+</main></body></html>

--- a/test/app-store-public-pages.test.mjs
+++ b/test/app-store-public-pages.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = path => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+const pages = {
+  privacy: read('privacy.html'),
+  terms: read('terms.html'),
+  support: read('support.html'),
+};
+const vercel = JSON.parse(read('vercel.json'));
+
+test('App Store public pages exist in Arabic and English', () => {
+  for (const [name, html] of Object.entries(pages)) {
+    assert.match(html, /<html lang="ar" dir="rtl">/i, `${name} must default to Arabic RTL`);
+    assert.match(html, /lang="en"/i, `${name} must contain an English section`);
+    assert.match(html, /DABBIR \| دبّر/);
+    assert.doesNotMatch(html, /support@bmalman\.com|Barman2013@icloud\.com/i, `${name} must not invent or expose an unverified support address`);
+  }
+});
+
+test('public legal/support routes resolve to static pages', () => {
+  const routes = new Map((vercel.routes || []).map(route => [route.src, route.dest]));
+  assert.equal(routes.get('^/privacy/?$'), '/privacy.html');
+  assert.equal(routes.get('^/terms/?$'), '/terms.html');
+  assert.equal(routes.get('^/support/?$'), '/support.html');
+});
+
+test('iOS-facing pages disclose Apple subscription separation without external checkout CTA', () => {
+  const combined = `${pages.terms}\n${pages.support}\n${pages.privacy}`;
+  assert.match(combined, /Apple In-App Purchase/i);
+  assert.match(combined, /does not automatically cancel an App Store subscription/i);
+  assert.doesNotMatch(combined, /buy on web|subscribe on web|Stripe checkout|payment link/i);
+});
+
+test('privacy page describes product-scoped deletion and iOS no-tracking declaration', () => {
+  assert.match(pages.privacy, /NSPrivacyTracking = false/);
+  assert.match(pages.privacy, /shared authentication identity/i);
+  assert.match(pages.privacy, /حذف حساب DABBIR/);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -11,6 +11,18 @@
   },
   "routes": [
     {
+      "src": "^/privacy/?$",
+      "dest": "/privacy.html"
+    },
+    {
+      "src": "^/terms/?$",
+      "dest": "/terms.html"
+    },
+    {
+      "src": "^/support/?$",
+      "dest": "/support.html"
+    },
+    {
       "src": "^/owner/?$",
       "dest": "/api/owner-login"
     },
@@ -24,6 +36,18 @@
     }
   ],
   "rewrites": [
+    {
+      "source": "/privacy",
+      "destination": "/privacy.html"
+    },
+    {
+      "source": "/terms",
+      "destination": "/terms.html"
+    },
+    {
+      "source": "/support",
+      "destination": "/support.html"
+    },
     {
       "source": "/owner",
       "destination": "/api/owner-login"


### PR DESCRIPTION
Adds bilingual Arabic/English public pages required by the iOS release path:
- `/privacy`
- `/terms`
- `/support`

The content is limited to verified DABBIR behavior: product-scoped account deletion, Apple subscription separation, StoreKit/IAP semantics, Meta/WhatsApp authorization truth, tenant/security controls, and no external iOS checkout CTA. It intentionally does not invent or expose an unverified support email.

Also adds explicit Vercel routes and regression tests so these pages cannot disappear silently.

This PR does not claim the URLs are App Store-ready yet: the Vercel project still needs a real public production custom domain and release URL verification.