### PR TITLE
Stabilization perf: activity-scope car-wash UI and persist FORCE RLS

### DIFF
--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -1,0 +1,35 @@
+const script=String.raw`(()=>{
+  if(window.__dabbirCarWashLoader)return;
+  const workspaceNow=()=>{try{return typeof workspace!=='undefined'?workspace:window.workspace}catch{return window.workspace||null}};
+  const isCarWash=()=>String(workspaceNow()?.business?.business_type||'').toLowerCase()==='car_wash';
+  let loading=false,loaded=false,attempts=0;
+  function load(){
+    if(loaded||loading||!isCarWash())return false;
+    if(window.__dabbirCarWashBookingUi){loaded=true;return true}
+    const existing=document.querySelector('script[data-dabbir-car-wash-ui="1"]');
+    if(existing){loading=true;return true}
+    loading=true;
+    const node=document.createElement('script');
+    node.src='/api/car-wash-booking-ui?v=20260831-ops-v1';
+    node.async=true;
+    node.dataset.dabbirCarWashUi='1';
+    node.onload=()=>{loaded=true;loading=false};
+    node.onerror=()=>{loading=false;console.error('dabbir_car_wash_ui_load_failed')};
+    document.head.appendChild(node);
+    return true;
+  }
+  const timer=setInterval(()=>{attempts+=1;if(load()||attempts>=40)clearInterval(timer)},500);
+  const observer=new MutationObserver(()=>{if(load())observer.disconnect()});
+  observer.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
+  setTimeout(()=>{load();if(attempts>=40)observer.disconnect()},20000);
+  window.addEventListener('focus',load,{passive:true});
+  window.__dabbirCarWashLoader={load,get loaded(){return loaded}};
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=300');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v1');
+  return res.status(200).send(script);
+}

--- a/config/dabbir-ui-bundles.json
+++ b/config/dabbir-ui-bundles.json
@@ -28,6 +28,6 @@
     "/api/customer-activation-ui",
     "/api/owner-copilot-ui",
     "/api/dabbir-contextual-navigation-ui",
-    "/api/car-wash-booking-ui"
+    "/api/car-wash-loader-ui"
   ]
 }

--- a/supabase/migrations/20260831190000_dabbir_car_wash_force_rls_v1.sql
+++ b/supabase/migrations/20260831190000_dabbir_car_wash_force_rls_v1.sql
@@ -1,0 +1,4 @@
+alter table public.dabbir_car_wash_vehicles force row level security;
+alter table public.dabbir_car_wash_booking_status_history force row level security;
+alter table public.dabbir_car_wash_booking_photos force row level security;
+alter table public.dabbir_car_wash_recurring_plans force row level security;

--- a/test/dabbir-car-wash-booking.test.mjs
+++ b/test/dabbir-car-wash-booking.test.mjs
@@ -59,10 +59,13 @@ test('booking migration has owner RLS, public functions, collision checks, and b
   assert.match(source,/location_lng numeric\(9,6\)/);
 });
 
-test('Vercel exposes the shareable booking route and deferred UI bundle',()=>{
+test('Vercel exposes the shareable booking route and activity-scoped car wash UI loader',()=>{
   const vercel=JSON.parse(read('vercel.json'));
   const manifest=JSON.parse(read('config/dabbir-ui-bundles.json'));
+  const loader=read('api/car-wash-loader-ui.js');
   assert.ok(vercel.routes.some(route=>route.src==='^/book/?$'&&route.dest==='/api/car-wash-booking'));
   assert.ok(vercel.rewrites.some(route=>route.source==='/book'&&route.destination==='/api/car-wash-booking'));
-  assert.ok(manifest.deferred.includes('/api/car-wash-booking-ui'));
+  assert.ok(manifest.deferred.includes('/api/car-wash-loader-ui'));
+  assert.ok(!manifest.deferred.includes('/api/car-wash-booking-ui'));
+  assert.match(loader,/\/api\/car-wash-booking-ui/);
 });

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const read=file=>fs.readFileSync(path.join(root,file),'utf8');
+
+test('universal deferred bundle carries only the car-wash loader',()=>{
+  const manifest=JSON.parse(read('config/dabbir-ui-bundles.json'));
+  assert.ok(manifest.deferred.includes('/api/car-wash-loader-ui'));
+  assert.ok(!manifest.deferred.includes('/api/car-wash-booking-ui'));
+});
+
+test('car-wash loader fetches the operations surface only for car_wash businesses',()=>{
+  const loader=read('api/car-wash-loader-ui.js');
+  assert.match(loader,/business_type/);
+  assert.match(loader,/===\s*'car_wash'/);
+  assert.match(loader,/\/api\/car-wash-booking-ui/);
+  assert.match(loader,/data-dabbir-car-wash-ui/);
+});


### PR DESCRIPTION
Second stabilization tranche after the car-wash operations merge.

- persists the already-applied FORCE RLS hardening for car-wash operations tables
- replaces the universally bundled car-wash UI with a tiny activity-aware loader
- loads the full car-wash booking/operations UI only for `business_type=car_wash`
- adds regression tests for the lazy-loading contract

Goal: keep the new operations capability without making every DABBIR tenant pay its bundle cost.