### PR TITLE
fix(dabbir): prevent business bootstrap SQLSTATE 42702 regression

### DIFF
--- a/db/dabbir_business_onboarding_v12.sql
+++ b/db/dabbir_business_onboarding_v12.sql
@@ -26,7 +26,7 @@ declare
 begin
   if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
   if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
-  if p_business_type not in ('store','clinic','creator','salon','real_estate','services','other') then
+  if p_business_type not in ('store','laundry','car_wash','clinic','creator','salon','real_estate','services','other') then
     raise exception 'UNSUPPORTED_BUSINESS_TYPE';
   end if;
 

--- a/db/dabbir_employee_access_v5.sql
+++ b/db/dabbir_employee_access_v5.sql
@@ -289,10 +289,9 @@ declare v_user uuid:=auth.uid(); v_id uuid:=gen_random_uuid(); v_slug text;
 begin
  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
  if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
- if p_business_type not in ('store','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
- v_slug:='pilot-'||substr(replace(v_id::text,'-',''),1,16);
- insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode) values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),true);
+ if p_business_type not in ('store','laundry','car_wash','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
+ v_slug:='dabbir-'||substr(replace(v_id::text,'-',''),1,16);
+ insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode) values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),false);
  insert into public.dabbir_memberships(business_id,user_id,role,status,accepted_at) values(v_id,v_user,'owner','active',now());
- insert into public.dabbir_channels(business_id,channel_type,status,metadata) values (v_id,'whatsapp','configured','{"reason":"runtime_verification_required"}'::jsonb),(v_id,'instagram','configured','{"reason":"runtime_verification_required"}'::jsonb) on conflict(business_id,channel_type) do nothing;
  return query select v_id,v_slug;
 end;$$;

--- a/db/dabbir_multi_vertical_business_types_v1.sql
+++ b/db/dabbir_multi_vertical_business_types_v1.sql
@@ -13,14 +13,11 @@ begin
  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
  if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
  if p_business_type not in ('store','laundry','car_wash','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
- v_slug:='pilot-'||substr(replace(v_id::text,'-',''),1,16);
+ v_slug:='dabbir-'||substr(replace(v_id::text,'-',''),1,16);
  insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode)
- values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),true);
- insert into public.dabbir_memberships(business_id,user_id,role) values(v_id,v_user,'owner');
- insert into public.dabbir_channels(business_id,channel_type,status,metadata) values
-  (v_id,'whatsapp','configured','{"reason":"runtime_verification_required"}'::jsonb),
-  (v_id,'instagram','configured','{"reason":"runtime_verification_required"}'::jsonb)
- on conflict(business_id,channel_type) do nothing;
+ values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),false);
+ insert into public.dabbir_memberships(business_id,user_id,role,status,accepted_at)
+ values(v_id,v_user,'owner','active',now());
  return query select v_id,v_slug;
 end;
 $$;

--- a/db/dabbir_phase2_auth_rbac_tenant_hardening_v1.sql
+++ b/db/dabbir_phase2_auth_rbac_tenant_hardening_v1.sql
@@ -171,14 +171,10 @@ declare v_user uuid:=auth.uid(); v_id uuid:=gen_random_uuid(); v_slug text;
 begin
  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
  if nullif(trim(p_name),'') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
- if p_business_type not in ('store','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
- v_slug:='pilot-'||substr(replace(v_id::text,'-',''),1,16);
- insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode) values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),true);
- insert into public.dabbir_memberships(business_id,user_id,role) values(v_id,v_user,'owner');
- insert into public.dabbir_channels(business_id,channel_type,status,metadata) values
-  (v_id,'whatsapp','configured','{"reason":"runtime_verification_required"}'::jsonb),
-  (v_id,'instagram','configured','{"reason":"runtime_verification_required"}'::jsonb)
- on conflict(business_id,channel_type) do nothing;
+ if p_business_type not in ('store','laundry','car_wash','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
+ v_slug:='dabbir-'||substr(replace(v_id::text,'-',''),1,16);
+ insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode) values(v_id,v_slug,left(trim(p_name),120),p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-AE'),false);
+ insert into public.dabbir_memberships(business_id,user_id,role,status,accepted_at) values(v_id,v_user,'owner','active',now());
  return query select v_id,v_slug;
 end;
 $$;

--- a/supabase/migrations/20260830131500_dabbir_create_business_regression_guard_v1.sql
+++ b/supabase/migrations/20260830131500_dabbir_create_business_regression_guard_v1.sql
@@ -1,0 +1,84 @@
+-- Repair dabbir_create_business after the multi-vertical rollout restored an
+-- obsolete function body with an ambiguous ON CONFLICT target (SQLSTATE 42702).
+-- Keep onboarding fail-closed: create only the business and active owner membership.
+
+create or replace function public.dabbir_create_business(
+  p_name text,
+  p_business_type text,
+  p_locale text default 'ar-AE'::text
+)
+returns table(business_id uuid, business_slug text)
+language plpgsql
+security invoker
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_user uuid := auth.uid();
+  v_id uuid := gen_random_uuid();
+  v_slug text;
+begin
+  if v_user is null then
+    raise exception 'AUTH_REQUIRED';
+  end if;
+
+  if nullif(trim(p_name), '') is null then
+    raise exception 'BUSINESS_NAME_REQUIRED';
+  end if;
+
+  if p_business_type not in (
+    'store',
+    'laundry',
+    'car_wash',
+    'clinic',
+    'creator',
+    'salon',
+    'real_estate',
+    'services',
+    'other'
+  ) then
+    raise exception 'UNSUPPORTED_BUSINESS_TYPE';
+  end if;
+
+  v_slug := 'dabbir-' || substr(replace(v_id::text, '-', ''), 1, 16);
+
+  insert into public.dabbir_businesses(
+    id,
+    slug,
+    name,
+    business_type,
+    owner_id,
+    locale,
+    demo_mode
+  ) values (
+    v_id,
+    v_slug,
+    left(trim(p_name), 120),
+    p_business_type,
+    v_user,
+    coalesce(nullif(trim(p_locale), ''), 'ar-AE'),
+    false
+  );
+
+  insert into public.dabbir_memberships(
+    business_id,
+    user_id,
+    role,
+    status,
+    accepted_at
+  ) values (
+    v_id,
+    v_user,
+    'owner',
+    'active',
+    now()
+  );
+
+  return query select v_id, v_slug;
+end;
+$function$;
+
+revoke all on function public.dabbir_create_business(text, text, text) from public, anon;
+grant execute on function public.dabbir_create_business(text, text, text) to authenticated, service_role;
+
+comment on function public.dabbir_create_business(text, text, text) is
+  'Creates a DABBIR business and its active owner membership without preconfiguring external channels.';

--- a/test/dabbir-team-direct-write-hardening.test.mjs
+++ b/test/dabbir-team-direct-write-hardening.test.mjs
@@ -4,9 +4,20 @@ import { readFile } from 'node:fs/promises';
 
 const migration = await readFile(new URL('../supabase/migrations/20260827181500_dabbir_team_direct_write_hardening_v1.sql', import.meta.url), 'utf8');
 const slugMigration = await readFile(new URL('../supabase/migrations/20260827182000_dabbir_business_slug_source_alignment_v1.sql', import.meta.url), 'utf8');
+const regressionGuardMigration = await readFile(new URL('../supabase/migrations/20260830131500_dabbir_create_business_regression_guard_v1.sql', import.meta.url), 'utf8');
 const invitationsApi = await readFile(new URL('../api/team/invitations.js', import.meta.url), 'utf8');
 const membersApi = await readFile(new URL('../api/team/members.js', import.meta.url), 'utf8');
 const onboarding = await readFile(new URL('../db/dabbir_business_onboarding_v12.sql', import.meta.url), 'utf8');
+const reapplicableBusinessSqlPaths = [
+  '../db/dabbir_business_onboarding_v12.sql',
+  '../db/dabbir_employee_access_v5.sql',
+  '../db/dabbir_multi_vertical_business_types_v1.sql',
+  '../db/dabbir_phase2_auth_rbac_tenant_hardening_v1.sql',
+  '../supabase/migrations/20260830131500_dabbir_create_business_regression_guard_v1.sql',
+];
+const reapplicableBusinessSql = await Promise.all(
+  reapplicableBusinessSqlPaths.map((path) => readFile(new URL(path, import.meta.url), 'utf8')),
+);
 
 test('team tables expose only the direct grants required by the runtime', () => {
   assert.match(migration, /revoke update on table public\.dabbir_memberships from authenticated/i);
@@ -33,4 +44,22 @@ test('new business slugs can never resurrect the retired PILOT prefix', () => {
   assert.doesNotMatch(onboarding, /v_slug\s*:=\s*'pilot-'/i);
   assert.match(slugMigration, /v_slug\s*:=\s*'dabbir-'/i);
   assert.doesNotMatch(slugMigration, /v_slug\s*:=\s*'pilot-'/i);
+});
+
+test('every re-applicable business bootstrap SQL preserves the safe DABBIR contract', () => {
+  for (const [index, sql] of reapplicableBusinessSql.entries()) {
+    const path = reapplicableBusinessSqlPaths[index];
+    assert.match(sql, /v_slug\s*:=\s*'dabbir-'/i, `${path} must create DABBIR slugs`);
+    assert.doesNotMatch(sql, /v_slug\s*:=\s*'pilot-'/i, `${path} must not restore PILOT slugs`);
+    assert.match(sql, /dabbir_memberships\s*\(\s*business_id\s*,\s*user_id\s*,\s*role\s*,\s*status\s*,\s*accepted_at\s*\)/is, `${path} must create an active owner membership`);
+    assert.doesNotMatch(sql, /insert\s+into\s+public\.dabbir_channels/i, `${path} must not preconfigure external channels`);
+    assert.doesNotMatch(sql, /on\s+conflict\s*\(\s*business_id\s*,/i, `${path} must not use an ambiguous output-column conflict target`);
+  }
+});
+
+test('business bootstrap repair supports every approved business type and keeps production truth defaults', () => {
+  assert.match(regressionGuardMigration, /'laundry'/);
+  assert.match(regressionGuardMigration, /'car_wash'/);
+  assert.match(regressionGuardMigration, /coalesce\(nullif\(trim\(p_locale\), ''\), 'ar-AE'\),\s*false/is);
+  assert.match(regressionGuardMigration, /grant execute on function public\.dabbir_create_business\(text, text, text\) to authenticated, service_role/i);
 });

--- a/test/phase2-security-contract.test.mjs
+++ b/test/phase2-security-contract.test.mjs
@@ -52,7 +52,7 @@ test('core relationship graph has business-scoped foreign keys', () => {
 test('channel state vocabulary cannot promote configuration into connection', () => {
   assert.match(migration, /update public\.dabbir_channels set status='configured' where status='simulated'/i);
   assert.match(migration, /'disconnected','configured','verifying','connected','degraded','failed'/i);
-  assert.match(migration, /runtime_verification_required/);
+  assert.doesNotMatch(migration, /insert\s+into\s+public\.dabbir_channels[\s\S]{0,500}runtime_verification_required/i);
   assert.equal(registry.projects.dabbir_clinics.external_channels, 'UNVERIFIED');
   assert.equal(registry.projects.dabbir_celebrities.external_channels, 'UNVERIFIED');
 });


### PR DESCRIPTION
## Root cause
A manually reapplied multi-vertical SQL file replaced `public.dabbir_create_business` with an obsolete body. Its `ON CONFLICT(business_id, channel_type)` target collided with the function output column `business_id`, causing PostgreSQL SQLSTATE `42702` and failing the full customer journey during business creation.

## Fix
- add a production repair migration with the canonical DABBIR bootstrap contract
- remove channel preconfiguration and the ambiguous conflict target
- preserve active owner membership, truthful `demo_mode=false`, DABBIR slugs, and all approved business types
- harden every re-applicable SQL source against restoring the obsolete definition
- add regression tests that scan all bootstrap SQL definitions

## Verification
- `node --test test/dabbir-team-direct-write-hardening.test.mjs` (6/6)
- `npm test` (623/623)
- production migration applied and live function definition verified
