### PR TITLE
test(dabbir): align journey logo with deployed asset

### DIFF
--- a/test/ai-full-customer-journey-oidc.mjs
+++ b/test/ai-full-customer-journey-oidc.mjs
@@ -218,7 +218,7 @@ async function browserJourney() {
   const logo = page.locator('.brand .logo').first();
   await logo.waitFor({ state: 'visible', timeout: 10_000 });
   const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
-  assert(String(logoBg).includes('dabbir-approved-icon'), 'APPROVED_LOGO_NOT_RENDERED');
+  assert(String(logoBg).includes('dabbir-app-icon'), 'APPROVED_LOGO_NOT_RENDERED');
 
   await page.locator('[data-screen="conversations"]').first().click();
   await page.locator('#screen-conversations.active').waitFor({ state: 'visible', timeout: 10_000 });

--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -301,7 +301,7 @@ async function browserJourney() {
 
   const logo = page.locator('#appShell:not(.hidden) .brand .logo').first();
   await logo.waitFor({ state: 'visible', timeout: 10_000 });
-  assert(String(await logo.evaluate(el => getComputedStyle(el).backgroundImage)).includes('dabbir-approved-icon'), 'BROWSER_APPROVED_LOGO_MISSING');
+  assert(String(await logo.evaluate(el => getComputedStyle(el).backgroundImage)).includes('dabbir-app-icon'), 'BROWSER_APPROVED_LOGO_MISSING');
 
   await page.locator('#bottomNav [data-screen="conversations"]').click();
   await page.locator('#screen-conversations.active').waitFor({ state: 'visible', timeout: 10_000 });

--- a/test/ai-full-customer-journey.mjs
+++ b/test/ai-full-customer-journey.mjs
@@ -269,7 +269,7 @@ async function browserJourney() {
   const logo = page.locator('.brand .logo').first();
   await logo.waitFor({ state: 'visible', timeout: 10_000 });
   const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
-  assert(String(logoBg).includes('dabbir-approved-icon'), 'APPROVED_LOGO_NOT_RENDERED');
+  assert(String(logoBg).includes('dabbir-app-icon'), 'APPROVED_LOGO_NOT_RENDERED');
 
   await page.locator('[data-screen="conversations"]').first().click();
   await page.locator('#screen-conversations.active').waitFor({ state: 'visible', timeout: 10_000 });

--- a/test/dabbir-ai-full-journey-oidc.mjs
+++ b/test/dabbir-ai-full-journey-oidc.mjs
@@ -205,7 +205,7 @@ async function browserJourney() {
 
   const logo = page.locator('.brand .logo').first();
   await logo.waitFor({ state: 'visible', timeout: 10_000 });
-  assert(String(await logo.evaluate(el => getComputedStyle(el).backgroundImage)).includes('dabbir-approved-icon'), 'BROWSER_LOGO_MISMATCH');
+  assert(String(await logo.evaluate(el => getComputedStyle(el).backgroundImage)).includes('dabbir-app-icon'), 'BROWSER_LOGO_MISMATCH');
 
   await page.locator('[data-screen="conversations"]').first().click();
   await page.locator('#screen-conversations.active').waitFor({ state: 'visible', timeout: 10_000 });

--- a/test/dabbir-customer-journey-logo-contract.test.mjs
+++ b/test/dabbir-customer-journey-logo-contract.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const journeyPaths = [
+  './ai-full-customer-journey-oidc.mjs',
+  './ai-full-customer-journey-v2.mjs',
+  './ai-full-customer-journey.mjs',
+  './dabbir-ai-full-journey-oidc.mjs',
+  './dabbir-protected-live-smoke.mjs',
+];
+const journeySources = await Promise.all(
+  journeyPaths.map((path) => readFile(new URL(path, import.meta.url), 'utf8')),
+);
+const indexHtml = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+test('browser journeys verify the approved app icon contract used by the deployed shell', () => {
+  assert.match(indexHtml, /<div class="logo"><img src="\/dabbir-app-icon\.png" alt="DABBIR"><\/div>/);
+
+  for (const [index, source] of journeySources.entries()) {
+    const path = journeyPaths[index];
+    assert.match(source, /includes\('dabbir-app-icon'\)/, `${path} must verify the deployed app icon`);
+    assert.doesNotMatch(source, /includes\('dabbir-approved-icon'\)/, `${path} must not verify the retired CSS URL`);
+  }
+});

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -158,7 +158,7 @@ try {
     assert(await logo.count() === 1, `AUTH_APPROVED_LOGO_COUNT_${await logo.count()}`);
     await logo.waitFor({ state: 'visible', timeout: 10_000 });
     const logoBg = await logo.evaluate(element => getComputedStyle(element).backgroundImage);
-    assert(String(logoBg).includes('dabbir-approved-icon'), 'AUTH_APPROVED_LOGO_NOT_RENDERED');
+    assert(String(logoBg).includes('dabbir-app-icon'), 'AUTH_APPROVED_LOGO_NOT_RENDERED');
 
     assert(pageErrors.length === 0, `PAGE_ERRORS:${pageErrors.join(' | ')}`);
     assert(consoleErrors.length === 0, `CONSOLE_ERRORS:${consoleErrors.slice(0, 8).join(' | ')}`);


### PR DESCRIPTION
## Context
The production journey now passes business creation and all functional steps through translation, but the WebKit assertion still expected the retired `dabbir-approved-icon` CSS URL. The deployed shell intentionally uses the approved `/dabbir-app-icon.png` asset.

## Fix
- align all browser journey and protected smoke assertions with `dabbir-app-icon`
- add a regression test covering all five browser journey sources

## Verification
- targeted logo-contract test passes
- `npm test` passes 624/624
