### PR TITLE
feat(dabbir): tailor business details by activity

### DIFF
--- a/api/business-activity-profile-ui.js
+++ b/api/business-activity-profile-ui.js
@@ -1,0 +1,149 @@
+const css=String.raw`
+.dap-card{margin-top:12px;border:1px solid #30363d;background:linear-gradient(180deg,#15191d,#101214);border-radius:16px;overflow:hidden}.dap-head{padding:15px 16px 13px;border-bottom:1px solid #292e34;background:#15181b}.dap-head-row{display:flex;align-items:flex-start;justify-content:space-between;gap:12px}.dap-head h2{font-size:14px;margin:0;color:#fff}.dap-head p{font-size:9px;line-height:1.7;color:var(--muted);margin:5px 0 0}.dap-badge{display:inline-flex;align-items:center;border:1px solid #42502f;background:#1b2415;color:var(--accent);border-radius:999px;padding:5px 8px;font-size:8px;font-weight:900;white-space:nowrap}.dap-form{padding:13px}.dap-grid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:10px}.dap-field{display:flex;flex-direction:column;gap:6px;min-width:0}.dap-field.wide{grid-column:1/-1}.dap-field label{font-size:9px;font-weight:800;color:#c5cbd1}.dap-field textarea{width:100%;min-height:84px;border:1px solid #30363d;background:#181b1f;color:#fff;border-radius:12px;padding:10px 12px;resize:vertical;line-height:1.55;font:inherit}.dap-field textarea:focus{outline:none;border-color:#687c37;box-shadow:0 0 0 3px #d7ff5f12}.dap-actions{display:flex;align-items:center;justify-content:space-between;gap:10px;padding-top:12px}.dap-msg{font-size:9px;color:var(--muted);min-height:18px}.dap-save{min-width:150px}.dk-field.dabbir-activity-hidden{display:none!important}
+@media(max-width:700px){.dap-card{margin-top:9px;border-radius:14px}.dap-head{padding:13px}.dap-head-row{gap:8px}.dap-head h2{font-size:13px}.dap-head p{font-size:9px}.dap-badge{font-size:7px}.dap-form{padding:10px}.dap-grid{grid-template-columns:1fr;gap:9px}.dap-field.wide{grid-column:auto}.dap-field textarea{font-size:16px;min-height:74px}.dap-actions{display:grid;grid-template-columns:1fr;gap:7px}.dap-save{width:100%;min-height:48px}.dap-msg{order:2;text-align:center}}
+`;
+
+const profiles={
+  salon:{
+    hideDelivery:true,
+    fields:['service_catalog','pricing_notes','team_specialists','appointment_details','customer_requirements','activity_operations'],
+    ar:{name:'الصالون',title:'تفاصيل الصالون',desc:'أضف ما يحتاجه دبّر لفهم خدمات الصالون والحجوزات والعميلات بدقة.',labels:{service_catalog:'الخدمات والأسعار',pricing_notes:'الأسعار والعروض والعربون',team_specialists:'الموظفات / المختصات وتخصصاتهن',appointment_details:'مدة الخدمات والفواصل بين الحجوزات',customer_requirements:'الإلغاء وعدم الحضور وتعليمات قبل الموعد',activity_operations:'ملاحظات تشغيلية مهمة'},placeholders:{service_catalog:'مثال: قص شعر 120 د.إ، مناكير 80 د.إ، صبغة من 250 د.إ',pricing_notes:'العربون، العروض، متى يتغير السعر، وما الذي يشمله السعر',team_specialists:'الأسماء والتخصصات أو المهارات التي يحتاج العميل معرفتها',appointment_details:'مدة كل خدمة، وقت التحضير أو التنظيف، وسياسة التأخير',customer_requirements:'شروط الإلغاء، عدم الحضور، وأي تعليمات قبل الموعد',activity_operations:'أي تفاصيل يومية تساعد دبّر على الرد بشكل صحيح'}},
+    en:{name:'Salon',title:'Salon details',desc:'Add the details DABBIR needs to understand salon services, bookings, and clients accurately.',labels:{service_catalog:'Services & prices',pricing_notes:'Pricing, offers & deposits',team_specialists:'Team / specialists and specialties',appointment_details:'Service duration & booking buffers',customer_requirements:'Cancellation, no-show & pre-visit instructions',activity_operations:'Important operating notes'},placeholders:{service_catalog:'Example: Haircut 120 AED, manicure 80 AED, color from 250 AED',pricing_notes:'Deposits, offers, price conditions, and what is included',team_specialists:'Names and specialties or skills customers may need to know',appointment_details:'Service duration, preparation/cleanup time, and lateness policy',customer_requirements:'Cancellation, no-show, and pre-appointment instructions',activity_operations:'Daily details that help DABBIR answer correctly'}}
+  },
+  clinic:{
+    hideDelivery:true,
+    fields:['service_catalog','team_specialists','appointment_details','customer_requirements','pricing_notes','activity_operations'],
+    ar:{name:'العيادة',title:'تفاصيل العيادة',desc:'معلومات المواعيد والخدمات والمختصين التي يحتاجها دبّر للرد الإداري فقط.',labels:{service_catalog:'أنواع المواعيد والخدمات',team_specialists:'الأطباء / المختصون',appointment_details:'مدة المواعيد والفواصل',customer_requirements:'تعليمات المراجع قبل الموعد',pricing_notes:'الرسوم وطرق التأكيد',activity_operations:'ملاحظات إدارية وتشغيلية'},placeholders:{service_catalog:'أنواع المواعيد أو الخدمات التي يمكن حجزها',team_specialists:'الأسماء والتخصصات ومواعيد التوفر العامة',appointment_details:'مدة الموعد، وقت الحضور المبكر، وسياسة التأخير',customer_requirements:'المستندات أو التعليمات الإدارية المطلوبة قبل الزيارة',pricing_notes:'الرسوم المعلنة، العربون أو شروط التأكيد إن وجدت',activity_operations:'معلومات إدارية غير طبية يحتاجها الرد على العملاء'}},
+    en:{name:'Clinic',title:'Clinic details',desc:'Administrative appointment, service, and specialist information DABBIR can use in customer replies.',labels:{service_catalog:'Appointment types & services',team_specialists:'Doctors / specialists',appointment_details:'Appointment duration & buffers',customer_requirements:'Pre-visit instructions',pricing_notes:'Fees & confirmation rules',activity_operations:'Administrative operating notes'},placeholders:{service_catalog:'Appointment or service types that can be booked',team_specialists:'Names, specialties, and general availability',appointment_details:'Duration, early arrival, and lateness policy',customer_requirements:'Administrative documents or instructions required before a visit',pricing_notes:'Published fees, deposits, or confirmation conditions',activity_operations:'Non-medical administrative information for customer replies'}}
+  },
+  car_wash:{
+    hideDelivery:true,
+    fields:['service_catalog','pricing_notes','appointment_details','customer_requirements','activity_operations'],
+    ar:{name:'غسيل السيارات',title:'تفاصيل غسيل السيارات',desc:'الخدمات والباقات ومدة الحجز وطريقة تنفيذ الخدمة بدون تعقيد إضافي.',labels:{service_catalog:'الخدمات والباقات والأسعار',pricing_notes:'فروقات السعر حسب السيارة والإضافات',appointment_details:'مدة الخدمة والحجز',customer_requirements:'تعليمات العميل قبل الخدمة',activity_operations:'طريقة تنفيذ الخدمة والموقع'},placeholders:{service_catalog:'مثال: غسيل خارجي، داخلي، تلميع، باقات وأسعارها',pricing_notes:'سيدان / SUV / مركبة كبيرة، والإضافات التي تغيّر السعر',appointment_details:'مدة كل باقة ووقت الوصول أو التأخير المسموح',customer_requirements:'مثال: توفر المركبة والمفتاح أو نقطة الكهرباء/الماء إن لزم',activity_operations:'هل الخدمة متنقلة أو في الموقع، وكيف يحدد العميل موقع المركبة'}},
+    en:{name:'Car wash',title:'Car wash details',desc:'Services, packages, booking duration, and how the service is delivered without extra complexity.',labels:{service_catalog:'Services, packages & prices',pricing_notes:'Vehicle-size pricing & add-ons',appointment_details:'Service and booking duration',customer_requirements:'Customer preparation instructions',activity_operations:'Service method & location details'},placeholders:{service_catalog:'Example: exterior wash, interior, polish, packages and prices',pricing_notes:'Sedan / SUV / large vehicle differences and paid add-ons',appointment_details:'Duration per package and arrival/lateness rules',customer_requirements:'Example: vehicle/key availability or power/water access if required',activity_operations:'Whether service is mobile or on-site and how the vehicle location is provided'}}
+  },
+  store:{
+    hideDelivery:false,
+    fields:['service_catalog','pricing_notes','customer_requirements','activity_operations'],
+    ar:{name:'المتجر',title:'تفاصيل المتجر',desc:'المنتجات والطلبات وشروط البيع التي يحتاجها دبّر بجانب سياسة التوصيل.',labels:{service_catalog:'فئات المنتجات والمنتجات المهمة',pricing_notes:'الأسعار والعروض والحد الأدنى',customer_requirements:'متطلبات الطلب من العميل',activity_operations:'طريقة تجهيز ومعالجة الطلبات'},placeholders:{service_catalog:'الفئات أو المنتجات الأكثر طلبًا وأي فروقات مهمة',pricing_notes:'العروض، الحد الأدنى للطلب، أو قواعد التسعير',customer_requirements:'المعلومات المطلوبة لتأكيد الطلب',activity_operations:'خطوات التجهيز والتأكيد والاستلام أو الشحن'}},
+    en:{name:'Store',title:'Store details',desc:'Products, orders, and selling rules DABBIR needs alongside the delivery policy.',labels:{service_catalog:'Product categories & key products',pricing_notes:'Pricing, offers & minimums',customer_requirements:'Customer order requirements',activity_operations:'Order preparation & handling'},placeholders:{service_catalog:'Top categories/products and important variations',pricing_notes:'Offers, minimum order, or pricing rules',customer_requirements:'Information required to confirm an order',activity_operations:'Preparation, confirmation, pickup, or shipping flow'}}
+  },
+  creator:{
+    hideDelivery:false,
+    fields:['service_catalog','pricing_notes','customer_requirements','activity_operations'],
+    ar:{name:'البيع عبر السوشيال',title:'تفاصيل الطلبات والبيع',desc:'معلومات عملية للبائعين عبر Instagram وWhatsApp.',labels:{service_catalog:'المنتجات أو أنواع الطلبات',pricing_notes:'الأسعار والعروض',customer_requirements:'بيانات تأكيد الطلب',activity_operations:'طريقة معالجة الطلبات'},placeholders:{service_catalog:'المنتجات أو الفئات التي تبيعها',pricing_notes:'العروض أو قواعد السعر',customer_requirements:'الاسم، الهاتف، المقاس/اللون أو أي بيانات لازمة',activity_operations:'من استقبال الرسالة حتى تجهيز الطلب وتسليمه'}},
+    en:{name:'Social selling',title:'Order & selling details',desc:'Practical information for Instagram and WhatsApp sellers.',labels:{service_catalog:'Products or order types',pricing_notes:'Pricing & offers',customer_requirements:'Order confirmation details',activity_operations:'Order handling flow'},placeholders:{service_catalog:'Products or categories you sell',pricing_notes:'Offers or pricing rules',customer_requirements:'Name, phone, size/color, or other required details',activity_operations:'From incoming message to prepared and handed-off order'}}
+  },
+  laundry:{
+    hideDelivery:false,
+    fields:['service_catalog','pricing_notes','appointment_details','customer_requirements','activity_operations'],
+    ar:{name:'المغسلة',title:'تفاصيل المغسلة',desc:'أنواع الغسيل والأسعار ومدة الإنجاز والاستلام والتسليم.',labels:{service_catalog:'الخدمات والأسعار',pricing_notes:'التسعير والإضافات',appointment_details:'مدة الإنجاز وأوقات الاستلام',customer_requirements:'تعليمات القطع من العميل',activity_operations:'مسار الاستلام والغسيل والجاهزية'},placeholders:{service_catalog:'غسيل، كي، تنظيف جاف وغيرها مع الأسعار',pricing_notes:'التسعير بالقطعة/الوزن وأي إضافات',appointment_details:'المدة المعتادة ومواعيد الاستلام أو التسليم',customer_requirements:'تعليمات خاصة للبقع أو القطع الحساسة',activity_operations:'كيف ينتقل الطلب من الاستلام حتى الجاهزية'}},
+    en:{name:'Laundry',title:'Laundry details',desc:'Cleaning types, pricing, turnaround, intake, and handoff.',labels:{service_catalog:'Services & prices',pricing_notes:'Pricing & add-ons',appointment_details:'Turnaround & handoff timing',customer_requirements:'Garment instructions',activity_operations:'Intake-to-ready workflow'},placeholders:{service_catalog:'Wash, press, dry-cleaning, etc. with prices',pricing_notes:'Per-item/weight pricing and add-ons',appointment_details:'Typical turnaround and pickup/delivery timing',customer_requirements:'Special stain or delicate-item instructions',activity_operations:'How an order moves from received to ready'}}
+  },
+  services:{
+    hideDelivery:true,
+    fields:['service_catalog','pricing_notes','appointment_details','customer_requirements','activity_operations'],
+    ar:{name:'الخدمات',title:'تفاصيل الخدمات',desc:'الخدمات والأسعار والمواعيد ومتطلبات العميل حسب طبيعة العمل.',labels:{service_catalog:'الخدمات والأسعار',pricing_notes:'التسعير والإضافات',appointment_details:'مدة الخدمة والمواعيد',customer_requirements:'ما يحتاجه العميل قبل الخدمة',activity_operations:'طريقة تنفيذ العمل'},placeholders:{service_catalog:'الخدمات المتاحة وما يشمله كل خيار',pricing_notes:'الأسعار الأساسية والإضافات',appointment_details:'مدة العمل وسياسة الموعد أو التأخير',customer_requirements:'البيانات أو التجهيزات المطلوبة من العميل',activity_operations:'كيف يبدأ العمل وكيف يعتبر مكتملًا'}},
+    en:{name:'Services',title:'Service details',desc:'Services, pricing, appointments, and customer requirements for this activity.',labels:{service_catalog:'Services & prices',pricing_notes:'Pricing & add-ons',appointment_details:'Service duration & appointments',customer_requirements:'Customer preparation',activity_operations:'How work is performed'},placeholders:{service_catalog:'Available services and what each includes',pricing_notes:'Base pricing and add-ons',appointment_details:'Work duration and appointment/lateness policy',customer_requirements:'Information or preparation required from the customer',activity_operations:'How work starts and when it is considered complete'}}
+  },
+  real_estate:{
+    hideDelivery:true,
+    fields:['service_catalog','team_specialists','appointment_details','customer_requirements','activity_operations'],
+    ar:{name:'العقار',title:'تفاصيل النشاط العقاري',desc:'أنواع العقارات والمعاينات والمتابعات ومعلومات العميل المطلوبة.',labels:{service_catalog:'أنواع العقارات والخدمات',team_specialists:'المسؤولون / الوسطاء',appointment_details:'المعاينات والمواعيد',customer_requirements:'بيانات العميل المطلوبة',activity_operations:'المتابعة والتشغيل'},placeholders:{service_catalog:'بيع، إيجار، إدارة أو أنواع العقارات المتاحة',team_specialists:'الأسماء أو الاختصاصات ذات الصلة',appointment_details:'طريقة حجز المعاينة ومدة الموعد',customer_requirements:'الميزانية، المنطقة، نوع العقار أو أي بيانات مطلوبة',activity_operations:'آلية المتابعة بعد الاستفسار أو المعاينة'}},
+    en:{name:'Real estate',title:'Real-estate details',desc:'Property types, viewings, follow-ups, and customer requirements.',labels:{service_catalog:'Property types & services',team_specialists:'Agents / responsible team',appointment_details:'Viewings & appointments',customer_requirements:'Required customer details',activity_operations:'Follow-up operations'},placeholders:{service_catalog:'Sale, rent, management, or property types available',team_specialists:'Relevant names or specialties',appointment_details:'How viewings are booked and appointment duration',customer_requirements:'Budget, area, property type, or other required details',activity_operations:'Follow-up flow after an inquiry or viewing'}}
+  },
+  other:{
+    hideDelivery:false,
+    fields:['service_catalog','pricing_notes','customer_requirements','activity_operations'],
+    ar:{name:'النشاط',title:'تفاصيل إضافية للنشاط',desc:'أضف المعلومات المتكررة التي يحتاجها دبّر لفهم عملك والرد بدقة.',labels:{service_catalog:'المنتجات أو الخدمات',pricing_notes:'الأسعار والعروض',customer_requirements:'متطلبات العميل',activity_operations:'طريقة تشغيل العمل'},placeholders:{service_catalog:'أهم المنتجات أو الخدمات',pricing_notes:'الأسعار أو قواعد التسعير',customer_requirements:'ما يجب أن يقدمه العميل',activity_operations:'أي خطوات تشغيلية مهمة'}},
+    en:{name:'Business',title:'Additional business details',desc:'Add recurring information DABBIR needs to understand the business and answer accurately.',labels:{service_catalog:'Products or services',pricing_notes:'Pricing & offers',customer_requirements:'Customer requirements',activity_operations:'Operating flow'},placeholders:{service_catalog:'Key products or services',pricing_notes:'Pricing or pricing rules',customer_requirements:'What the customer must provide',activity_operations:'Important operating steps'}}
+  }
+};
+
+const client=String.raw`
+(()=>{
+  if(window.__dabbirBusinessActivityProfile)return;
+  window.__dabbirBusinessActivityProfile=true;
+  const style=document.createElement('style');style.dataset.dabbirActivityProfile='v1';style.textContent=${JSON.stringify(css)};document.head.append(style);
+  const profiles=${JSON.stringify(profiles)};
+  const q=s=>document.querySelector(s);
+  const ar=()=>document.documentElement.lang!=='en';
+  const business=()=>{try{if(typeof workspace!=='undefined'&&workspace?.business)return workspace.business}catch{}return window.workspace?.business||null};
+  const type=()=>String(business()?.business_type||'other').toLowerCase();
+  const profile=()=>profiles[type()]||profiles.other;
+  const copy=()=>profile()[ar()?'ar':'en'];
+  const esc=value=>String(value??'').replace(/[&<>\"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c]));
+  let loadedFor='',values={},busy=false,lastRenderKey='';
+
+  function genericCard(){return q('.dabbir-knowledge-card')}
+  function applyGenericVisibility(){
+    const p=profile();
+    const delivery=q('.dk-field[data-key="delivery_policy"]');
+    if(delivery)delivery.classList.toggle('dabbir-activity-hidden',Boolean(p.hideDelivery));
+  }
+
+  function ensureCard(){
+    const base=genericCard();if(!base||!business()?.id)return null;
+    applyGenericVisibility();
+    let card=q('#dabbirActivityDetailsCard');
+    if(!card){card=document.createElement('section');card.id='dabbirActivityDetailsCard';card.className='dap-card';base.insertAdjacentElement('afterend',card)}
+    return card;
+  }
+
+  function render(){
+    const card=ensureCard();if(!card)return;
+    const p=profile(),c=copy(),renderKey=[business().id,type(),ar()?'ar':'en',p.fields.join(',')].join('|');
+    if(renderKey===lastRenderKey&&card.dataset.ready==='1')return;
+    lastRenderKey=renderKey;
+    card.innerHTML='<div class="dap-head"><div class="dap-head-row"><div><h2>'+esc(c.title)+'</h2><p>'+esc(c.desc)+'</p></div><span class="dap-badge">'+esc(c.name)+'</span></div></div><form class="dap-form" id="dabbirActivityDetailsForm"><div class="dap-grid">'+p.fields.map((key,index)=>'<div class="dap-field '+(index===p.fields.length-1&&p.fields.length%2?'wide':'')+'" data-activity-key="'+esc(key)+'"><label>'+esc(c.labels[key]||key)+'</label><textarea maxlength="1800" placeholder="'+esc(c.placeholders[key]||'')+'">'+esc(values[key]||'')+'</textarea></div>').join('')+'</div><div class="dap-actions"><div class="dap-msg" id="dabbirActivityDetailsMsg"></div><button class="primary dap-save" type="submit">'+esc(ar()?'حفظ تفاصيل النشاط':'Save activity details')+'</button></div></form>';
+    q('#dabbirActivityDetailsForm').onsubmit=save;
+    card.dataset.ready='1';
+  }
+
+  function message(value,isError=false){const node=q('#dabbirActivityDetailsMsg');if(node){node.textContent=value||'';node.style.color=isError?'#ff9b9b':''}}
+
+  async function load(force=false){
+    const id=business()?.id;if(!id||busy)return;
+    const key=id+'|'+type();
+    if(!force&&loadedFor===key){render();return}
+    busy=true;render();message(ar()?'جارٍ تحميل تفاصيل النشاط…':'Loading activity details…');
+    try{
+      const response=await fetch('/api/business-activity-profile?business_id='+encodeURIComponent(id),{credentials:'same-origin',cache:'no-store',headers:{accept:'application/json'}});
+      const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw new Error(body?.error||'ACTIVITY_PROFILE_LOAD_FAILED');
+      values=body.facts||{};loadedFor=key;lastRenderKey='';render();message('');
+    }catch(error){message(ar()?'تعذر تحميل تفاصيل النشاط':'Could not load activity details',true)}finally{busy=false}
+  }
+
+  async function save(event){
+    event.preventDefault();if(busy)return;
+    const id=business()?.id;if(!id)return;
+    const form=q('#dabbirActivityDetailsForm');if(!form)return;
+    const facts={};form.querySelectorAll('[data-activity-key]').forEach(field=>{facts[field.dataset.activityKey]=field.querySelector('textarea')?.value||''});
+    const button=form.querySelector('button[type="submit"]');busy=true;if(button)button.disabled=true;message(ar()?'جارٍ الحفظ…':'Saving…');
+    try{
+      const response=await fetch('/api/business-activity-profile',{method:'POST',credentials:'same-origin',headers:{'content-type':'application/json',accept:'application/json'},body:JSON.stringify({business_id:id,facts})});
+      const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw new Error(body?.error||'ACTIVITY_PROFILE_SAVE_FAILED');
+      values=body.facts||facts;loadedFor=id+'|'+type();message(ar()?'تم الحفظ — أصبح دبّر يعرف تفاصيل نشاطك':'Saved — DABBIR now has your activity details');
+    }catch(error){message(ar()?'تعذر حفظ تفاصيل النشاط':'Could not save activity details',true)}finally{busy=false;if(button)button.disabled=false}
+  }
+
+  function enforce(){
+    if(!business()?.id)return;
+    applyGenericVisibility();ensureCard();render();load(false);
+  }
+
+  const observer=new MutationObserver(()=>{if(genericCard()&&business()?.id)setTimeout(enforce,0)});
+  observer.observe(document.body,{subtree:true,childList:true});
+  try{const baseRenderAll=renderAll;renderAll=function(){const result=baseRenderAll.apply(this,arguments);setTimeout(enforce,0);return result}}catch{}
+  try{const baseApplyLang=applyLang;applyLang=function(){const result=baseApplyLang.apply(this,arguments);lastRenderKey='';setTimeout(enforce,0);return result}}catch{}
+  setTimeout(enforce,0);setTimeout(enforce,500);setTimeout(enforce,1500);
+  window.__dabbirBusinessActivityProfileApi={refresh:()=>{loadedFor='';lastRenderKey='';enforce()},version:'activity-business-profile-v1'};
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=300, s-maxage=300');
+  res.setHeader('x-dabbir-business-activity-profile','v1');
+  return res.status(200).send(client);
+}

--- a/api/business-activity-profile.js
+++ b/api/business-activity-profile.js
@@ -1,0 +1,136 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+} from './_auth-core.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const clean=(value,max=1800)=>String(value??'').trim().slice(0,max);
+
+const FIELDS={
+  service_catalog:{type:'fact',max:1800},
+  pricing_notes:{type:'policy',max:1400},
+  team_specialists:{type:'fact',max:1400},
+  appointment_details:{type:'policy',max:1400},
+  customer_requirements:{type:'policy',max:1600},
+  activity_operations:{type:'fact',max:1600},
+};
+const FIELD_KEYS=Object.keys(FIELDS);
+
+async function parse(response,fallback){
+  const text=await response.text();
+  let data=null;
+  try{data=text?JSON.parse(text):null}catch{data=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=response.status;
+    error.detail=data?.message||data?.code||null;
+    throw error;
+  }
+  return data;
+}
+
+async function context(req,res){
+  const token=accessTokenFromRequest(req);
+  if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+  return {token,user,memberships};
+}
+
+function membershipFor(rows,businessId){return rows.find(row=>row.business_id===businessId)||null}
+function unwrapValue(value){
+  if(value==null)return '';
+  if(typeof value==='string')return value;
+  if(typeof value==='object'&&typeof value.text==='string')return value.text;
+  return JSON.stringify(value);
+}
+
+async function readProfile(token,businessId){
+  const rows=await supabaseRest(
+    `dabbir_business_knowledge?select=knowledge_key,knowledge_type,value,source,status,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=100`,
+    token,
+  ).then(r=>parse(r,'BUSINESS_ACTIVITY_PROFILE_READ_FAILED'));
+  const facts={};
+  const metadata={};
+  for(const row of rows||[]){
+    if(!FIELD_KEYS.includes(row.knowledge_key))continue;
+    facts[row.knowledge_key]=unwrapValue(row.value);
+    metadata[row.knowledge_key]={status:row.status,source:row.source,updated_at:row.updated_at};
+  }
+  for(const key of FIELD_KEYS)if(!(key in facts))facts[key]='';
+  return {facts,metadata};
+}
+
+export default async function handler(req,res){
+  if(!['GET','POST'].includes(req.method))return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
+  if(req.method==='POST'&&!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+  const ctx=await context(req,res);
+  if(!ctx)return;
+
+  try{
+    const body=req.method==='POST'?await readJsonBody(req):null;
+    const businessId=safeId(req.method==='GET'?singleQueryValue(req,'business_id'):body?.business_id);
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_ID_REQUIRED'});
+    if(!membershipFor(ctx.memberships,businessId))return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+
+    if(req.method==='GET'){
+      const profile=await readProfile(ctx.token,businessId);
+      return json(res,200,{ok:true,business_id:businessId,...profile,truth:{source:'owner_approved_activity_knowledge'}});
+    }
+
+    const input=body?.facts&&typeof body.facts==='object'?body.facts:{};
+    const submitted=FIELD_KEYS.filter(key=>Object.prototype.hasOwnProperty.call(input,key));
+    if(!submitted.length)return json(res,400,{ok:false,error:'ACTIVITY_PROFILE_FACTS_REQUIRED'});
+
+    const upserts=[];
+    const deletes=[];
+    for(const key of submitted){
+      const spec=FIELDS[key];
+      const value=clean(input[key],spec.max);
+      if(!value){deletes.push(key);continue}
+      upserts.push({
+        business_id:businessId,
+        knowledge_key:key,
+        knowledge_type:spec.type,
+        value:{text:value},
+        source:'owner_approved',
+        confidence:1,
+        status:'approved',
+        updated_at:new Date().toISOString(),
+      });
+    }
+
+    if(upserts.length){
+      await supabaseRest(`dabbir_business_knowledge?on_conflict=business_id,knowledge_key`,ctx.token,{
+        method:'POST',
+        headers:{prefer:'resolution=merge-duplicates,return=minimal'},
+        body:JSON.stringify(upserts),
+      }).then(r=>parse(r,'BUSINESS_ACTIVITY_PROFILE_SAVE_FAILED'));
+    }
+    for(const key of deletes){
+      await supabaseRest(
+        `dabbir_business_knowledge?business_id=eq.${businessId}&knowledge_key=eq.${encodeURIComponent(key)}`,
+        ctx.token,
+        {method:'DELETE',headers:{prefer:'return=minimal'}},
+      ).then(r=>parse(r,'BUSINESS_ACTIVITY_PROFILE_DELETE_FAILED'));
+    }
+
+    const profile=await readProfile(ctx.token,businessId);
+    return json(res,200,{ok:true,business_id:businessId,saved:upserts.length,removed:deletes.length,...profile});
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,413].includes(status)?status:500;
+    console.error('dabbir_business_activity_profile_failed',{status:safe,error:String(error?.message||'BUSINESS_ACTIVITY_PROFILE_FAILED').slice(0,160)});
+    return json(res,safe,{ok:false,error:String(error?.message||'BUSINESS_ACTIVITY_PROFILE_FAILED').slice(0,160),detail:error?.detail||undefined});
+  }
+}

--- a/api/calendar-live-ui.js
+++ b/api/calendar-live-ui.js
@@ -1,6 +1,7 @@
 import activityProfileHandler from './activity-profile-ui.js';
 import appointmentManagementUiHandler from './appointment-management-ui.js';
 import salonModeUiHandler from './salon-mode-ui.js';
+import businessActivityProfileUiHandler from './business-activity-profile-ui.js';
 
 const liveScript=String.raw`(()=>{
   if(window.__dabbirCalendarLiveUi)return;
@@ -103,14 +104,17 @@ export default async function handler(req,res){
   const activityCaptured=captureResponse();
   const managementCaptured=captureResponse();
   const salonCaptured=captureResponse();
+  const businessActivityCaptured=captureResponse();
   await activityProfileHandler(req,activityCaptured);
   await appointmentManagementUiHandler(req,managementCaptured);
   await salonModeUiHandler(req,salonCaptured);
+  await businessActivityProfileUiHandler(req,businessActivityCaptured);
   if(activityCaptured.statusCode!==200||!activityCaptured.body) return res.status(500).end('Activity profile UI unavailable');
   if(managementCaptured.statusCode!==200||!managementCaptured.body) return res.status(500).end('Appointment management UI unavailable');
   if(salonCaptured.statusCode!==200||!salonCaptured.body) return res.status(500).end('Salon Mode UI unavailable');
+  if(businessActivityCaptured.statusCode!==200||!businessActivityCaptured.body) return res.status(500).end('Business activity profile UI unavailable');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-calendar-live-ui','v5-salon-mode');
-  return res.status(200).send(activityCaptured.body+'\n'+liveScript+'\n'+managementCaptured.body+'\n'+salonCaptured.body);
+  res.setHeader('x-dabbir-calendar-live-ui','v6-activity-profile');
+  return res.status(200).send(activityCaptured.body+'\n'+liveScript+'\n'+managementCaptured.body+'\n'+salonCaptured.body+'\n'+businessActivityCaptured.body);
 }

--- a/test/dabbir-business-activity-profile.test.mjs
+++ b/test/dabbir-business-activity-profile.test.mjs
@@ -1,0 +1,52 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import businessActivityProfileUiHandler from '../api/business-activity-profile-ui.js';
+
+const root=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,root),'utf8');
+
+function responseCapture(){
+  return {
+    statusCode:200,headers:{},body:'',
+    status(code){this.statusCode=Number(code||200);return this},
+    setHeader(key,value){this.headers[String(key).toLowerCase()]=value;return this},
+    end(body=''){this.body=String(body);return this},
+    send(body=''){this.body=String(body);return this},
+  };
+}
+
+test('activity-specific business UI compiles and removes delivery from salon mode',async()=>{
+  const response=responseCapture();
+  await businessActivityProfileUiHandler({method:'GET'},response);
+  assert.equal(response.statusCode,200);
+  assert.match(response.body,/delivery_policy/);
+  assert.match(response.body,/hideDelivery/);
+  assert.match(response.body,/salon/);
+  assert.match(response.body,/تفاصيل الصالون/);
+  assert.doesNotThrow(()=>new Function(response.body));
+});
+
+test('car wash profile avoids worker selection and service-zone concepts',()=>{
+  const source=read('api/business-activity-profile-ui.js');
+  assert.match(source,/car_wash/);
+  assert.match(source,/الخدمات والباقات والأسعار/);
+  assert.doesNotMatch(source,/مناطق الخدمة|service zones?/i);
+  assert.doesNotMatch(source,/اختيار العامل|select worker|worker selection/i);
+});
+
+test('activity profile persists only approved whitelisted knowledge keys',()=>{
+  const source=read('api/business-activity-profile.js');
+  for(const key of ['service_catalog','pricing_notes','team_specialists','appointment_details','customer_requirements','activity_operations'])assert.match(source,new RegExp(key));
+  assert.match(source,/source:'owner_approved'/);
+  assert.match(source,/status:'approved'/);
+  assert.doesNotMatch(source,/service_role|supabase_service_role/i);
+});
+
+test('activity UI is aggregated through existing calendar bundle instead of adding a shell module',()=>{
+  const calendar=read('api/calendar-live-ui.js');
+  const manifest=JSON.parse(read('config/dabbir-ui-bundles.json'));
+  assert.match(calendar,/business-activity-profile-ui/);
+  assert.equal([...manifest.critical,...manifest.deferred].length,26);
+  assert.equal(manifest.deferred.includes('/api/business-activity-profile-ui'),false);
+});


### PR DESCRIPTION
Updates DABBIR business information so each activity gets relevant operational fields instead of one generic form.

Key changes:
- Salon hides the irrelevant delivery/shipping policy field.
- Adds activity-specific business details for salon, clinic, car wash, store/social sellers, laundry, services, real estate, and fallback activities.
- Car wash intentionally avoids manual worker selection and service-zone concepts.
- Stores new facts in the existing tenant-scoped `dabbir_business_knowledge` model; no database schema migration or service-role credential is introduced.
- New approved facts are automatically available to the existing grounded DABBIR AI context.
- Uses the existing calendar UI aggregate so the shell module ceiling remains unchanged.

Verification:
- Vercel preview build gate on `248c26bc84e2863c562a39a7a384792389a6d376` passed 666/666 tests, including four new regression tests for this change.