### PR TITLE
fix(dabbir): order QA cleanup by commerce FKs

### DIFF
--- a/supabase/migrations/20260830133500_dabbir_qa_cleanup_fk_graph_v2.sql
+++ b/supabase/migrations/20260830133500_dabbir_qa_cleanup_fk_graph_v2.sql
@@ -1,0 +1,86 @@
+-- Keep the disposable QA tenant cleanup aligned with the live commerce FK graph.
+-- RESTRICT children must be removed before their order/product/business parents.
+
+create or replace function public.dabbir_qa_cleanup_business(p_business_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = public, auth
+as $$
+declare
+  v_name text;
+  v_owner_id uuid;
+begin
+  select b.name, b.owner_id into v_name, v_owner_id
+  from public.dabbir_businesses as b
+  where b.id = p_business_id;
+
+  if not found then
+    return jsonb_build_object('ok', true, 'deleted', false, 'reason', 'BUSINESS_NOT_FOUND');
+  end if;
+
+  if v_name not like 'DABBIR AI QA %' then
+    raise exception 'QA_CLEANUP_SCOPE_DENIED' using errcode = '42501';
+  end if;
+
+  delete from public.dabbir_access_audit where business_id = p_business_id;
+  delete from public.dabbir_platform_owner_audit where business_id = p_business_id;
+  delete from public.dabbir_privacy_audit where business_id = p_business_id;
+  delete from public.dabbir_procedure_audit where business_id = p_business_id;
+  delete from public.dabbir_message_batch_items where business_id = p_business_id;
+  delete from public.dabbir_message_batches where business_id = p_business_id;
+  delete from public.dabbir_quality_regression_cases where business_id = p_business_id;
+  delete from public.dabbir_quality_events where business_id = p_business_id;
+  delete from public.dabbir_quality_cases where business_id = p_business_id;
+  delete from public.dabbir_customer_evidence where business_id = p_business_id;
+  delete from public.dabbir_verification_challenges where business_id = p_business_id;
+  delete from public.dabbir_customer_consents where business_id = p_business_id;
+  delete from public.dabbir_privacy_requests where business_id = p_business_id;
+  delete from public.dabbir_event_inbox where business_id = p_business_id;
+  delete from public.dabbir_operation_outcomes where business_id = p_business_id;
+  delete from public.dabbir_procedure_steps where business_id = p_business_id;
+  delete from public.dabbir_procedure_runs where business_id = p_business_id;
+  delete from public.dabbir_procedure_definitions where business_id = p_business_id;
+  delete from public.dabbir_action_policies where business_id = p_business_id;
+  delete from public.dabbir_conversation_outcomes where business_id = p_business_id;
+  delete from public.dabbir_handoffs where business_id = p_business_id;
+  delete from public.dabbir_followups where business_id = p_business_id;
+  delete from public.dabbir_appointments where business_id = p_business_id;
+
+  -- Commerce children with product/order RESTRICT constraints come first.
+  delete from public.dabbir_order_returns where business_id = p_business_id;
+  delete from public.dabbir_inventory_movements where business_id = p_business_id;
+  delete from public.dabbir_order_items where business_id = p_business_id;
+  delete from public.dabbir_orders where business_id = p_business_id;
+  delete from public.dabbir_inventory where business_id = p_business_id;
+  delete from public.dabbir_products where business_id = p_business_id;
+
+  delete from public.dabbir_services where business_id = p_business_id;
+  delete from public.dabbir_messages where business_id = p_business_id;
+  delete from public.dabbir_conversations where business_id = p_business_id;
+  delete from public.dabbir_customer_memory where business_id = p_business_id;
+  delete from public.dabbir_customer_management where business_id = p_business_id;
+  delete from public.dabbir_customer_identities where business_id = p_business_id;
+  delete from public.dabbir_business_knowledge where business_id = p_business_id;
+  delete from public.dabbir_demo_events where business_id = p_business_id;
+  delete from public.dabbir_employee_invitations where business_id = p_business_id;
+  delete from public.dabbir_retention_policies where business_id = p_business_id;
+  delete from public.dabbir_privacy_controls where business_id = p_business_id;
+  delete from public.dabbir_channels where business_id = p_business_id;
+
+  -- The designated owner membership is immutable while the parent exists.
+  delete from public.dabbir_memberships
+  where business_id = p_business_id and role <> 'owner';
+  delete from public.dabbir_businesses where id = p_business_id;
+
+  return jsonb_build_object(
+    'ok', true,
+    'deleted', true,
+    'business_id', p_business_id,
+    'owner_id', v_owner_id
+  );
+end;
+$$;
+
+revoke all on function public.dabbir_qa_cleanup_business(uuid) from public, anon, authenticated;
+grant execute on function public.dabbir_qa_cleanup_business(uuid) to service_role;

--- a/test/dabbir-qa-cleanup-order.test.mjs
+++ b/test/dabbir-qa-cleanup-order.test.mjs
@@ -2,20 +2,35 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
-const migration = await readFile(new URL('../supabase/migrations/20260829141000_dabbir_qa_cleanup_inventory_movements.sql', import.meta.url), 'utf8');
+const migration = await readFile(new URL('../supabase/migrations/20260830133500_dabbir_qa_cleanup_fk_graph_v2.sql', import.meta.url), 'utf8');
 
-test('QA business cleanup removes inventory movements before products', () => {
+test('QA business cleanup follows the commerce RESTRICT dependency order', () => {
+  const returnsDelete = migration.indexOf('delete from public.dabbir_order_returns where business_id = p_business_id;');
   const movementsDelete = migration.indexOf('delete from public.dabbir_inventory_movements where business_id = p_business_id;');
+  const itemsDelete = migration.indexOf('delete from public.dabbir_order_items where business_id = p_business_id;');
+  const ordersDelete = migration.indexOf('delete from public.dabbir_orders where business_id = p_business_id;');
   const inventoryDelete = migration.indexOf('delete from public.dabbir_inventory where business_id = p_business_id;');
   const productsDelete = migration.indexOf('delete from public.dabbir_products where business_id = p_business_id;');
 
+  assert.ok(returnsDelete >= 0, 'QA cleanup must delete order returns');
   assert.ok(movementsDelete >= 0, 'QA cleanup must delete inventory movements');
-  assert.ok(inventoryDelete > movementsDelete, 'inventory rows must be deleted after inventory movements');
+  assert.ok(itemsDelete >= 0, 'QA cleanup must delete order items');
+  assert.ok(ordersDelete > returnsDelete, 'orders must be deleted after order returns');
+  assert.ok(ordersDelete > movementsDelete, 'orders must be deleted after inventory movements');
+  assert.ok(ordersDelete > itemsDelete, 'orders must be deleted after order items');
+  assert.ok(productsDelete > returnsDelete, 'products must be deleted after order returns');
   assert.ok(productsDelete > movementsDelete, 'products must be deleted after inventory movements');
+  assert.ok(productsDelete > itemsDelete, 'products must be deleted after order items');
+  assert.ok(inventoryDelete > movementsDelete, 'inventory rows must be deleted after inventory movements');
 });
 
-test('QA cleanup migration preserves the QA-only scope guard', () => {
+test('QA cleanup migration preserves its scope and business-level RESTRICT guards', () => {
+  const platformAuditDelete = migration.indexOf('delete from public.dabbir_platform_owner_audit where business_id = p_business_id;');
+  const businessDelete = migration.indexOf('delete from public.dabbir_businesses where id = p_business_id;');
+
   assert.match(migration, /if v_name not like 'DABBIR AI QA %'/);
   assert.match(migration, /QA_CLEANUP_SCOPE_DENIED/);
+  assert.ok(platformAuditDelete >= 0, 'QA cleanup must remove platform owner audit rows');
+  assert.ok(businessDelete > platformAuditDelete, 'the business must be deleted after platform owner audit rows');
   assert.match(migration, /grant execute on function public\.dabbir_qa_cleanup_business\(uuid\) to service_role/);
 });


### PR DESCRIPTION
## Root cause
The journey itself passed all 27 required steps, but cleanup returned FAIL because the live `dabbir_qa_cleanup_business` definition had drifted behind the commerce schema. It attempted to delete products while `dabbir_inventory_movements` still referenced them with `ON DELETE RESTRICT`.

## Fix
- delete order returns, inventory movements, and order items before orders/products
- delete platform-owner audit rows before the business because that FK is RESTRICT
- retain the QA-name scope guard and service-role-only execution
- extend regression tests for the full commerce FK order

## Verification
- live cleanup succeeded against the exact leaked QA tenant from run 33314112053
- targeted cleanup-order tests pass
- `npm test` passes 631/631 after rebasing on current main
