### PR TITLE
DABBIR iOS: run TestFlight release via Linux EAS runner

### DIFF
--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -21,7 +21,7 @@ concurrency:
 
 jobs:
   signed-testflight-release:
-    runs-on: macos-26
+    runs-on: ubuntu-latest
     timeout-minutes: 120
     defaults:
       run:


### PR DESCRIPTION
Moves the EAS/TestFlight orchestration job from `macos-26` to `ubuntu-latest`. EAS Build/Submit runs remotely and does not require a macOS runner; this removes contention with native Xcode/Maestro checks and lets the release credential gate execute immediately. No app code or release credentials are changed.