### PR TITLE
DABBIR iOS: revalidate current App Store preflight and device compile

### DIFF
--- a/.github/workflows/dabbir-mobile-ci.yml
+++ b/.github/workflows/dabbir-mobile-ci.yml
@@ -11,6 +11,10 @@ on:
       - 'supabase/migrations/*dabbir_*account_deletion*'
       - 'scripts/dabbir-app-store-preflight.mjs'
       - 'test/dabbir-app-store-preflight.test.mjs'
+      - 'privacy.html'
+      - 'terms.html'
+      - 'support.html'
+      - 'vercel.json'
       - '.github/workflows/dabbir-mobile-ci.yml'
   push:
     branches: [main]
@@ -23,6 +27,10 @@ on:
       - 'supabase/migrations/*dabbir_*account_deletion*'
       - 'scripts/dabbir-app-store-preflight.mjs'
       - 'test/dabbir-app-store-preflight.test.mjs'
+      - 'privacy.html'
+      - 'terms.html'
+      - 'support.html'
+      - 'vercel.json'
       - '.github/workflows/dabbir-mobile-ci.yml'
 
 permissions:

--- a/docs/app-store/APP_STORE_RELEASE_PLAN.md
+++ b/docs/app-store/APP_STORE_RELEASE_PLAN.md
@@ -3,16 +3,24 @@
 ## Current release verdict
 `APP_STORE_READY=FALSE`
 
-The native application, server-side Apple entitlement path, account deletion, web/auth journey, and cross-tenant isolation now have executable evidence. A signed Apple Distribution artifact and TestFlight device run do not yet exist, so App Store readiness must remain false.
+The native application, server-side Apple entitlement path, account deletion, web/auth journey, cross-tenant isolation, App Store public-page source, and unsigned native Release compile now have executable evidence. A signed Apple Distribution artifact and TestFlight device run do not yet exist, so App Store readiness must remain false.
 
 ## Verified native foundation
 PR #158 created the first native DABBIR iPhone implementation without wrapping the website.
 
-Verified on final PR #158 head `04ba4aecbf8318ffc4068bd41739e484efaa21b0`:
+Foundational PR #158 evidence on head `04ba4aecbf8318ffc4068bd41739e484efaa21b0`:
 - DABBIR Mobile CI run `33161772286` completed successfully.
 - `mobile-static` job `98817684658` completed successfully.
 - `ios-native-compile` job `98817684653` completed successfully.
-- The native compile job runs on `macos-26`, explicitly requires Xcode major >= 26, generates the native iOS project, installs CocoaPods, and compiles the Release configuration for the iOS Simulator with code signing disabled.
+
+The native compile gate was subsequently strengthened by PR #202. Verified on main commit `2f721876a8014d1bea302149f26f164a97d03dff`:
+- DABBIR Mobile CI run `33181956120` (#52) completed successfully.
+- The native job runs on `macos-26`, explicitly requires Xcode major >= 26, generates the native iOS project, installs CocoaPods, and compiles the Release configuration twice with signing disabled:
+  - generic iOS Simulator Release compile;
+  - generic physical iOS device (`iphoneos`) Release compile.
+- These unsigned compile gates prove the source/native dependency graph compiles for both simulator and device targets; they do **not** substitute for Apple Distribution signing, an archive/IPA, or TestFlight.
+
+Verified native capabilities:
 - Native React Native / Expo SDK 57 iPhone app; no WebView wrapper.
 - Secure device session storage via iOS Keychain (`expo-secure-store`).
 - Native Bearer auth bridge preserving browser CSRF/same-origin behavior.
@@ -47,6 +55,16 @@ Canonical Full Customer Journey run `33175328444` (#138) completed successfully 
 
 This verifies server/web authentication, tenant isolation and WhatsApp cross-tenant authorization. It does **not** substitute for a real iPhone/TestFlight Meta WhatsApp pairing and message test.
 
+## App Store public pages
+The repository contains bilingual Arabic/English App Store-facing pages and stable Vercel routes:
+- `/privacy` → `privacy.html`
+- `/terms` → `terms.html`
+- `/support` → `support.html`
+
+Source and route contracts are covered by automated tests and the App Store static preflight. These pages do not contain a Stripe/web purchase CTA. The privacy page records the current no-tracking declaration and product-scoped deletion behavior.
+
+This is **source readiness only**. App Store release mode still requires these paths to resolve on a genuinely public, stable HTTPS production hostname. Protected/prelaunch Vercel hosts are intentionally rejected.
+
 ## App Store preflight contract
 The release pipeline must distinguish internal source readiness from Apple/external readiness.
 
@@ -57,9 +75,11 @@ Static preflight is required to verify:
 - No entitlement before server verification.
 - Restore Purchases.
 - StoreKit-derived subscription period and introductory-offer disclosure; no hardcoded 7-day trial claim in the client.
-- Public Privacy Policy and Terms links are required by the subscription UI before purchase is enabled.
+- Privacy Policy and Terms links are required by the subscription UI before purchase is enabled.
 - No Stripe, web checkout, or external purchase CTA in the iOS subscription component.
 - Native API base remains explicit HTTPS and fail-closed.
+- EAS production profile uses remote app versions, production environment, and build auto-increment.
+- Privacy/Terms/Support source pages remain bilingual and mapped to stable Vercel routes.
 
 Release-mode preflight must additionally fail unless all of these are real and configured:
 - Bundle ID exactly `com.barmansystems.dabbir`.
@@ -67,7 +87,7 @@ Release-mode preflight must additionally fail unless all of these are real and c
 - Same subscription product ID on the iOS client and server.
 - Apple IAP enabled for the production candidate.
 - Public production HTTPS API URL, not a protected/prelaunch deployment URL.
-- Public HTTPS Privacy Policy, Terms of Use, and Support URLs.
+- Public HTTPS `/privacy`, `/terms`, and `/support` URLs.
 - Apple root certificates for JWS verification.
 - Server-side entitlement storage credential.
 
@@ -76,7 +96,7 @@ The preflight must never print private keys, root certificate bodies, or service
 ## Remaining P0 release gates
 1. Register/verify `com.barmansystems.dabbir` in the Apple Developer account and create/verify the App Store Connect app record.
 2. Create the real auto-renewable subscription in App Store Connect and configure the intended introductory free trial there. The client must display only StoreKit-reported offer data; it must not manufacture eligibility or duration.
-3. Configure production Apple/IAP values and public API/legal/support URLs, then obtain a RELEASE preflight PASS.
+3. Bind a genuinely public stable production hostname for the native API and `/privacy`, `/terms`, `/support`; configure the production Apple/IAP values; then obtain a RELEASE preflight PASS.
 4. Reconcile the Privacy Manifest and App Privacy questionnaire against the exact final binary, backend processing, and third-party SDKs.
 5. Produce a signed Apple Distribution archive/IPA from the exact candidate and record its build/artifact identity.
 6. Upload that exact build to TestFlight.

--- a/docs/app-store/APP_STORE_RELEASE_PLAN.md
+++ b/docs/app-store/APP_STORE_RELEASE_PLAN.md
@@ -66,7 +66,7 @@ Source and route contracts are covered by automated tests and the App Store stat
 This is **source readiness only**. App Store release mode still requires these paths to resolve on a genuinely public, stable HTTPS production hostname. Protected/prelaunch Vercel hosts are intentionally rejected.
 
 ## App Store preflight contract
-The release pipeline must distinguish internal source readiness from Apple/external readiness.
+The release pipeline must distinguish internal source/config readiness from Apple/external verification.
 
 Static preflight is required to verify:
 - Native/non-WebView client.
@@ -81,27 +81,38 @@ Static preflight is required to verify:
 - EAS production profile uses remote app versions, production environment, and build auto-increment.
 - Privacy/Terms/Support source pages remain bilingual and mapped to stable Vercel routes.
 
-Release-mode preflight must additionally fail unless all of these are real and configured:
+Release-mode configuration checks fail unless all of these candidate values are present and structurally valid:
 - Bundle ID exactly `com.barmansystems.dabbir`.
-- Numeric App Store Apple ID.
-- Same subscription product ID on the iOS client and server.
+- Numeric App Store Apple ID candidate.
+- Same configured subscription product ID on the iOS client and server.
 - Apple IAP enabled for the production candidate.
-- Public production HTTPS API URL, not a protected/prelaunch deployment URL.
-- Public HTTPS `/privacy`, `/terms`, and `/support` URLs.
-- Apple root certificates for JWS verification.
-- Server-side entitlement storage credential.
+- HTTPS production API URL that is not a protected/prelaunch Vercel host.
+- HTTPS `/privacy`, `/terms`, and `/support` URL paths.
+- At least two configured Apple root-certificate values.
+- A non-public server-side entitlement storage credential.
+
+Passing those configuration checks is **not** a final release PASS. When configuration is structurally complete, the preflight returns `RELEASE_CONFIG_PASS_EXTERNAL_VERIFICATION_REQUIRED`, `app_store_ready=false`, and a non-zero exit until independent evidence verifies:
+- the real App Store Connect app record and bundle/app ID;
+- the real subscription product and introductory offer;
+- live public reachability of the final API/Privacy/Terms/Support hostname;
+- Apple root-certificate parsing/trust in the release environment;
+- live server entitlement persistence using the intended credential path;
+- the signed Apple Distribution/TestFlight artifact on the exact candidate.
+
+Placeholder-shaped values, example domains, arbitrary base64 blobs, or non-empty credential strings must never manufacture a final RELEASE `PASS`.
 
 The preflight must never print private keys, root certificate bodies, or service-role credentials.
 
 ## Remaining P0 release gates
 1. Register/verify `com.barmansystems.dabbir` in the Apple Developer account and create/verify the App Store Connect app record.
 2. Create the real auto-renewable subscription in App Store Connect and configure the intended introductory free trial there. The client must display only StoreKit-reported offer data; it must not manufacture eligibility or duration.
-3. Bind a genuinely public stable production hostname for the native API and `/privacy`, `/terms`, `/support`; configure the production Apple/IAP values; then obtain a RELEASE preflight PASS.
-4. Reconcile the Privacy Manifest and App Privacy questionnaire against the exact final binary, backend processing, and third-party SDKs.
-5. Produce a signed Apple Distribution archive/IPA from the exact candidate and record its build/artifact identity.
-6. Upload that exact build to TestFlight.
-7. Perform exact TestFlight artifact QA on a real iPhone: install, launch, signup/email verification, login, password recovery, dashboard, native WhatsApp Embedded Signup/pairing, send/receive path, StoreKit purchase, server entitlement, Restore Purchases, logout/login, product-scoped account deletion, reinstall/re-auth behavior.
-8. Capture App Store screenshots from the exact candidate and finish Arabic/English metadata, age rating, export-compliance answers, privacy answers, Support/Privacy/Terms URLs, reviewer demo access, and review notes.
+3. Bind a genuinely public stable production hostname for the native API and `/privacy`, `/terms`, `/support`; configure the production Apple/IAP values; then obtain `RELEASE_CONFIG_PASS_EXTERNAL_VERIFICATION_REQUIRED` with no configuration failures.
+4. Supply independent external verification for the App Store Connect record/product, live public URLs, Apple certificate trust, and entitlement persistence path; do not convert configuration shape into a final PASS.
+5. Reconcile the Privacy Manifest and App Privacy questionnaire against the exact final binary, backend processing, and third-party SDKs.
+6. Produce a signed Apple Distribution archive/IPA from the exact candidate and record its build/artifact identity.
+7. Upload that exact build to TestFlight.
+8. Perform exact TestFlight artifact QA on a real iPhone: install, launch, signup/email verification, login, password recovery, dashboard, native WhatsApp Embedded Signup/pairing, send/receive path, StoreKit purchase, server entitlement, Restore Purchases, logout/login, product-scoped account deletion, reinstall/re-auth behavior.
+9. Capture App Store screenshots from the exact candidate and finish Arabic/English metadata, age rating, export-compliance answers, privacy answers, Support/Privacy/Terms URLs, reviewer demo access, and review notes.
 
 ## Known security warning outside the native source gate
 Supabase Security Advisor still reports Leaked Password Protection disabled. It remains unresolved until Supabase Auth configuration can be changed through an authorized management surface. Do not mark it fixed merely because application tests pass.

--- a/scripts/dabbir-app-store-preflight.mjs
+++ b/scripts/dabbir-app-store-preflight.mjs
@@ -123,24 +123,40 @@ const supportUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL);
 const rootCerts = String(process.env.APPLE_ROOT_CERTIFICATES_BASE64 || '').trim();
 const serviceRole = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
 
-requireRelease(bundleId === 'com.barmansystems.dabbir', 'APPLE_BUNDLE_REGISTERED_VALUE', 'Release bundle ID must be com.barmansystems.dabbir.');
-requireRelease(/^\d{5,20}$/.test(appAppleId), 'APP_STORE_APPLE_ID', 'App Store numeric Apple ID must be configured.');
-requireRelease(serverProductId.length > 2 && clientProductId === serverProductId, 'IAP_PRODUCT_MATCH', 'Client and server must use the exact same App Store subscription product ID.');
+requireRelease(bundleId === 'com.barmansystems.dabbir', 'APPLE_BUNDLE_REGISTERED_VALUE', 'Release bundle ID candidate must be com.barmansystems.dabbir; App Store Connect registration is externally verified.');
+requireRelease(/^\d{5,20}$/.test(appAppleId), 'APP_STORE_APPLE_ID', 'A numeric App Store Apple ID candidate must be configured; existence is externally verified.');
+requireRelease(serverProductId.length > 2 && clientProductId === serverProductId, 'IAP_PRODUCT_MATCH', 'Client and server must use the same configured product ID; App Store product existence is externally verified.');
 requireRelease(iapEnabled === 'true', 'IAP_ENABLED_RELEASE', 'Production candidate must enable Apple IAP.');
-requireRelease(Boolean(apiUrl) && !isProtectedPrelaunchHost(apiUrl), 'PUBLIC_PRODUCTION_API', 'Production iOS API base must be public HTTPS and not a protected/prelaunch Vercel host.');
-requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl) && /^\/privacy\/?$/i.test(privacyUrl.pathname), 'PUBLIC_PRIVACY_URL', 'Privacy Policy URL must be the public HTTPS /privacy route.');
-requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl) && /^\/terms\/?$/i.test(termsUrl.pathname), 'PUBLIC_TERMS_URL', 'Terms of Use URL must be the public HTTPS /terms route.');
-requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl) && /^\/support\/?$/i.test(supportUrl.pathname), 'PUBLIC_SUPPORT_URL', 'Support URL must be the public HTTPS /support route.');
-requireRelease(rootCerts.split(',').map(v => v.trim()).filter(Boolean).length >= 2, 'APPLE_ROOT_CERTIFICATES', 'Apple root certificates must be configured server-side.');
-requireRelease(Boolean(serviceRole) && !serviceRole.startsWith('sb_publishable_'), 'IAP_SERVER_STORAGE_CREDENTIAL', 'Server-side entitlement persistence credential must exist.');
+requireRelease(Boolean(apiUrl) && !isProtectedPrelaunchHost(apiUrl), 'PUBLIC_PRODUCTION_API', 'Configured production iOS API URL must be HTTPS and not a protected/prelaunch Vercel host; live reachability is externally verified.');
+requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl) && /^\/privacy\/?$/i.test(privacyUrl.pathname), 'PUBLIC_PRIVACY_URL', 'Configured Privacy URL must use HTTPS /privacy; live public reachability is externally verified.');
+requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl) && /^\/terms\/?$/i.test(termsUrl.pathname), 'PUBLIC_TERMS_URL', 'Configured Terms URL must use HTTPS /terms; live public reachability is externally verified.');
+requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl) && /^\/support\/?$/i.test(supportUrl.pathname), 'PUBLIC_SUPPORT_URL', 'Configured Support URL must use HTTPS /support; live public reachability is externally verified.');
+requireRelease(rootCerts.split(',').map(v => v.trim()).filter(Boolean).length >= 2, 'APPLE_ROOT_CERTIFICATES_CONFIG', 'At least two Apple root certificate values must be configured; certificate parsing/trust is externally verified before release.');
+requireRelease(Boolean(serviceRole) && !serviceRole.startsWith('sb_publishable_'), 'IAP_SERVER_STORAGE_CREDENTIAL_CONFIG', 'A non-public server storage credential must be configured; live entitlement persistence is externally verified before release.');
 
+const releaseExternalVerification = releaseMode && failures.length === 0 ? [
+  { code: 'APP_STORE_CONNECT_RECORD_VERIFICATION', detail: 'Verify the configured bundle/app ID against the real App Store Connect record.' },
+  { code: 'APP_STORE_SUBSCRIPTION_PRODUCT_VERIFICATION', detail: 'Verify the configured subscription product and introductory offer in App Store Connect.' },
+  { code: 'PUBLIC_RELEASE_URL_LIVE_VERIFICATION', detail: 'Verify the production API, Privacy, Terms and Support URLs are publicly reachable from the final hostname.' },
+  { code: 'APPLE_ROOT_TRUST_VERIFICATION', detail: 'Parse and validate the configured Apple root certificates in the release environment.' },
+  { code: 'ENTITLEMENT_STORAGE_LIVE_VERIFICATION', detail: 'Verify the release server credential can persist and read an entitlement through the intended server path without exposing the credential.' },
+  { code: 'SIGNED_DISTRIBUTION_TESTFLIGHT_VERIFICATION', detail: 'Produce and verify the signed Distribution/TestFlight artifact on the exact release candidate.' },
+] : [];
+
+const releaseConfigOnly = releaseMode && failures.length === 0 && releaseExternalVerification.length > 0;
 const report = {
-  ok: failures.length === 0,
+  ok: failures.length === 0 && !releaseConfigOnly,
   mode: releaseMode ? 'RELEASE' : 'STATIC',
-  verdict: failures.length ? 'FAIL' : (external.length ? 'INTERNAL_PASS_EXTERNAL_BLOCKED' : 'PASS'),
+  verdict: failures.length
+    ? 'FAIL'
+    : releaseConfigOnly
+      ? 'RELEASE_CONFIG_PASS_EXTERNAL_VERIFICATION_REQUIRED'
+      : (external.length ? 'INTERNAL_PASS_EXTERNAL_BLOCKED' : 'PASS'),
   passes: passes.map(item => item.code),
   failures,
-  external_blockers: external,
+  external_blockers: [...external, ...releaseExternalVerification],
+  release_config_only: releaseConfigOnly,
+  app_store_ready: false,
   privacy_manifest_final_binary_reconciliation: 'REQUIRED_BEFORE_SUBMISSION',
   signed_distribution_testflight: 'EXTERNAL_APPLE_GATE',
 };
@@ -149,3 +165,4 @@ const json = JSON.stringify(report, null, 2);
 if (reportPath) fs.writeFileSync(path.resolve(ROOT, reportPath), `${json}\n`);
 console.log(json);
 if (failures.length) process.exit(2);
+if (releaseConfigOnly) process.exit(3);

--- a/scripts/dabbir-app-store-preflight.mjs
+++ b/scripts/dabbir-app-store-preflight.mjs
@@ -37,7 +37,21 @@ function isProtectedPrelaunchHost(url) {
   return /-3619s-projects\.vercel\.app$/i.test(url.hostname) || /-nd56cm4j5v-/i.test(url.hostname);
 }
 
+function routeDestination(vercelConfig, source) {
+  const route = (vercelConfig.routes || []).find(item => item?.src === source);
+  return route?.dest || null;
+}
+
+function legalPageContract(html, key) {
+  return /<html\s+lang=["']ar["']\s+dir=["']rtl["']/i.test(html)
+    && /lang=["']en["']/i.test(html)
+    && /DABBIR \| دبّر/.test(html)
+    && !/buy on web|subscribe on web|Stripe checkout|payment link/i.test(html)
+    && (key !== 'privacy' || /NSPrivacyTracking\s*=\s*false/i.test(html));
+}
+
 const appConfig = read('mobile/app.config.ts');
+const easConfig = JSON.parse(read('mobile/eas.json'));
 const app = read('mobile/App.tsx');
 const subscription = read('mobile/src/SubscriptionCard.tsx');
 const mobileApi = read('mobile/src/api.ts');
@@ -47,6 +61,12 @@ const appleVerify = read('api/mobile/iap/verify.js');
 const appleNotifications = read('api/apple/app-store-notifications.js');
 const accountDelete = read('api/mobile/account-delete.js');
 const entitlementMigration = read('supabase/migrations/20260828091500_dabbir_apple_entitlements_v1.sql');
+const vercelConfig = JSON.parse(read('vercel.json'));
+const publicPages = {
+  privacy: read('privacy.html'),
+  terms: read('terms.html'),
+  support: read('support.html'),
+};
 
 requireStatic(/name:\s*['"]DABBIR \| دبّر['"]/.test(appConfig), 'APP_NAME_LOCKED', 'Native app name is DABBIR | دبّر.');
 requireStatic(/supportsTablet:\s*false/.test(appConfig), 'IPHONE_ONLY', 'iPad distribution is disabled for v1.');
@@ -70,6 +90,26 @@ requireStatic(/introductoryOffer|introOffer/.test(subscription) && /free-trial/.
 requireStatic(/EXPO_PUBLIC_DABBIR_PRIVACY_URL/.test(subscription) && /EXPO_PUBLIC_DABBIR_TERMS_URL/.test(subscription), 'SUBSCRIPTION_LEGAL_LINKS', 'Subscription screen requires privacy and Terms links.');
 requireStatic(!/stripe|checkout|payment[_ -]?link|buy on web|subscribe on web/i.test(subscription), 'NO_EXTERNAL_PAYMENT_CTA', 'The iOS subscription component contains no Stripe/external purchase CTA.');
 requireStatic(mobileApi.includes('DABBIR_API_BASE_URL_NOT_CONFIGURED') && mobileApi.includes('configuredBase') && mobileApi.includes('https:'), 'HTTPS_API_FAIL_CLOSED', 'Native API requires an explicit HTTPS base URL.');
+requireStatic(
+  easConfig?.cli?.appVersionSource === 'remote'
+    && easConfig?.build?.production?.autoIncrement === true
+    && easConfig?.build?.production?.environment === 'production'
+    && Boolean(easConfig?.build?.production?.ios),
+  'EAS_PRODUCTION_PROFILE',
+  'EAS production profile uses remote app versions, auto-increments builds, and targets the production environment.',
+);
+requireStatic(
+  Object.entries(publicPages).every(([key, html]) => legalPageContract(html, key)),
+  'APP_STORE_PUBLIC_PAGE_SOURCE',
+  'Privacy, Terms and Support source pages are bilingual DABBIR pages without an external purchase CTA.',
+);
+requireStatic(
+  routeDestination(vercelConfig, '^/privacy/?$') === '/privacy.html'
+    && routeDestination(vercelConfig, '^/terms/?$') === '/terms.html'
+    && routeDestination(vercelConfig, '^/support/?$') === '/support.html',
+  'APP_STORE_PUBLIC_PAGE_ROUTES',
+  'Vercel routes expose stable /privacy, /terms and /support paths.',
+);
 
 const bundleId = String(process.env.DABBIR_IOS_BUNDLE_ID || '').trim();
 const appAppleId = String(process.env.DABBIR_IOS_APP_APPLE_ID || '').trim();
@@ -88,9 +128,9 @@ requireRelease(/^\d{5,20}$/.test(appAppleId), 'APP_STORE_APPLE_ID', 'App Store n
 requireRelease(serverProductId.length > 2 && clientProductId === serverProductId, 'IAP_PRODUCT_MATCH', 'Client and server must use the exact same App Store subscription product ID.');
 requireRelease(iapEnabled === 'true', 'IAP_ENABLED_RELEASE', 'Production candidate must enable Apple IAP.');
 requireRelease(Boolean(apiUrl) && !isProtectedPrelaunchHost(apiUrl), 'PUBLIC_PRODUCTION_API', 'Production iOS API base must be public HTTPS and not a protected/prelaunch Vercel host.');
-requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl), 'PUBLIC_PRIVACY_URL', 'Privacy Policy URL must be public HTTPS.');
-requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl), 'PUBLIC_TERMS_URL', 'Terms of Use URL must be public HTTPS.');
-requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl), 'PUBLIC_SUPPORT_URL', 'Support URL must be public HTTPS.');
+requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl) && /^\/privacy\/?$/i.test(privacyUrl.pathname), 'PUBLIC_PRIVACY_URL', 'Privacy Policy URL must be the public HTTPS /privacy route.');
+requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl) && /^\/terms\/?$/i.test(termsUrl.pathname), 'PUBLIC_TERMS_URL', 'Terms of Use URL must be the public HTTPS /terms route.');
+requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl) && /^\/support\/?$/i.test(supportUrl.pathname), 'PUBLIC_SUPPORT_URL', 'Support URL must be the public HTTPS /support route.');
 requireRelease(rootCerts.split(',').map(v => v.trim()).filter(Boolean).length >= 2, 'APPLE_ROOT_CERTIFICATES', 'Apple root certificates must be configured server-side.');
 requireRelease(Boolean(serviceRole) && !serviceRole.startsWith('sb_publishable_'), 'IAP_SERVER_STORAGE_CREDENTIAL', 'Server-side entitlement persistence credential must exist.');
 

--- a/test/dabbir-app-store-preflight.test.mjs
+++ b/test/dabbir-app-store-preflight.test.mjs
@@ -43,6 +43,9 @@ test('static App Store preflight passes internal invariants while reporting exte
   assert.ok(report.passes.includes('NO_UNVERIFIED_ENTITLEMENT'));
   assert.ok(report.passes.includes('SUBSCRIPTION_LEGAL_LINKS'));
   assert.ok(report.passes.includes('STOREKIT_INTRO_OFFER_DISCLOSURE'));
+  assert.ok(report.passes.includes('EAS_PRODUCTION_PROFILE'));
+  assert.ok(report.passes.includes('APP_STORE_PUBLIC_PAGE_SOURCE'));
+  assert.ok(report.passes.includes('APP_STORE_PUBLIC_PAGE_ROUTES'));
   assert.ok(report.external_blockers.some(item => item.code === 'APP_STORE_APPLE_ID'));
   assert.ok(report.external_blockers.some(item => item.code === 'PUBLIC_PRODUCTION_API'));
   assert.equal(report.signed_distribution_testflight, 'EXTERNAL_APPLE_GATE');
@@ -59,6 +62,38 @@ test('release App Store preflight fails closed when Apple/public release configu
   for (const required of ['APPLE_BUNDLE_REGISTERED_VALUE', 'APP_STORE_APPLE_ID', 'IAP_PRODUCT_MATCH', 'IAP_ENABLED_RELEASE', 'PUBLIC_PRODUCTION_API', 'PUBLIC_PRIVACY_URL', 'PUBLIC_TERMS_URL', 'PUBLIC_SUPPORT_URL', 'APPLE_ROOT_CERTIFICATES', 'IAP_SERVER_STORAGE_CREDENTIAL']) {
     assert.ok(codes.has(required), `missing fail-closed release blocker ${required}`);
   }
+});
+
+test('release App Store preflight accepts only canonical public legal route paths', () => {
+  const common = {
+    DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1',
+    DABBIR_IOS_BUNDLE_ID: 'com.barmansystems.dabbir',
+    DABBIR_IOS_APP_APPLE_ID: '1234567890',
+    DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID: 'com.barmansystems.dabbir.owner.monthly',
+    EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID: 'com.barmansystems.dabbir.owner.monthly',
+    EXPO_PUBLIC_IOS_IAP_ENABLED: 'true',
+    EXPO_PUBLIC_DABBIR_API_BASE_URL: 'https://app.example.com',
+    APPLE_ROOT_CERTIFICATES_BASE64: `${Buffer.alloc(400).toString('base64')},${Buffer.alloc(400, 1).toString('base64')}`,
+    SUPABASE_SERVICE_ROLE_KEY: 'service-role-test-value',
+  };
+
+  const wrong = runPreflight({
+    ...common,
+    EXPO_PUBLIC_DABBIR_PRIVACY_URL: 'https://app.example.com/privacy-policy',
+    EXPO_PUBLIC_DABBIR_TERMS_URL: 'https://app.example.com/terms',
+    EXPO_PUBLIC_DABBIR_SUPPORT_URL: 'https://app.example.com/support',
+  });
+  assert.equal(wrong.status, 2, wrong.stderr || wrong.stdout);
+  assert.ok(JSON.parse(wrong.stdout).failures.some(item => item.code === 'PUBLIC_PRIVACY_URL'));
+
+  const canonical = runPreflight({
+    ...common,
+    EXPO_PUBLIC_DABBIR_PRIVACY_URL: 'https://app.example.com/privacy',
+    EXPO_PUBLIC_DABBIR_TERMS_URL: 'https://app.example.com/terms',
+    EXPO_PUBLIC_DABBIR_SUPPORT_URL: 'https://app.example.com/support',
+  });
+  assert.equal(canonical.status, 0, canonical.stderr || canonical.stdout);
+  assert.equal(JSON.parse(canonical.stdout).verdict, 'PASS');
 });
 
 test('subscription UI discloses StoreKit-derived period/offer and legal links without external payment CTA', async () => {

--- a/test/dabbir-app-store-preflight.test.mjs
+++ b/test/dabbir-app-store-preflight.test.mjs
@@ -39,6 +39,7 @@ test('static App Store preflight passes internal invariants while reporting exte
   assert.equal(report.ok, true);
   assert.equal(report.mode, 'STATIC');
   assert.equal(report.verdict, 'INTERNAL_PASS_EXTERNAL_BLOCKED');
+  assert.equal(report.app_store_ready, false);
   assert.ok(report.passes.includes('NATIVE_NOT_WEBVIEW'));
   assert.ok(report.passes.includes('NO_UNVERIFIED_ENTITLEMENT'));
   assert.ok(report.passes.includes('SUBSCRIPTION_LEGAL_LINKS'));
@@ -58,13 +59,14 @@ test('release App Store preflight fails closed when Apple/public release configu
   assert.equal(report.ok, false);
   assert.equal(report.mode, 'RELEASE');
   assert.equal(report.verdict, 'FAIL');
+  assert.equal(report.app_store_ready, false);
   const codes = new Set(report.failures.map(item => item.code));
-  for (const required of ['APPLE_BUNDLE_REGISTERED_VALUE', 'APP_STORE_APPLE_ID', 'IAP_PRODUCT_MATCH', 'IAP_ENABLED_RELEASE', 'PUBLIC_PRODUCTION_API', 'PUBLIC_PRIVACY_URL', 'PUBLIC_TERMS_URL', 'PUBLIC_SUPPORT_URL', 'APPLE_ROOT_CERTIFICATES', 'IAP_SERVER_STORAGE_CREDENTIAL']) {
+  for (const required of ['APPLE_BUNDLE_REGISTERED_VALUE', 'APP_STORE_APPLE_ID', 'IAP_PRODUCT_MATCH', 'IAP_ENABLED_RELEASE', 'PUBLIC_PRODUCTION_API', 'PUBLIC_PRIVACY_URL', 'PUBLIC_TERMS_URL', 'PUBLIC_SUPPORT_URL', 'APPLE_ROOT_CERTIFICATES_CONFIG', 'IAP_SERVER_STORAGE_CREDENTIAL_CONFIG']) {
     assert.ok(codes.has(required), `missing fail-closed release blocker ${required}`);
   }
 });
 
-test('release App Store preflight accepts only canonical public legal route paths', () => {
+test('release config cannot manufacture final PASS from placeholder-shaped values', () => {
   const common = {
     DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1',
     DABBIR_IOS_BUNDLE_ID: 'com.barmansystems.dabbir',
@@ -86,14 +88,28 @@ test('release App Store preflight accepts only canonical public legal route path
   assert.equal(wrong.status, 2, wrong.stderr || wrong.stdout);
   assert.ok(JSON.parse(wrong.stdout).failures.some(item => item.code === 'PUBLIC_PRIVACY_URL'));
 
-  const canonical = runPreflight({
+  const shapedOnly = runPreflight({
     ...common,
     EXPO_PUBLIC_DABBIR_PRIVACY_URL: 'https://app.example.com/privacy',
     EXPO_PUBLIC_DABBIR_TERMS_URL: 'https://app.example.com/terms',
     EXPO_PUBLIC_DABBIR_SUPPORT_URL: 'https://app.example.com/support',
   });
-  assert.equal(canonical.status, 0, canonical.stderr || canonical.stdout);
-  assert.equal(JSON.parse(canonical.stdout).verdict, 'PASS');
+  assert.equal(shapedOnly.status, 3, shapedOnly.stderr || shapedOnly.stdout);
+  const report = JSON.parse(shapedOnly.stdout);
+  assert.equal(report.ok, false);
+  assert.equal(report.app_store_ready, false);
+  assert.equal(report.release_config_only, true);
+  assert.equal(report.verdict, 'RELEASE_CONFIG_PASS_EXTERNAL_VERIFICATION_REQUIRED');
+  for (const required of [
+    'APP_STORE_CONNECT_RECORD_VERIFICATION',
+    'APP_STORE_SUBSCRIPTION_PRODUCT_VERIFICATION',
+    'PUBLIC_RELEASE_URL_LIVE_VERIFICATION',
+    'APPLE_ROOT_TRUST_VERIFICATION',
+    'ENTITLEMENT_STORAGE_LIVE_VERIFICATION',
+    'SIGNED_DISTRIBUTION_TESTFLIGHT_VERIFICATION',
+  ]) {
+    assert.ok(report.external_blockers.some(item => item.code === required), `missing external verification blocker ${required}`);
+  }
 });
 
 test('subscription UI discloses StoreKit-derived period/offer and legal links without external payment CTA', async () => {

--- a/test/dabbir-app-store-preflight.test.mjs
+++ b/test/dabbir-app-store-preflight.test.mjs
@@ -110,10 +110,14 @@ test('subscription UI discloses StoreKit-derived period/offer and legal links wi
   assert.doesNotMatch(source, /7\s*(day|days|يوم|أيام)/i);
 });
 
-test('mobile CI permanently runs the static App Store preflight and watches its contract paths', async () => {
+test('mobile CI permanently runs the preflight and watches every App Store source contract path', async () => {
   const workflow = await read('.github/workflows/dabbir-mobile-ci.yml');
   assert.match(workflow, /scripts\/dabbir-app-store-preflight\.mjs/);
   assert.match(workflow, /test\/dabbir-app-store-preflight\.test\.mjs/);
   assert.match(workflow, /Run App Store static preflight/);
   assert.match(workflow, /node scripts\/dabbir-app-store-preflight\.mjs/);
+  for (const watched of ['privacy.html', 'terms.html', 'support.html', 'vercel.json']) {
+    const count = workflow.split(`- '${watched}'`).length - 1;
+    assert.equal(count, 2, `${watched} must trigger Mobile CI on PR and main push`);
+  }
 });


### PR DESCRIPTION
Refresh the App Store release authority without weakening any Apple gate.

Changes:
- aggregate the existing bilingual Privacy/Terms/Support source and Vercel route contract into the App Store preflight;
- verify the EAS production profile is remote-versioned, auto-incrementing and production-scoped;
- require canonical public `/privacy`, `/terms`, `/support` paths in RELEASE mode;
- add regression coverage for those contracts;
- align the release plan with the already-verified generic `iphoneos` Release compile gate from Mobile CI run #52 (`33181956120`).

No runtime/Auth/WhatsApp/database behavior changes. No Apple readiness claim is added. RELEASE preflight remains fail-closed until real App Store IDs/product configuration, public stable hostname, Apple roots/storage credential, signing and TestFlight are verified.

Acceptance:
- DABBIR tests PASS;
- App Store static preflight = INTERNAL_PASS_EXTERNAL_BLOCKED;
- Mobile static PASS;
- Expo Doctor + TypeScript + Expo config PASS;
- macOS/Xcode 26 Release compile PASS for simulator and generic `iphoneos` device with code signing disabled.

This PR intentionally touches the preflight contract so Mobile CI recompiles the native app against a current base.