### PR TITLE
DABBIR iOS: isolate real TestFlight client blockers

### DIFF
--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -37,10 +37,8 @@ jobs:
       EXPO_PUBLIC_DABBIR_PRIVACY_URL: ${{ vars.DABBIR_IOS_PRIVACY_URL }}
       EXPO_PUBLIC_DABBIR_TERMS_URL: ${{ vars.DABBIR_IOS_TERMS_URL }}
       EXPO_PUBLIC_DABBIR_SUPPORT_URL: ${{ vars.DABBIR_IOS_SUPPORT_URL }}
-      APPLE_ROOT_CERTIFICATES_BASE64: ${{ secrets.APPLE_ROOT_CERTIFICATES_BASE64 }}
-      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
-      DABBIR_APP_STORE_RELEASE_PREFLIGHT: '1'
-      DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-testflight-release-preflight.json
+      DABBIR_APP_STORE_RELEASE_PREFLIGHT: '0'
+      DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-testflight-client-preflight.json
       DABBIR_WHAT_TO_TEST: ${{ inputs.what_to_test || 'DABBIR iOS release-candidate validation.' }}
 
     steps:
@@ -50,7 +48,7 @@ jobs:
         with:
           node-version: '22.23.1'
 
-      - name: Verify release credential/config contract
+      - name: Verify signed client build configuration
         shell: bash
         run: |
           set -euo pipefail
@@ -63,19 +61,42 @@ jobs:
             fi
           }
           require_value EXPO_TOKEN "${EXPO_TOKEN:-}"
-          require_value DABBIR_IOS_APP_APPLE_ID "${DABBIR_IOS_APP_APPLE_ID:-}"
           require_value DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID "${DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID:-}"
           require_value DABBIR_IOS_API_BASE_URL "${EXPO_PUBLIC_DABBIR_API_BASE_URL:-}"
           require_value DABBIR_IOS_PRIVACY_URL "${EXPO_PUBLIC_DABBIR_PRIVACY_URL:-}"
           require_value DABBIR_IOS_TERMS_URL "${EXPO_PUBLIC_DABBIR_TERMS_URL:-}"
           require_value DABBIR_IOS_SUPPORT_URL "${EXPO_PUBLIC_DABBIR_SUPPORT_URL:-}"
-          require_value APPLE_ROOT_CERTIFICATES_BASE64 "${APPLE_ROOT_CERTIFICATES_BASE64:-}"
-          require_value SUPABASE_SERVICE_ROLE_KEY "${SUPABASE_SERVICE_ROLE_KEY:-}"
           if (( ${#missing[@]} > 0 )); then
-            printf 'Missing release configuration: %s\n' "${missing[*]}" >&2
+            printf 'Missing signed-client configuration: %s\n' "${missing[*]}" >&2
             exit 11
           fi
-          [[ "${DABBIR_IOS_APP_APPLE_ID}" =~ ^[0-9]{5,20}$ ]] || { echo 'DABBIR_IOS_APP_APPLE_ID must be the numeric App Store Connect Apple ID.' >&2; exit 12; }
+
+          node <<'NODE'
+          const values = {
+            DABBIR_IOS_API_BASE_URL: process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL,
+            DABBIR_IOS_PRIVACY_URL: process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL,
+            DABBIR_IOS_TERMS_URL: process.env.EXPO_PUBLIC_DABBIR_TERMS_URL,
+            DABBIR_IOS_SUPPORT_URL: process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL,
+          };
+          const expectedPaths = {
+            DABBIR_IOS_PRIVACY_URL: /^\/privacy\/?$/i,
+            DABBIR_IOS_TERMS_URL: /^\/terms\/?$/i,
+            DABBIR_IOS_SUPPORT_URL: /^\/support\/?$/i,
+          };
+          for (const [name, raw] of Object.entries(values)) {
+            let url;
+            try { url = new URL(String(raw || '').trim()); }
+            catch { throw new Error(`${name}_INVALID_URL`); }
+            if (url.protocol !== 'https:') throw new Error(`${name}_HTTPS_REQUIRED`);
+            if (['localhost', '127.0.0.1', '::1'].includes(url.hostname)) throw new Error(`${name}_PUBLIC_HOST_REQUIRED`);
+            if (/-3619s-projects\.vercel\.app$/i.test(url.hostname) || /-nd56cm4j5v-/i.test(url.hostname)) {
+              throw new Error(`${name}_PROTECTED_PRELAUNCH_HOST_NOT_ALLOWED`);
+            }
+            if (expectedPaths[name] && !expectedPaths[name].test(url.pathname)) {
+              throw new Error(`${name}_EXPECTED_PATH_MISMATCH`);
+            }
+          }
+          NODE
 
       - name: Install mobile dependencies
         run: npm install --no-audit --no-fund
@@ -86,23 +107,9 @@ jobs:
       - name: Verify Expo authentication
         run: eas whoami --non-interactive
 
-      - name: Run release-mode App Store preflight
+      - name: Run client App Store static preflight
         working-directory: .
         run: node scripts/dabbir-app-store-preflight.mjs
-
-      - name: Inject App Store Connect app ID into runtime submit profile
-        shell: bash
-        run: |
-          node <<'NODE'
-          const fs = require('fs');
-          const file = 'eas.json';
-          const data = JSON.parse(fs.readFileSync(file, 'utf8'));
-          data.submit ??= {};
-          data.submit.production ??= {};
-          data.submit.production.ios ??= {};
-          data.submit.production.ios.ascAppId = process.env.DABBIR_IOS_APP_APPLE_ID;
-          fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
-          NODE
 
       - name: Build signed production IPA on EAS
         shell: bash
@@ -117,6 +124,30 @@ jobs:
           const id = build?.id;
           if (!id) throw new Error('EAS_BUILD_ID_NOT_FOUND');
           fs.appendFileSync(process.env.GITHUB_ENV, `DABBIR_EAS_BUILD_ID=${id}\n`);
+          NODE
+
+      - name: Verify TestFlight submit configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${DABBIR_IOS_APP_APPLE_ID:-}" ]]; then
+            echo 'Missing TestFlight submit configuration: DABBIR_IOS_APP_APPLE_ID' >&2
+            exit 21
+          fi
+          [[ "${DABBIR_IOS_APP_APPLE_ID}" =~ ^[0-9]{5,20}$ ]] || { echo 'DABBIR_IOS_APP_APPLE_ID must be the numeric App Store Connect Apple ID.' >&2; exit 22; }
+
+      - name: Inject App Store Connect app ID into runtime submit profile
+        shell: bash
+        run: |
+          node <<'NODE'
+          const fs = require('fs');
+          const file = 'eas.json';
+          const data = JSON.parse(fs.readFileSync(file, 'utf8'));
+          data.submit ??= {};
+          data.submit.production ??= {};
+          data.submit.production.ios ??= {};
+          data.submit.production.ios.ascAppId = process.env.DABBIR_IOS_APP_APPLE_ID;
+          fs.writeFileSync(file, JSON.stringify(data, null, 2) + '\n');
           NODE
 
       - name: Submit exact signed build to TestFlight
@@ -146,7 +177,7 @@ jobs:
         with:
           name: dabbir-ios-testflight-release-evidence
           path: |
-            dabbir-testflight-release-preflight.json
+            dabbir-testflight-client-preflight.json
             /tmp/dabbir-eas-build.json
             /tmp/dabbir-testflight-status.json
             /tmp/dabbir-testflight-status.err


### PR DESCRIPTION
Separates signed iOS/TestFlight client requirements from backend-only release secrets. Removes Apple root certificates and Supabase service-role credentials from the client build job, runs the existing App Store preflight in static/client mode, validates public HTTPS release URLs, builds the signed IPA first, and only then requires the numeric App Store Connect app ID for submission. This leaves backend trust/storage checks in the full release-readiness gate instead of duplicating server secrets into EAS client CI.