### PR TITLE
DABBIR iOS: cancel superseded TestFlight releases

### DIFF
--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -17,7 +17,7 @@ permissions:
 
 concurrency:
   group: dabbir-ios-testflight-release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   signed-testflight-release:


### PR DESCRIPTION
Makes the TestFlight release concurrency fail-forward: a newer release attempt cancels an older queued/in-progress attempt. This allows the current Linux EAS release gate to run immediately and prevents stale release jobs from blocking the authoritative candidate.