### PR TITLE
Use Gemini free tier as primary DABBIR AI provider

### DIFF
--- a/api/_ai-core.js
+++ b/api/_ai-core.js
@@ -1,11 +1,24 @@
+const GEMINI_ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions';
 const GROQ_ENDPOINT = 'https://api.groq.com/openai/v1/chat/completions';
 const GATEWAY_ENDPOINT = 'https://ai-gateway.vercel.sh/v1/chat/completions';
+const DEFAULT_GEMINI_MODEL = 'gemini-3.7-flash';
 const DEFAULT_MODEL = 'openai/gpt-oss-20b';
 const DEFAULT_GATEWAY_MODEL = 'minimax/minimax-m3-free';
 const FALLBACK_GATEWAY_MODELS = ['minimax/minimax-m2.7-free'];
 const PROJECTS = new Set(['dabbir_clinics', 'dabbir_celebrities', 'dabbir_businesses']);
 
 export function getDABBIRAiConfig(env = process.env) {
+  if (env.GEMINI_API_KEY) {
+    return {
+      provider: 'google-gemini',
+      endpoint: GEMINI_ENDPOINT,
+      model: String(env.DABBIR_GEMINI_MODEL || DEFAULT_GEMINI_MODEL),
+      configured: true,
+      auth_mode: 'API_KEY',
+      cost_mode: 'FREE_TIER_ONLY',
+    };
+  }
+
   if (env.GROQ_API_KEY) {
     return {
       provider: 'groq',
@@ -224,12 +237,83 @@ export async function generateDABBIRAiReply({ project, message, language = 'auto
   if (!input) return { ok: false, state: 'REJECTED', error: 'message_required' };
 
   const config = getDABBIRAiConfig(env);
+  const geminiKey = String(env.GEMINI_API_KEY || '');
   const groqKey = String(env.GROQ_API_KEY || '');
   const messages = [
     { role: 'system', content: systemPrompt(normalizedProject, language, businessContext) },
     ...normalizeHistory(history),
     { role: 'user', content: input },
   ];
+
+  if (geminiKey) {
+    try {
+      const { response, payload } = await callOpenAiCompatible({
+        endpoint: GEMINI_ENDPOINT,
+        credential: geminiKey,
+        model: config.model,
+        messages,
+        fetchImpl,
+        timeoutMs: 5000,
+      });
+      if (response.ok) {
+        return finalizeReply({
+          reply: String(payload?.choices?.[0]?.message?.content || '').trim(),
+          input,
+          language,
+          config,
+          model: String(payload?.model || config.model),
+        });
+      }
+
+      if (groqKey || env.VERCEL_ENV) {
+        const { GEMINI_API_KEY: _geminiKey, DABBIR_GEMINI_MODEL: _geminiModel, ...fallbackEnv } = env;
+        return generateDABBIRAiReply({
+          project: normalizedProject,
+          message: input,
+          language,
+          businessContext,
+          history,
+          env: fallbackEnv,
+          fetchImpl,
+          oidcGetter,
+        });
+      }
+
+      return {
+        ok: false,
+        state: response.status === 429 ? 'RATE_LIMITED' : 'PROVIDER_ERROR',
+        error: `gemini_http_${response.status}`,
+        provider: config.provider,
+        model: config.model,
+        auth_mode: config.auth_mode,
+        cost_mode: config.cost_mode,
+      };
+    } catch (error) {
+      if (groqKey || env.VERCEL_ENV) {
+        const { GEMINI_API_KEY: _geminiKey, DABBIR_GEMINI_MODEL: _geminiModel, ...fallbackEnv } = env;
+        return generateDABBIRAiReply({
+          project: normalizedProject,
+          message: input,
+          language,
+          businessContext,
+          history,
+          env: fallbackEnv,
+          fetchImpl,
+          oidcGetter,
+        });
+      }
+
+      return {
+        ok: false,
+        state: error?.name === 'AbortError' ? 'TIMEOUT' : 'PROVIDER_ERROR',
+        error: error?.name === 'AbortError' ? 'gemini_timeout' : 'gemini_network_error',
+        provider: config.provider,
+        model: config.model,
+        auth_mode: config.auth_mode,
+        cost_mode: config.cost_mode,
+      };
+    }
+  }
 
   if (!groqKey && env.VERCEL_ENV) {
     const gatewayAuth = await resolveGatewayCredential(env, oidcGetter);

--- a/test/dabbir-gemini-ai.test.mjs
+++ b/test/dabbir-gemini-ai.test.mjs
@@ -1,0 +1,84 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { generateDABBIRAiReply, getDABBIRAiConfig } from '../api/_ai-core.js';
+
+test('Gemini free tier is primary when GEMINI_API_KEY is configured', async () => {
+  const config = getDABBIRAiConfig({
+    GEMINI_API_KEY: 'test-gemini-key',
+    GROQ_API_KEY: 'test-groq-key',
+    VERCEL_ENV: 'production',
+  });
+
+  assert.equal(config.provider, 'google-gemini');
+  assert.equal(config.model, 'gemini-3.7-flash');
+  assert.equal(config.configured, true);
+  assert.equal(config.cost_mode, 'FREE_TIER_ONLY');
+});
+
+test('Gemini uses Google OpenAI-compatible endpoint and DABBIR grounding prompt', async () => {
+  let request;
+  const fakeFetch = async (url, options) => {
+    request = { url, options, body: JSON.parse(options.body) };
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return {
+          model: 'gemini-3.7-flash',
+          choices: [{ message: { content: 'أكيد، أقدر أساعدك في الطلب.' } }],
+        };
+      },
+    };
+  };
+
+  const result = await generateDABBIRAiReply({
+    project: 'dabbir_businesses',
+    message: 'أريد أعرف حالة طلبي',
+    language: 'ar',
+    env: { GEMINI_API_KEY: 'test-gemini-key' },
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.provider, 'google-gemini');
+  assert.equal(result.model, 'gemini-3.7-flash');
+  assert.equal(request.url, 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
+  assert.equal(request.options.headers.authorization, 'Bearer test-gemini-key');
+  assert.equal(request.body.model, 'gemini-3.7-flash');
+  assert.match(request.body.messages[0].content, /Never invent or guess phone numbers/);
+  assert.match(request.body.messages[0].content, /Gulf-friendly Arabic/);
+});
+
+test('Gemini failure falls back to existing free provider when available', async () => {
+  const calls = [];
+  const fakeFetch = async (url, options) => {
+    calls.push({ url, options, body: JSON.parse(options.body) });
+    if (url.includes('generativelanguage.googleapis.com')) {
+      return { ok: false, status: 429, async json() { return { error: { message: 'quota' } }; } };
+    }
+    return {
+      ok: true,
+      status: 200,
+      async json() {
+        return { model: 'openai/gpt-oss-20b', choices: [{ message: { content: 'تم التحويل للمزود الاحتياطي بأمان.' } }] };
+      },
+    };
+  };
+
+  const result = await generateDABBIRAiReply({
+    project: 'dabbir_businesses',
+    message: 'مرحبا',
+    language: 'ar',
+    env: {
+      GEMINI_API_KEY: 'test-gemini-key',
+      GROQ_API_KEY: 'test-groq-key',
+    },
+    fetchImpl: fakeFetch,
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.provider, 'groq');
+  assert.equal(calls.length, 2);
+  assert.match(calls[0].url, /generativelanguage\.googleapis\.com/);
+  assert.match(calls[1].url, /api\.groq\.com/);
+});


### PR DESCRIPTION
Switch DABBIR conversational AI to prefer Google Gemini when `GEMINI_API_KEY` is configured, using the current OpenAI-compatible Gemini endpoint and `gemini-3.7-flash` by default.

Safety/reliability:
- Keeps DABBIR grounding and no-invention guardrails unchanged.
- Preserves Groq/Vercel AI Gateway paths as fallback when Gemini fails or rate-limits.
- Keeps AI limited to conversational responses; business state remains deterministic.
- Adds regression coverage for provider priority, endpoint/auth/model, prompt guardrails, and fallback behavior.

Local verification: new Gemini tests pass 3/3 and the updated core passes Node syntax check.