### PR TITLE
DABBIR iOS: WhatsApp mobile session storage only — superseded

### DIFF
--- a/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
+++ b/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
@@ -18,16 +18,47 @@ create table if not exists public.dabbir_whatsapp_mobile_connect_sessions (
   phone_number_id text,
   onboarding_mode text not null default 'whatsapp_business_app_onboarding',
   created_at timestamptz not null default now(),
-  expires_at timestamptz not null,
+  expires_at timestamptz not null check (expires_at > created_at),
   captured_at timestamptz,
   completing_at timestamptz,
   consumed_at timestamptz,
   failed_at timestamptz,
   last_error text,
   constraint dabbir_whatsapp_mobile_connect_capture_shape check (
-    (status = 'pending' and code_ciphertext is null and code_iv is null and code_tag is null)
+    (
+      status = 'pending'
+      and code_ciphertext is null
+      and code_iv is null
+      and code_tag is null
+      and code_key_version is null
+    )
     or
-    (status <> 'pending' and code_ciphertext is not null and code_iv is not null and code_tag is not null and code_key_version is not null)
+    (
+      status in ('captured','completing','consumed')
+      and code_ciphertext is not null
+      and code_iv is not null
+      and code_tag is not null
+      and code_key_version is not null
+    )
+    or
+    (
+      status = 'failed'
+      and (
+        (
+          code_ciphertext is null
+          and code_iv is null
+          and code_tag is null
+          and code_key_version is null
+        )
+        or
+        (
+          code_ciphertext is not null
+          and code_iv is not null
+          and code_tag is not null
+          and code_key_version is not null
+        )
+      )
+    )
   )
 );
 

--- a/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
+++ b/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
@@ -1,0 +1,50 @@
+-- DABBIR WhatsApp mobile connect sessions v1
+-- Short-lived one-time state for iPhone system-browser Embedded Signup.
+-- No user access token or Meta access token is stored here. The short-lived Meta
+-- authorization code is encrypted by the application before storage.
+
+create table if not exists public.dabbir_whatsapp_mobile_connect_sessions (
+  state_hash text primary key check (state_hash ~ '^[0-9a-f]{64}$'),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  status text not null default 'pending'
+    check (status in ('pending','captured','completing','consumed','failed')),
+  redirect_uri text not null check (length(redirect_uri) between 12 and 2048),
+  code_ciphertext text,
+  code_iv text,
+  code_tag text,
+  code_key_version text,
+  waba_id text,
+  phone_number_id text,
+  onboarding_mode text not null default 'whatsapp_business_app_onboarding',
+  created_at timestamptz not null default now(),
+  expires_at timestamptz not null,
+  captured_at timestamptz,
+  completing_at timestamptz,
+  consumed_at timestamptz,
+  failed_at timestamptz,
+  last_error text,
+  constraint dabbir_whatsapp_mobile_connect_capture_shape check (
+    (status = 'pending' and code_ciphertext is null and code_iv is null and code_tag is null)
+    or
+    (status <> 'pending' and code_ciphertext is not null and code_iv is not null and code_tag is not null and code_key_version is not null)
+  )
+);
+
+create index if not exists dabbir_whatsapp_mobile_connect_sessions_user_idx
+  on public.dabbir_whatsapp_mobile_connect_sessions(user_id, created_at desc);
+create index if not exists dabbir_whatsapp_mobile_connect_sessions_business_idx
+  on public.dabbir_whatsapp_mobile_connect_sessions(business_id, created_at desc);
+create index if not exists dabbir_whatsapp_mobile_connect_sessions_expiry_idx
+  on public.dabbir_whatsapp_mobile_connect_sessions(expires_at);
+
+alter table public.dabbir_whatsapp_mobile_connect_sessions enable row level security;
+alter table public.dabbir_whatsapp_mobile_connect_sessions force row level security;
+
+revoke all on table public.dabbir_whatsapp_mobile_connect_sessions from public;
+revoke all on table public.dabbir_whatsapp_mobile_connect_sessions from anon;
+revoke all on table public.dabbir_whatsapp_mobile_connect_sessions from authenticated;
+grant select, insert, update, delete on table public.dabbir_whatsapp_mobile_connect_sessions to service_role;
+
+comment on table public.dabbir_whatsapp_mobile_connect_sessions is
+  'Service-only, short-lived one-time state for DABBIR iPhone WhatsApp Embedded Signup. No end-user RLS policies by design.';

--- a/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
+++ b/supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql
@@ -1,7 +1,8 @@
 -- DABBIR WhatsApp mobile connect sessions v1
 -- Short-lived one-time state for iPhone system-browser Embedded Signup.
 -- No user access token or Meta access token is stored here. The short-lived Meta
--- authorization code is encrypted by the application before storage.
+-- authorization code is encrypted by the application before storage and erased
+-- once the session reaches a terminal state.
 
 create table if not exists public.dabbir_whatsapp_mobile_connect_sessions (
   state_hash text primary key check (state_hash ~ '^[0-9a-f]{64}$'),
@@ -26,7 +27,7 @@ create table if not exists public.dabbir_whatsapp_mobile_connect_sessions (
   last_error text,
   constraint dabbir_whatsapp_mobile_connect_capture_shape check (
     (
-      status = 'pending'
+      status in ('pending','consumed','failed')
       and code_ciphertext is null
       and code_iv is null
       and code_tag is null
@@ -34,30 +35,11 @@ create table if not exists public.dabbir_whatsapp_mobile_connect_sessions (
     )
     or
     (
-      status in ('captured','completing','consumed')
+      status in ('captured','completing')
       and code_ciphertext is not null
       and code_iv is not null
       and code_tag is not null
       and code_key_version is not null
-    )
-    or
-    (
-      status = 'failed'
-      and (
-        (
-          code_ciphertext is null
-          and code_iv is null
-          and code_tag is null
-          and code_key_version is null
-        )
-        or
-        (
-          code_ciphertext is not null
-          and code_iv is not null
-          and code_tag is not null
-          and code_key_version is not null
-        )
-      )
     )
   )
 );
@@ -78,4 +60,4 @@ revoke all on table public.dabbir_whatsapp_mobile_connect_sessions from authenti
 grant select, insert, update, delete on table public.dabbir_whatsapp_mobile_connect_sessions to service_role;
 
 comment on table public.dabbir_whatsapp_mobile_connect_sessions is
-  'Service-only, short-lived one-time state for DABBIR iPhone WhatsApp Embedded Signup. No end-user RLS policies by design.';
+  'Service-only, short-lived one-time state for DABBIR iPhone WhatsApp Embedded Signup. Authorization codes are encrypted in transient states and erased on consumed/failed terminal states. No end-user RLS policies by design.';

--- a/test/dabbir-whatsapp-mobile-connect-session.test.mjs
+++ b/test/dabbir-whatsapp-mobile-connect-session.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration = fs.readFileSync(
+  new URL('../supabase/migrations/20260828183100_dabbir_whatsapp_mobile_connect_sessions_v1.sql', import.meta.url),
+  'utf8',
+);
+
+test('WhatsApp mobile connect session storage is service-only and force-RLS protected', () => {
+  assert.match(migration, /enable row level security/i);
+  assert.match(migration, /force row level security/i);
+  assert.match(migration, /revoke all on table public\.dabbir_whatsapp_mobile_connect_sessions from public/i);
+  assert.match(migration, /revoke all on table public\.dabbir_whatsapp_mobile_connect_sessions from anon/i);
+  assert.match(migration, /revoke all on table public\.dabbir_whatsapp_mobile_connect_sessions from authenticated/i);
+  assert.match(migration, /grant select, insert, update, delete on table public\.dabbir_whatsapp_mobile_connect_sessions to service_role/i);
+});
+
+test('failed OAuth sessions can terminate before Meta issues an authorization code', () => {
+  assert.match(
+    migration,
+    /status = 'failed'[\s\S]*code_ciphertext is null[\s\S]*code_iv is null[\s\S]*code_tag is null[\s\S]*code_key_version is null/i,
+  );
+});
+
+test('captured or consumed OAuth state never permits partial encrypted code material', () => {
+  assert.match(
+    migration,
+    /status in \('captured','completing','consumed'\)[\s\S]*code_ciphertext is not null[\s\S]*code_iv is not null[\s\S]*code_tag is not null[\s\S]*code_key_version is not null/i,
+  );
+  assert.match(
+    migration,
+    /status = 'pending'[\s\S]*code_ciphertext is null[\s\S]*code_iv is null[\s\S]*code_tag is null[\s\S]*code_key_version is null/i,
+  );
+});
+
+test('connect sessions must expire after creation and do not store user or Meta access tokens', () => {
+  assert.match(migration, /expires_at timestamptz not null check \(expires_at > created_at\)/i);
+  assert.doesNotMatch(migration, /user_access_token|meta_access_token|refresh_token/i);
+});

--- a/test/dabbir-whatsapp-mobile-connect-session.test.mjs
+++ b/test/dabbir-whatsapp-mobile-connect-session.test.mjs
@@ -16,21 +16,17 @@ test('WhatsApp mobile connect session storage is service-only and force-RLS prot
   assert.match(migration, /grant select, insert, update, delete on table public\.dabbir_whatsapp_mobile_connect_sessions to service_role/i);
 });
 
-test('failed OAuth sessions can terminate before Meta issues an authorization code', () => {
+test('pending and terminal OAuth sessions contain no authorization-code material', () => {
   assert.match(
     migration,
-    /status = 'failed'[\s\S]*code_ciphertext is null[\s\S]*code_iv is null[\s\S]*code_tag is null[\s\S]*code_key_version is null/i,
+    /status in \('pending','consumed','failed'\)[\s\S]*code_ciphertext is null[\s\S]*code_iv is null[\s\S]*code_tag is null[\s\S]*code_key_version is null/i,
   );
 });
 
-test('captured or consumed OAuth state never permits partial encrypted code material', () => {
+test('only captured or completing OAuth sessions can contain a complete encrypted code', () => {
   assert.match(
     migration,
-    /status in \('captured','completing','consumed'\)[\s\S]*code_ciphertext is not null[\s\S]*code_iv is not null[\s\S]*code_tag is not null[\s\S]*code_key_version is not null/i,
-  );
-  assert.match(
-    migration,
-    /status = 'pending'[\s\S]*code_ciphertext is null[\s\S]*code_iv is null[\s\S]*code_tag is null[\s\S]*code_key_version is null/i,
+    /status in \('captured','completing'\)[\s\S]*code_ciphertext is not null[\s\S]*code_iv is not null[\s\S]*code_tag is not null[\s\S]*code_key_version is not null/i,
   );
 });
 


### PR DESCRIPTION
Closed from the TestFlight release path after source review proved this branch does not contain a native WhatsApp connect UI or callback flow. Its exact diff contains only the service-only session-table migration and static migration tests, while both current main and this branch's `mobile/App.tsx` only display WhatsApp state.

Do not merge or apply the migration as a standalone artifact. The table is security-sensible (FORCE RLS, service-role-only, encrypted transient authorization-code fields, terminal erasure contract), but a release migration must have an actual caller and executable end-to-end flow.

Replacement requirement: build one complete native iPhone flow first — authenticated owner/business binding → short-lived state → Meta system-browser authorization → callback/state validation → one-time code handling → server completion → terminal secret erasure → refreshed verified WhatsApp state — then include the storage migration in that coherent PR and TestFlight gate.