### PR TITLE
fix: bridge Salon reminders with Vercel OIDC

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -1,4 +1,4 @@
-const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
+export const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
 // Supabase publishable keys are intentionally safe for public/client use. Never place a service-role key here.
 const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;

--- a/api/_whatsapp-live-core.js
+++ b/api/_whatsapp-live-core.js
@@ -250,12 +250,9 @@ export async function sendMetaText({ connection, businessId, recipient, body }) 
 }
 
 export async function sendMetaTemplate({ connection, businessId, recipient, templateName, language = 'ar', parameters = [] }) {
-  const capability = whatsappLiveServerCapability();
-  if (!capability.service_data_access) {
-    const error = new Error('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED');
-    error.status = 503;
-    throw error;
-  }
+  // The caller may load the encrypted connection through the local service key
+  // or through the OIDC-authenticated Supabase worker. Sending only needs the
+  // explicit tenant-scoped connection plus the platform decryption secret.
   const platform = applyDabbirMetaPublicIdentifiers(embeddedPlatformConfig());
   if (!platform.appSecret || !platform.encryptionSecret) {
     const error = new Error('WHATSAPP_PLATFORM_SECRET_NOT_CONFIGURED');

--- a/api/salon-reminders-cron.js
+++ b/api/salon-reminders-cron.js
@@ -1,11 +1,12 @@
 import { timingSafeEqual } from 'node:crypto';
-import { json, supabaseRpc } from './_auth-core.js';
+import { json, SUPABASE_URL, supabaseRpc } from './_auth-core.js';
 import { loadBusinessConnection } from './_whatsapp-embedded-core.js';
 import { sendMetaTemplate } from './_whatsapp-live-core.js';
 
 const clean=(value,max=500)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
 const serviceKey=()=>clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
 const EXPECTED_SCHEDULE='*/5 * * * *';
+const EDGE_WORKER_URL=`${SUPABASE_URL}/functions/v1/dabbir-salon-reminder-worker`;
 
 function sameSecret(left,right){
   const a=Buffer.from(String(left||''));const b=Buffer.from(String(right||''));
@@ -28,6 +29,16 @@ async function readRpc(response,fallback){
   return payload;
 }
 async function rpc(key,name,params){return readRpc(await supabaseRpc(name,key,params),`${name.toUpperCase()}_FAILED`)}
+async function edge(req,action,payload={}){
+  const token=clean(req.headers?.['x-vercel-oidc-token'],16384);
+  if(!token)throw Object.assign(new Error('VERCEL_OIDC_TOKEN_REQUIRED'),{status:503});
+  const response=await fetch(EDGE_WORKER_URL,{
+    method:'POST',cache:'no-store',redirect:'manual',
+    headers:{authorization:`Bearer ${token}`,'content-type':'application/json',accept:'application/json'},
+    body:JSON.stringify({action,...payload}),
+  });
+  return readRpc(response,'SALON_REMINDER_EDGE_WORKER_FAILED');
+}
 
 function datePart(item){
   if(!item.starts_at)return item.template_language==='en'?'the agreed time':'الموعد المتفق عليه';
@@ -44,19 +55,25 @@ function templateParameters(item){
     clean(datePart(item),160),
   ];
 }
-async function finalize(key,item,status,providerMessageId=null,error=null){
-  return rpc(key,'dabbir_finalize_workflow_notification',{
+async function finalize(req,key,item,status,providerMessageId=null,error=null){
+  if(key)return rpc(key,'dabbir_finalize_workflow_notification',{
     p_notification_id:item.notification_id,
     p_status:status,
     p_provider_message_id:providerMessageId,
     p_error:error,
   });
+  return edge(req,'finalize',{
+    notification_id:item.notification_id,
+    status,
+    provider_message_id:providerMessageId,
+    error,
+  });
 }
-async function deliver(key,item){
+async function deliver(req,key,item){
   try{
-    const connection=await loadBusinessConnection(key,item.business_id);
+    const connection=key?await loadBusinessConnection(key,item.business_id):item.connection;
     if(!connection||connection.status!=='connected'){
-      await finalize(key,item,'failed',null,'WHATSAPP_TENANT_NOT_LINKED');
+      await finalize(req,key,item,'failed',null,'WHATSAPP_TENANT_NOT_LINKED');
       return {id:item.notification_id,status:'failed',error:'WHATSAPP_TENANT_NOT_LINKED'};
     }
     const sent=await sendMetaTemplate({
@@ -67,12 +84,12 @@ async function deliver(key,item){
       language:item.template_language,
       parameters:templateParameters(item),
     });
-    await finalize(key,item,'sent',sent.providerMessageId,null);
+    await finalize(req,key,item,'sent',sent.providerMessageId,null);
     return {id:item.notification_id,status:'sent'};
   }catch(error){
     const code=clean(error?.message||'SALON_REMINDER_FAILED',160);
     const status=error?.ambiguous===true?'ambiguous':'failed';
-    await finalize(key,item,status,null,code).catch(()=>null);
+    await finalize(req,key,item,status,null,code).catch(()=>null);
     return {id:item.notification_id,status,error:code};
   }
 }
@@ -82,11 +99,12 @@ export default async function handler(req,res){
   const authMode=cronAuthMode(req);
   if(!authMode)return json(res,401,{ok:false,error:'CRON_AUTH_REQUIRED'});
   const key=serviceKey();
-  if(!key)return json(res,503,{ok:false,error:'SUPABASE_SERVICE_ROLE_REQUIRED'});
   try{
-    const claimed=await rpc(key,'dabbir_claim_workflow_notifications',{p_limit:25});
+    const claimed=key
+      ?await rpc(key,'dabbir_claim_workflow_notifications',{p_limit:25})
+      :(await edge(req,'claim',{limit:25})).items;
     const results=[];
-    for(const item of Array.isArray(claimed)?claimed:[])results.push(await deliver(key,item));
+    for(const item of Array.isArray(claimed)?claimed:[])results.push(await deliver(req,key,item));
     const summary={ok:true,claimed:results.length,sent:results.filter(x=>x.status==='sent').length,failed:results.filter(x=>x.status==='failed').length,ambiguous:results.filter(x=>x.status==='ambiguous').length,results};
     console.info('dabbir_salon_reminder_cron',{auth_mode:authMode,claimed:summary.claimed,sent:summary.sent,failed:summary.failed,ambiguous:summary.ambiguous});
     return json(res,200,summary);

--- a/supabase/functions/dabbir-salon-reminder-worker/index.ts
+++ b/supabase/functions/dabbir-salon-reminder-worker/index.ts
@@ -1,0 +1,131 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2";
+import { createRemoteJWKSet, decodeJwt, jwtVerify } from "npm:jose@6.1.0";
+
+const OWNER_SLUG = "nd56cm4j5v-3619s-projects";
+const OWNER_ID = "team_pwfKq8jHuyW1XFVSZirAJiId";
+const PROJECT_NAME = "dabbir";
+const PROJECT_ID = "prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq";
+const EXPECTED_AUDIENCE = `https://vercel.com/${OWNER_SLUG}`;
+const EXPECTED_SUBJECT = `owner:${OWNER_SLUG}:project:${PROJECT_NAME}:environment:production`;
+const ALLOWED_ISSUERS = new Set([
+  "https://oidc.vercel.com",
+  `https://oidc.vercel.com/${OWNER_SLUG}`,
+]);
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const CONNECTION_COLUMNS = [
+  "id",
+  "business_id",
+  "status",
+  "meta_app_id",
+  "waba_id",
+  "phone_number_id",
+  "display_phone_number",
+  "verified_name",
+  "access_token_ciphertext",
+  "access_token_iv",
+  "access_token_tag",
+  "token_key_version",
+  "token_expires_at",
+  "connected_at",
+  "last_verified_at",
+  "last_provider_status",
+  "last_error",
+].join(",");
+
+function json(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}
+
+function bearer(req: Request) {
+  const value = req.headers.get("authorization") || "";
+  return value.startsWith("Bearer ") ? value.slice(7).trim() : "";
+}
+
+async function verifyVercelIdentity(token: string) {
+  if (!token) throw new Error("OIDC_REQUIRED");
+  const issuer = String(decodeJwt(token).iss || "");
+  if (!ALLOWED_ISSUERS.has(issuer)) throw new Error("OIDC_ISSUER_REJECTED");
+  const jwks = createRemoteJWKSet(new URL(`${issuer}/.well-known/jwks`));
+  const { payload } = await jwtVerify(token, jwks, {
+    issuer,
+    audience: EXPECTED_AUDIENCE,
+    subject: EXPECTED_SUBJECT,
+  });
+  if (
+    payload.owner_id !== OWNER_ID ||
+    payload.project_id !== PROJECT_ID ||
+    payload.project !== PROJECT_NAME ||
+    payload.environment !== "production"
+  ) throw new Error("OIDC_IDENTITY_REJECTED");
+}
+
+function adminClient() {
+  const url = Deno.env.get("SUPABASE_URL") || "";
+  const key = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || "";
+  if (!url || !key) throw new Error("SUPABASE_EDGE_SERVICE_CONFIG_REQUIRED");
+  return createClient(url, key, {
+    auth: { persistSession: false, autoRefreshToken: false },
+    global: { headers: { "x-dabbir-worker": "salon-reminders" } },
+  });
+}
+
+async function claim(admin: ReturnType<typeof adminClient>, requestedLimit: unknown) {
+  const parsed = Number(requestedLimit);
+  const limit = Number.isFinite(parsed) ? Math.max(1, Math.min(Math.trunc(parsed), 100)) : 25;
+  const { data, error } = await admin.rpc("dabbir_claim_workflow_notifications", { p_limit: limit });
+  if (error) throw new Error(`CLAIM_FAILED:${error.code || "UNKNOWN"}`);
+  const items = Array.isArray(data) ? data : [];
+  const businessIds = [...new Set(items.map((item) => String(item.business_id || "")).filter(UUID_RE.test.bind(UUID_RE)))];
+  if (!businessIds.length) return [];
+  const { data: connections, error: connectionError } = await admin
+    .from("dabbir_whatsapp_connections")
+    .select(CONNECTION_COLUMNS)
+    .in("business_id", businessIds);
+  if (connectionError) throw new Error(`CONNECTION_READ_FAILED:${connectionError.code || "UNKNOWN"}`);
+  const byBusiness = new Map((connections || []).map((row) => [String(row.business_id), row]));
+  return items.map((item) => ({ ...item, connection: byBusiness.get(String(item.business_id)) || null }));
+}
+
+async function finalize(admin: ReturnType<typeof adminClient>, body: Record<string, unknown>) {
+  const notificationId = String(body.notification_id || "");
+  const status = String(body.status || "");
+  if (!UUID_RE.test(notificationId) || !["sent", "failed", "ambiguous"].includes(status)) {
+    throw new Error("INVALID_FINALIZE_INPUT");
+  }
+  const { data, error } = await admin.rpc("dabbir_finalize_workflow_notification", {
+    p_notification_id: notificationId,
+    p_status: status,
+    p_provider_message_id: body.provider_message_id ? String(body.provider_message_id).slice(0, 320) : null,
+    p_error: body.error ? String(body.error).slice(0, 500) : null,
+  });
+  if (error) throw new Error(`FINALIZE_FAILED:${error.code || "UNKNOWN"}`);
+  return Boolean(data);
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method !== "POST") return json(405, { ok: false, error: "METHOD_NOT_ALLOWED" });
+  try {
+    await verifyVercelIdentity(bearer(req));
+  } catch (error) {
+    console.warn("dabbir_salon_reminder_worker_auth_rejected", { error: String(error?.message || error).slice(0, 160) });
+    return json(401, { ok: false, error: "OIDC_AUTH_REQUIRED" });
+  }
+  try {
+    const body = await req.json().catch(() => ({})) as Record<string, unknown>;
+    const admin = adminClient();
+    if (body.action === "claim") return json(200, { ok: true, items: await claim(admin, body.limit) });
+    if (body.action === "finalize") return json(200, { ok: true, finalized: await finalize(admin, body) });
+    return json(400, { ok: false, error: "INVALID_ACTION" });
+  } catch (error) {
+    const code = String(error?.message || "SALON_REMINDER_WORKER_FAILED").slice(0, 200);
+    console.error("dabbir_salon_reminder_worker_failed", { error: code });
+    return json(500, { ok: false, error: code });
+  }
+});

--- a/test/dabbir-salon-mode.test.mjs
+++ b/test/dabbir-salon-mode.test.mjs
@@ -12,6 +12,7 @@ const api=read('api/salon-operations.js');
 const ui=read('api/salon-mode-ui.js');
 const cron=read('api/salon-reminders-cron.js');
 const whatsapp=read('api/_whatsapp-live-core.js');
+const edgeWorker=read('supabase/functions/dabbir-salon-reminder-worker/index.ts');
 
 function hasAll(source,markers){for(const marker of markers)assert.match(source,new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')))}
 
@@ -73,8 +74,11 @@ test('scenario 7: tenant isolation is enforced with business-scoped foreign keys
 
 test('scenario 8: WhatsApp reminders are claimed concurrently and never automatically duplicated',()=>{
   hasAll(migration,['unique (business_id,idempotency_key)','for update skip locked',"status='processing'","status='ambiguous'",'STALE_PROCESSING_REQUIRES_RECONCILIATION','dabbir_claim_workflow_notifications','dabbir_finalize_workflow_notification']);
-  hasAll(cron,['CRON_SECRET','dabbir_claim_workflow_notifications','sendMetaTemplate',"error?.ambiguous===true?'ambiguous':'failed'",'dabbir_finalize_workflow_notification']);
+  hasAll(cron,['CRON_SECRET','dabbir_claim_workflow_notifications','sendMetaTemplate',"error?.ambiguous===true?'ambiguous':'failed'",'dabbir_finalize_workflow_notification','x-vercel-oidc-token','dabbir-salon-reminder-worker']);
   hasAll(whatsapp,["type: 'template'",'providerMessageId','META_WHATSAPP_TEMPLATE_TIMEOUT_AMBIGUOUS']);
+  hasAll(edgeWorker,['createRemoteJWKSet','jwtVerify','EXPECTED_AUDIENCE','EXPECTED_SUBJECT','owner_id !== OWNER_ID','project_id !== PROJECT_ID','environment !== "production"','dabbir_claim_workflow_notifications','dabbir_finalize_workflow_notification','CONNECTION_COLUMNS']);
+  assert.doesNotMatch(edgeWorker,/dabbir_(salon_quick_book|salon_transition_appointment|salon_rebook)/);
+  assert.doesNotMatch(whatsapp.slice(whatsapp.indexOf('export async function sendMetaTemplate')),/WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED/);
 });
 
 test('calendar UI provides day, week, month, employee columns, drag/drop and duration changes',()=>{


### PR DESCRIPTION
## Root cause

Vercel Cron authentication now succeeds, but production intentionally has no `SUPABASE_SERVICE_ROLE_KEY`, so the reminder route could not claim or finalize the protected queue.

## Credentialless service-to-service fix

- Added `dabbir-salon-reminder-worker` as a Supabase Edge Function with custom Vercel OIDC verification.
- The worker validates the signed issuer JWKS plus exact owner, owner ID, project, project ID, audience, subject, and `production` environment.
- The worker exposes only `claim` and `finalize`, and returns the minimum tenant-scoped encrypted WhatsApp connection fields required for sending.
- Vercel keeps Meta transport and token decryption; Supabase Edge keeps service-role database access.
- No browser login, copied token, or new long-lived credential is required.
- Direct unauthenticated calls to the Edge worker return 401.

## Verification

- Supabase Edge deployment `dabbir-salon-reminder-worker` version 1 is ACTIVE with custom auth.
- `npm test`: 660/660 passed.
- `npm run vercel-build`: passed.
- `npm audit --omit=dev --audit-level=high`: 0 vulnerabilities.
