### PR TITLE
perf(dabbir): harden latency and Supabase membership lookups

### DIFF
--- a/api/_auth-core.js
+++ b/api/_auth-core.js
@@ -1,10 +1,15 @@
-export const SUPABASE_URL = 'https://spohjzrsymsmzsseygtw.supabase.co';
+export const SUPABASE_URL = String(process.env.SUPABASE_URL || 'https://spohjzrsymsmzsseygtw.supabase.co').replace(/\/$/, '');
 // Supabase publishable keys are intentionally safe for public/client use. Never place a service-role key here.
-const SUPABASE_PUBLISHABLE_KEY = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
+const SUPABASE_PUBLISHABLE_KEY = String(process.env.SUPABASE_PUBLISHABLE_KEY || 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3').trim();
+const DEFAULT_SUPABASE_TIMEOUT_MS = Math.max(1000, Number(process.env.DABBIR_SUPABASE_TIMEOUT_MS || 15000));
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export const ACCESS_COOKIE = '__Host-dabbir_access';
 export const REFRESH_COOKIE = '__Host-dabbir_refresh';
+
+function boundedSignal(options = {}) {
+  return options.signal || AbortSignal.timeout(DEFAULT_SUPABASE_TIMEOUT_MS);
+}
 
 export function json(res, status, body, extraHeaders = {}) {
   res.statusCode = status;
@@ -72,7 +77,12 @@ export async function supabaseAuth(path, options = {}) {
   const headers = new Headers(options.headers || {});
   headers.set('apikey', SUPABASE_PUBLISHABLE_KEY);
   headers.set('content-type', 'application/json');
-  return fetch(`${SUPABASE_URL}${path}`, { ...options, headers, redirect: 'manual' });
+  return fetch(`${SUPABASE_URL}${path}`, {
+    ...options,
+    headers,
+    redirect: 'manual',
+    signal: boundedSignal(options),
+  });
 }
 
 export async function supabaseRest(path, accessToken, options = {}) {
@@ -82,7 +92,12 @@ export async function supabaseRest(path, accessToken, options = {}) {
   headers.set('authorization', `Bearer ${accessToken}`);
   headers.set('accept', 'application/json');
   if (options.body !== undefined) headers.set('content-type', 'application/json');
-  return fetch(`${SUPABASE_URL}/rest/v1/${path}`, { ...options, headers, cache: 'no-store' });
+  return fetch(`${SUPABASE_URL}/rest/v1/${path}`, {
+    ...options,
+    headers,
+    cache: 'no-store',
+    signal: boundedSignal(options),
+  });
 }
 
 export function accessTokenFromRequest(req) {
@@ -119,7 +134,7 @@ export async function getVerifiedUserWithAccess(accessToken, options = {}) {
     accessToken,
     options,
   ).catch(error => {
-    if (options.signal?.aborted) throw error;
+    if (options.signal?.aborted || error?.name === 'TimeoutError' || error?.name === 'AbortError') throw error;
     return null;
   });
   if (!response?.ok) return null;
@@ -175,8 +190,11 @@ export function userClaimsFromValidatedAccessToken(accessToken, nowSeconds = Mat
 }
 
 export async function getBusinessMemberships(accessToken, options = {}) {
+  const payload = decodeJwtPayload(accessToken);
+  const userId = UUID_RE.test(String(payload?.sub || '')) ? String(payload.sub) : null;
+  const selfFilter = userId ? `&user_id=eq.${encodeURIComponent(userId)}` : '';
   const response = await supabaseRest(
-    'dabbir_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active',
+    `dabbir_memberships?select=business_id,role,status,permissions,accepted_at&status=eq.active${selfFilter}`,
     accessToken,
     options,
   );

--- a/api/calendar-connections.js
+++ b/api/calendar-connections.js
@@ -13,21 +13,28 @@ function statusCode(error){
   return [400,401,403,404,409,429,502,503].includes(code)?code:500;
 }
 
+function calendarStorageConfigured(){
+  const key=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
+  return Boolean(key&&!key.startsWith('sb_publishable_'));
+}
+
 export default async function handler(req,res){
   try{
     if(req.method==='GET'){
       const businessId=safeBusinessId(req.query?.business_id);
       await requireCalendarMember(req,businessId);
-      const connections=await listConnections(businessId);
       const google=providerConfig('google',req),outlook=providerConfig('outlook',req);
       const securityReady=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24&&String(process.env.DABBIR_CALENDAR_STATE_SECRET||process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24;
+      const storageConfigured=calendarStorageConfigured();
+      const connections=storageConfigured?await listConnections(businessId):[];
       return json(res,200,{
         ok:true,
         business_id:businessId,
+        storage_configured:storageConfigured,
         connections,
         providers:{
-          google:{configured:Boolean(google.configured&&securityReady)},
-          outlook:{configured:Boolean(outlook.configured&&securityReady)},
+          google:{configured:Boolean(storageConfigured&&google.configured&&securityReady)},
+          outlook:{configured:Boolean(storageConfigured&&outlook.configured&&securityReady)},
         },
       });
     }

--- a/supabase/migrations/20260831181500_dabbir_latency_hardening.sql
+++ b/supabase/migrations/20260831181500_dabbir_latency_hardening.sql
@@ -49,6 +49,9 @@ begin
   ) as v(tablename, old_policy, predicate)
   loop
     execute format('drop policy if exists %I on public.%I', r.old_policy, r.tablename);
+    execute format('drop policy if exists %I_insert on public.%I', r.old_policy, r.tablename);
+    execute format('drop policy if exists %I_update on public.%I', r.old_policy, r.tablename);
+    execute format('drop policy if exists %I_delete on public.%I', r.old_policy, r.tablename);
     execute format('create policy %I_insert on public.%I for insert to authenticated with check (%s)', r.old_policy, r.tablename, r.predicate);
     execute format('create policy %I_update on public.%I for update to authenticated using (%s) with check (%s)', r.old_policy, r.tablename, r.predicate, r.predicate);
     execute format('create policy %I_delete on public.%I for delete to authenticated using (%s)', r.old_policy, r.tablename, r.predicate);

--- a/supabase/migrations/20260831181500_dabbir_latency_hardening.sql
+++ b/supabase/migrations/20260831181500_dabbir_latency_hardening.sql
@@ -1,0 +1,56 @@
+-- DABBIR latency hardening: FK indexes, duplicate-index cleanup, and RLS SELECT de-duplication.
+
+create index if not exists dabbir_appointment_services_business_service_idx
+  on public.dabbir_appointment_services (business_id, service_id);
+create index if not exists dabbir_commissions_business_appointment_idx
+  on public.dabbir_commissions (business_id, appointment_id);
+create index if not exists dabbir_customer_notes_created_by_idx
+  on public.dabbir_customer_notes (created_by);
+create index if not exists dabbir_operational_payments_recorded_by_idx
+  on public.dabbir_operational_payments (recorded_by);
+create index if not exists dabbir_waitlist_business_customer_idx
+  on public.dabbir_waitlist_entries (business_id, customer_id);
+create index if not exists dabbir_waitlist_business_preferred_worker_idx
+  on public.dabbir_waitlist_entries (business_id, preferred_worker_id);
+create index if not exists dabbir_waitlist_matched_appointment_idx
+  on public.dabbir_waitlist_entries (matched_appointment_id);
+create index if not exists dabbir_worker_services_business_worker_idx
+  on public.dabbir_worker_services (business_id, worker_id);
+create index if not exists dabbir_workers_membership_user_idx
+  on public.dabbir_workers (membership_user_id);
+create index if not exists dabbir_workflow_audit_actor_user_idx
+  on public.dabbir_workflow_audit (actor_user_id);
+create index if not exists dabbir_workflow_notifications_customer_idx
+  on public.dabbir_workflow_notifications (customer_id);
+create index if not exists dabbir_workflow_notifications_waitlist_idx
+  on public.dabbir_workflow_notifications (waitlist_entry_id);
+create index if not exists dabbir_workflow_notifications_appointment_fk_idx
+  on public.dabbir_workflow_notifications (appointment_id);
+create index if not exists dabbir_workflow_status_history_actor_user_idx
+  on public.dabbir_workflow_status_history (actor_user_id);
+create index if not exists dabbir_workflow_status_history_appointment_fk_idx
+  on public.dabbir_workflow_status_history (appointment_id);
+
+drop index if exists public.dabbir_conversations_business_updated_idx;
+
+-- The former ALL policies duplicated SELECT evaluation with the explicit read
+-- policies. Split them into write-only policies so reads evaluate one path.
+do $$
+declare r record;
+begin
+  for r in select * from (values
+    ('dabbir_appointment_services','dabbir_appointment_services_write','dabbir_private.salon_member_scope(business_id, worker_id, true)'),
+    ('dabbir_customer_notes','dabbir_customer_notes_write','dabbir_private.salon_customer_scope(business_id, customer_id, true)'),
+    ('dabbir_salon_settings','dabbir_salon_settings_write','dabbir_private.has_permission(business_id, ''manage_business''::text)'),
+    ('dabbir_waitlist_entries','dabbir_waitlist_write','dabbir_private.salon_customer_scope(business_id, customer_id, true)'),
+    ('dabbir_worker_schedules','dabbir_worker_schedules_write','dabbir_private.has_permission(business_id, ''manage_team''::text)'),
+    ('dabbir_worker_services','dabbir_worker_services_write','dabbir_private.has_permission(business_id, ''manage_team''::text)'),
+    ('dabbir_worker_time_off','dabbir_worker_time_off_write','dabbir_private.has_permission(business_id, ''manage_team''::text)')
+  ) as v(tablename, old_policy, predicate)
+  loop
+    execute format('drop policy if exists %I on public.%I', r.old_policy, r.tablename);
+    execute format('create policy %I_insert on public.%I for insert to authenticated with check (%s)', r.old_policy, r.tablename, r.predicate);
+    execute format('create policy %I_update on public.%I for update to authenticated using (%s) with check (%s)', r.old_policy, r.tablename, r.predicate, r.predicate);
+    execute format('create policy %I_delete on public.%I for delete to authenticated using (%s)', r.old_policy, r.tablename, r.predicate);
+  end loop;
+end $$;

--- a/test/dabbir-auth-fastpath.test.mjs
+++ b/test/dabbir-auth-fastpath.test.mjs
@@ -1,10 +1,11 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
-import { userClaimsFromValidatedAccessToken } from '../api/_auth-core.js';
+import { getBusinessMemberships, userClaimsFromValidatedAccessToken } from '../api/_auth-core.js';
 
 const root = new URL('../', import.meta.url);
 const runtimeSource = await readFile(new URL('api/dabbir-runtime-fast.js', root), 'utf8');
+const authSource = await readFile(new URL('api/_auth-core.js', root), 'utf8');
 
 const now = 1_800_000_000;
 const userId = '11111111-1111-4111-8111-111111111111';
@@ -44,6 +45,32 @@ test('validated-token claims fail closed for wrong issuer, role, audience, expir
   assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ nbf: now + 30 })), now), null);
   assert.equal(userClaimsFromValidatedAccessToken(token(validPayload({ sub: 'not-a-uuid' })), now), null);
   assert.equal(userClaimsFromValidatedAccessToken('not-a-jwt', now), null);
+});
+
+test('membership lookup is self-scoped and receives a default abort deadline', async () => {
+  const previousFetch = globalThis.fetch;
+  let seenUrl = '';
+  let seenSignal = null;
+  globalThis.fetch = async (url, options = {}) => {
+    seenUrl = String(url);
+    seenSignal = options.signal || null;
+    return new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } });
+  };
+
+  try {
+    await getBusinessMemberships(token(validPayload()));
+  } finally {
+    globalThis.fetch = previousFetch;
+  }
+
+  assert.match(seenUrl, new RegExp(`user_id=eq\\.${userId}`));
+  assert.ok(seenSignal instanceof AbortSignal, 'Supabase request must have a bounded signal');
+  assert.match(authSource, /DABBIR_SUPABASE_TIMEOUT_MS/);
+});
+
+test('Supabase endpoint remains cutover-ready through environment configuration', () => {
+  assert.match(authSource, /process\.env\.SUPABASE_URL/);
+  assert.match(authSource, /process\.env\.SUPABASE_PUBLISHABLE_KEY/);
 });
 
 test('fast runtime validates membership before trusting decoded claims and retains fallback verification', () => {


### PR DESCRIPTION
Production hardening for DABBIR latency/disconnection symptoms:

- Bound Supabase Auth/Data API calls with a 15s default deadline instead of allowing requests to hang to the Vercel 300s ceiling.
- Scope current-user membership lookup by JWT `sub` so the existing `(user_id, status)` index is usable while RLS still verifies the same bearer token.
- Make Supabase URL/publishable key environment-configurable to support the UAE cutover without source edits.
- Degrade optional calendar connection reads safely when calendar server-side storage credentials are not configured, instead of surfacing repeated 503s to the appointments UI.
- Persist the production DB hardening migration: missing DABBIR FK indexes, duplicate conversation index cleanup, and removal of duplicate SELECT evaluation from seven RLS write policies.
- Add regression tests for self-scoped membership lookup, abort deadlines, and env-configured cutover readiness.

The corresponding DB changes have already been applied to the current production Supabase project; the migration file keeps future environments/UAE cutover reproducible.