### PR TITLE
DABBIR iOS: add Maestro App Store smoke gate

### DIFF
--- a/.github/workflows/dabbir-ios-maestro.yml
+++ b/.github/workflows/dabbir-ios-maestro.yml
@@ -1,0 +1,90 @@
+name: DABBIR iOS Maestro Smoke
+
+on:
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - '.github/workflows/dabbir-ios-maestro.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  maestro-smoke:
+    runs-on: macos-26
+    timeout-minutes: 35
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      DABBIR_IOS_BUNDLE_ID: com.barmansystems.dabbir
+      DABBIR_IOS_BUILD_NUMBER: '1'
+      EXPO_PUBLIC_DABBIR_API_BASE_URL: https://example.invalid
+      EXPO_PUBLIC_IOS_IAP_ENABLED: 'false'
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+      - name: Install dependencies
+        run: npm install --no-audit --no-fund
+      - name: Generate native iOS project
+        run: npx expo prebuild --platform ios --clean --no-install
+      - name: Install CocoaPods
+        working-directory: mobile/ios
+        run: pod install
+      - name: Select and boot iPhone simulator
+        shell: bash
+        run: |
+          UDID="$(xcrun simctl list devices available -j | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(x["udid"] for group in d["devices"].values() for x in group if x.get("isAvailable") and x.get("name","").startswith("iPhone")))')"
+          echo "DABBIR_SIMULATOR_UDID=${UDID}" >> "$GITHUB_ENV"
+          xcrun simctl boot "${UDID}" || true
+          open -a Simulator
+          xcrun simctl bootstatus "${UDID}" -b
+      - name: Resolve Xcode workspace and scheme
+        shell: bash
+        run: |
+          WORKSPACE="$(find ios -maxdepth 1 -name '*.xcworkspace' -print -quit)"
+          test -n "${WORKSPACE}"
+          SCHEME="$(xcodebuild -workspace "${WORKSPACE}" -list -json | python3 -c 'import json,sys; data=json.load(sys.stdin); schemes=data.get("workspace",{}).get("schemes",[]); print(schemes[0] if schemes else "")')"
+          test -n "${SCHEME}"
+          echo "DABBIR_XCODE_WORKSPACE=${WORKSPACE}" >> "$GITHUB_ENV"
+          echo "DABBIR_XCODE_SCHEME=${SCHEME}" >> "$GITHUB_ENV"
+      - name: Build app for simulator
+        shell: bash
+        run: |
+          set -o pipefail
+          xcodebuild \
+            -workspace "${DABBIR_XCODE_WORKSPACE}" \
+            -scheme "${DABBIR_XCODE_SCHEME}" \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination "id=${DABBIR_SIMULATOR_UDID}" \
+            -derivedDataPath /tmp/dabbir-maestro-derived \
+            CODE_SIGNING_ALLOWED=NO \
+            build | tee /tmp/dabbir-maestro-xcodebuild.log
+          APP_PATH="$(find /tmp/dabbir-maestro-derived/Build/Products -path '*iphonesimulator/*.app' -maxdepth 4 -print -quit)"
+          test -n "${APP_PATH}"
+          echo "DABBIR_SIMULATOR_APP_PATH=${APP_PATH}" >> "$GITHUB_ENV"
+      - name: Install app on simulator
+        run: xcrun simctl install "${DABBIR_SIMULATOR_UDID}" "${DABBIR_SIMULATOR_APP_PATH}"
+      - name: Install Maestro
+        shell: bash
+        working-directory: .
+        run: |
+          curl -Ls https://get.maestro.mobile.dev | bash
+          echo "$HOME/.maestro/bin" >> "$GITHUB_PATH"
+      - name: Run App Store smoke flow
+        shell: bash
+        run: maestro test .maestro/app-store-smoke.yaml
+      - name: Upload Maestro evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-ios-maestro-evidence
+          path: |
+            /tmp/dabbir-maestro-xcodebuild.log
+            ~/.maestro/tests/**
+          if-no-files-found: warn
+          retention-days: 7

--- a/.github/workflows/dabbir-ios-maestro.yml
+++ b/.github/workflows/dabbir-ios-maestro.yml
@@ -10,6 +10,10 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: dabbir-ios-maestro-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   maestro-smoke:
     runs-on: macos-26

--- a/.github/workflows/dabbir-ios-maestro.yml
+++ b/.github/workflows/dabbir-ios-maestro.yml
@@ -37,11 +37,17 @@ jobs:
       - name: Select and boot iPhone simulator
         shell: bash
         run: |
+          set -euo pipefail
           UDID="$(xcrun simctl list devices available -j | python3 -c 'import json,sys; d=json.load(sys.stdin); print(next(x["udid"] for group in d["devices"].values() for x in group if x.get("isAvailable") and x.get("name","").startswith("iPhone")))')"
+          test -n "${UDID}"
           echo "DABBIR_SIMULATOR_UDID=${UDID}" >> "$GITHUB_ENV"
-          xcrun simctl boot "${UDID}" || true
-          open -a Simulator
-          xcrun simctl bootstatus "${UDID}" -b
+          xcrun simctl boot "${UDID}" 2>/dev/null || true
+          DABBIR_SIMULATOR_UDID="${UDID}" python3 <<'PY'
+          import os, subprocess
+          udid = os.environ['DABBIR_SIMULATOR_UDID']
+          subprocess.run(['xcrun', 'simctl', 'bootstatus', udid, '-b'], check=True, timeout=180)
+          PY
+          xcrun simctl list devices | grep -F "${UDID}" | grep -F '(Booted)'
       - name: Resolve Xcode workspace and scheme
         shell: bash
         run: |

--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -1,6 +1,10 @@
 name: DABBIR iOS TestFlight Release
 
 on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/dabbir-ios-testflight-release.yml'
   workflow_dispatch:
     inputs:
       what_to_test:
@@ -37,6 +41,7 @@ jobs:
       SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
       DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1'
       DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-testflight-release-preflight.json
+      DABBIR_WHAT_TO_TEST: ${{ inputs.what_to_test || 'DABBIR iOS release-candidate validation.' }}
 
     steps:
       - uses: actions/checkout@v4
@@ -125,7 +130,7 @@ jobs:
             --non-interactive \
             --wait \
             --auto-testflight-setup \
-            --what-to-test "${{ inputs.what_to_test }}"
+            --what-to-test "${DABBIR_WHAT_TO_TEST}"
 
       - name: Record TestFlight status evidence
         if: always()

--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -1,0 +1,150 @@
+name: DABBIR iOS TestFlight Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      what_to_test:
+        description: 'TestFlight What to Test note'
+        required: false
+        default: 'DABBIR iOS release-candidate validation.'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dabbir-ios-testflight-release
+  cancel-in-progress: false
+
+jobs:
+  signed-testflight-release:
+    runs-on: macos-26
+    timeout-minutes: 120
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      DABBIR_IOS_BUNDLE_ID: com.barmansystems.dabbir
+      DABBIR_IOS_APP_APPLE_ID: ${{ vars.DABBIR_IOS_APP_APPLE_ID }}
+      DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID: ${{ vars.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID }}
+      EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID: ${{ vars.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID }}
+      EXPO_PUBLIC_IOS_IAP_ENABLED: 'true'
+      EXPO_PUBLIC_DABBIR_API_BASE_URL: ${{ vars.DABBIR_IOS_API_BASE_URL }}
+      EXPO_PUBLIC_DABBIR_PRIVACY_URL: ${{ vars.DABBIR_IOS_PRIVACY_URL }}
+      EXPO_PUBLIC_DABBIR_TERMS_URL: ${{ vars.DABBIR_IOS_TERMS_URL }}
+      EXPO_PUBLIC_DABBIR_SUPPORT_URL: ${{ vars.DABBIR_IOS_SUPPORT_URL }}
+      APPLE_ROOT_CERTIFICATES_BASE64: ${{ secrets.APPLE_ROOT_CERTIFICATES_BASE64 }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1'
+      DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-testflight-release-preflight.json
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+
+      - name: Verify release credential/config contract
+        shell: bash
+        run: |
+          set -euo pipefail
+          missing=()
+          require_value() {
+            local name="$1"
+            local value="$2"
+            if [[ -z "${value}" ]]; then
+              missing+=("${name}")
+            fi
+          }
+          require_value EXPO_TOKEN "${EXPO_TOKEN:-}"
+          require_value DABBIR_IOS_APP_APPLE_ID "${DABBIR_IOS_APP_APPLE_ID:-}"
+          require_value DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID "${DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID:-}"
+          require_value DABBIR_IOS_API_BASE_URL "${EXPO_PUBLIC_DABBIR_API_BASE_URL:-}"
+          require_value DABBIR_IOS_PRIVACY_URL "${EXPO_PUBLIC_DABBIR_PRIVACY_URL:-}"
+          require_value DABBIR_IOS_TERMS_URL "${EXPO_PUBLIC_DABBIR_TERMS_URL:-}"
+          require_value DABBIR_IOS_SUPPORT_URL "${EXPO_PUBLIC_DABBIR_SUPPORT_URL:-}"
+          require_value APPLE_ROOT_CERTIFICATES_BASE64 "${APPLE_ROOT_CERTIFICATES_BASE64:-}"
+          require_value SUPABASE_SERVICE_ROLE_KEY "${SUPABASE_SERVICE_ROLE_KEY:-}"
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing release configuration: %s\n' "${missing[*]}" >&2
+            exit 11
+          fi
+          [[ "${DABBIR_IOS_APP_APPLE_ID}" =~ ^[0-9]{5,20}$ ]] || { echo 'DABBIR_IOS_APP_APPLE_ID must be the numeric App Store Connect Apple ID.' >&2; exit 12; }
+
+      - name: Install mobile dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install current EAS CLI
+        run: npm install --global eas-cli@latest
+
+      - name: Verify Expo authentication
+        run: eas whoami --non-interactive
+
+      - name: Run release-mode App Store preflight
+        working-directory: .
+        run: node scripts/dabbir-app-store-preflight.mjs
+
+      - name: Inject App Store Connect app ID into runtime submit profile
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const file = 'eas.json';
+          const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+          data.submit ??= {};
+          data.submit.production ??= {};
+          data.submit.production.ios ??= {};
+          data.submit.production.ios.ascAppId = process.env.DABBIR_IOS_APP_APPLE_ID;
+          fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
+          NODE
+
+      - name: Build signed production IPA on EAS
+        shell: bash
+        run: |
+          set -euo pipefail
+          eas build --platform ios --profile production --non-interactive --wait --json > /tmp/dabbir-eas-build.json
+          node <<'NODE'
+          const fs = require('fs');
+          const raw = fs.readFileSync('/tmp/dabbir-eas-build.json', 'utf8');
+          const parsed = JSON.parse(raw);
+          const build = Array.isArray(parsed) ? parsed[0] : parsed;
+          const id = build?.id;
+          if (!id) throw new Error('EAS_BUILD_ID_NOT_FOUND');
+          fs.appendFileSync(process.env.GITHUB_ENV, `DABBIR_EAS_BUILD_ID=${id}\n`);
+          NODE
+
+      - name: Submit exact signed build to TestFlight
+        shell: bash
+        run: |
+          set -euo pipefail
+          eas build:submit \
+            --platform ios \
+            --profile production \
+            --id "${DABBIR_EAS_BUILD_ID}" \
+            --non-interactive \
+            --wait \
+            --auto-testflight-setup \
+            --what-to-test "${{ inputs.what_to_test }}"
+
+      - name: Record TestFlight status evidence
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          eas submit:status --platform ios --profile production --json --non-interactive > /tmp/dabbir-testflight-status.json 2>/tmp/dabbir-testflight-status.err
+          printf 'commit=%s\nbuild_id=%s\n' "${GITHUB_SHA}" "${DABBIR_EAS_BUILD_ID:-UNAVAILABLE}" > /tmp/dabbir-testflight-release-evidence.txt
+
+      - name: Upload signed release evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-ios-testflight-release-evidence
+          path: |
+            dabbir-testflight-release-preflight.json
+            /tmp/dabbir-eas-build.json
+            /tmp/dabbir-testflight-status.json
+            /tmp/dabbir-testflight-status.err
+            /tmp/dabbir-testflight-release-evidence.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/mobile/.maestro/app-store-smoke.yaml
+++ b/mobile/.maestro/app-store-smoke.yaml
@@ -1,0 +1,6 @@
+appId: com.barmansystems.dabbir
+---
+- launchApp:
+    clearState: true
+- assertVisible: "DABBIR | دبّر"
+- takeScreenshot: dabbir-app-store-smoke


### PR DESCRIPTION
Adds a first automated iOS UI smoke gate for Apple release readiness.

Changes:
- adds `mobile/.maestro/app-store-smoke.yaml`
- adds a macOS 26 GitHub Actions workflow that prebuilds the Expo iOS app, builds it for an iPhone simulator, installs Maestro, launches the app, verifies the DABBIR native UI, and uploads evidence

This is intentionally separate from signed Distribution/TestFlight validation. Remaining external gates still include App Store Connect registration/product verification, signed IPA/TestFlight, final binary privacy-manifest reconciliation, and optional MobSF/Sentry service integration.