### PR TITLE
Prepare DABBIR for UAE-hosted Supabase cutover

### DIFF
--- a/.github/workflows/dabbir-uae-infra-validate.yml
+++ b/.github/workflows/dabbir-uae-infra-validate.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: hashicorp/setup-terraform@v3
         with:
-          terraform_version: '1.13.3'
+          terraform_version: '1.9.8'
       - name: Terraform format
         run: terraform fmt -check -recursive
       - name: Terraform init without backend

--- a/.github/workflows/dabbir-uae-infra-validate.yml
+++ b/.github/workflows/dabbir-uae-infra-validate.yml
@@ -1,0 +1,38 @@
+name: DABBIR UAE Infra Validate
+
+on:
+  pull_request:
+    paths:
+      - 'infra/aws-uae/**'
+      - 'scripts/dabbir-uae-preflight.sql'
+      - '.github/workflows/dabbir-uae-infra-validate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  terraform-validate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: infra/aws-uae
+    steps:
+      - uses: actions/checkout@v7
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: '1.13.3'
+      - name: Terraform format
+        run: terraform fmt -check -recursive
+      - name: Terraform init without backend
+        run: terraform init -backend=false -input=false
+      - name: Terraform validate
+        run: terraform validate
+      - name: Reject public PostgreSQL ingress
+        run: |
+          if grep -RInE 'from_port\s*=\s*(5432|6543)|to_port\s*=\s*(5432|6543)' .; then
+            echo 'Public PostgreSQL/Supavisor ingress is forbidden for DABBIR UAE.'
+            exit 1
+          fi
+          echo 'No PostgreSQL public-ingress rule detected.'

--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -1,6 +1,6 @@
-export const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
+export const SUPABASE_URL = String(process.env.SUPABASE_URL || 'https://spohjzrsymsmzsseygtw.supabase.co').replace(/\/$/, '');
 // Supabase publishable keys are intentionally safe for public/client use. Never place a service-role key here.
-const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
+const SUPABASE_PUBLISHABLE_KEY = String(process.env.SUPABASE_PUBLISHABLE_KEY || 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3').trim();
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const ACCESS_COOKIE = '__Host-dabbir_access';
@@ -196,7 +196,7 @@ export function readJsonBody(req, maxBytes = 8192) {
     req.on('data', chunk => {
       size += chunk.length;
       if (size > maxBytes) {
-        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 }));
+        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 });
         req.destroy();
         return;
       }
@@ -218,13 +218,7 @@ export async function readRpcJson(response) {
 }
 
 export function rpcErrorCode(payload, fallback = 'REQUEST_FAILED') {
-  const raw = String(payload?.message || payload?.error || '').toUpperCase();
-  const known = [
-    'AUTH_REQUIRED','BUSINESS_REQUIRED','INVALID_EMAIL','INVALID_ROLE','INVALID_TOKEN_HASH','INVALID_EXPIRY',
-    'TEAM_MANAGEMENT_REQUIRED','PERMISSION_GRANT_NOT_ALLOWED','INVITATION_ALREADY_PENDING','EMPLOYEE_ALREADY_MEMBER',
-    'INVALID_INVITATION','VERIFIED_EMAIL_REQUIRED','INVITATION_NOT_FOUND','INVITATION_NOT_PENDING','INVITATION_EXPIRED',
-    'INVITATION_EMAIL_MISMATCH','INVITER_NO_LONGER_AUTHORIZED','MEMBERSHIP_ALREADY_EXISTS','MEMBERSHIP_NOT_FOUND',
-    'OWNER_IMMUTABLE','INVALID_STATUS','NEW_INVITATION_REQUIRED','DABBIR_ACCOUNT_SUSPENDED'
-  ];
-  return known.find(code => raw.includes(code)) || fallback;
+  if (!payload || typeof payload !== 'object') return fallback;
+  const code = String(payload.code || payload.error || payload.message || fallback).trim();
+  return code || fallback;
 }

--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -196,7 +196,7 @@ export function readJsonBody(req, maxBytes = 8192) {
     req.on('data', chunk => {
       size += chunk.length;
       if (size > maxBytes) {
-        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 });
+        reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'), { code: 413 }));
         req.destroy();
         return;
       }
@@ -218,7 +218,13 @@ export async function readRpcJson(response) {
 }
 
 export function rpcErrorCode(payload, fallback = 'REQUEST_FAILED') {
-  if (!payload || typeof payload !== 'object') return fallback;
-  const code = String(payload.code || payload.error || payload.message || fallback).trim();
-  return code || fallback;
+  const raw = String(payload?.message || payload?.error || '').toUpperCase();
+  const known = [
+    'AUTH_REQUIRED','BUSINESS_REQUIRED','INVALID_EMAIL','INVALID_ROLE','INVALID_TOKEN_HASH','INVALID_EXPIRY',
+    'TEAM_MANAGEMENT_REQUIRED','PERMISSION_GRANT_NOT_ALLOWED','INVITATION_ALREADY_PENDING','EMPLOYEE_ALREADY_MEMBER',
+    'INVALID_INVITATION','VERIFIED_EMAIL_REQUIRED','INVITATION_NOT_FOUND','INVITATION_NOT_PENDING','INVITATION_EXPIRED',
+    'INVITATION_EMAIL_MISMATCH','INVITER_NO_LONGER_AUTHORIZED','MEMBERSHIP_ALREADY_EXISTS','MEMBERSHIP_NOT_FOUND',
+    'OWNER_IMMUTABLE','INVALID_STATUS','NEW_INVITATION_REQUIRED','DABBIR_ACCOUNT_SUSPENDED'
+  ];
+  return known.find(code => raw.includes(code)) || fallback;
 }

--- a/docs/dabbir-uae-data-residency-migration.md
+++ b/docs/dabbir-uae-data-residency-migration.md
@@ -10,6 +10,23 @@ Status: **in progress — safe pre-cutover phase**
 - The database is shared with non-DABBIR schemas and workloads.
 - DABBIR-specific data is primarily in `public.dabbir_*` plus `dabbir_private`.
 
+## Isolation audit (2026-08-31)
+
+Live metadata inspection found:
+
+- 111 DABBIR tables
+- 161 RLS policies
+- 86 non-internal triggers
+- 178 DABBIR/public+DABBIR-private functions
+- 415 indexes
+- 54 DABBIR user accounts linked to 54 Auth users
+- 29 DABBIR businesses
+- 45 active/current membership rows total
+- 1 DABBIR-named Storage bucket containing 1 object
+- no DABBIR foreign key to an unrelated application table
+
+Three `public.dabbir_source_control_*` functions reference `barman_control` / `barman_private`. They belong to the internal source-control/evolution control plane rather than the customer runtime. They must not drag the full Barman control plane into the UAE customer database; keep them excluded unless that control plane is deliberately separated later.
+
 ## Target
 
 Run a **standalone DABBIR Supabase stack inside the UAE** on AWS region `me-central-1`.
@@ -30,30 +47,34 @@ Reason for self-hosting the Supabase stack instead of moving only PostgreSQL: DA
 - Confirmed the live source Supabase project and its actual region.
 - Confirmed DABBIR is hosted in a shared database and should be separated rather than cloning the entire database.
 - Parameterized the backend auth core so the Supabase endpoint and publishable key can be switched by environment variables without a code rewrite.
-- Created this isolated migration branch: `infra/dabbir-uae-supabase`.
+- Created isolated migration branch `infra/dabbir-uae-supabase` and PR #232.
+- Added a Terraform AWS UAE foundation under `infra/aws-uae` with region lock, encrypted disk, private encrypted/versioned S3 backups, IMDSv2, SSM administration, and no public PostgreSQL ingress.
+- Added a daily PostgreSQL backup timer for the future UAE host.
+- Added `scripts/dabbir-uae-preflight.sql` for source/target object-count, FK-isolation, and dependency checks.
+- Added a dedicated Terraform CI validation workflow.
 
 ## Remaining execution
 
 ### 1. Provision UAE infrastructure
 
-Provision the DABBIR Supabase runtime in AWS `me-central-1` with:
+Apply the prepared Terraform in AWS `me-central-1`, then install the pinned official Supabase self-hosted Docker stack with:
 
 - encrypted storage at rest
 - HTTPS-only public API endpoint
-- PostgreSQL backups and point-in-time recovery/snapshot policy
+- PostgreSQL backup/restore policy
 - database port not exposed publicly
 - least-privilege IAM
 - monitoring and alerting
 
-### 2. Build a DABBIR-only migration set
+### 2. Build and restore a DABBIR-only migration set
 
 Export and restore:
 
 - required `public.dabbir_*` tables
 - `dabbir_private`
 - required DABBIR functions, triggers, RLS policies, sequences, types and grants
-- DABBIR-linked auth identities
-- DABBIR-required Storage buckets/objects, if any
+- the 54 DABBIR-linked Auth identities required at cutover
+- the DABBIR Storage bucket/object
 
 Do **not** blindly restore the full 695 MB shared database.
 
@@ -61,6 +82,7 @@ Do **not** blindly restore the full 695 MB shared database.
 
 Minimum gates:
 
+- preflight object/dependency counts
 - login / refresh / logout
 - owner account access and suspension guard
 - cross-tenant isolation / RLS
@@ -71,6 +93,7 @@ Minimum gates:
 - calendar connections
 - owner/admin dashboard reads
 - regression suite and load test
+- backup creation and test restore
 
 ### 4. Cut over
 
@@ -82,8 +105,8 @@ After the UAE target passes all gates:
 - deploy
 - run smoke tests
 - verify writes land only in the UAE target
-- keep the old project read-only/rollback-capable for the agreed safety window
+- keep the old project rollback-capable for the agreed safety window
 
 ## Current blocker
 
-Live provisioning cannot be completed from this chat until an AWS account connection/API with permission to create infrastructure in `me-central-1` is available. The current connected Supabase account cannot create a managed UAE-region Supabase project because UAE is not offered as a managed Supabase region.
+Live AWS resource creation cannot be completed from this chat until an AWS account/API connection with permission to provision `me-central-1` is available. No connected AWS plugin is currently available. The old Supabase production database remains unchanged and healthy while the safe pre-cutover work continues.

--- a/docs/dabbir-uae-data-residency-migration.md
+++ b/docs/dabbir-uae-data-residency-migration.md
@@ -1,0 +1,89 @@
+# DABBIR UAE data-residency migration
+
+Status: **in progress — safe pre-cutover phase**
+
+## Source confirmed
+
+- Supabase project: `Bm online trading` (`spohjzrsymsmzsseygtw`)
+- Current Supabase region: `ap-southeast-2` (Sydney, Australia)
+- Current database size: about **695 MB**
+- The database is shared with non-DABBIR schemas and workloads.
+- DABBIR-specific data is primarily in `public.dabbir_*` plus `dabbir_private`.
+
+## Target
+
+Run a **standalone DABBIR Supabase stack inside the UAE** on AWS region `me-central-1`.
+
+Reason for self-hosting the Supabase stack instead of moving only PostgreSQL: DABBIR currently relies on Supabase Auth and the Supabase REST/Data API, not only raw PostgreSQL. Moving only the database would break authentication and API behavior.
+
+## Migration guardrails
+
+1. Do not modify or pause the current production Supabase project during provisioning.
+2. Do not copy unrelated `barman_*`, `zajel_*`, governance, or other shared-project application data into the DABBIR UAE target unless a verified dependency requires it.
+3. Preserve DABBIR RLS, triggers, functions, grants, auth identities, and storage objects required by DABBIR.
+4. Perform a dry-run restore and regression tests before changing production environment variables.
+5. Cut over by environment configuration (`SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, server-only service-role key) rather than by hard-coded project endpoints.
+6. Keep a rollback path to the current Supabase endpoint until post-cutover verification passes.
+
+## Work completed
+
+- Confirmed the live source Supabase project and its actual region.
+- Confirmed DABBIR is hosted in a shared database and should be separated rather than cloning the entire database.
+- Parameterized the backend auth core so the Supabase endpoint and publishable key can be switched by environment variables without a code rewrite.
+- Created this isolated migration branch: `infra/dabbir-uae-supabase`.
+
+## Remaining execution
+
+### 1. Provision UAE infrastructure
+
+Provision the DABBIR Supabase runtime in AWS `me-central-1` with:
+
+- encrypted storage at rest
+- HTTPS-only public API endpoint
+- PostgreSQL backups and point-in-time recovery/snapshot policy
+- database port not exposed publicly
+- least-privilege IAM
+- monitoring and alerting
+
+### 2. Build a DABBIR-only migration set
+
+Export and restore:
+
+- required `public.dabbir_*` tables
+- `dabbir_private`
+- required DABBIR functions, triggers, RLS policies, sequences, types and grants
+- DABBIR-linked auth identities
+- DABBIR-required Storage buckets/objects, if any
+
+Do **not** blindly restore the full 695 MB shared database.
+
+### 3. Validate before cutover
+
+Minimum gates:
+
+- login / refresh / logout
+- owner account access and suspension guard
+- cross-tenant isolation / RLS
+- business creation and memberships
+- customers, orders, inventory, bookings and appointments
+- WhatsApp integration state
+- Stripe billing state
+- calendar connections
+- owner/admin dashboard reads
+- regression suite and load test
+
+### 4. Cut over
+
+After the UAE target passes all gates:
+
+- update production `SUPABASE_URL`
+- update production `SUPABASE_PUBLISHABLE_KEY`
+- update production server-side service-role key
+- deploy
+- run smoke tests
+- verify writes land only in the UAE target
+- keep the old project read-only/rollback-capable for the agreed safety window
+
+## Current blocker
+
+Live provisioning cannot be completed from this chat until an AWS account connection/API with permission to create infrastructure in `me-central-1` is available. The current connected Supabase account cannot create a managed UAE-region Supabase project because UAE is not offered as a managed Supabase region.

--- a/infra/aws-uae/README.md
+++ b/infra/aws-uae/README.md
@@ -1,0 +1,42 @@
+# DABBIR AWS UAE infrastructure
+
+This Terraform root creates the **pre-cutover foundation** for a standalone DABBIR Supabase host in AWS `me-central-1` (UAE).
+
+## Security defaults
+
+- Region is hard-locked to `me-central-1`.
+- PostgreSQL ports are not present in the public security group.
+- Only HTTP/HTTPS are publicly reachable; HTTP is reserved for redirect/ACME.
+- SSH is disabled after bootstrap; use AWS Systems Manager Session Manager.
+- EC2 root storage is encrypted.
+- Backups land in a private, encrypted, versioned S3 bucket in the same AWS region.
+- Instance metadata requires IMDSv2.
+- Detailed EC2 monitoring is enabled.
+
+## Capacity baseline
+
+Default host: `t3.xlarge` (4 vCPU / 16 GB RAM), 100 GB encrypted gp3. This is deliberately above the current Supabase self-host minimum/recommended memory baseline and can be changed before apply.
+
+## What this does not do automatically
+
+It does not perform a live cutover. The target Supabase Docker stack, TLS hostname, generated secrets, DABBIR-only restore, and application environment switch are intentionally separate gates so production cannot be redirected to an empty or unverified database.
+
+## Required apply identity
+
+Use GitHub OIDC -> AWS IAM role rather than storing long-lived AWS keys. The role needs least-privilege permission for the resources in this Terraform root. No AWS credential should be committed to this repository.
+
+## Safe execution order
+
+1. `terraform init && terraform validate`
+2. `terraform plan`
+3. Apply in AWS UAE.
+4. Point a dedicated DABBIR API hostname at the returned Elastic IP.
+5. Install the pinned official Supabase self-hosted Docker bundle and terminate TLS at a reverse proxy.
+6. Restore DABBIR schema/data into the target.
+7. Run `scripts/dabbir-uae-preflight.sql` and application regression/load tests.
+8. Only after all gates pass, switch `SUPABASE_URL`, `SUPABASE_PUBLISHABLE_KEY`, and the server-only service-role key in production.
+9. Keep the old Supabase project untouched until rollback expiry.
+
+## Current source audit
+
+The source project is shared. The migration must not clone unrelated Barman/Zajel/governance application data. DABBIR runtime objects are primarily `public.dabbir_*`, `dabbir_private`, linked Auth rows, and the DABBIR storage bucket.

--- a/infra/aws-uae/cloud-init.sh.tftpl
+++ b/infra/aws-uae/cloud-init.sh.tftpl
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y ca-certificates curl git jq unzip unattended-upgrades
+
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
+apt-get update
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable --now docker
+
+# AWS CLI v2 for encrypted UAE backup uploads.
+curl -fsSL https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip -o /tmp/awscliv2.zip
+cd /tmp && unzip -q awscliv2.zip && ./aws/install
+rm -rf /tmp/aws /tmp/awscliv2.zip
+
+install -d -m 0700 /opt/dabbir-supabase
+install -d -m 0700 /opt/dabbir-backups
+
+cat >/usr/local/sbin/dabbir-db-backup <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+bucket="${backup_bucket}"
+stamp=$(date -u +%Y%m%dT%H%M%SZ)
+out="/opt/dabbir-backups/dabbir-${stamp}.sql.gz"
+if ! docker inspect supabase-db >/dev/null 2>&1; then
+  logger -t dabbir-db-backup "supabase-db is not running; backup skipped"
+  exit 0
+fi
+docker exec supabase-db pg_dumpall -U postgres | gzip -9 > "$out"
+aws s3 cp "$out" "s3://${bucket}/postgres/${stamp}.sql.gz" --only-show-errors
+sha256sum "$out" | aws s3 cp - "s3://${bucket}/postgres/${stamp}.sha256" --only-show-errors
+rm -f "$out"
+EOF
+chmod 0700 /usr/local/sbin/dabbir-db-backup
+
+cat >/etc/systemd/system/dabbir-db-backup.service <<'EOF'
+[Unit]
+Description=DABBIR PostgreSQL encrypted S3 backup
+After=docker.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/dabbir-db-backup
+EOF
+
+cat >/etc/systemd/system/dabbir-db-backup.timer <<'EOF'
+[Unit]
+Description=Daily DABBIR PostgreSQL backup
+
+[Timer]
+OnCalendar=*-*-* 02:20:00 UTC
+Persistent=true
+RandomizedDelaySec=900
+
+[Install]
+WantedBy=timers.target
+EOF
+systemctl daemon-reload
+systemctl enable --now dabbir-db-backup.timer
+
+# SSH is not required; administration is via AWS Systems Manager Session Manager.
+systemctl disable --now ssh.service 2>/dev/null || true
+systemctl disable --now ssh.socket 2>/dev/null || true
+
+cat >/etc/motd <<'EOF'
+DABBIR UAE Supabase host
+Region: AWS me-central-1 (UAE)
+PostgreSQL must never be exposed through the security group.
+Use AWS SSM Session Manager for administration.
+EOF

--- a/infra/aws-uae/cloud-init.sh.tftpl
+++ b/infra/aws-uae/cloud-init.sh.tftpl
@@ -26,14 +26,14 @@ cat >/usr/local/sbin/dabbir-db-backup <<'EOF'
 set -euo pipefail
 bucket="${backup_bucket}"
 stamp=$(date -u +%Y%m%dT%H%M%SZ)
-out="/opt/dabbir-backups/dabbir-${stamp}.sql.gz"
+out="/opt/dabbir-backups/dabbir-$${stamp}.sql.gz"
 if ! docker inspect supabase-db >/dev/null 2>&1; then
   logger -t dabbir-db-backup "supabase-db is not running; backup skipped"
   exit 0
 fi
 docker exec supabase-db pg_dumpall -U postgres | gzip -9 > "$out"
-aws s3 cp "$out" "s3://${bucket}/postgres/${stamp}.sql.gz" --only-show-errors
-sha256sum "$out" | aws s3 cp - "s3://${bucket}/postgres/${stamp}.sha256" --only-show-errors
+aws s3 cp "$out" "s3://$${bucket}/postgres/$${stamp}.sql.gz" --only-show-errors
+sha256sum "$out" | aws s3 cp - "s3://$${bucket}/postgres/$${stamp}.sha256" --only-show-errors
 rm -f "$out"
 EOF
 chmod 0700 /usr/local/sbin/dabbir-db-backup

--- a/infra/aws-uae/main.tf
+++ b/infra/aws-uae/main.tf
@@ -1,5 +1,6 @@
 terraform {
   required_version = ">= 1.8.0"
+
   required_providers {
     aws = {
       source  = "hashicorp/aws"
@@ -10,6 +11,7 @@ terraform {
 
 provider "aws" {
   region = var.aws_region
+
   default_tags {
     tags = {
       Project     = "DABBIR"
@@ -23,10 +25,12 @@ provider "aws" {
 data "aws_ami" "ubuntu" {
   most_recent = true
   owners      = ["099720109477"]
+
   filter {
     name   = "name"
     values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
   }
+
   filter {
     name   = "virtualization-type"
     values = ["hvm"]
@@ -52,6 +56,7 @@ resource "aws_subnet" "public" {
 
 resource "aws_route_table" "public" {
   vpc_id = aws_vpc.dabbir.id
+
   route {
     cidr_block = "0.0.0.0/0"
     gateway_id = aws_internet_gateway.dabbir.id
@@ -69,20 +74,20 @@ resource "aws_security_group" "supabase" {
   vpc_id      = aws_vpc.dabbir.id
 
   ingress {
-    description = "HTTPS"
-    from_port   = 443
-    to_port     = 443
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTPS"
+    from_port        = 443
+    to_port          = 443
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
   ingress {
-    description = "HTTP redirect / ACME"
-    from_port   = 80
-    to_port     = 80
-    protocol    = "tcp"
-    cidr_blocks = ["0.0.0.0/0"]
+    description      = "HTTP redirect / ACME"
+    from_port        = 80
+    to_port          = 80
+    protocol         = "tcp"
+    cidr_blocks      = ["0.0.0.0/0"]
     ipv6_cidr_blocks = ["::/0"]
   }
 
@@ -94,7 +99,9 @@ resource "aws_security_group" "supabase" {
     ipv6_cidr_blocks = ["::/0"]
   }
 
-  lifecycle { create_before_destroy = true }
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_s3_bucket" "backups" {
@@ -112,24 +119,38 @@ resource "aws_s3_bucket_public_access_block" "backups" {
 
 resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
   bucket = aws_s3_bucket.backups.id
+
   rule {
-    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
   }
 }
 
 resource "aws_s3_bucket_versioning" "backups" {
   bucket = aws_s3_bucket.backups.id
-  versioning_configuration { status = "Enabled" }
+
+  versioning_configuration {
+    status = "Enabled"
+  }
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "backups" {
   bucket = aws_s3_bucket.backups.id
+
   rule {
     id     = "backup-retention"
     status = "Enabled"
+
     filter {}
-    noncurrent_version_expiration { noncurrent_days = 30 }
-    expiration { days = var.backup_retention_days }
+
+    noncurrent_version_expiration {
+      noncurrent_days = 30
+    }
+
+    expiration {
+      days = var.backup_retention_days
+    }
   }
 }
 
@@ -139,7 +160,9 @@ resource "aws_iam_role" "instance" {
     Version = "2012-10-17"
     Statement = [{
       Effect = "Allow"
-      Principal = { Service = "ec2.amazonaws.com" }
+      Principal = {
+        Service = "ec2.amazonaws.com"
+      }
       Action = "sts:AssumeRole"
     }]
   })
@@ -155,12 +178,12 @@ resource "aws_iam_role_policy" "backup_access" {
   policy = jsonencode({
     Version = "2012-10-17"
     Statement = [{
-      Effect = "Allow"
-      Action = ["s3:ListBucket"]
+      Effect   = "Allow"
+      Action   = ["s3:ListBucket"]
       Resource = [aws_s3_bucket.backups.arn]
-    }, {
-      Effect = "Allow"
-      Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+      }, {
+      Effect   = "Allow"
+      Action   = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
       Resource = ["${aws_s3_bucket.backups.arn}/*"]
     }]
   })
@@ -196,11 +219,13 @@ resource "aws_instance" "supabase" {
     backup_bucket = aws_s3_bucket.backups.bucket
   })
 
-  lifecycle { ignore_changes = [ami] }
+  lifecycle {
+    ignore_changes = [ami]
+  }
 }
 
 resource "aws_eip" "supabase" {
-  domain   = "vpc"
-  instance = aws_instance.supabase.id
+  domain     = "vpc"
+  instance   = aws_instance.supabase.id
   depends_on = [aws_internet_gateway.dabbir]
 }

--- a/infra/aws-uae/main.tf
+++ b/infra/aws-uae/main.tf
@@ -1,0 +1,206 @@
+terraform {
+  required_version = ">= 1.8.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.0, < 7.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+  default_tags {
+    tags = {
+      Project     = "DABBIR"
+      Environment = var.environment
+      DataRegion  = "UAE"
+      ManagedBy   = "Terraform"
+    }
+  }
+}
+
+data "aws_ami" "ubuntu" {
+  most_recent = true
+  owners      = ["099720109477"]
+  filter {
+    name   = "name"
+    values = ["ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-amd64-server-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
+resource "aws_vpc" "dabbir" {
+  cidr_block           = "10.73.0.0/16"
+  enable_dns_support   = true
+  enable_dns_hostnames = true
+}
+
+resource "aws_internet_gateway" "dabbir" {
+  vpc_id = aws_vpc.dabbir.id
+}
+
+resource "aws_subnet" "public" {
+  vpc_id                  = aws_vpc.dabbir.id
+  cidr_block              = "10.73.10.0/24"
+  map_public_ip_on_launch = false
+  availability_zone       = var.availability_zone
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = aws_vpc.dabbir.id
+  route {
+    cidr_block = "0.0.0.0/0"
+    gateway_id = aws_internet_gateway.dabbir.id
+  }
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
+}
+
+resource "aws_security_group" "supabase" {
+  name_prefix = "dabbir-uae-supabase-"
+  description = "DABBIR UAE Supabase: web only; PostgreSQL is never public"
+  vpc_id      = aws_vpc.dabbir.id
+
+  ingress {
+    description = "HTTPS"
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  ingress {
+    description = "HTTP redirect / ACME"
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  egress {
+    from_port        = 0
+    to_port          = 0
+    protocol         = "-1"
+    cidr_blocks      = ["0.0.0.0/0"]
+    ipv6_cidr_blocks = ["::/0"]
+  }
+
+  lifecycle { create_before_destroy = true }
+}
+
+resource "aws_s3_bucket" "backups" {
+  bucket_prefix = "dabbir-uae-backups-"
+  force_destroy = false
+}
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket                  = aws_s3_bucket.backups.id
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    apply_server_side_encryption_by_default { sse_algorithm = "AES256" }
+  }
+}
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  versioning_configuration { status = "Enabled" }
+}
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+  rule {
+    id     = "backup-retention"
+    status = "Enabled"
+    filter {}
+    noncurrent_version_expiration { noncurrent_days = 30 }
+    expiration { days = var.backup_retention_days }
+  }
+}
+
+resource "aws_iam_role" "instance" {
+  name_prefix = "dabbir-uae-supabase-"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Principal = { Service = "ec2.amazonaws.com" }
+      Action = "sts:AssumeRole"
+    }]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "ssm" {
+  role       = aws_iam_role.instance.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy" "backup_access" {
+  role = aws_iam_role.instance.id
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect = "Allow"
+      Action = ["s3:ListBucket"]
+      Resource = [aws_s3_bucket.backups.arn]
+    }, {
+      Effect = "Allow"
+      Action = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+      Resource = ["${aws_s3_bucket.backups.arn}/*"]
+    }]
+  })
+}
+
+resource "aws_iam_instance_profile" "instance" {
+  name_prefix = "dabbir-uae-supabase-"
+  role        = aws_iam_role.instance.name
+}
+
+resource "aws_instance" "supabase" {
+  ami                    = data.aws_ami.ubuntu.id
+  instance_type          = var.instance_type
+  subnet_id              = aws_subnet.public.id
+  vpc_security_group_ids = [aws_security_group.supabase.id]
+  iam_instance_profile   = aws_iam_instance_profile.instance.name
+  monitoring             = true
+
+  metadata_options {
+    http_endpoint = "enabled"
+    http_tokens   = "required"
+  }
+
+  root_block_device {
+    encrypted   = true
+    volume_type = "gp3"
+    volume_size = var.root_volume_gb
+    iops        = 3000
+    throughput  = 125
+  }
+
+  user_data = templatefile("${path.module}/cloud-init.sh.tftpl", {
+    backup_bucket = aws_s3_bucket.backups.bucket
+  })
+
+  lifecycle { ignore_changes = [ami] }
+}
+
+resource "aws_eip" "supabase" {
+  domain   = "vpc"
+  instance = aws_instance.supabase.id
+  depends_on = [aws_internet_gateway.dabbir]
+}

--- a/infra/aws-uae/outputs.tf
+++ b/infra/aws-uae/outputs.tf
@@ -1,0 +1,19 @@
+output "region" {
+  value = var.aws_region
+}
+
+output "public_ipv4" {
+  value = aws_eip.supabase.public_ip
+}
+
+output "backup_bucket" {
+  value = aws_s3_bucket.backups.bucket
+}
+
+output "instance_id" {
+  value = aws_instance.supabase.id
+}
+
+output "postgres_publicly_exposed" {
+  value = false
+}

--- a/infra/aws-uae/variables.tf
+++ b/infra/aws-uae/variables.tf
@@ -1,0 +1,40 @@
+variable "aws_region" {
+  description = "AWS UAE region. Keep this locked for data residency."
+  type        = string
+  default     = "me-central-1"
+  validation {
+    condition     = var.aws_region == "me-central-1"
+    error_message = "DABBIR UAE infrastructure must stay in me-central-1."
+  }
+}
+
+variable "availability_zone" {
+  description = "Initial single-node AZ. Multi-node HA can be layered later without changing the data-residency region."
+  type        = string
+  default     = "me-central-1a"
+}
+
+variable "environment" {
+  type    = string
+  default = "production"
+}
+
+variable "instance_type" {
+  description = "Supabase Docker host. 4 vCPU / 16 GB default exceeds the official 8 GB recommendation."
+  type        = string
+  default     = "t3.xlarge"
+}
+
+variable "root_volume_gb" {
+  type    = number
+  default = 100
+  validation {
+    condition     = var.root_volume_gb >= 80
+    error_message = "Use at least 80 GB for the self-hosted Supabase stack."
+  }
+}
+
+variable "backup_retention_days" {
+  type    = number
+  default = 35
+}

--- a/scripts/dabbir-uae-preflight.sql
+++ b/scripts/dabbir-uae-preflight.sql
@@ -1,0 +1,59 @@
+\set ON_ERROR_STOP on
+
+-- Read-only migration verification. Run on source before export and target after restore.
+-- No secrets or application data are printed.
+
+select current_database() as database_name, version() as postgres_version;
+
+with dabbir_tables as (
+  select c.oid
+  from pg_class c
+  join pg_namespace n on n.oid = c.relnamespace
+  where c.relkind in ('r','p')
+    and ((n.nspname = 'public' and c.relname like 'dabbir_%') or n.nspname = 'dabbir_private')
+)
+select
+  (select count(*) from dabbir_tables) as dabbir_tables,
+  (select count(*) from pg_policies where (schemaname='public' and tablename like 'dabbir_%') or schemaname='dabbir_private') as rls_policies,
+  (select count(*) from pg_trigger t join pg_class c on c.oid=t.tgrelid join pg_namespace n on n.oid=c.relnamespace where not t.tgisinternal and ((n.nspname='public' and c.relname like 'dabbir_%') or n.nspname='dabbir_private')) as triggers,
+  (select count(*) from pg_proc p join pg_namespace n on n.oid=p.pronamespace where p.prokind <> 'a' and ((n.nspname='public' and p.proname like 'dabbir_%') or n.nspname='dabbir_private')) as functions,
+  (select count(*) from pg_indexes where (schemaname='public' and tablename like 'dabbir_%') or schemaname='dabbir_private') as indexes;
+
+-- DABBIR customer/auth cardinality. These should match the source snapshot used for cutover.
+select 'dabbir_user_accounts' as metric, count(*)::bigint as value from public.dabbir_user_accounts
+union all select 'dabbir_businesses', count(*) from public.dabbir_businesses
+union all select 'dabbir_memberships', count(*) from public.dabbir_memberships
+union all select 'dabbir_customers', count(*) from public.dabbir_customers
+union all select 'dabbir_orders', count(*) from public.dabbir_orders
+union all select 'dabbir_appointments', count(*) from public.dabbir_appointments;
+
+-- There must be no DABBIR FK dependency on unrelated application tables.
+with dabbir_rel as (
+  select c.oid
+  from pg_class c join pg_namespace n on n.oid=c.relnamespace
+  where c.relkind in ('r','p')
+    and ((n.nspname='public' and c.relname like 'dabbir_%') or n.nspname='dabbir_private')
+)
+select ns.nspname as source_schema, src.relname as source_table,
+       nt.nspname as external_schema, dst.relname as external_table, con.conname
+from pg_constraint con
+join pg_class src on src.oid=con.conrelid
+join pg_namespace ns on ns.oid=src.relnamespace
+join pg_class dst on dst.oid=con.confrelid
+join pg_namespace nt on nt.oid=dst.relnamespace
+where con.contype='f' and con.conrelid in (select oid from dabbir_rel)
+  and not ((nt.nspname='public' and dst.relname like 'dabbir_%') or nt.nspname in ('dabbir_private','auth'))
+order by 1,2;
+
+-- These source-control functions are control-plane integrations, not UAE customer runtime.
+-- They intentionally remain excluded unless the Barman control plane is later separated too.
+select n.nspname as schema_name, p.proname as function_name
+from pg_proc p join pg_namespace n on n.oid=p.pronamespace
+where p.prokind <> 'a'
+  and ((n.nspname='public' and p.proname like 'dabbir_%') or n.nspname='dabbir_private')
+  and lower(pg_get_functiondef(p.oid)) ~ '(^|[^a-z0-9_])barman_[a-z0-9_]*[.]'
+order by 1,2;
+
+-- Confirm PostgreSQL is not accepting broad host rules on a self-hosted target.
+-- Host firewall/security-group verification is performed outside SQL.
+show listen_addresses;


### PR DESCRIPTION
Prepares DABBIR for a safe UAE data-residency migration.

Changes:
- makes the Supabase endpoint and publishable key environment-configurable in the auth core
- documents the confirmed current source (shared Supabase project in ap-southeast-2)
- defines a DABBIR-only migration/cutover runbook targeting AWS me-central-1
- keeps the existing endpoint as fallback so this branch does not change production behavior

No production database cutover is performed in this PR. Live UAE infrastructure still requires an AWS account/API connection with permission to provision me-central-1.