### PR TITLE
DABBIR: keep Meta bearer tokens out of Graph URLs

### DIFF
--- a/api/_whatsapp-embedded-core.js
+++ b/api/_whatsapp-embedded-core.js
@@ -88,8 +88,15 @@ async function discoverAppIdFromExistingToken(config) {
   try {
     const url = new URL(`https://graph.facebook.com/${encodeURIComponent(config.graphVersion)}/app`);
     url.searchParams.set('fields', 'id');
-    url.searchParams.set('access_token', token);
-    const response = await fetch(url, { method: 'GET', cache: 'no-store', signal: controller.signal });
+    const response = await fetch(url, {
+      method: 'GET',
+      cache: 'no-store',
+      signal: controller.signal,
+      headers: {
+        accept: 'application/json',
+        authorization: `Bearer ${token}`,
+      },
+    });
     const payload = await response.json().catch(() => ({}));
     const id = String(payload?.id || '').trim();
     if (!response.ok || !/^[0-9]{5,40}$/.test(id)) return '';

--- a/test/dabbir-meta-secret-transport.test.mjs
+++ b/test/dabbir-meta-secret-transport.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source = fs.readFileSync(new URL('../api/_whatsapp-embedded-core.js', import.meta.url), 'utf8');
+
+function between(startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.ok(start >= 0, `missing start marker ${startMarker}`);
+  assert.ok(end > start, `missing end marker ${endMarker}`);
+  return source.slice(start, end);
+}
+
+test('legacy Meta access-token discovery uses Authorization header, never URL transport', () => {
+  const discovery = between(
+    'async function discoverAppIdFromExistingToken(config)',
+    'export async function resolveEmbeddedPlatformConfig()',
+  );
+
+  assert.doesNotMatch(discovery, /searchParams\.set\(['"]access_token['"]/);
+  assert.doesNotMatch(discovery, /[?&]access_token=/);
+  assert.match(discovery, /authorization:\s*`Bearer \$\{token\}`/);
+  assert.match(discovery, /setTimeout\(\(\) => controller\.abort\(\),\s*5000\)/);
+  assert.match(discovery, /cache:\s*['"]no-store['"]/);
+  assert.match(discovery, /\^\[0-9\]\{5,40\}\$/);
+});
+
+test('provider-required OAuth client secret remains server-only and is not returned or logged', () => {
+  const exchange = between(
+    'export async function exchangeEmbeddedCode(config, code)',
+    'export async function verifyEmbeddedAssets(config, token, wabaId, phoneNumberId)',
+  );
+
+  // Meta's official Tech Provider sample documents client_secret as a required
+  // query parameter for this server-side token exchange. Keep the provider
+  // contract isolated to this backend function and never expose the URL/secret.
+  assert.match(exchange, /searchParams\.set\(['"]client_secret['"],\s*config\.appSecret\)/);
+  assert.doesNotMatch(exchange, /console\.(?:log|info|warn|error)/);
+  assert.doesNotMatch(exchange, /return\s+\{[^}]*appSecret/s);
+  assert.doesNotMatch(exchange, /return\s+url/);
+  assert.match(exchange, /setTimeout\(\(\) => controller\.abort\(\),\s*8000\)/);
+  assert.match(exchange, /cache:\s*['"]no-store['"]/);
+});


### PR DESCRIPTION
Fixes #214.

Security hardening only:
- `discoverAppIdFromExistingToken()` no longer appends the legacy Meta/WhatsApp access token to the Graph API URL.
- The token is sent as `Authorization: Bearer ...`, matching DABBIR's other Graph calls.
- Preserves GET semantics, 5s timeout, `no-store`, app-id validation and discovery cache.
- Regression test prevents `access_token` URL transport from returning.
- The test also documents the separate provider-required OAuth `client_secret` query parameter. Meta's current official Tech Provider sample explicitly states that this server-side token exchange requires `client_secret` as a query parameter, so this PR does not alter that provider contract; it verifies the secret is neither logged nor returned.

Evidence:
- Vercel Preview `dpl_7BEL9h4dpBimtU482TbB6iR8NE8p` READY on exact head `c7de6fbed6d799b2af56d5d98d8a39c12dfbb925`.
- Vercel build gate ran `npm test` on that exact SHA and completed successfully.

GitHub Actions remains independently blocked before runner allocation under #210; do not treat that platform failure as a regression in this PR.