### PR TITLE
DABBIR: fail closed TikTok live sends pending duplicate safety

### DIFF
--- a/api/dabbir-tiktok-send.js
+++ b/api/dabbir-tiktok-send.js
@@ -1,29 +1,15 @@
-import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
-import { tiktokOwnerContext } from './_tiktok-pilot-core.js';
-import { sendTikTokText } from './_tiktok-messaging-core.js';
-
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+import { json, requireSameOrigin } from './_auth-core.js';
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
   if (!requireSameOrigin(req)) return json(res, 403, { ok: false, error: 'SAME_ORIGIN_REQUIRED' });
-  try {
-    const body = await readJsonBody(req, 16384);
-    const businessId = String(body?.business_id || '').trim();
-    const conversationId = String(body?.conversation_id || '').trim().slice(0, 1600);
-    const message = String(body?.message || '').trim().slice(0, 6000);
-    if (!UUID_RE.test(businessId)) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
-    if (!conversationId) return json(res, 400, { ok: false, error: 'CONVERSATION_REQUIRED' });
-    if (!message) return json(res, 400, { ok: false, error: 'MESSAGE_REQUIRED' });
-    await tiktokOwnerContext(req, businessId);
-    const sent = await sendTikTokText(req, businessId, conversationId, message);
-    return json(res, 200, { ok: true, provider: 'tiktok', sent: true, ...sent });
-  } catch (error) {
-    const status = Number(error?.status || error?.code || 500);
-    return json(res, [400,401,403,409,413,502,503,504].includes(status) ? status : 500, {
-      ok: false,
-      error: String(error?.message || 'TIKTOK_SEND_FAILED').slice(0,160),
-      provider_code: error?.providerCode ?? undefined,
-    });
-  }
+
+  return json(res, 409, {
+    ok: false,
+    provider: 'tiktok',
+    state: 'SAFETY_BLOCKED',
+    error: 'TIKTOK_SEND_SAFETY_GATE_REQUIRED',
+    live_send_enabled: false,
+    external_side_effects: false,
+  });
 }

--- a/api/dabbir-tiktok-status.js
+++ b/api/dabbir-tiktok-status.js
@@ -7,6 +7,7 @@ import {
 } from './_tiktok-pilot-core.js';
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SEND_SAFETY_BLOCKER = 'TIKTOK_SEND_SAFETY_GATE_REQUIRED';
 
 function businessIdFromRequest(req) {
   try {
@@ -26,10 +27,16 @@ export default async function handler(req, res) {
     await tiktokOwnerContext(req, businessId);
     const config = tiktokPilotConfig(req);
     const connection = await findTikTokConnection(businessId);
+    const status = safeTikTokStatus(connection, config);
     return json(res, 200, {
       ok: true,
       provider: 'tiktok',
-      ...safeTikTokStatus(connection, config),
+      ...status,
+      messaging_send_scope: status.messaging_send === true,
+      messaging_send: false,
+      messaging_ready: false,
+      live_send_enabled: false,
+      send_blocker: SEND_SAFETY_BLOCKER,
     });
   } catch (error) {
     const status = Number(error?.status || error?.code || 500);

--- a/test/dabbir-tiktok-safety.test.mjs
+++ b/test/dabbir-tiktok-safety.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root = new URL('../', import.meta.url);
+const read = path => fs.readFileSync(new URL(path, root), 'utf8');
+
+const sendRoute = read('api/dabbir-tiktok-send.js');
+const statusRoute = read('api/dabbir-tiktok-status.js');
+const pilotPage = read('api/dabbir-tiktok-pilot.js');
+const apiFiles = fs.readdirSync(new URL('api/', root)).filter(name => name.endsWith('.js'));
+
+test('TikTok live send route is fail-closed until durable duplicate safety exists', () => {
+  assert.match(sendRoute, /TIKTOK_SEND_SAFETY_GATE_REQUIRED/);
+  assert.match(sendRoute, /state:\s*'SAFETY_BLOCKED'/);
+  assert.match(sendRoute, /live_send_enabled:\s*false/);
+  assert.match(sendRoute, /external_side_effects:\s*false/);
+  assert.doesNotMatch(sendRoute, /sendTikTokText/);
+});
+
+test('TikTok status cannot advertise send readiness while the safety gate is blocked', () => {
+  assert.match(statusRoute, /messaging_send_scope:\s*status\.messaging_send === true/);
+  assert.match(statusRoute, /messaging_send:\s*false/);
+  assert.match(statusRoute, /messaging_ready:\s*false/);
+  assert.match(statusRoute, /live_send_enabled:\s*false/);
+  assert.match(statusRoute, /send_blocker:\s*SEND_SAFETY_BLOCKER/);
+  assert.match(pilotPage, /disabled=!st\.messaging_send/);
+});
+
+test('no HTTP route invokes TikTok live send while containment is active', () => {
+  const callers = apiFiles
+    .filter(name => !name.startsWith('_'))
+    .filter(name => read(`api/${name}`).includes('sendTikTokText'));
+  assert.deepEqual(callers, []);
+});


### PR DESCRIPTION
P1 containment for #211 while GitHub Actions execution is blocked by #210.

This PR does not add new TikTok capability. It reduces external-side-effect risk:
- TikTok status preserves whether the provider granted send scope but reports `messaging_send=false`, `messaging_ready=false`, and an explicit safety blocker.
- `/api/dabbir-tiktok-send` is fail-closed and performs no provider send.
- A regression test prevents any HTTP route from calling `sendTikTokText` while containment is active.

Why: merged #208 has bounded provider calls but no durable tenant-scoped idempotency/reservation/reconciliation state. A lost/timeout response after provider acceptance can make a retry duplicate a real customer message.

This is containment only. #211 remains open for the full repair: bounded Auth/Supabase reads plus durable outbound reservation/idempotency/reconciliation before live send is re-enabled.

Release rule: do not merge based on GitHub Actions while #210 is failing before runner allocation. Require at minimum Vercel Preview READY and source-level review; ideally merge only after #210 is restored and CI passes.