### PR TITLE
DABBIR: fix WhatsApp Embedded Signup redirect URI mismatch

### DIFF
--- a/api/dabbir-whatsapp-embedded-complete.js
+++ b/api/dabbir-whatsapp-embedded-complete.js
@@ -1,7 +1,6 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
 import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
 import {
-  exchangeEmbeddedCode,
   ownerContext,
   resolveEmbeddedPlatformConfig,
   sealAccessToken,
@@ -36,7 +35,73 @@ function metaProviderError(payload, response, fallback) {
   error.status = 502;
   error.providerStatus = response?.status || null;
   error.providerCode = payload?.error?.code || null;
+  error.providerSubcode = payload?.error?.error_subcode || null;
   return error;
+}
+
+function oauthRedirectUriFromRequest(req) {
+  const header = name => {
+    const value = req?.headers?.[name] ?? req?.headers?.[name.toLowerCase()];
+    return Array.isArray(value) ? String(value[0] || '').trim() : String(value || '').trim();
+  };
+
+  const originHeader = header('origin');
+  let requestOrigin = '';
+  if (originHeader) {
+    try {
+      requestOrigin = new URL(originHeader).origin;
+    } catch {
+      requestOrigin = '';
+    }
+  }
+
+  const candidates = [header('referer'), requestOrigin ? `${requestOrigin}/` : ''];
+  for (const candidate of candidates) {
+    if (!candidate) continue;
+    try {
+      const url = new URL(candidate);
+      const localDevelopment = url.hostname === 'localhost' || url.hostname === '127.0.0.1';
+      if (url.protocol !== 'https:' && !(localDevelopment && url.protocol === 'http:')) continue;
+      if (requestOrigin && url.origin !== requestOrigin) continue;
+      url.hash = '';
+      return url.toString();
+    } catch {
+      // Try the next trusted request-derived candidate.
+    }
+  }
+
+  throw Object.assign(new Error('META_OAUTH_REDIRECT_URI_REQUIRED'), { status: 400 });
+}
+
+async function exchangeEmbeddedCodeWithRedirect(platform, code, redirectUri) {
+  if (!platform?.ready) {
+    throw Object.assign(new Error('META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED'), { status: 503 });
+  }
+  if (!redirectUri) {
+    throw Object.assign(new Error('META_OAUTH_REDIRECT_URI_REQUIRED'), { status: 400 });
+  }
+
+  const url = new URL(`https://graph.facebook.com/${encodeURIComponent(platform.graphVersion)}/oauth/access_token`);
+  url.searchParams.set('client_id', platform.appId);
+  url.searchParams.set('client_secret', platform.appSecret);
+  url.searchParams.set('code', String(code));
+  url.searchParams.set('redirect_uri', redirectUri);
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  try {
+    const response = await fetch(url, { cache: 'no-store', signal: controller.signal });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload?.access_token) {
+      throw metaProviderError(payload, response, 'META_CODE_EXCHANGE_FAILED');
+    }
+    return {
+      accessToken: String(payload.access_token),
+      expiresIn: Number(payload.expires_in || 0) || null,
+    };
+  } finally {
+    clearTimeout(timeout);
+  }
 }
 
 export async function discoverWabaIdFromAccessToken(platform, token, options = {}) {
@@ -130,7 +195,8 @@ export default async function handler(req, res) {
     const platform = applyDabbirMetaPublicIdentifiers(await resolveEmbeddedPlatformConfig());
     if (!platform.ready) return json(res, 503, { ok: false, error: 'META_EMBEDDED_SIGNUP_PLATFORM_NOT_CONFIGURED' });
 
-    const exchanged = await exchangeEmbeddedCode(platform, code);
+    const oauthRedirectUri = oauthRedirectUriFromRequest(req);
+    const exchanged = await exchangeEmbeddedCodeWithRedirect(platform, code, oauthRedirectUri);
     if (!wabaId) {
       wabaId = await discoverWabaIdFromAccessToken(platform, exchanged.accessToken);
     }
@@ -193,6 +259,7 @@ export default async function handler(req, res) {
       error: String(error?.message || 'WHATSAPP_EMBEDDED_SIGNUP_FAILED').slice(0, 300),
       provider_status: error?.providerStatus || null,
       provider_code: error?.providerCode || null,
+      provider_subcode: error?.providerSubcode || null,
     });
   }
 }

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -106,6 +106,16 @@ test('Embedded completion exchanges authorization code server-side and never ret
   assert.doesNotMatch(endpoint, /access_token:\s*exchanged\.accessToken/);
 });
 
+test('Embedded completion binds Meta code exchange to the exact same-origin page redirect URI', async () => {
+  const endpoint = await read('api/dabbir-whatsapp-embedded-complete.js');
+  assert.match(endpoint, /function oauthRedirectUriFromRequest\(req\)/);
+  assert.match(endpoint, /header\('referer'\)/);
+  assert.match(endpoint, /url\.origin !== requestOrigin/);
+  assert.match(endpoint, /url\.searchParams\.set\('redirect_uri', redirectUri\)/);
+  assert.match(endpoint, /META_OAUTH_REDIRECT_URI_REQUIRED/);
+  assert.match(endpoint, /providerSubcode/);
+});
+
 test('WhatsApp connection storage is tenant-scoped and RLS protected', async () => {
   const migration = await read('supabase/migrations/20260826195230_dabbir_whatsapp_embedded_signup_v17.sql');
   assert.match(migration, /dabbir_whatsapp_connections/);


### PR DESCRIPTION
Root cause reproduced in production: Meta returns an authorization code, then `/api/dabbir-whatsapp-embedded-complete` fails during code exchange with OAuth error 100 / redirect_uri mismatch.

This patch binds the server-side token exchange to the exact same-origin page URL from the request Referer, with Origin validation and HTTPS enforcement, and sends that value as `redirect_uri` to Meta. It also preserves provider subcodes for diagnostics and adds a regression assertion.

No incomplete WhatsApp connection is stored on failure.