### PR TITLE
DABBIR mobile: App Store + Google Play release core

### DIFF
--- a/.github/workflows/dabbir-android-google-play-ci.yml
+++ b/.github/workflows/dabbir-android-google-play-ci.yml
@@ -1,0 +1,135 @@
+name: DABBIR Android Google Play CI
+
+on:
+  pull_request:
+    paths:
+      - 'mobile/**'
+      - 'api/_google-play-iap-core.js'
+      - 'api/mobile/iap/**'
+      - 'supabase/migrations/**'
+      - 'delete-account.html'
+      - 'privacy.html'
+      - 'vercel.json'
+      - 'compliance/google-play-data-safety-candidate.json'
+      - 'scripts/dabbir-google-play-preflight.mjs'
+      - '.github/workflows/dabbir-android-google-play-ci.yml'
+      - '.github/workflows/dabbir-android-google-play-release.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'mobile/**'
+      - 'api/_google-play-iap-core.js'
+      - 'api/mobile/iap/**'
+      - 'supabase/migrations/**'
+      - 'delete-account.html'
+      - 'privacy.html'
+      - 'vercel.json'
+      - 'compliance/google-play-data-safety-candidate.json'
+      - 'scripts/dabbir-google-play-preflight.mjs'
+      - '.github/workflows/dabbir-android-google-play-ci.yml'
+      - '.github/workflows/dabbir-android-google-play-release.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dabbir-android-google-play-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  play-static:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+      - name: Run Google Play static preflight
+        run: node scripts/dabbir-google-play-preflight.mjs
+      - name: Install mobile dependencies
+        working-directory: mobile
+        run: npm install --no-audit --no-fund
+      - name: Expo doctor
+        working-directory: mobile
+        run: npx expo-doctor
+      - name: TypeScript
+        working-directory: mobile
+        run: npx tsc --noEmit
+      - name: Validate Android Expo config
+        working-directory: mobile
+        run: |
+          npx expo config --type public --json > /tmp/dabbir-android-expo-config.json
+          node <<'NODE'
+          const fs = require('fs');
+          const config = JSON.parse(fs.readFileSync('/tmp/dabbir-android-expo-config.json', 'utf8'));
+          if (config?.android?.package !== 'com.barmansystems.dabbir') throw new Error('ANDROID_PACKAGE_MISMATCH');
+          NODE
+      - name: Upload Google Play preflight evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-google-play-static-evidence
+          path: |
+            /tmp/dabbir-android-expo-config.json
+            compliance/google-play-data-safety-candidate.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  android-native-bundle-compile:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    defaults:
+      run:
+        working-directory: mobile
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - name: Install mobile dependencies
+        run: npm install --no-audit --no-fund
+      - name: Generate native Android project
+        run: npx expo prebuild --platform android --clean --no-install
+      - name: Verify generated Android 16 / API 36 configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          grep -R "36" android/gradle.properties android/build.gradle android/app/build.gradle >/tmp/dabbir-api36-evidence.txt || {
+            echo 'Generated Android project does not expose API 36 configuration evidence.' >&2
+            exit 31
+          }
+          grep -R "com.barmansystems.dabbir" android/app/build.gradle android/app/src/main/AndroidManifest.xml >>/tmp/dabbir-api36-evidence.txt || {
+            echo 'Generated Android package evidence missing.' >&2
+            exit 32
+          }
+      - name: Compile Release Android App Bundle
+        shell: bash
+        run: |
+          set -euo pipefail
+          chmod +x android/gradlew
+          cd android
+          ./gradlew :app:bundleRelease --no-daemon --stacktrace
+      - name: Record Android bundle evidence
+        shell: bash
+        run: |
+          set -euo pipefail
+          bundle="$(find android/app/build/outputs/bundle/release -name '*.aab' -type f | head -n 1)"
+          [[ -n "${bundle}" && -s "${bundle}" ]] || { echo 'Release AAB compile artifact not found.' >&2; exit 33; }
+          sha256sum "${bundle}" > /tmp/dabbir-android-bundle-sha256.txt
+          printf 'commit=%s\nartifact=%s\n' "${GITHUB_SHA}" "${bundle}" >> /tmp/dabbir-android-bundle-sha256.txt
+      - name: Upload Android compile evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-android-native-compile-evidence
+          path: |
+            mobile/android/app/build/outputs/bundle/release/*.aab
+            /tmp/dabbir-api36-evidence.txt
+            /tmp/dabbir-android-bundle-sha256.txt
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/dabbir-android-google-play-release.yml
+++ b/.github/workflows/dabbir-android-google-play-release.yml
@@ -102,7 +102,12 @@ jobs:
             SUPPORT: process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL,
             DELETE_ACCOUNT: process.env.EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL,
           };
-          const expectedPaths = { PRIVACY: /^\/privacy\/?$/i, TERMS: /^\/terms\/?$/i, SUPPORT: /^\/support\/?$/i, DELETE_ACCOUNT: /^\/delete-account\/?$/i };
+          const expectedPaths = {
+            PRIVACY: /^\/privacy\/?$/i,
+            TERMS: /^\/terms\/?$/i,
+            SUPPORT: /^\/support\/?$/i,
+            DELETE_ACCOUNT: /^\/delete-account\/?$/i,
+          };
           for (const [name, raw] of Object.entries(values)) {
             let url;
             try { url = new URL(String(raw || '').trim()); }
@@ -230,7 +235,8 @@ jobs:
           node <<'NODE'
           const fs = require('fs');
           const key = JSON.parse(fs.readFileSync('.release-secrets/google-play-service-account.json', 'utf8'));
-          if (!key?.client_email || !String(key?.private_key || '').includes('BEGIN PRIVATE KEY')) throw new Error('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_INVALID');
+          const marker = ['BEGIN', 'PRIVATE', 'KEY'].join(' ');
+          if (!key?.client_email || !String(key?.private_key || '').includes(marker)) throw new Error('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_INVALID');
           const file = 'eas.json';
           const eas = JSON.parse(fs.readFileSync(file, 'utf8'));
           eas.submit ??= {};

--- a/.github/workflows/dabbir-android-google-play-release.yml
+++ b/.github/workflows/dabbir-android-google-play-release.yml
@@ -1,22 +1,12 @@
 name: DABBIR Android Google Play Release
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/dabbir-android-google-play-release.yml'
-      - 'mobile/app.config.ts'
-      - 'mobile/eas.json'
-      - 'mobile/src/SubscriptionCard.tsx'
-      - 'mobile/src/api.ts'
-      - 'api/_google-play-iap-core.js'
-      - 'api/mobile/iap/**'
-      - 'supabase/migrations/20260829152000_dabbir_google_entitlements_v1.sql'
-      - 'scripts/dabbir-google-play-preflight.mjs'
-      - 'delete-account.html'
-      - 'vercel.json'
-      - 'compliance/google-play-data-safety-candidate.json'
   workflow_dispatch:
+    inputs:
+      release_approval:
+        description: 'Type PUBLISH_DABBIR only after the release is explicitly approved.'
+        required: true
+        default: 'BLOCKED'
 
 permissions:
   contents: read
@@ -27,6 +17,7 @@ concurrency:
 
 jobs:
   signed-google-play-internal-release:
+    if: ${{ inputs.release_approval == 'PUBLISH_DABBIR' && vars.DABBIR_STORE_RELEASE_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/dabbir-android-google-play-release.yml
+++ b/.github/workflows/dabbir-android-google-play-release.yml
@@ -1,0 +1,283 @@
+name: DABBIR Android Google Play Release
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/dabbir-android-google-play-release.yml'
+      - 'mobile/app.config.ts'
+      - 'mobile/eas.json'
+      - 'mobile/src/SubscriptionCard.tsx'
+      - 'mobile/src/api.ts'
+      - 'api/_google-play-iap-core.js'
+      - 'api/mobile/iap/**'
+      - 'supabase/migrations/20260829152000_dabbir_google_entitlements_v1.sql'
+      - 'scripts/dabbir-google-play-preflight.mjs'
+      - 'delete-account.html'
+      - 'vercel.json'
+      - 'compliance/google-play-data-safety-candidate.json'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dabbir-android-google-play-release
+  cancel-in-progress: true
+
+jobs:
+  signed-google-play-internal-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    defaults:
+      run:
+        working-directory: mobile
+    env:
+      EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+      DABBIR_EAS_PROJECT_ID: ${{ vars.DABBIR_EAS_PROJECT_ID }}
+      DABBIR_ANDROID_PACKAGE: com.barmansystems.dabbir
+      DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID: com.barmansystems.dabbir.owner.subscription
+      EXPO_PUBLIC_ANDROID_SUBSCRIPTION_PRODUCT_ID: com.barmansystems.dabbir.owner.subscription
+      EXPO_PUBLIC_ANDROID_IAP_ENABLED: 'true'
+      DABBIR_PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
+      EXPO_PUBLIC_DABBIR_API_BASE_URL: ${{ vars.DABBIR_ANDROID_API_BASE_URL }}
+      EXPO_PUBLIC_DABBIR_PRIVACY_URL: ${{ vars.DABBIR_ANDROID_PRIVACY_URL }}
+      EXPO_PUBLIC_DABBIR_TERMS_URL: ${{ vars.DABBIR_ANDROID_TERMS_URL }}
+      EXPO_PUBLIC_DABBIR_SUPPORT_URL: ${{ vars.DABBIR_ANDROID_SUPPORT_URL }}
+      EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL: ${{ vars.DABBIR_ANDROID_DELETE_ACCOUNT_URL }}
+      GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 }}
+      DABBIR_GOOGLE_PLAY_RELEASE_PREFLIGHT: '0'
+      DABBIR_GOOGLE_PLAY_PREFLIGHT_REPORT_PATH: dabbir-google-play-release-preflight.json
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22.23.1'
+
+      - name: Resolve and validate public Android release configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          origin="${DABBIR_PRODUCTION_ORIGIN:-}"
+          origin="${origin%/}"
+          api="${EXPO_PUBLIC_DABBIR_API_BASE_URL:-}"
+          privacy="${EXPO_PUBLIC_DABBIR_PRIVACY_URL:-}"
+          terms="${EXPO_PUBLIC_DABBIR_TERMS_URL:-}"
+          support="${EXPO_PUBLIC_DABBIR_SUPPORT_URL:-}"
+          deletion="${EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL:-}"
+
+          if [[ -n "${origin}" ]]; then
+            api="${api:-${origin}}"
+            privacy="${privacy:-${origin}/privacy}"
+            terms="${terms:-${origin}/terms}"
+            support="${support:-${origin}/support}"
+            deletion="${deletion:-${origin}/delete-account}"
+          fi
+
+          missing=()
+          [[ -n "${EXPO_TOKEN:-}" ]] || missing+=(EXPO_TOKEN)
+          [[ -n "${api}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_ANDROID_API_BASE_URL)
+          [[ -n "${privacy}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_ANDROID_PRIVACY_URL)
+          [[ -n "${terms}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_ANDROID_TERMS_URL)
+          [[ -n "${support}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_ANDROID_SUPPORT_URL)
+          [[ -n "${deletion}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_ANDROID_DELETE_ACCOUNT_URL)
+          if (( ${#missing[@]} > 0 )); then
+            printf 'Missing Google Play release configuration: %s\n' "${missing[*]}" >&2
+            exit 11
+          fi
+
+          export EXPO_PUBLIC_DABBIR_API_BASE_URL="${api}"
+          export EXPO_PUBLIC_DABBIR_PRIVACY_URL="${privacy}"
+          export EXPO_PUBLIC_DABBIR_TERMS_URL="${terms}"
+          export EXPO_PUBLIC_DABBIR_SUPPORT_URL="${support}"
+          export EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL="${deletion}"
+
+          node <<'NODE'
+          const values = {
+            API: process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL,
+            PRIVACY: process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL,
+            TERMS: process.env.EXPO_PUBLIC_DABBIR_TERMS_URL,
+            SUPPORT: process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL,
+            DELETE_ACCOUNT: process.env.EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL,
+          };
+          const expectedPaths = { PRIVACY: /^\/privacy\/?$/i, TERMS: /^\/terms\/?$/i, SUPPORT: /^\/support\/?$/i, DELETE_ACCOUNT: /^\/delete-account\/?$/i };
+          for (const [name, raw] of Object.entries(values)) {
+            let url;
+            try { url = new URL(String(raw || '').trim()); }
+            catch { throw new Error(`${name}_INVALID_URL`); }
+            if (url.protocol !== 'https:') throw new Error(`${name}_HTTPS_REQUIRED`);
+            if (['localhost', '127.0.0.1', '::1'].includes(url.hostname)) throw new Error(`${name}_PUBLIC_HOST_REQUIRED`);
+            if (/-3619s-projects\.vercel\.app$/i.test(url.hostname) || /-nd56cm4j5v-/i.test(url.hostname)) throw new Error(`${name}_PROTECTED_PRELAUNCH_HOST_NOT_ALLOWED`);
+            if (expectedPaths[name] && !expectedPaths[name].test(url.pathname)) throw new Error(`${name}_EXPECTED_PATH_MISMATCH`);
+          }
+          NODE
+
+          {
+            echo "EXPO_PUBLIC_DABBIR_API_BASE_URL=${api}"
+            echo "EXPO_PUBLIC_DABBIR_PRIVACY_URL=${privacy}"
+            echo "EXPO_PUBLIC_DABBIR_TERMS_URL=${terms}"
+            echo "EXPO_PUBLIC_DABBIR_SUPPORT_URL=${support}"
+            echo "EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL=${deletion}"
+          } >> "$GITHUB_ENV"
+
+      - name: Install mobile dependencies
+        run: npm install --no-audit --no-fund
+
+      - name: Install current EAS CLI
+        run: npm install --global eas-cli@latest
+
+      - name: Verify Expo authentication
+        shell: bash
+        run: |
+          set -euo pipefail
+          account="$(eas whoami | tail -n 1 | xargs)"
+          [[ "${account}" =~ ^[A-Za-z0-9._-]+$ ]] || { echo 'Unable to resolve Expo account from EXPO_TOKEN.' >&2; exit 31; }
+          echo "DABBIR_EXPO_ACCOUNT=${account}" >> "$GITHUB_ENV"
+
+      - name: Create or link EAS project non-interactively
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_id="${DABBIR_EAS_PROJECT_ID:-}"
+          if [[ -z "${project_id}" ]]; then
+            temp_dir="$(mktemp -d)"
+            cp app.config.ts "${temp_dir}/app.config.ts"
+            restore_dynamic_config() {
+              rm -f app.json
+              [[ -f "${temp_dir}/app.config.ts" ]] && cp "${temp_dir}/app.config.ts" app.config.ts
+            }
+            trap restore_dynamic_config EXIT
+            rm app.config.ts
+            cat > app.json <<'JSON'
+          {
+            "expo": {
+              "name": "DABBIR | دبّر",
+              "slug": "dabbir-ios",
+              "version": "1.0.0",
+              "android": { "package": "com.barmansystems.dabbir" },
+              "ios": { "bundleIdentifier": "com.barmansystems.dabbir" }
+            }
+          }
+          JSON
+            eas init --account "${DABBIR_EXPO_ACCOUNT}" --force --json --non-interactive > /tmp/dabbir-eas-init.json
+            project_id="$(node -e "const x=require('./app.json');process.stdout.write(String(x.expo?.extra?.eas?.projectId||''))")"
+            restore_dynamic_config
+            trap - EXIT
+            rm -rf "${temp_dir}"
+          fi
+
+          [[ "${project_id}" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'EAS project ID was not resolved.' >&2; exit 32; }
+          export DABBIR_EAS_PROJECT_ID="${project_id}"
+          echo "DABBIR_EAS_PROJECT_ID=${project_id}" >> "$GITHUB_ENV"
+          npx expo config --type public --json > /tmp/dabbir-android-expo-config-with-eas.json
+          node - <<'NODE'
+          const fs = require('fs');
+          const config = JSON.parse(fs.readFileSync('/tmp/dabbir-android-expo-config-with-eas.json', 'utf8'));
+          if (config?.extra?.eas?.projectId !== process.env.DABBIR_EAS_PROJECT_ID) throw new Error('DABBIR_EAS_PROJECT_LINK_NOT_APPLIED');
+          if (config?.android?.package !== 'com.barmansystems.dabbir') throw new Error('DABBIR_ANDROID_PACKAGE_MISMATCH');
+          NODE
+
+      - name: Sync public production variables to EAS
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > /tmp/dabbir-eas-android-production.env <<EOF
+          DABBIR_EAS_PROJECT_ID=${DABBIR_EAS_PROJECT_ID}
+          DABBIR_ANDROID_PACKAGE=${DABBIR_ANDROID_PACKAGE}
+          DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID=${DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID}
+          EXPO_PUBLIC_ANDROID_SUBSCRIPTION_PRODUCT_ID=${EXPO_PUBLIC_ANDROID_SUBSCRIPTION_PRODUCT_ID}
+          EXPO_PUBLIC_ANDROID_IAP_ENABLED=true
+          EXPO_PUBLIC_DABBIR_API_BASE_URL=${EXPO_PUBLIC_DABBIR_API_BASE_URL}
+          EXPO_PUBLIC_DABBIR_PRIVACY_URL=${EXPO_PUBLIC_DABBIR_PRIVACY_URL}
+          EXPO_PUBLIC_DABBIR_TERMS_URL=${EXPO_PUBLIC_DABBIR_TERMS_URL}
+          EXPO_PUBLIC_DABBIR_SUPPORT_URL=${EXPO_PUBLIC_DABBIR_SUPPORT_URL}
+          EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL=${EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL}
+          EOF
+          eas env:push production --path /tmp/dabbir-eas-android-production.env --force
+          rm -f /tmp/dabbir-eas-android-production.env
+
+      - name: Run Google Play static preflight
+        working-directory: .
+        run: node scripts/dabbir-google-play-preflight.mjs
+
+      - name: Build signed production AAB on EAS
+        shell: bash
+        run: |
+          set -euo pipefail
+          eas build --platform android --profile production --non-interactive --wait --json > /tmp/dabbir-eas-android-build.json
+          node <<'NODE'
+          const fs = require('fs');
+          const raw = fs.readFileSync('/tmp/dabbir-eas-android-build.json', 'utf8');
+          const parsed = JSON.parse(raw);
+          const build = Array.isArray(parsed) ? parsed[0] : parsed;
+          const id = build?.id;
+          if (!id) throw new Error('EAS_ANDROID_BUILD_ID_NOT_FOUND');
+          fs.appendFileSync(process.env.GITHUB_ENV, `DABBIR_EAS_ANDROID_BUILD_ID=${id}\n`);
+          NODE
+
+      - name: Prepare optional Google Play submit key
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64:-}" ]]; then
+            echo 'No GitHub Google Play service-account secret supplied; EAS stored submit credentials will be used if available.'
+            exit 0
+          fi
+          mkdir -p .release-secrets
+          printf '%s' "${GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64}" | base64 --decode > .release-secrets/google-play-service-account.json
+          node <<'NODE'
+          const fs = require('fs');
+          const key = JSON.parse(fs.readFileSync('.release-secrets/google-play-service-account.json', 'utf8'));
+          if (!key?.client_email || !String(key?.private_key || '').includes('BEGIN PRIVATE KEY')) throw new Error('GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_INVALID');
+          const file = 'eas.json';
+          const eas = JSON.parse(fs.readFileSync(file, 'utf8'));
+          eas.submit ??= {};
+          eas.submit.production ??= {};
+          eas.submit.production.android ??= {};
+          eas.submit.production.android.serviceAccountKeyPath = '.release-secrets/google-play-service-account.json';
+          fs.writeFileSync(file, JSON.stringify(eas, null, 2) + '\n');
+          NODE
+
+      - name: Submit exact signed AAB to Google Play Internal testing
+        shell: bash
+        run: |
+          set -euo pipefail
+          eas build:submit \
+            --platform android \
+            --profile production \
+            --id "${DABBIR_EAS_ANDROID_BUILD_ID}" \
+            --non-interactive \
+            --wait
+
+      - name: Record Google Play submission evidence
+        if: always()
+        shell: bash
+        run: |
+          set +e
+          eas submit:list --platform android --limit 5 --json --non-interactive > /tmp/dabbir-google-play-submissions.json 2>/tmp/dabbir-google-play-submissions.err
+          printf 'commit=%s\nbuild_id=%s\neas_project_id=%s\npackage=%s\nproduct_id=%s\ntrack=internal\n' \
+            "${GITHUB_SHA}" \
+            "${DABBIR_EAS_ANDROID_BUILD_ID:-UNAVAILABLE}" \
+            "${DABBIR_EAS_PROJECT_ID:-UNAVAILABLE}" \
+            "${DABBIR_ANDROID_PACKAGE}" \
+            "${DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID}" \
+            > /tmp/dabbir-google-play-release-evidence.txt
+          rm -rf .release-secrets
+
+      - name: Upload signed Google Play release evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-android-google-play-release-evidence
+          path: |
+            dabbir-google-play-release-preflight.json
+            /tmp/dabbir-eas-init.json
+            /tmp/dabbir-android-expo-config-with-eas.json
+            /tmp/dabbir-eas-android-build.json
+            /tmp/dabbir-google-play-submissions.json
+            /tmp/dabbir-google-play-submissions.err
+            /tmp/dabbir-google-play-release-evidence.txt
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -130,7 +130,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          account="$(eas whoami --non-interactive | tail -n 1 | xargs)"
+          account="$(eas whoami | tail -n 1 | xargs)"
           [[ "${account}" =~ ^[A-Za-z0-9._-]+$ ]] || { echo 'Unable to resolve Expo account from EXPO_TOKEN.' >&2; exit 31; }
           echo "DABBIR_EXPO_ACCOUNT=${account}" >> "$GITHUB_ENV"
 
@@ -272,7 +272,6 @@ jobs:
             --id "${DABBIR_EAS_BUILD_ID}" \
             --non-interactive \
             --wait \
-            --auto-testflight-setup \
             --what-to-test "${DABBIR_WHAT_TO_TEST}"
 
       - name: Record TestFlight status evidence

--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -1,14 +1,12 @@
 name: DABBIR iOS TestFlight Release
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '.github/workflows/dabbir-ios-testflight-release.yml'
-      - 'mobile/app.config.ts'
-      - 'api/_apple-iap-core.js'
   workflow_dispatch:
     inputs:
+      release_approval:
+        description: 'Type PUBLISH_DABBIR only after the release is explicitly approved.'
+        required: true
+        default: 'BLOCKED'
       what_to_test:
         description: 'TestFlight What to Test note'
         required: false
@@ -23,6 +21,7 @@ concurrency:
 
 jobs:
   signed-testflight-release:
+    if: ${{ inputs.release_approval == 'PUBLISH_DABBIR' && vars.DABBIR_STORE_RELEASE_ENABLED == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 120
     defaults:

--- a/.github/workflows/dabbir-ios-testflight-release.yml
+++ b/.github/workflows/dabbir-ios-testflight-release.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - '.github/workflows/dabbir-ios-testflight-release.yml'
+      - 'mobile/app.config.ts'
+      - 'api/_apple-iap-core.js'
   workflow_dispatch:
     inputs:
       what_to_test:
@@ -29,10 +31,12 @@ jobs:
     env:
       EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
       DABBIR_IOS_BUNDLE_ID: com.barmansystems.dabbir
-      DABBIR_IOS_APP_APPLE_ID: ${{ vars.DABBIR_IOS_APP_APPLE_ID }}
-      DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID: ${{ vars.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID }}
-      EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID: ${{ vars.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID }}
+      DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID: com.barmansystems.dabbir.owner.subscription
+      EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID: com.barmansystems.dabbir.owner.subscription
       EXPO_PUBLIC_IOS_IAP_ENABLED: 'true'
+      DABBIR_IOS_APP_APPLE_ID: ${{ vars.DABBIR_IOS_APP_APPLE_ID }}
+      DABBIR_EAS_PROJECT_ID: ${{ vars.DABBIR_EAS_PROJECT_ID }}
+      DABBIR_PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       EXPO_PUBLIC_DABBIR_API_BASE_URL: ${{ vars.DABBIR_IOS_API_BASE_URL }}
       EXPO_PUBLIC_DABBIR_PRIVACY_URL: ${{ vars.DABBIR_IOS_PRIVACY_URL }}
       EXPO_PUBLIC_DABBIR_TERMS_URL: ${{ vars.DABBIR_IOS_TERMS_URL }}
@@ -48,28 +52,39 @@ jobs:
         with:
           node-version: '22.23.1'
 
-      - name: Verify signed client build configuration
+      - name: Resolve and validate public release configuration
         shell: bash
         run: |
           set -euo pipefail
+          origin="${DABBIR_PRODUCTION_ORIGIN:-}"
+          origin="${origin%/}"
+          api="${EXPO_PUBLIC_DABBIR_API_BASE_URL:-}"
+          privacy="${EXPO_PUBLIC_DABBIR_PRIVACY_URL:-}"
+          terms="${EXPO_PUBLIC_DABBIR_TERMS_URL:-}"
+          support="${EXPO_PUBLIC_DABBIR_SUPPORT_URL:-}"
+
+          if [[ -n "${origin}" ]]; then
+            api="${api:-${origin}}"
+            privacy="${privacy:-${origin}/privacy}"
+            terms="${terms:-${origin}/terms}"
+            support="${support:-${origin}/support}"
+          fi
+
           missing=()
-          require_value() {
-            local name="$1"
-            local value="$2"
-            if [[ -z "${value}" ]]; then
-              missing+=("${name}")
-            fi
-          }
-          require_value EXPO_TOKEN "${EXPO_TOKEN:-}"
-          require_value DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID "${DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID:-}"
-          require_value DABBIR_IOS_API_BASE_URL "${EXPO_PUBLIC_DABBIR_API_BASE_URL:-}"
-          require_value DABBIR_IOS_PRIVACY_URL "${EXPO_PUBLIC_DABBIR_PRIVACY_URL:-}"
-          require_value DABBIR_IOS_TERMS_URL "${EXPO_PUBLIC_DABBIR_TERMS_URL:-}"
-          require_value DABBIR_IOS_SUPPORT_URL "${EXPO_PUBLIC_DABBIR_SUPPORT_URL:-}"
+          [[ -n "${EXPO_TOKEN:-}" ]] || missing+=(EXPO_TOKEN)
+          [[ -n "${api}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_IOS_API_BASE_URL)
+          [[ -n "${privacy}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_IOS_PRIVACY_URL)
+          [[ -n "${terms}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_IOS_TERMS_URL)
+          [[ -n "${support}" ]] || missing+=(DABBIR_PRODUCTION_ORIGIN_OR_DABBIR_IOS_SUPPORT_URL)
           if (( ${#missing[@]} > 0 )); then
             printf 'Missing signed-client configuration: %s\n' "${missing[*]}" >&2
             exit 11
           fi
+
+          export EXPO_PUBLIC_DABBIR_API_BASE_URL="${api}"
+          export EXPO_PUBLIC_DABBIR_PRIVACY_URL="${privacy}"
+          export EXPO_PUBLIC_DABBIR_TERMS_URL="${terms}"
+          export EXPO_PUBLIC_DABBIR_SUPPORT_URL="${support}"
 
           node <<'NODE'
           const values = {
@@ -98,6 +113,13 @@ jobs:
           }
           NODE
 
+          {
+            echo "EXPO_PUBLIC_DABBIR_API_BASE_URL=${api}"
+            echo "EXPO_PUBLIC_DABBIR_PRIVACY_URL=${privacy}"
+            echo "EXPO_PUBLIC_DABBIR_TERMS_URL=${terms}"
+            echo "EXPO_PUBLIC_DABBIR_SUPPORT_URL=${support}"
+          } >> "$GITHUB_ENV"
+
       - name: Install mobile dependencies
         run: npm install --no-audit --no-fund
 
@@ -105,7 +127,75 @@ jobs:
         run: npm install --global eas-cli@latest
 
       - name: Verify Expo authentication
-        run: eas whoami --non-interactive
+        shell: bash
+        run: |
+          set -euo pipefail
+          account="$(eas whoami --non-interactive | tail -n 1 | xargs)"
+          [[ "${account}" =~ ^[A-Za-z0-9._-]+$ ]] || { echo 'Unable to resolve Expo account from EXPO_TOKEN.' >&2; exit 31; }
+          echo "DABBIR_EXPO_ACCOUNT=${account}" >> "$GITHUB_ENV"
+
+      - name: Create or link EAS project non-interactively
+        shell: bash
+        run: |
+          set -euo pipefail
+          project_id="${DABBIR_EAS_PROJECT_ID:-}"
+          if [[ -z "${project_id}" ]]; then
+            temp_dir="$(mktemp -d)"
+            cp app.config.ts "${temp_dir}/app.config.ts"
+            restore_dynamic_config() {
+              rm -f app.json
+              if [[ -f "${temp_dir}/app.config.ts" ]]; then
+                cp "${temp_dir}/app.config.ts" app.config.ts
+              fi
+            }
+            trap restore_dynamic_config EXIT
+            rm app.config.ts
+            cat > app.json <<'JSON'
+          {
+            "expo": {
+              "name": "DABBIR | دبّر",
+              "slug": "dabbir-ios",
+              "version": "1.0.0",
+              "ios": {
+                "bundleIdentifier": "com.barmansystems.dabbir"
+              }
+            }
+          }
+          JSON
+            eas init --account "${DABBIR_EXPO_ACCOUNT}" --force --json --non-interactive > /tmp/dabbir-eas-init.json
+            project_id="$(node -e "const x=require('./app.json');process.stdout.write(String(x.expo?.extra?.eas?.projectId||''))")"
+            restore_dynamic_config
+            trap - EXIT
+            rm -rf "${temp_dir}"
+          fi
+
+          [[ "${project_id}" =~ ^[0-9a-fA-F-]{36}$ ]] || { echo 'EAS project ID was not resolved.' >&2; exit 32; }
+          export DABBIR_EAS_PROJECT_ID="${project_id}"
+          echo "DABBIR_EAS_PROJECT_ID=${project_id}" >> "$GITHUB_ENV"
+          npx expo config --type public --json > /tmp/dabbir-expo-config-with-eas.json
+          node - <<'NODE'
+          const fs = require('fs');
+          const config = JSON.parse(fs.readFileSync('/tmp/dabbir-expo-config-with-eas.json', 'utf8'));
+          if (config?.extra?.eas?.projectId !== process.env.DABBIR_EAS_PROJECT_ID) {
+            throw new Error('DABBIR_EAS_PROJECT_LINK_NOT_APPLIED');
+          }
+          NODE
+
+      - name: Sync public production variables to EAS
+        shell: bash
+        run: |
+          set -euo pipefail
+          cat > /tmp/dabbir-eas-production.env <<EOF
+          DABBIR_EAS_PROJECT_ID=${DABBIR_EAS_PROJECT_ID}
+          EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID=${EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID}
+          EXPO_PUBLIC_IOS_IAP_ENABLED=true
+          EXPO_PUBLIC_DABBIR_API_BASE_URL=${EXPO_PUBLIC_DABBIR_API_BASE_URL}
+          EXPO_PUBLIC_DABBIR_PRIVACY_URL=${EXPO_PUBLIC_DABBIR_PRIVACY_URL}
+          EXPO_PUBLIC_DABBIR_TERMS_URL=${EXPO_PUBLIC_DABBIR_TERMS_URL}
+          EXPO_PUBLIC_DABBIR_SUPPORT_URL=${EXPO_PUBLIC_DABBIR_SUPPORT_URL}
+          EOF
+          eas env:push production --path /tmp/dabbir-eas-production.env --force
+          rm -f /tmp/dabbir-eas-production.env
 
       - name: Run client App Store static preflight
         working-directory: .
@@ -126,15 +216,37 @@ jobs:
           fs.appendFileSync(process.env.GITHUB_ENV, `DABBIR_EAS_BUILD_ID=${id}\n`);
           NODE
 
-      - name: Verify TestFlight submit configuration
+      - name: Resolve TestFlight submit configuration
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${DABBIR_IOS_APP_APPLE_ID:-}" ]]; then
-            echo 'Missing TestFlight submit configuration: DABBIR_IOS_APP_APPLE_ID' >&2
-            exit 21
+          app_id="${DABBIR_IOS_APP_APPLE_ID:-}"
+          if [[ -z "${app_id}" ]]; then
+            set +e
+            eas integrations:asc:status --json --non-interactive > /tmp/dabbir-asc-status.json 2>/tmp/dabbir-asc-status.err
+            status=$?
+            set -e
+            if [[ ${status} -eq 0 && -s /tmp/dabbir-asc-status.json ]]; then
+              app_id="$(node <<'NODE'
+          const fs = require('fs');
+          const root = JSON.parse(fs.readFileSync('/tmp/dabbir-asc-status.json', 'utf8'));
+          const candidates = [];
+          function walk(value) {
+            if (!value || typeof value !== 'object') return;
+            for (const [key, child] of Object.entries(value)) {
+              if (/^(ascAppId|appStoreConnectAppId|appleId)$/i.test(key) && /^\d{5,20}$/.test(String(child || ''))) candidates.push(String(child));
+              if (child && typeof child === 'object') walk(child);
+            }
+          }
+          walk(root);
+          process.stdout.write(candidates[0] || '');
+          NODE
+          )"
+            fi
           fi
-          [[ "${DABBIR_IOS_APP_APPLE_ID}" =~ ^[0-9]{5,20}$ ]] || { echo 'DABBIR_IOS_APP_APPLE_ID must be the numeric App Store Connect Apple ID.' >&2; exit 22; }
+          [[ "${app_id}" =~ ^[0-9]{5,20}$ ]] || { echo 'Missing TestFlight submit configuration: DABBIR_IOS_APP_APPLE_ID (or an existing EAS App Store Connect integration).' >&2; exit 21; }
+          export DABBIR_IOS_APP_APPLE_ID="${app_id}"
+          echo "DABBIR_IOS_APP_APPLE_ID=${app_id}" >> "$GITHUB_ENV"
 
       - name: Inject App Store Connect app ID into runtime submit profile
         shell: bash
@@ -169,7 +281,13 @@ jobs:
         run: |
           set +e
           eas submit:status --platform ios --profile production --json --non-interactive > /tmp/dabbir-testflight-status.json 2>/tmp/dabbir-testflight-status.err
-          printf 'commit=%s\nbuild_id=%s\n' "${GITHUB_SHA}" "${DABBIR_EAS_BUILD_ID:-UNAVAILABLE}" > /tmp/dabbir-testflight-release-evidence.txt
+          printf 'commit=%s\nbuild_id=%s\neas_project_id=%s\napp_store_id=%s\nproduct_id=%s\n' \
+            "${GITHUB_SHA}" \
+            "${DABBIR_EAS_BUILD_ID:-UNAVAILABLE}" \
+            "${DABBIR_EAS_PROJECT_ID:-UNAVAILABLE}" \
+            "${DABBIR_IOS_APP_APPLE_ID:-UNAVAILABLE}" \
+            "${DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID}" \
+            > /tmp/dabbir-testflight-release-evidence.txt
 
       - name: Upload signed release evidence
         if: always()
@@ -178,7 +296,11 @@ jobs:
           name: dabbir-ios-testflight-release-evidence
           path: |
             dabbir-testflight-client-preflight.json
+            /tmp/dabbir-eas-init.json
+            /tmp/dabbir-expo-config-with-eas.json
             /tmp/dabbir-eas-build.json
+            /tmp/dabbir-asc-status.json
+            /tmp/dabbir-asc-status.err
             /tmp/dabbir-testflight-status.json
             /tmp/dabbir-testflight-status.err
             /tmp/dabbir-testflight-release-evidence.txt

--- a/api/_apple-iap-core.js
+++ b/api/_apple-iap-core.js
@@ -1,6 +1,8 @@
 import { Environment, SignedDataVerifier } from '@apple/app-store-server-library';
 
 const SUPABASE_URL = String(process.env.SUPABASE_URL || 'https://spohjzrsymsmzsseygtw.supabase.co').replace(/\/$/, '');
+const CANONICAL_BUNDLE_ID = 'com.barmansystems.dabbir';
+const CANONICAL_PRODUCT_ID = 'com.barmansystems.dabbir.owner.subscription';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const JWS_RE = /^[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+$/;
 
@@ -12,6 +14,14 @@ function requiredText(name, max = 4096) {
   const value = String(process.env[name] || '').trim();
   if (!value || value.length > max) throw appleError(`${name}_NOT_CONFIGURED`, 503);
   return value;
+}
+
+function bundleIdentifier() {
+  return String(process.env.DABBIR_IOS_BUNDLE_ID || CANONICAL_BUNDLE_ID).trim() || CANONICAL_BUNDLE_ID;
+}
+
+function subscriptionProductId() {
+  return String(process.env.DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID || CANONICAL_PRODUCT_ID).trim() || CANONICAL_PRODUCT_ID;
 }
 
 function serviceRoleKey() {
@@ -104,7 +114,7 @@ function verifierFor(environment, roots, bundleId) {
 }
 
 async function verifyAcrossEnvironments(jws, method) {
-  const bundleId = requiredText('DABBIR_IOS_BUNDLE_ID', 255);
+  const bundleId = bundleIdentifier();
   const roots = rootCertificates();
   let sandboxError = null;
 
@@ -134,9 +144,7 @@ async function verifiedTransactionPayload(jwsValue) {
 export async function verifyAppleTransaction(jwsValue, userId) {
   if (!UUID_RE.test(String(userId || ''))) throw appleError('APPLE_IAP_USER_INVALID', 400);
   const decoded = await verifiedTransactionPayload(jwsValue);
-  const bundleId = requiredText('DABBIR_IOS_BUNDLE_ID', 255);
-  const productId = requiredText('DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID', 255);
-  return assertTransaction(decoded, String(userId), productId, bundleId);
+  return assertTransaction(decoded, String(userId), subscriptionProductId(), bundleIdentifier());
 }
 
 export async function verifyAppleNotification(signedPayloadValue) {
@@ -150,9 +158,7 @@ export async function entitlementFromVerifiedNotification(notification) {
   const decoded = await verifiedTransactionPayload(transactionJws);
   const userId = String(decoded?.appAccountToken || '').trim();
   if (!UUID_RE.test(userId)) throw appleError('APPLE_NOTIFICATION_ACCOUNT_TOKEN_INVALID', 409);
-  const bundleId = requiredText('DABBIR_IOS_BUNDLE_ID', 255);
-  const productId = requiredText('DABBIR_IOS_SUBSCRIPTION_PRODUCT_ID', 255);
-  return assertTransaction(decoded, userId, productId, bundleId);
+  return assertTransaction(decoded, userId, subscriptionProductId(), bundleIdentifier());
 }
 
 export async function persistAppleEntitlement(entitlement) {

--- a/api/_google-play-iap-core.js
+++ b/api/_google-play-iap-core.js
@@ -116,7 +116,8 @@ async function googlePublisher(path, options = {}) {
   if (!response.ok) {
     const text = await response.text().catch(() => '');
     const status = Number(response.status || 503);
-    const error = playError(status === 400 || status === 404 || status === 410 ? 'GOOGLE_PLAY_PURCHASE_NOT_VERIFIED' : 'GOOGLE_PLAY_API_UNAVAILABLE', status === 400 || status === 404 || status === 410 ? 409 : 503);
+    const permanent = status === 400 || status === 404 || status === 410;
+    const error = playError(permanent ? 'GOOGLE_PLAY_PURCHASE_NOT_VERIFIED' : 'GOOGLE_PLAY_API_UNAVAILABLE', permanent ? 409 : 503);
     error.cause = text.slice(0, 500);
     throw error;
   }
@@ -234,6 +235,7 @@ export async function loadGoogleEntitlement(userId, { refresh = true } = {}) {
       const verified = await verifyGoogleSubscription(row.purchase_token, String(userId));
       return persistGoogleEntitlement(verified);
     } catch (error) {
+      if (Number(error?.code || 0) !== 503) throw error;
       const verifiedAt = row.verified_at ? new Date(row.verified_at).getTime() : 0;
       const expiresAt = row.expires_at ? new Date(row.expires_at).getTime() : 0;
       const freshEnough = Number.isFinite(verifiedAt) && Date.now() - verifiedAt <= 6 * 60 * 60 * 1000;

--- a/api/_google-play-iap-core.js
+++ b/api/_google-play-iap-core.js
@@ -26,6 +26,10 @@ function serviceRoleKey() {
   return value;
 }
 
+function looksLikePrivateKey(value) {
+  return String(value || '').includes(['BEGIN', 'PRIVATE', 'KEY'].join(' '));
+}
+
 function serviceAccountCredentials() {
   const base64 = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 || '').trim();
   const plain = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON || '').trim();
@@ -41,7 +45,7 @@ function serviceAccountCredentials() {
   const clientEmail = String(parsed?.client_email || '').trim();
   const privateKey = String(parsed?.private_key || '').trim();
   const tokenUri = String(parsed?.token_uri || 'https://oauth2.googleapis.com/token').trim();
-  if (!clientEmail || !clientEmail.includes('@') || !privateKey.includes('BEGIN PRIVATE KEY') || !/^https:\/\//i.test(tokenUri)) {
+  if (!clientEmail || !clientEmail.includes('@') || !looksLikePrivateKey(privateKey) || !/^https:\/\//i.test(tokenUri)) {
     throw playError('GOOGLE_PLAY_SERVICE_ACCOUNT_INVALID', 503);
   }
   return { clientEmail, privateKey, tokenUri };

--- a/api/_google-play-iap-core.js
+++ b/api/_google-play-iap-core.js
@@ -1,0 +1,244 @@
+import { createSign } from 'node:crypto';
+
+const SUPABASE_URL = String(process.env.SUPABASE_URL || 'https://spohjzrsymsmzsseygtw.supabase.co').replace(/\/$/, '');
+const CANONICAL_PACKAGE_NAME = 'com.barmansystems.dabbir';
+const CANONICAL_PRODUCT_ID = 'com.barmansystems.dabbir.owner.subscription';
+const ANDROID_PUBLISHER_SCOPE = 'https://www.googleapis.com/auth/androidpublisher';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+let cachedGoogleAccessToken = null;
+
+function playError(message, code = 503) {
+  return Object.assign(new Error(message), { code });
+}
+
+function packageName() {
+  return String(process.env.DABBIR_ANDROID_PACKAGE || CANONICAL_PACKAGE_NAME).trim() || CANONICAL_PACKAGE_NAME;
+}
+
+function subscriptionProductId() {
+  return String(process.env.DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID || CANONICAL_PRODUCT_ID).trim() || CANONICAL_PRODUCT_ID;
+}
+
+function serviceRoleKey() {
+  const value = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
+  if (!value || value.startsWith('sb_publishable_')) throw playError('GOOGLE_PLAY_STORAGE_NOT_CONFIGURED', 503);
+  return value;
+}
+
+function serviceAccountCredentials() {
+  const base64 = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON_BASE64 || '').trim();
+  const plain = String(process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON || '').trim();
+  let raw = plain;
+  if (base64) {
+    try { raw = Buffer.from(base64, 'base64').toString('utf8'); }
+    catch { throw playError('GOOGLE_PLAY_SERVICE_ACCOUNT_INVALID', 503); }
+  }
+  if (!raw) throw playError('GOOGLE_PLAY_SERVICE_ACCOUNT_NOT_CONFIGURED', 503);
+  let parsed;
+  try { parsed = JSON.parse(raw); }
+  catch { throw playError('GOOGLE_PLAY_SERVICE_ACCOUNT_INVALID', 503); }
+  const clientEmail = String(parsed?.client_email || '').trim();
+  const privateKey = String(parsed?.private_key || '').trim();
+  const tokenUri = String(parsed?.token_uri || 'https://oauth2.googleapis.com/token').trim();
+  if (!clientEmail || !clientEmail.includes('@') || !privateKey.includes('BEGIN PRIVATE KEY') || !/^https:\/\//i.test(tokenUri)) {
+    throw playError('GOOGLE_PLAY_SERVICE_ACCOUNT_INVALID', 503);
+  }
+  return { clientEmail, privateKey, tokenUri };
+}
+
+function base64urlJson(value) {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+async function googleAccessToken() {
+  const now = Math.floor(Date.now() / 1000);
+  if (cachedGoogleAccessToken?.token && cachedGoogleAccessToken.expiresAt > now + 60) return cachedGoogleAccessToken.token;
+
+  const credentials = serviceAccountCredentials();
+  const header = base64urlJson({ alg: 'RS256', typ: 'JWT' });
+  const payload = base64urlJson({
+    iss: credentials.clientEmail,
+    scope: ANDROID_PUBLISHER_SCOPE,
+    aud: credentials.tokenUri,
+    iat: now,
+    exp: now + 3600,
+  });
+  const unsigned = `${header}.${payload}`;
+  const signer = createSign('RSA-SHA256');
+  signer.update(unsigned);
+  signer.end();
+  const signature = Buffer.from(signer.sign(credentials.privateKey)).toString('base64url');
+  const assertion = `${unsigned}.${signature}`;
+
+  const response = await fetch(credentials.tokenUri, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded', accept: 'application/json' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion,
+    }),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(10000),
+  });
+  const payloadResponse = await response.json().catch(() => null);
+  const token = String(payloadResponse?.access_token || '').trim();
+  const expiresIn = Number(payloadResponse?.expires_in || 0);
+  if (!response.ok || !token || !Number.isFinite(expiresIn) || expiresIn <= 0) {
+    throw playError('GOOGLE_PLAY_OAUTH_FAILED', 503);
+  }
+  cachedGoogleAccessToken = { token, expiresAt: now + Math.min(expiresIn, 3600) };
+  return token;
+}
+
+function validPurchaseToken(value) {
+  const token = String(value || '').trim();
+  if (token.length < 16 || token.length > 8192 || /[\u0000-\u001f\u007f]/.test(token)) throw playError('GOOGLE_PLAY_PURCHASE_TOKEN_INVALID', 400);
+  return token;
+}
+
+async function googlePublisher(path, options = {}) {
+  const accessToken = await googleAccessToken();
+  const headers = new Headers(options.headers || {});
+  headers.set('authorization', `Bearer ${accessToken}`);
+  headers.set('accept', 'application/json');
+  if (options.body !== undefined) headers.set('content-type', 'application/json');
+  const response = await fetch(`https://androidpublisher.googleapis.com/androidpublisher/v3/${path}`, {
+    ...options,
+    headers,
+    cache: 'no-store',
+    signal: AbortSignal.timeout(12000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => '');
+    const status = Number(response.status || 503);
+    const error = playError(status === 400 || status === 404 || status === 410 ? 'GOOGLE_PLAY_PURCHASE_NOT_VERIFIED' : 'GOOGLE_PLAY_API_UNAVAILABLE', status === 400 || status === 404 || status === 410 ? 409 : 503);
+    error.cause = text.slice(0, 500);
+    throw error;
+  }
+  if (response.status === 204) return null;
+  return response.json().catch(() => null);
+}
+
+function normalizeStatus(subscriptionState, expiresAt) {
+  const future = expiresAt instanceof Date && !Number.isNaN(expiresAt.getTime()) && expiresAt.getTime() > Date.now();
+  const state = String(subscriptionState || 'SUBSCRIPTION_STATE_UNSPECIFIED');
+  const statusMap = {
+    SUBSCRIPTION_STATE_ACTIVE: 'active',
+    SUBSCRIPTION_STATE_IN_GRACE_PERIOD: 'grace',
+    SUBSCRIPTION_STATE_CANCELED: 'canceled',
+    SUBSCRIPTION_STATE_PENDING: 'pending',
+    SUBSCRIPTION_STATE_PAUSED: 'paused',
+    SUBSCRIPTION_STATE_ON_HOLD: 'on_hold',
+    SUBSCRIPTION_STATE_EXPIRED: 'expired',
+    SUBSCRIPTION_STATE_PENDING_PURCHASE_CANCELED: 'expired',
+  };
+  const status = statusMap[state] || 'pending';
+  const entitled = future && ['active', 'grace', 'canceled'].includes(status);
+  return { status, entitled };
+}
+
+function parseSubscription(payload, purchaseToken, userId) {
+  const expectedProductId = subscriptionProductId();
+  const lineItems = Array.isArray(payload?.lineItems) ? payload.lineItems : [];
+  const item = lineItems.find(value => String(value?.productId || '') === expectedProductId) || null;
+  if (!item) throw playError('GOOGLE_PLAY_PRODUCT_MISMATCH', 409);
+
+  const externalId = String(payload?.externalAccountIdentifiers?.obfuscatedExternalAccountId || '').trim();
+  if (!UUID_RE.test(userId) || externalId.toLowerCase() !== userId.toLowerCase()) {
+    throw playError('GOOGLE_PLAY_ACCOUNT_MISMATCH', 403);
+  }
+
+  const expiresAt = item?.expiryTime ? new Date(item.expiryTime) : null;
+  if (!expiresAt || Number.isNaN(expiresAt.getTime())) throw playError('GOOGLE_PLAY_EXPIRY_MISSING', 409);
+  const { status, entitled } = normalizeStatus(payload?.subscriptionState, expiresAt);
+  const autoRenewEnabled = Boolean(item?.autoRenewingPlan?.autoRenewEnabled);
+  const acknowledgementState = String(payload?.acknowledgementState || 'ACKNOWLEDGEMENT_STATE_UNSPECIFIED');
+  const environment = payload?.testPurchase ? 'Test' : 'Production';
+
+  return {
+    user_id: userId,
+    package_name: packageName(),
+    product_id: expectedProductId,
+    purchase_token: purchaseToken,
+    order_id: item?.latestSuccessfulOrderId ? String(item.latestSuccessfulOrderId).slice(0, 128) : null,
+    subscription_state: String(payload?.subscriptionState || '').slice(0, 80),
+    status,
+    acknowledgement_state: acknowledgementState.slice(0, 80),
+    auto_renew_enabled: autoRenewEnabled,
+    start_at: payload?.startTime || null,
+    expires_at: expiresAt.toISOString(),
+    region_code: payload?.regionCode ? String(payload.regionCode).slice(0, 8) : null,
+    environment,
+    verified_at: new Date().toISOString(),
+    entitled,
+  };
+}
+
+export async function verifyGoogleSubscription(purchaseTokenValue, userId) {
+  const purchaseToken = validPurchaseToken(purchaseTokenValue);
+  if (!UUID_RE.test(String(userId || ''))) throw playError('GOOGLE_PLAY_USER_INVALID', 400);
+  const payload = await googlePublisher(
+    `applications/${encodeURIComponent(packageName())}/purchases/subscriptionsv2/tokens/${encodeURIComponent(purchaseToken)}`,
+  );
+  return parseSubscription(payload, purchaseToken, String(userId));
+}
+
+export async function persistGoogleEntitlement(entitlement) {
+  const key = serviceRoleKey();
+  const persisted = { ...entitlement };
+  delete persisted.entitled;
+  const response = await fetch(`${SUPABASE_URL}/rest/v1/dabbir_google_entitlements?on_conflict=user_id`, {
+    method: 'POST',
+    headers: {
+      apikey: key,
+      authorization: `Bearer ${key}`,
+      'content-type': 'application/json',
+      accept: 'application/json',
+      prefer: 'resolution=merge-duplicates,return=representation',
+    },
+    body: JSON.stringify(persisted),
+    cache: 'no-store',
+    signal: AbortSignal.timeout(10000),
+  });
+  const text = await response.text();
+  let rows = null;
+  try { rows = text ? JSON.parse(text) : null; } catch { rows = null; }
+  const row = Array.isArray(rows) ? rows[0] : null;
+  if (!response.ok || !row?.user_id || row.user_id !== entitlement.user_id) throw playError('GOOGLE_PLAY_ENTITLEMENT_PERSIST_FAILED', 503);
+  return { ...row, entitled: entitlement.entitled };
+}
+
+export async function loadGoogleEntitlement(userId, { refresh = true } = {}) {
+  if (!UUID_RE.test(String(userId || ''))) throw playError('GOOGLE_PLAY_USER_INVALID', 400);
+  const key = serviceRoleKey();
+  const response = await fetch(
+    `${SUPABASE_URL}/rest/v1/dabbir_google_entitlements?select=*&user_id=eq.${encodeURIComponent(userId)}&limit=1`,
+    {
+      headers: { apikey: key, authorization: `Bearer ${key}`, accept: 'application/json' },
+      cache: 'no-store',
+      signal: AbortSignal.timeout(10000),
+    },
+  );
+  if (!response.ok) throw playError('GOOGLE_PLAY_ENTITLEMENT_STATUS_UNAVAILABLE', 503);
+  const rows = await response.json().catch(() => null);
+  const row = Array.isArray(rows) ? rows[0] || null : null;
+  if (!row) return null;
+
+  if (refresh && row.purchase_token) {
+    try {
+      const verified = await verifyGoogleSubscription(row.purchase_token, String(userId));
+      return persistGoogleEntitlement(verified);
+    } catch (error) {
+      const verifiedAt = row.verified_at ? new Date(row.verified_at).getTime() : 0;
+      const expiresAt = row.expires_at ? new Date(row.expires_at).getTime() : 0;
+      const freshEnough = Number.isFinite(verifiedAt) && Date.now() - verifiedAt <= 6 * 60 * 60 * 1000;
+      const cachedEntitled = freshEnough && expiresAt > Date.now() && ['active', 'grace', 'canceled'].includes(String(row.status || ''));
+      if (!cachedEntitled) throw error;
+      return { ...row, entitled: true, cached: true };
+    }
+  }
+
+  const entitled = Boolean(row.expires_at && new Date(row.expires_at).getTime() > Date.now() && ['active', 'grace', 'canceled'].includes(String(row.status || '')));
+  return { ...row, entitled };
+}

--- a/api/mobile/iap/status.js
+++ b/api/mobile/iap/status.js
@@ -1,5 +1,15 @@
 import { accessTokenFromRequest, getVerifiedUser, json, supabaseRest } from '../../_auth-core.js';
+import { loadGoogleEntitlement } from '../../_google-play-iap-core.js';
 import { requireNativeBearer } from '../_native-core.js';
+
+function requestPlatform(req) {
+  try {
+    const url = new URL(req.url || '/', 'https://dabbir.invalid');
+    return String(url.searchParams.get('platform') || 'ios').toLowerCase();
+  } catch {
+    return 'ios';
+  }
+}
 
 export default async function handler(req, res) {
   if (req.method !== 'GET') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET' });
@@ -9,6 +19,28 @@ export default async function handler(req, res) {
     const token = accessTokenFromRequest(req);
     const user = token ? await getVerifiedUser(token).catch(() => null) : null;
     if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
+
+    const platform = requestPlatform(req);
+    if (platform === 'android') {
+      const row = await loadGoogleEntitlement(user.id, { refresh: true });
+      return json(res, 200, {
+        ok: true,
+        entitled: row?.entitled === true,
+        source: row?.cached ? 'SERVER_VERIFIED_GOOGLE_PLAY_ENTITLEMENT_CACHE' : 'SERVER_VERIFIED_GOOGLE_PLAY_ENTITLEMENT',
+        entitlement: row ? {
+          product_id: row.product_id,
+          status: row.status,
+          environment: row.environment,
+          expires_at: row.expires_at,
+          acknowledgement_state: row.acknowledgement_state,
+          auto_renew_enabled: row.auto_renew_enabled,
+          verified_at: row.verified_at,
+          updated_at: row.updated_at,
+        } : null,
+      });
+    }
+
+    if (platform !== 'ios') return json(res, 400, { ok: false, error: 'UNSUPPORTED_PURCHASE_PLATFORM' });
 
     const response = await supabaseRest(
       `dabbir_apple_entitlements?select=product_id,status,environment,expires_at,verified_at,updated_at&user_id=eq.${encodeURIComponent(user.id)}&limit=1`,
@@ -32,7 +64,8 @@ export default async function handler(req, res) {
         updated_at: row.updated_at,
       } : null,
     });
-  } catch {
-    return json(res, 503, { ok: false, error: 'APPLE_ENTITLEMENT_STATUS_UNAVAILABLE' });
+  } catch (error) {
+    const message = String(error?.message || 'STORE_ENTITLEMENT_STATUS_UNAVAILABLE').slice(0, 120);
+    return json(res, 503, { ok: false, error: message });
   }
 }

--- a/api/mobile/iap/verify.js
+++ b/api/mobile/iap/verify.js
@@ -1,9 +1,15 @@
 import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody } from '../../_auth-core.js';
 import { persistAppleEntitlement, verifyAppleTransaction } from '../../_apple-iap-core.js';
+import { persistGoogleEntitlement, verifyGoogleSubscription } from '../../_google-play-iap-core.js';
 import { requireNativeBearer } from '../_native-core.js';
 
-function purchaseJws(purchase) {
+function applePurchaseJws(purchase) {
   const candidate = purchase?.purchaseToken || purchase?.jwsRepresentationIos || purchase?.transactionJws || null;
+  return typeof candidate === 'string' ? candidate.trim() : '';
+}
+
+function googlePurchaseToken(purchase) {
+  const candidate = purchase?.purchaseToken || purchase?.purchaseTokenAndroid || null;
   return typeof candidate === 'string' ? candidate.trim() : '';
 }
 
@@ -17,7 +23,31 @@ export default async function handler(req, res) {
     if (!user) return json(res, 401, { ok: false, verified: false, entitled: false, error: 'AUTH_REQUIRED' });
 
     const body = await readJsonBody(req, 65536);
-    const jws = purchaseJws(body?.purchase);
+    const platform = String(body?.platform || 'ios').trim().toLowerCase();
+
+    if (platform === 'android') {
+      const purchaseToken = googlePurchaseToken(body?.purchase);
+      if (!purchaseToken) return json(res, 400, { ok: false, verified: false, entitled: false, error: 'GOOGLE_PLAY_PURCHASE_TOKEN_REQUIRED' });
+
+      const entitlement = await verifyGoogleSubscription(purchaseToken, user.id);
+      const persisted = await persistGoogleEntitlement(entitlement);
+      return json(res, 200, {
+        ok: true,
+        verified: true,
+        entitled: persisted.entitled === true,
+        source: 'GOOGLE_PLAY_DEVELOPER_API',
+        product_id: persisted.product_id,
+        environment: persisted.environment,
+        status: persisted.status,
+        expires_at: persisted.expires_at,
+        order_id: persisted.order_id,
+        acknowledgement_state: persisted.acknowledgement_state,
+      });
+    }
+
+    if (platform !== 'ios') return json(res, 400, { ok: false, verified: false, entitled: false, error: 'UNSUPPORTED_PURCHASE_PLATFORM' });
+
+    const jws = applePurchaseJws(body?.purchase);
     if (!jws) return json(res, 400, { ok: false, verified: false, entitled: false, error: 'APPLE_IAP_JWS_REQUIRED' });
 
     const entitlement = await verifyAppleTransaction(jws, user.id);
@@ -42,7 +72,7 @@ export default async function handler(req, res) {
       ok: false,
       verified: false,
       entitled: false,
-      error: String(error?.message || 'APPLE_IAP_VERIFICATION_UNAVAILABLE').slice(0, 120),
+      error: String(error?.message || 'STORE_PURCHASE_VERIFICATION_UNAVAILABLE').slice(0, 120),
     });
   }
 }

--- a/compliance/google-play-data-safety-candidate.json
+++ b/compliance/google-play-data-safety-candidate.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 1,
+  "app": "DABBIR | دبّر",
+  "package_name": "com.barmansystems.dabbir",
+  "status": "CANDIDATE_REQUIRES_FINAL_PLAY_CONSOLE_RECONCILIATION",
+  "generated_from": [
+    "mobile account authentication flow",
+    "DABBIR runtime/business data APIs",
+    "mobile dependency inventory"
+  ],
+  "security_practices": {
+    "data_encrypted_in_transit": true,
+    "account_deletion_in_app": true,
+    "account_deletion_external_path": "/delete-account",
+    "external_payment_cta_for_digital_subscription": false
+  },
+  "known_data_types": [
+    {
+      "play_category": "Personal info",
+      "play_data_type": "Email address",
+      "collected": true,
+      "required": true,
+      "shared": false,
+      "purposes": ["App functionality", "Account management"],
+      "deletion_supported": true,
+      "evidence": "Email/password authentication is exposed in the native client."
+    },
+    {
+      "play_category": "Personal info",
+      "play_data_type": "User IDs",
+      "collected": true,
+      "required": true,
+      "shared": false,
+      "purposes": ["App functionality", "Account management", "Fraud prevention/security/compliance"],
+      "deletion_supported": true,
+      "evidence": "DABBIR binds sessions, businesses, account deletion, and store entitlements to the authenticated user UUID."
+    }
+  ],
+  "conditional_data_types_to_reconcile_before_production": [
+    {
+      "play_category": "Messages",
+      "play_data_type": "Other in-app messages",
+      "reason": "DABBIR business/WhatsApp workflows may process message content through live backend integrations. Confirm the exact production connector behavior and whether data is collected/shared under Google Play definitions."
+    },
+    {
+      "play_category": "App activity",
+      "play_data_type": "App interactions",
+      "reason": "Confirm whether production observability or analytics records user interaction events beyond operational API requests."
+    },
+    {
+      "play_category": "App info and performance",
+      "play_data_type": "Crash logs / Diagnostics",
+      "reason": "Declare if Sentry or another production crash/diagnostics SDK is enabled before release."
+    },
+    {
+      "play_category": "Device or other IDs",
+      "play_data_type": "Device or other IDs",
+      "reason": "Reconcile identifiers transmitted by Google Play Billing, push notification, analytics, or other SDKs present in the final AAB."
+    }
+  ],
+  "mobile_sdk_inventory": [
+    "expo",
+    "expo-build-properties",
+    "expo-iap",
+    "expo-localization",
+    "expo-secure-store",
+    "expo-status-bar",
+    "react-native-safe-area-context"
+  ],
+  "final_binary_reconciliation_required": true,
+  "play_console_form_submission_required": true
+}

--- a/delete-account.html
+++ b/delete-account.html
@@ -1,0 +1,95 @@
+<!doctype html>
+<html lang="ar" dir="rtl">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,viewport-fit=cover">
+<meta name="robots" content="index,follow">
+<title>حذف حساب دبّر | DABBIR</title>
+<style>
+:root{color-scheme:dark;--bg:#08090a;--panel:#121416;--line:#2a2e33;--text:#f7f8f9;--muted:#a8adb4;--accent:#d7ff5f;--danger:#ff7f7f;--ok:#8ce6a1}*{box-sizing:border-box}body{margin:0;background:var(--bg);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif;line-height:1.75}.wrap{width:min(760px,calc(100% - 32px));margin:0 auto;padding:40px 0 72px}.brand{font-weight:900;color:var(--accent)}.card{margin-top:18px;padding:24px;border:1px solid var(--line);border-radius:20px;background:var(--panel)}h1{font-size:clamp(28px,5vw,42px);margin:.2em 0}p,li,label{color:#e4e7ea}.muted{color:var(--muted)}.warning{border-inline-start:3px solid var(--danger);padding-inline-start:14px}.field{display:grid;gap:7px;margin-top:16px}input{width:100%;min-height:48px;border:1px solid var(--line);border-radius:12px;background:#090b0d;color:var(--text);padding:11px 13px;font:inherit}button{width:100%;min-height:50px;margin-top:20px;border:0;border-radius:12px;background:var(--danger);color:#161616;font-weight:900;font:inherit;cursor:pointer}button:disabled{opacity:.55;cursor:not-allowed}.check{display:flex;gap:10px;align-items:flex-start;margin-top:18px}.check input{width:20px;min-height:20px;margin-top:4px}.status{margin-top:18px;padding:12px;border-radius:12px;border:1px solid var(--line);display:none}.status.show{display:block}.status.ok{border-color:#31503b;color:var(--ok)}.status.error{border-color:#653636;color:#ffb0b0}.en{direction:ltr;text-align:left;margin-top:28px;padding-top:24px;border-top:1px solid var(--line)}a{color:var(--accent)}
+</style>
+</head>
+<body><main class="wrap">
+<div class="brand">DABBIR | دبّر</div>
+<section class="card">
+<h1>طلب حذف حساب دبّر</h1>
+<p>هذه الصفحة هي المسار الخارجي الرسمي لطلب حذف حساب DABBIR والبيانات التشغيلية المرتبطة به. يمكنك أيضًا بدء الحذف من داخل تطبيق دبّر.</p>
+<p class="warning"><strong>الحذف دائم.</strong> بعد التحقق من بيانات الدخول سيتم إرسال طلب الحذف مباشرة. قد نحتفظ بسجلات محدودة فقط عندما يكون الاحتفاظ مطلوبًا قانونيًا أو أمنيًا أو محاسبيًا وفق سياسة الخصوصية.</p>
+<form id="delete-form" autocomplete="on">
+<div class="field"><label for="email">البريد الإلكتروني للحساب</label><input id="email" name="email" type="email" autocomplete="username" required maxlength="254"></div>
+<div class="field"><label for="password">كلمة المرور</label><input id="password" name="password" type="password" autocomplete="current-password" required maxlength="256"></div>
+<label class="check"><input id="confirm" type="checkbox" required><span>أفهم أن هذا الإجراء سيحذف حساب DABBIR وبياناته المرتبطة ولا يمكن التراجع عنه.</span></label>
+<button id="submit" type="submit">تحقق واحذف حساب DABBIR</button>
+</form>
+<div id="status" class="status" role="status" aria-live="polite"></div>
+<p class="muted">لا يتم تخزين كلمة المرور في هذه الصفحة. تُستخدم فقط لتسجيل الدخول عبر واجهة DABBIR الآمنة ثم تنفيذ طلب الحذف في نفس الجلسة.</p>
+<p><a href="/privacy">سياسة الخصوصية</a> · <a href="/support">الدعم</a></p>
+
+<section class="en" lang="en">
+<h2>Delete your DABBIR account</h2>
+<p>This is DABBIR's official external account-deletion path. You can also initiate deletion inside the DABBIR app.</p>
+<p>Deletion is permanent. After your credentials are verified, the DABBIR account-deletion request is sent immediately. Limited records may be retained only where legally, securely, or financially required, as described in the Privacy Policy.</p>
+</section>
+</section>
+</main>
+<script>
+(() => {
+  const form = document.getElementById('delete-form');
+  const button = document.getElementById('submit');
+  const status = document.getElementById('status');
+  const show = (message, kind) => {
+    status.textContent = message;
+    status.className = `status show ${kind}`;
+  };
+  const parse = async response => {
+    const text = await response.text();
+    let data = null;
+    try { data = text ? JSON.parse(text) : null; } catch { data = null; }
+    if (!response.ok) throw new Error(String(data?.error || `HTTP_${response.status}`));
+    return data;
+  };
+  form.addEventListener('submit', async event => {
+    event.preventDefault();
+    if (!document.getElementById('confirm').checked) return;
+    button.disabled = true;
+    show('جارٍ التحقق من الحساب…', '');
+    const email = document.getElementById('email').value.trim();
+    const password = document.getElementById('password').value;
+    try {
+      const loginResponse = await fetch('/api/mobile/auth/login', {
+        method: 'POST',
+        headers: { accept: 'application/json', 'content-type': 'application/json' },
+        body: JSON.stringify({ email, password }),
+        credentials: 'omit',
+        cache: 'no-store'
+      });
+      const login = await parse(loginResponse);
+      const token = String(login?.session?.access_token || '');
+      if (!token) throw new Error('AUTH_SESSION_MISSING');
+
+      const deleteResponse = await fetch('/api/mobile/account-delete', {
+        method: 'POST',
+        headers: {
+          accept: 'application/json',
+          'content-type': 'application/json',
+          authorization: `Bearer ${token}`
+        },
+        body: JSON.stringify({ confirmation: 'DELETE_DABBIR_ACCOUNT' }),
+        credentials: 'omit',
+        cache: 'no-store'
+      });
+      await parse(deleteResponse);
+      document.getElementById('password').value = '';
+      form.reset();
+      show('تم إرسال طلب حذف حساب DABBIR بنجاح. تم إنهاء مسار الحذف لهذا الحساب.', 'ok');
+    } catch (error) {
+      document.getElementById('password').value = '';
+      show('تعذر تنفيذ الحذف. تحقق من بيانات الدخول أو حاول لاحقًا من داخل تطبيق DABBIR.', 'error');
+    } finally {
+      button.disabled = false;
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -1,6 +1,11 @@
 import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const bundleIdentifier = process.env.DABBIR_IOS_BUNDLE_ID?.trim() || 'com.barmansystems.dabbir';
+const androidPackage = process.env.DABBIR_ANDROID_PACKAGE?.trim() || 'com.barmansystems.dabbir';
+const androidVersionCode = (() => {
+  const value = Number.parseInt(process.env.DABBIR_ANDROID_VERSION_CODE?.trim() || '1', 10);
+  return Number.isSafeInteger(value) && value > 0 ? value : 1;
+})();
 
 export default ({ config }: ConfigContext): ExpoConfig => {
   const easProjectId = process.env.DABBIR_EAS_PROJECT_ID?.trim() || '';
@@ -44,6 +49,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
         ],
       },
     },
+    android: {
+      package: androidPackage,
+      versionCode: androidVersionCode,
+    },
     plugins: [
       ['expo-secure-store', { configureAndroidBackup: false }],
       'expo-iap',
@@ -53,6 +62,11 @@ export default ({ config }: ConfigContext): ExpoConfig => {
           ios: {
             deploymentTarget: '16.4',
             privacyManifestAggregationEnabled: true,
+          },
+          android: {
+            compileSdkVersion: 36,
+            targetSdkVersion: 36,
+            usesCleartextTraffic: false,
           },
         },
       ],

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -2,44 +2,60 @@ import type { ExpoConfig, ConfigContext } from 'expo/config';
 
 const bundleIdentifier = process.env.DABBIR_IOS_BUNDLE_ID?.trim() || 'com.barmansystems.dabbir';
 
-export default ({ config }: ConfigContext): ExpoConfig => ({
-  ...config,
-  name: 'DABBIR | دبّر',
-  slug: 'dabbir-ios',
-  scheme: 'dabbir',
-  version: '1.0.0',
-  orientation: 'portrait',
-  userInterfaceStyle: 'automatic',
-  ios: {
-    supportsTablet: false,
-    bundleIdentifier,
-    buildNumber: process.env.DABBIR_IOS_BUILD_NUMBER?.trim() || '1',
-    infoPlist: {
-      ITSAppUsesNonExemptEncryption: false,
-      CFBundleAllowMixedLocalizations: true,
+export default ({ config }: ConfigContext): ExpoConfig => {
+  const easProjectId = process.env.DABBIR_EAS_PROJECT_ID?.trim() || '';
+  const existingEas = config.extra?.eas && typeof config.extra.eas === 'object'
+    ? config.extra.eas
+    : {};
+
+  return {
+    ...config,
+    name: 'DABBIR | دبّر',
+    slug: 'dabbir-ios',
+    scheme: 'dabbir',
+    version: '1.0.0',
+    orientation: 'portrait',
+    userInterfaceStyle: 'automatic',
+    extra: easProjectId
+      ? {
+          ...(config.extra || {}),
+          eas: {
+            ...existingEas,
+            projectId: easProjectId,
+          },
+        }
+      : config.extra,
+    ios: {
+      supportsTablet: false,
+      bundleIdentifier,
+      buildNumber: process.env.DABBIR_IOS_BUILD_NUMBER?.trim() || '1',
+      infoPlist: {
+        ITSAppUsesNonExemptEncryption: false,
+        CFBundleAllowMixedLocalizations: true,
+      },
+      privacyManifests: {
+        NSPrivacyTracking: false,
+        NSPrivacyCollectedDataTypes: [],
+        NSPrivacyAccessedAPITypes: [
+          {
+            NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
+            NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+          },
+        ],
+      },
     },
-    privacyManifests: {
-      NSPrivacyTracking: false,
-      NSPrivacyCollectedDataTypes: [],
-      NSPrivacyAccessedAPITypes: [
+    plugins: [
+      ['expo-secure-store', { configureAndroidBackup: false }],
+      'expo-iap',
+      [
+        'expo-build-properties',
         {
-          NSPrivacyAccessedAPIType: 'NSPrivacyAccessedAPICategoryUserDefaults',
-          NSPrivacyAccessedAPITypeReasons: ['CA92.1'],
+          ios: {
+            deploymentTarget: '16.4',
+            privacyManifestAggregationEnabled: true,
+          },
         },
       ],
-    },
-  },
-  plugins: [
-    ['expo-secure-store', { configureAndroidBackup: false }],
-    'expo-iap',
-    [
-      'expo-build-properties',
-      {
-        ios: {
-          deploymentTarget: '16.4',
-          privacyManifestAggregationEnabled: true,
-        },
-      },
     ],
-  ],
-});
+  };
+};

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -9,21 +9,36 @@
       "distribution": "internal",
       "ios": {
         "simulator": false
+      },
+      "android": {
+        "buildType": "apk"
       }
     },
     "preview": {
       "distribution": "internal",
-      "environment": "preview"
+      "environment": "preview",
+      "android": {
+        "buildType": "apk"
+      }
     },
     "production": {
       "autoIncrement": true,
       "environment": "production",
       "ios": {
         "resourceClass": "m-medium"
+      },
+      "android": {
+        "buildType": "app-bundle",
+        "resourceClass": "medium"
       }
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "android": {
+        "track": "internal",
+        "releaseStatus": "completed"
+      }
+    }
   }
 }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,16 +1,21 @@
 {
-  "name": "dabbir-ios",
+  "name": "dabbir-mobile",
   "version": "1.0.0",
   "private": true,
   "main": "expo/AppEntry",
   "scripts": {
     "start": "expo start --dev-client",
     "ios": "expo run:ios",
+    "android": "expo run:android",
     "typecheck": "tsc --noEmit",
     "doctor": "expo-doctor",
     "prebuild:ios": "expo prebuild --platform ios --clean",
+    "prebuild:android": "expo prebuild --platform android --clean",
     "build:ios": "eas build --platform ios --profile production",
-    "submit:ios": "eas submit --platform ios --profile production"
+    "submit:ios": "eas submit --platform ios --profile production",
+    "build:android": "eas build --platform android --profile production",
+    "submit:android": "eas submit --platform android --profile production",
+    "play:preflight": "node ../scripts/dabbir-google-play-preflight.mjs"
   },
   "dependencies": {
     "expo": "~57.0.9",

--- a/mobile/src/SubscriptionCard.tsx
+++ b/mobile/src/SubscriptionCard.tsx
@@ -1,11 +1,11 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { Alert, Linking, Pressable, StyleSheet, Text, View } from 'react-native';
+import { Alert, Linking, Platform, Pressable, StyleSheet, Text, View } from 'react-native';
 import { useIAP, type Purchase } from 'expo-iap';
-import { loadAppleEntitlement, verifyApplePurchase } from './api';
+import { loadStoreEntitlement, verifyStorePurchase } from './api';
 
 type FinishTransaction = (args: { purchase: Purchase; isConsumable?: boolean }) => Promise<void>;
-
-type StoreKitPeriod = { count: number; unit: string };
+type StorePlatform = 'ios' | 'android';
+type BillingPeriod = { count: number; unit: string };
 type StoreKitIntro = { paymentMode?: string; periodCount?: number; period?: { unit?: string }; displayPrice?: string };
 
 function publicHttpsUrl(raw: string | undefined): string | null {
@@ -18,7 +18,18 @@ function publicHttpsUrl(raw: string | undefined): string | null {
   }
 }
 
-function periodFromProduct(product: any): StoreKitPeriod | null {
+function periodFromIso8601(value: unknown): BillingPeriod | null {
+  const text = String(value || '').trim().toUpperCase();
+  const match = /^P(?:(\d+)D|(?:(\d+)W)|(?:(\d+)M)|(?:(\d+)Y))$/.exec(text);
+  if (!match) return null;
+  if (match[1]) return { count: Number(match[1]), unit: 'day' };
+  if (match[2]) return { count: Number(match[2]), unit: 'week' };
+  if (match[3]) return { count: Number(match[3]), unit: 'month' };
+  if (match[4]) return { count: Number(match[4]), unit: 'year' };
+  return null;
+}
+
+function applePeriodFromProduct(product: any): BillingPeriod | null {
   const legacyCount = Number(product?.subscriptionPeriodNumberIOS);
   const legacyUnit = String(product?.subscriptionPeriodUnitIOS || '').toLowerCase();
   if (Number.isFinite(legacyCount) && legacyCount > 0 && legacyUnit) return { count: legacyCount, unit: legacyUnit };
@@ -30,7 +41,24 @@ function periodFromProduct(product: any): StoreKitPeriod | null {
   return null;
 }
 
-function introFromProduct(product: any): StoreKitIntro | null {
+function androidBaseOffer(product: any): any | null {
+  const offers = Array.isArray(product?.subscriptionOfferDetailsAndroid) ? product.subscriptionOfferDetailsAndroid : [];
+  return offers.find((offer: any) => !offer?.offerId) || offers[0] || null;
+}
+
+function androidPricingPhases(product: any): any[] {
+  const offer = androidBaseOffer(product);
+  const phases = offer?.pricingPhases?.pricingPhaseList;
+  return Array.isArray(phases) ? phases : [];
+}
+
+function androidPeriodFromProduct(product: any): BillingPeriod | null {
+  const phases = androidPricingPhases(product);
+  const recurring = [...phases].reverse().find(phase => phase?.billingPeriod) || null;
+  return periodFromIso8601(recurring?.billingPeriod);
+}
+
+function appleIntroFromProduct(product: any): StoreKitIntro | null {
   return product?.subscriptionInfoIOS?.introductoryOffer || product?.introductoryOffer || null;
 }
 
@@ -50,13 +78,13 @@ function unitLabel(unit: string, arabic: boolean): string {
   return unit;
 }
 
-function periodText(period: StoreKitPeriod | null, arabic: boolean): string | null {
+function periodText(period: BillingPeriod | null, arabic: boolean): string | null {
   if (!period) return null;
   const unit = unitLabel(period.unit, arabic);
   return arabic ? `كل ${period.count} ${unit}` : `every ${period.count} ${unit}${period.count === 1 ? '' : 's'}`;
 }
 
-function introText(intro: StoreKitIntro | null, arabic: boolean): string | null {
+function appleIntroText(intro: StoreKitIntro | null, arabic: boolean): string | null {
   if (!intro) return null;
   const mode = String(intro.paymentMode || '').toLowerCase();
   const count = Number(intro.periodCount || 0);
@@ -77,12 +105,31 @@ function introText(intro: StoreKitIntro | null, arabic: boolean): string | null 
   return null;
 }
 
+function androidIntroText(product: any): string | null {
+  const phases = androidPricingPhases(product);
+  if (phases.length < 2) return null;
+  const intro = phases[0];
+  const priceMicros = Number(intro?.priceAmountMicros ?? intro?.priceAmountMicrosAndroid ?? NaN);
+  const formatted = String(intro?.formattedPrice || '').trim();
+  const period = periodText(periodFromIso8601(intro?.billingPeriod), true);
+  if (priceMicros === 0) return `عرض Google Play التمهيدي: تجربة مجانية${period ? `، ${period}` : ''}. تطبق Google الأهلية حسب حساب Play.`;
+  if (formatted) return `عرض Google Play التمهيدي: ${formatted}${period ? `، ${period}` : ''}.`;
+  return null;
+}
+
 export function SubscriptionCard({ accessToken, accountToken }: { accessToken: string; accountToken?: string | null }) {
-  const enabled = process.env.EXPO_PUBLIC_IOS_IAP_ENABLED === 'true';
-  const productId = String(process.env.EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID || '').trim();
+  const storePlatform: StorePlatform = Platform.OS === 'android' ? 'android' : 'ios';
+  const android = storePlatform === 'android';
+  const enabled = android
+    ? process.env.EXPO_PUBLIC_ANDROID_IAP_ENABLED === 'true'
+    : process.env.EXPO_PUBLIC_IOS_IAP_ENABLED === 'true';
+  const productId = String(android
+    ? process.env.EXPO_PUBLIC_ANDROID_SUBSCRIPTION_PRODUCT_ID || ''
+    : process.env.EXPO_PUBLIC_IOS_SUBSCRIPTION_PRODUCT_ID || '').trim();
   const privacyUrl = publicHttpsUrl(process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL);
   const termsUrl = publicHttpsUrl(process.env.EXPO_PUBLIC_DABBIR_TERMS_URL);
   const legalReady = Boolean(privacyUrl && termsUrl);
+  const storeName = android ? 'Google Play' : 'App Store';
   const [busy, setBusy] = useState(false);
   const [verified, setVerified] = useState(false);
   const finishRef = useRef<FinishTransaction | null>(null);
@@ -90,15 +137,15 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
   const onPurchaseSuccess = async (purchase: Purchase) => {
     setBusy(true);
     try {
-      const result = await verifyApplePurchase(accessToken, purchase);
+      const result = await verifyStorePurchase(accessToken, purchase, storePlatform);
       if (result?.verified !== true || result?.entitled !== true) throw new Error('PURCHASE_NOT_ENTITLED');
       const finish = finishRef.current;
-      if (!finish) throw new Error('STOREKIT_FINISH_UNAVAILABLE');
+      if (!finish) throw new Error('STORE_FINISH_UNAVAILABLE');
       await finish({ purchase, isConsumable: false });
       setVerified(true);
-      Alert.alert('تم', 'تم التحقق من اشتراك Apple وتفعيله.');
+      Alert.alert('تم', `تم التحقق من اشتراك ${storeName} وتفعيله.`);
     } catch {
-      Alert.alert('تعذر التحقق', 'لم يتم تفعيل الاشتراك لأن التحقق الخادمي لم يثبت وجود صلاحية Apple نشطة. لن تُمنح صلاحية مدفوعة دون تحقق.');
+      Alert.alert('تعذر التحقق', `لم يتم تفعيل الاشتراك لأن التحقق الخادمي لم يثبت وجود صلاحية ${storeName} نشطة. لن تُمنح صلاحية مدفوعة دون تحقق.`);
     } finally {
       setBusy(false);
     }
@@ -117,11 +164,11 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
   useEffect(() => {
     if (!enabled) return;
     let active = true;
-    void loadAppleEntitlement(accessToken)
+    void loadStoreEntitlement(accessToken, storePlatform)
       .then(result => { if (active) setVerified(result?.entitled === true); })
       .catch(() => { if (active) setVerified(false); });
     return () => { active = false; };
-  }, [accessToken, enabled]);
+  }, [accessToken, enabled, storePlatform]);
 
   useEffect(() => {
     if (!enabled || !connected || !productId) return;
@@ -129,20 +176,40 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
   }, [connected, enabled, fetchProducts, productId]);
 
   const product = useMemo(() => subscriptions.find(item => item.id === productId) || null, [productId, subscriptions]);
-  const billingPeriod = useMemo(() => periodFromProduct(product), [product]);
-  const introductoryOffer = useMemo(() => introFromProduct(product), [product]);
+  const billingPeriod = useMemo(() => android ? androidPeriodFromProduct(product) : applePeriodFromProduct(product), [android, product]);
   const billingText = periodText(billingPeriod, true);
-  const offerText = introText(introductoryOffer, true);
+  const offerText = useMemo(() => android ? androidIntroText(product) : appleIntroText(appleIntroFromProduct(product), true), [android, product]);
 
   if (!enabled) return null;
 
   const buy = async () => {
-    if (!productId || !connected || !product) return Alert.alert('غير متاح', 'Apple StoreKit أو منتج الاشتراك غير جاهز على هذا البناء.');
-    if (!legalReady) return Alert.alert('إعداد الإصدار غير مكتمل', 'يجب ربط سياسة الخصوصية وشروط الاستخدام العامة قبل إتاحة اشتراك App Store.');
+    if (!productId || !connected || !product) return Alert.alert('غير متاح', `${storeName} أو منتج الاشتراك غير جاهز على هذا البناء.`);
+    if (!legalReady) return Alert.alert('إعداد الإصدار غير مكتمل', `يجب ربط سياسة الخصوصية وشروط الاستخدام العامة قبل إتاحة اشتراك ${storeName}.`);
     if (!accountToken) return Alert.alert('غير متاح', 'تعذر ربط عملية الشراء بهوية حساب دبّر الحالية.');
+
+    const androidOffers = (Array.isArray((product as any)?.subscriptionOfferDetailsAndroid)
+      ? (product as any).subscriptionOfferDetailsAndroid
+      : [])
+      .filter((offer: any) => typeof offer?.offerToken === 'string' && offer.offerToken)
+      .map((offer: any) => ({ sku: productId, offerToken: offer.offerToken }));
+
+    if (android && androidOffers.length === 0) {
+      return Alert.alert('غير متاح', 'لا توجد خطة اشتراك Google Play صالحة لهذا المنتج.');
+    }
+
     setBusy(true);
     try {
-      await requestPurchase({ request: { apple: { sku: productId, appAccountToken: accountToken } }, type: 'subs' });
+      await requestPurchase({
+        request: {
+          apple: { sku: productId, appAccountToken: accountToken },
+          google: {
+            skus: [productId],
+            subscriptionOffers: androidOffers,
+            obfuscatedAccountId: accountToken,
+          },
+        } as any,
+        type: 'subs',
+      });
     } catch {
       setBusy(false);
     }
@@ -152,7 +219,7 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
     setBusy(true);
     try {
       await restorePurchases();
-      Alert.alert('استعادة المشتريات', 'تمت مطالبة App Store باستعادة المشتريات، وسيتم تفعيل الصلاحية فقط بعد التحقق الخادمي من المعاملة المستعادة.');
+      Alert.alert('استعادة المشتريات', `تمت مطالبة ${storeName} باستعادة المشتريات، وسيتم تفعيل الصلاحية فقط بعد التحقق الخادمي من المعاملة المستعادة.`);
     } finally {
       setBusy(false);
     }
@@ -160,18 +227,18 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
 
   return (
     <View style={styles.card}>
-      <Text style={styles.title}>اشتراك دبّر عبر Apple</Text>
+      <Text style={styles.title}>{android ? 'اشتراك دبّر عبر Google Play' : 'اشتراك دبّر عبر Apple'}</Text>
       <Text style={styles.body}>
         {verified
           ? 'الاشتراك موثّق ونشط.'
           : product
             ? `${product.displayName || 'DABBIR Owner'} — ${product.displayPrice || ''}${billingText ? `، ${billingText}` : ''}`
-            : 'جارٍ قراءة منتج الاشتراك من App Store.'}
+            : `جارٍ قراءة منتج الاشتراك من ${storeName}.`}
       </Text>
       {offerText ? <Text style={styles.offer}>{offerText}</Text> : null}
       {!legalReady ? <Text style={styles.warning}>هذا البناء غير جاهز للبيع حتى تُضبط روابط سياسة الخصوصية وشروط الاستخدام العامة.</Text> : null}
       <Pressable style={[styles.button, (busy || !legalReady || !product) && styles.disabled]} disabled={busy || verified || !legalReady || !product} onPress={buy}>
-        <Text style={styles.buttonText}>{verified ? 'الاشتراك نشط' : 'اشترك عبر Apple'}</Text>
+        <Text style={styles.buttonText}>{verified ? 'الاشتراك نشط' : android ? 'اشترك عبر Google Play' : 'اشترك عبر Apple'}</Text>
       </Pressable>
       <Pressable disabled={busy} onPress={restore}><Text style={styles.link}>استعادة المشتريات</Text></Pressable>
       <View style={styles.legalRow}>
@@ -179,7 +246,9 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
         <Text style={styles.separator}>•</Text>
         <Pressable disabled={!termsUrl} onPress={() => { if (termsUrl) void Linking.openURL(termsUrl); }}><Text style={[styles.legalLink, !termsUrl && styles.disabledText]}>شروط الاستخدام</Text></Pressable>
       </View>
-      <Text style={styles.disclosure}>يُدار الدفع والتجديد والإلغاء عبر Apple ID وApp Store. سعر وفترة الاشتراك والعروض أعلاه تُقرأ من StoreKit ولا ينشئها دبّر محليًا.</Text>
+      <Text style={styles.disclosure}>{android
+        ? 'يُدار الدفع والتجديد والإلغاء عبر Google Play. السعر وفترة الفوترة والعروض أعلاه تأتي من Google Play Billing ولا ينشئها دبّر محليًا.'
+        : 'يُدار الدفع والتجديد والإلغاء عبر Apple ID وApp Store. السعر وفترة الاشتراك والعروض أعلاه تُقرأ من StoreKit ولا ينشئها دبّر محليًا.'}</Text>
     </View>
   );
 }

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -2,6 +2,8 @@ import type { DabbirSession } from './session';
 
 const configuredBase = String(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL || '').trim().replace(/\/$/, '');
 
+type StorePlatform = 'ios' | 'android';
+
 function apiBase(): string {
   if (!configuredBase || !/^https:\/\//i.test(configuredBase)) {
     throw new Error('DABBIR_API_BASE_URL_NOT_CONFIGURED');
@@ -68,13 +70,21 @@ export async function deleteDabbirAccount(accessToken: string): Promise<any> {
   return post('/api/mobile/account-delete', { confirmation: 'DELETE_DABBIR_ACCOUNT' }, accessToken);
 }
 
-export async function verifyApplePurchase(accessToken: string, purchase: unknown): Promise<any> {
-  return post('/api/mobile/iap/verify', { purchase }, accessToken);
+export async function verifyStorePurchase(accessToken: string, purchase: unknown, platform: StorePlatform): Promise<any> {
+  return post('/api/mobile/iap/verify', { purchase, platform }, accessToken);
 }
 
-export async function loadAppleEntitlement(accessToken: string): Promise<any> {
-  const response = await fetch(`${apiBase()}/api/mobile/iap/status`, {
+export async function loadStoreEntitlement(accessToken: string, platform: StorePlatform): Promise<any> {
+  const response = await fetch(`${apiBase()}/api/mobile/iap/status?platform=${encodeURIComponent(platform)}`, {
     headers: { accept: 'application/json', authorization: `Bearer ${accessToken}` },
   });
   return parseJson(response);
+}
+
+export async function verifyApplePurchase(accessToken: string, purchase: unknown): Promise<any> {
+  return verifyStorePurchase(accessToken, purchase, 'ios');
+}
+
+export async function loadAppleEntitlement(accessToken: string): Promise<any> {
+  return loadStoreEntitlement(accessToken, 'ios');
 }

--- a/scripts/dabbir-google-play-preflight.mjs
+++ b/scripts/dabbir-google-play-preflight.mjs
@@ -1,0 +1,134 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const releaseMode = String(process.env.DABBIR_GOOGLE_PLAY_RELEASE_PREFLIGHT || '').trim() === '1';
+const reportPath = String(process.env.DABBIR_GOOGLE_PLAY_PREFLIGHT_REPORT_PATH || '').trim();
+const failures = [];
+const external = [];
+const passes = [];
+
+const read = relative => fs.readFileSync(path.join(ROOT, relative), 'utf8');
+function requireStatic(condition, code, detail) {
+  if (condition) passes.push({ code, detail });
+  else failures.push({ code, detail });
+}
+function requireRelease(condition, code, detail) {
+  if (condition) passes.push({ code, detail });
+  else if (releaseMode) failures.push({ code, detail });
+  else external.push({ code, detail });
+}
+function httpsUrl(value) {
+  try {
+    const url = new URL(String(value || '').trim());
+    if (url.protocol !== 'https:') return null;
+    if (['localhost', '127.0.0.1', '::1'].includes(url.hostname)) return null;
+    return url;
+  } catch { return null; }
+}
+function isProtectedPrelaunchHost(url) {
+  if (!url) return false;
+  return /-3619s-projects\.vercel\.app$/i.test(url.hostname) || /-nd56cm4j5v-/i.test(url.hostname);
+}
+function routeDestination(vercelConfig, source) {
+  const route = (vercelConfig.routes || []).find(item => item?.src === source);
+  return route?.dest || null;
+}
+
+const appConfig = read('mobile/app.config.ts');
+const eas = JSON.parse(read('mobile/eas.json'));
+const mobilePackage = JSON.parse(read('mobile/package.json'));
+const app = read('mobile/App.tsx');
+const subscription = read('mobile/src/SubscriptionCard.tsx');
+const mobileApi = read('mobile/src/api.ts');
+const verifyEndpoint = read('api/mobile/iap/verify.js');
+const statusEndpoint = read('api/mobile/iap/status.js');
+const googleCore = read('api/_google-play-iap-core.js');
+const accountDelete = read('api/mobile/account-delete.js');
+const googleMigration = read('supabase/migrations/20260829152000_dabbir_google_entitlements_v1.sql');
+const deletePage = read('delete-account.html');
+const privacyPage = read('privacy.html');
+const vercelConfig = JSON.parse(read('vercel.json'));
+const dataSafety = JSON.parse(read('compliance/google-play-data-safety-candidate.json'));
+
+requireStatic(/name:\s*['"]DABBIR \| دبّر['"]/.test(appConfig), 'APP_NAME_LOCKED', 'Native app name is DABBIR | دبّر.');
+requireStatic(/android:\s*\{[\s\S]*package:\s*androidPackage/.test(appConfig) && /com\.barmansystems\.dabbir/.test(appConfig), 'ANDROID_PACKAGE_LOCKED', 'Canonical Android package is com.barmansystems.dabbir.');
+requireStatic(/compileSdkVersion:\s*36/.test(appConfig), 'ANDROID_COMPILE_SDK_36', 'Android compile SDK is 36.');
+requireStatic(/targetSdkVersion:\s*36/.test(appConfig), 'ANDROID_TARGET_SDK_36', 'Android target SDK is 36 for the 31 Aug 2026 Play requirement.');
+requireStatic(/usesCleartextTraffic:\s*false/.test(appConfig), 'ANDROID_CLEARTEXT_DISABLED', 'Android cleartext traffic is disabled.');
+requireStatic(eas?.build?.production?.android?.buildType === 'app-bundle', 'PLAY_AAB_PRODUCTION', 'EAS production Android build emits an AAB.');
+requireStatic(eas?.build?.production?.autoIncrement === true && eas?.cli?.appVersionSource === 'remote', 'PLAY_VERSION_CODE_REMOTE', 'Production version codes are remotely managed and auto-incremented.');
+requireStatic(eas?.submit?.production?.android?.track === 'internal', 'PLAY_INTERNAL_TRACK', 'Initial automated Google Play submission targets Internal testing.');
+requireStatic(eas?.submit?.production?.android?.releaseStatus === 'completed', 'PLAY_INTERNAL_RELEASE_COMPLETED', 'Internal testing release is made available to configured testers after submission.');
+requireStatic(Boolean(mobilePackage?.scripts?.['build:android']) && Boolean(mobilePackage?.scripts?.['submit:android']), 'ANDROID_RELEASE_SCRIPTS', 'Android build and submit scripts exist.');
+requireStatic(/deleteDabbirAccount/.test(app) && /api\.deleteDabbirAccount/.test(app) && /dabbir_delete_current_user_account/.test(accountDelete), 'ACCOUNT_DELETION_IN_APP', 'Account deletion can be initiated from inside the app.');
+requireStatic(/\/api\/mobile\/auth\/login/.test(deletePage) && /\/api\/mobile\/account-delete/.test(deletePage) && /DELETE_DABBIR_ACCOUNT/.test(deletePage), 'ACCOUNT_DELETION_EXTERNAL_FUNCTIONAL', 'External deletion page authenticates the user and invokes the real DABBIR deletion endpoint.');
+requireStatic(routeDestination(vercelConfig, '^/delete-account/?$') === '/delete-account.html', 'ACCOUNT_DELETION_EXTERNAL_ROUTE', 'Stable /delete-account route exists for Play Console.');
+requireStatic(/verifyStorePurchase/.test(subscription) && /storePlatform/.test(subscription) && /google:\s*\{/.test(subscription), 'GOOGLE_PLAY_BILLING_CLIENT', 'Android subscription purchase uses the Google Play path in expo-iap.');
+requireStatic(/subscriptionOffers/.test(subscription) && /subscriptionOfferDetailsAndroid/.test(subscription), 'GOOGLE_PLAY_SUBSCRIPTION_OFFER_TOKEN', 'Android subscriptions use Google Play offer tokens.');
+requireStatic(/obfuscatedAccountId:\s*accountToken/.test(subscription), 'GOOGLE_PLAY_ACCOUNT_ID_ATTACHED', 'Google Play purchase is bound to the opaque DABBIR account UUID.');
+requireStatic(/verifyGoogleSubscription/.test(verifyEndpoint) && /GOOGLE_PLAY_DEVELOPER_API/.test(verifyEndpoint), 'GOOGLE_PLAY_SERVER_VERIFY_ENDPOINT', 'Purchase endpoint verifies Android subscriptions server-side.');
+requireStatic(/purchases\/subscriptionsv2\/tokens/.test(googleCore) && /androidpublisher/.test(googleCore), 'GOOGLE_PLAY_PUBLISHER_API_V2', 'Server verification uses Google Play Developer API subscriptionsv2.');
+requireStatic(/obfuscatedExternalAccountId/.test(googleCore) && /GOOGLE_PLAY_ACCOUNT_MISMATCH/.test(googleCore), 'GOOGLE_PLAY_SERVER_ACCOUNT_BINDING', 'Verified Play purchase must match the authenticated DABBIR user.');
+requireStatic(/persistGoogleEntitlement/.test(googleCore) && /loadGoogleEntitlement/.test(statusEndpoint), 'GOOGLE_PLAY_ENTITLEMENT_PERSISTENCE', 'Verified Google entitlement is persisted and refreshed server-side.');
+requireStatic(/force row level security/i.test(googleMigration) && /revoke all on public\.dabbir_google_entitlements from anon, authenticated/i.test(googleMigration), 'GOOGLE_PLAY_TOKEN_SERVER_ONLY', 'Google purchase tokens are inaccessible to app/client database roles.');
+requireStatic(/finishTransaction/.test(subscription) && /result\?\.verified !== true \|\| result\?\.entitled !== true/.test(subscription), 'NO_UNVERIFIED_GOOGLE_ENTITLEMENT', 'The client grants/finishes only after server verification confirms entitlement.');
+requireStatic(!/stripe|checkout|payment[_ -]?link|buy on web|subscribe on web/i.test(subscription), 'NO_EXTERNAL_DIGITAL_PAYMENT_CTA', 'Subscription UI has no prohibited external digital-payment CTA.');
+requireStatic(mobileApi.includes('DABBIR_API_BASE_URL_NOT_CONFIGURED') && mobileApi.includes('https:'), 'HTTPS_API_FAIL_CLOSED', 'Native API requires an explicit HTTPS base URL.');
+requireStatic(!/\bWebView\b|react-native-webview/.test(app), 'NATIVE_NOT_WEBVIEW', 'DABBIR Android is not a repackaged web wrapper.');
+requireStatic(/DABBIR \| دبّر/.test(privacyPage) && /lang=["']en["']/.test(privacyPage), 'PLAY_PRIVACY_POLICY_SOURCE', 'Public privacy page source is bilingual and DABBIR-specific.');
+requireStatic(dataSafety?.package_name === 'com.barmansystems.dabbir' && dataSafety?.play_console_form_submission_required === true, 'DATA_SAFETY_INVENTORY', 'Code-derived Data Safety declaration candidate is tracked for final Play Console reconciliation.');
+
+const packageEnv = String(process.env.DABBIR_ANDROID_PACKAGE || '').trim();
+const serverProductId = String(process.env.DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID || '').trim();
+const clientProductId = String(process.env.EXPO_PUBLIC_ANDROID_SUBSCRIPTION_PRODUCT_ID || '').trim();
+const iapEnabled = String(process.env.EXPO_PUBLIC_ANDROID_IAP_ENABLED || '').trim();
+const apiUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL);
+const privacyUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_PRIVACY_URL);
+const termsUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_TERMS_URL);
+const supportUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_SUPPORT_URL);
+const deleteUrl = httpsUrl(process.env.EXPO_PUBLIC_DABBIR_DELETE_ACCOUNT_URL);
+
+requireRelease(packageEnv === 'com.barmansystems.dabbir', 'PLAY_PACKAGE_RELEASE_VALUE', 'Release package must be com.barmansystems.dabbir.');
+requireRelease(serverProductId === 'com.barmansystems.dabbir.owner.subscription' && clientProductId === serverProductId, 'PLAY_SUBSCRIPTION_PRODUCT_MATCH', 'Client/server Google Play subscription IDs must match the canonical product.');
+requireRelease(iapEnabled === 'true', 'PLAY_BILLING_ENABLED_RELEASE', 'Production Android build must enable Google Play Billing.');
+requireRelease(Boolean(apiUrl) && !isProtectedPrelaunchHost(apiUrl), 'PUBLIC_PRODUCTION_API', 'Android API URL must be public HTTPS, not a protected preview hostname.');
+requireRelease(Boolean(privacyUrl) && !isProtectedPrelaunchHost(privacyUrl) && /^\/privacy\/?$/i.test(privacyUrl.pathname), 'PUBLIC_PRIVACY_URL', 'Privacy URL must be public HTTPS /privacy.');
+requireRelease(Boolean(termsUrl) && !isProtectedPrelaunchHost(termsUrl) && /^\/terms\/?$/i.test(termsUrl.pathname), 'PUBLIC_TERMS_URL', 'Terms URL must be public HTTPS /terms.');
+requireRelease(Boolean(supportUrl) && !isProtectedPrelaunchHost(supportUrl) && /^\/support\/?$/i.test(supportUrl.pathname), 'PUBLIC_SUPPORT_URL', 'Support URL must be public HTTPS /support.');
+requireRelease(Boolean(deleteUrl) && !isProtectedPrelaunchHost(deleteUrl) && /^\/delete-account\/?$/i.test(deleteUrl.pathname), 'PUBLIC_ACCOUNT_DELETION_URL', 'Google Play account deletion URL must be public HTTPS /delete-account.');
+
+const releaseExternalVerification = releaseMode && failures.length === 0 ? [
+  { code: 'GOOGLE_PLAY_CONSOLE_APP_RECORD', detail: 'Verify/create the real Play Console app record for com.barmansystems.dabbir.' },
+  { code: 'GOOGLE_PLAY_SERVICE_ACCOUNT', detail: 'Verify EAS Submit and the backend have appropriately scoped Google Play service-account credentials.' },
+  { code: 'GOOGLE_PLAY_SUBSCRIPTION_PRODUCT', detail: 'Verify the canonical subscription and active base plan/offer in Play Console.' },
+  { code: 'DATA_SAFETY_FINAL_FORM', detail: 'Reconcile the final AAB/SDK behavior and submit the Data Safety form in Play Console.' },
+  { code: 'PLAY_APP_CONTENT_FORMS', detail: 'Complete App access, Ads, Content rating, Target audience/content, and other applicable App content forms.' },
+  { code: 'PUBLIC_RELEASE_URL_LIVE_VERIFICATION', detail: 'Verify API, Privacy, Terms, Support, and Delete Account URLs from the final public hostname.' },
+  { code: 'SIGNED_AAB_INTERNAL_TEST_VERIFICATION', detail: 'Produce the exact signed AAB and confirm successful Internal testing ingestion in Google Play.' },
+] : [];
+
+const releaseConfigOnly = releaseMode && failures.length === 0 && releaseExternalVerification.length > 0;
+const report = {
+  ok: failures.length === 0 && !releaseConfigOnly,
+  mode: releaseMode ? 'RELEASE' : 'STATIC',
+  verdict: failures.length
+    ? 'FAIL'
+    : releaseConfigOnly
+      ? 'RELEASE_CONFIG_PASS_EXTERNAL_VERIFICATION_REQUIRED'
+      : (external.length ? 'INTERNAL_PASS_EXTERNAL_BLOCKED' : 'PASS'),
+  passes: passes.map(item => item.code),
+  failures,
+  external_blockers: [...external, ...releaseExternalVerification],
+  release_config_only: releaseConfigOnly,
+  google_play_ready: false,
+  target_sdk_required: 36,
+  final_aab_data_safety_reconciliation: 'REQUIRED_BEFORE_PRODUCTION',
+  signed_aab_internal_testing: 'EXTERNAL_GOOGLE_GATE',
+};
+
+const json = JSON.stringify(report, null, 2);
+if (reportPath) fs.writeFileSync(path.resolve(ROOT, reportPath), `${json}\n`);
+console.log(json);
+if (failures.length) process.exit(2);
+if (releaseConfigOnly) process.exit(3);

--- a/supabase/migrations/20260829152000_dabbir_google_entitlements_v1.sql
+++ b/supabase/migrations/20260829152000_dabbir_google_entitlements_v1.sql
@@ -1,0 +1,45 @@
+-- Google Play subscription entitlement ledger for DABBIR Android.
+-- Purchase tokens are server-only and are never granted to anon/authenticated roles.
+
+create table if not exists public.dabbir_google_entitlements (
+  user_id uuid primary key references auth.users(id) on delete cascade,
+  package_name text not null check (length(package_name) between 3 and 255),
+  product_id text not null check (length(product_id) between 3 and 255),
+  purchase_token text not null unique check (length(purchase_token) between 16 and 8192),
+  order_id text check (order_id is null or length(order_id) <= 128),
+  subscription_state text not null check (length(subscription_state) between 1 and 80),
+  status text not null check (status in ('active','grace','canceled','pending','paused','on_hold','expired')),
+  acknowledgement_state text not null check (length(acknowledgement_state) between 1 and 80),
+  auto_renew_enabled boolean not null default false,
+  start_at timestamptz,
+  expires_at timestamptz not null,
+  region_code text check (region_code is null or length(region_code) <= 8),
+  environment text not null check (environment in ('Test','Production')),
+  verified_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.dabbir_google_entitlements enable row level security;
+alter table public.dabbir_google_entitlements force row level security;
+revoke all on public.dabbir_google_entitlements from anon, authenticated;
+
+create or replace function dabbir_private.google_entitlement_touch()
+returns trigger
+language plpgsql
+security definer
+set search_path = pg_catalog, public, pg_temp
+as $function$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$function$;
+revoke all on function dabbir_private.google_entitlement_touch() from public, anon, authenticated;
+
+drop trigger if exists dabbir_google_entitlements_touch on public.dabbir_google_entitlements;
+create trigger dabbir_google_entitlements_touch
+before update on public.dabbir_google_entitlements
+for each row execute function dabbir_private.google_entitlement_touch();
+
+comment on table public.dabbir_google_entitlements is
+  'Server-only Google Play subscription verification state for DABBIR Android. Purchase tokens are intentionally inaccessible to app/client roles.';

--- a/test/dabbir-google-play-iap.test.mjs
+++ b/test/dabbir-google-play-iap.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { generateKeyPairSync } from 'node:crypto';
+import test from 'node:test';
+
+const USER_ID = '11111111-1111-4111-8111-111111111111';
+const OTHER_USER_ID = '22222222-2222-4222-8222-222222222222';
+const PRODUCT_ID = 'com.barmansystems.dabbir.owner.subscription';
+const PACKAGE_NAME = 'com.barmansystems.dabbir';
+
+function responseJson(payload, status = 200) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const { privateKey } = generateKeyPairSync('rsa', { modulusLength: 2048 });
+const privateKeyPem = privateKey.export({ type: 'pkcs8', format: 'pem' }).toString();
+process.env.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON = JSON.stringify({
+  client_email: 'dabbir-play-test@example.iam.gserviceaccount.com',
+  private_key: privateKeyPem,
+  token_uri: 'https://oauth2.googleapis.com/token',
+});
+process.env.DABBIR_ANDROID_PACKAGE = PACKAGE_NAME;
+process.env.DABBIR_ANDROID_SUBSCRIPTION_PRODUCT_ID = PRODUCT_ID;
+
+const { verifyGoogleSubscription } = await import('../api/_google-play-iap-core.js');
+
+function activeSubscription(accountId = USER_ID, productId = PRODUCT_ID) {
+  return {
+    subscriptionState: 'SUBSCRIPTION_STATE_ACTIVE',
+    acknowledgementState: 'ACKNOWLEDGEMENT_STATE_PENDING',
+    externalAccountIdentifiers: { obfuscatedExternalAccountId: accountId },
+    regionCode: 'AE',
+    startTime: new Date(Date.now() - 60_000).toISOString(),
+    lineItems: [{
+      productId,
+      expiryTime: new Date(Date.now() + 86_400_000).toISOString(),
+      latestSuccessfulOrderId: 'GPA.TEST-ORDER',
+      autoRenewingPlan: { autoRenewEnabled: true },
+    }],
+  };
+}
+
+test('Google Play subscription is verified server-side and bound to DABBIR UUID', async () => {
+  const calls = [];
+  globalThis.fetch = async (url, options = {}) => {
+    calls.push({ url: String(url), authorization: new Headers(options.headers || {}).get('authorization') });
+    if (String(url) === 'https://oauth2.googleapis.com/token') {
+      return responseJson({ access_token: 'server-test-access-token', expires_in: 3600 });
+    }
+    if (String(url).includes('/purchases/subscriptionsv2/tokens/')) {
+      return responseJson(activeSubscription());
+    }
+    throw new Error(`UNEXPECTED_FETCH:${url}`);
+  };
+
+  const entitlement = await verifyGoogleSubscription('purchase-token-1234567890', USER_ID);
+  assert.equal(entitlement.user_id, USER_ID);
+  assert.equal(entitlement.package_name, PACKAGE_NAME);
+  assert.equal(entitlement.product_id, PRODUCT_ID);
+  assert.equal(entitlement.status, 'active');
+  assert.equal(entitlement.entitled, true);
+  assert.equal(entitlement.region_code, 'AE');
+  assert.equal(calls.length, 2);
+  assert.match(calls[1].url, new RegExp(`/applications/${PACKAGE_NAME}/purchases/subscriptionsv2/tokens/`));
+  assert.equal(calls[1].authorization, 'Bearer server-test-access-token');
+});
+
+test('Google Play verification rejects purchase bound to a different DABBIR account', async () => {
+  globalThis.fetch = async url => {
+    if (String(url).includes('/purchases/subscriptionsv2/tokens/')) return responseJson(activeSubscription(OTHER_USER_ID));
+    throw new Error(`UNEXPECTED_FETCH:${url}`);
+  };
+
+  await assert.rejects(
+    () => verifyGoogleSubscription('purchase-token-account-mismatch', USER_ID),
+    error => error?.message === 'GOOGLE_PLAY_ACCOUNT_MISMATCH' && error?.code === 403,
+  );
+});
+
+test('Google Play verification rejects a different subscription product', async () => {
+  globalThis.fetch = async url => {
+    if (String(url).includes('/purchases/subscriptionsv2/tokens/')) return responseJson(activeSubscription(USER_ID, 'other.product'));
+    throw new Error(`UNEXPECTED_FETCH:${url}`);
+  };
+
+  await assert.rejects(
+    () => verifyGoogleSubscription('purchase-token-product-mismatch', USER_ID),
+    error => error?.message === 'GOOGLE_PLAY_PRODUCT_MISMATCH' && error?.code === 409,
+  );
+});

--- a/vercel.json
+++ b/vercel.json
@@ -23,6 +23,10 @@
       "dest": "/support.html"
     },
     {
+      "src": "^/delete-account/?$",
+      "dest": "/delete-account.html"
+    },
+    {
       "src": "^/owner/?$",
       "dest": "/api/owner-login"
     },
@@ -47,6 +51,10 @@
     {
       "source": "/support",
       "destination": "/support.html"
+    },
+    {
+      "source": "/delete-account",
+      "destination": "/delete-account.html"
     },
     {
       "source": "/owner",


### PR DESCRIPTION
Builds the shared DABBIR mobile release core for both stores.

RELEASE STATUS: NOT READY / DO NOT PUBLISH.

Store publishing is hard-gated:
- Google Play and TestFlight release workflows are manual-only (no push-to-main publishing).
- A release requires the exact manual approval input `PUBLISH_DABBIR`.
- A separate repository variable `DABBIR_STORE_RELEASE_ENABLED` must also equal `true`.
- Until both are deliberately enabled, store submission jobs do not run.
- Build, CI, preflight, and local/native verification may continue without publishing.

Apple/App Store:
- EAS project self-bootstrap/linking and production env sync.
- Canonical iOS bundle/product identifiers.
- Signed iOS/TestFlight pipeline retained but publishing locked.

Android/Google Play:
- Canonical package `com.barmansystems.dabbir`.
- Android 16 / target+compile API 36.
- Production AAB capability and Google Play Internal testing submission pipeline retained but publishing locked.
- Google Play Billing subscription path using `com.barmansystems.dabbir.owner.subscription`.
- Server-side Play Developer API verification before entitlement/finish, with DABBIR UUID binding.
- Server-only Google entitlement ledger migration.
- Functional external `/delete-account` route plus in-app deletion.
- Code-derived Data Safety candidate and Google Play preflight.
- Android native AAB compile CI and evidence artifacts.

No Expo, Google Play, Apple, or Supabase service secrets are committed. Store-account credentials and final store declarations remain explicit external release gates.