### PR TITLE
Stabilization security/perf: car-wash RLS + FK indexes

### DIFF
--- a/supabase/migrations/20260831193000_dabbir_car_wash_security_performance_v1.sql
+++ b/supabase/migrations/20260831193000_dabbir_car_wash_security_performance_v1.sql
@@ -1,0 +1,160 @@
+begin;
+
+-- Cover foreign keys used by joins, deletes and tenant-scoped operational reads.
+create index if not exists dabbir_car_wash_booking_photos_business_idx
+  on public.dabbir_car_wash_booking_photos(business_id);
+create index if not exists dabbir_car_wash_booking_photos_created_by_idx
+  on public.dabbir_car_wash_booking_photos(created_by)
+  where created_by is not null;
+create index if not exists dabbir_car_wash_booking_photos_vehicle_idx
+  on public.dabbir_car_wash_booking_photos(vehicle_id)
+  where vehicle_id is not null;
+
+create index if not exists dabbir_car_wash_booking_customer_fk_idx
+  on public.dabbir_car_wash_booking_requests(business_id, customer_id)
+  where customer_id is not null;
+create index if not exists dabbir_car_wash_booking_vehicle_fk_idx
+  on public.dabbir_car_wash_booking_requests(vehicle_id)
+  where vehicle_id is not null;
+
+create index if not exists dabbir_car_wash_history_business_idx
+  on public.dabbir_car_wash_booking_status_history(business_id);
+create index if not exists dabbir_car_wash_history_changed_by_idx
+  on public.dabbir_car_wash_booking_status_history(changed_by)
+  where changed_by is not null;
+
+create index if not exists dabbir_car_wash_recurring_customer_fk_idx
+  on public.dabbir_car_wash_recurring_plans(business_id, customer_id);
+create index if not exists dabbir_car_wash_recurring_offer_idx
+  on public.dabbir_car_wash_recurring_plans(offer_id);
+create index if not exists dabbir_car_wash_recurring_vehicle_idx
+  on public.dabbir_car_wash_recurring_plans(vehicle_id);
+
+-- Evaluate auth.uid() once per statement instead of once per candidate row.
+drop policy if exists dabbir_car_wash_booking_operations_update on public.dabbir_car_wash_booking_requests;
+create policy dabbir_car_wash_booking_operations_update
+on public.dabbir_car_wash_booking_requests
+for update to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_requests.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_requests.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_vehicles_member on public.dabbir_car_wash_vehicles;
+create policy dabbir_car_wash_vehicles_member
+on public.dabbir_car_wash_vehicles
+for all to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_vehicles.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_vehicles.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_history_member on public.dabbir_car_wash_booking_status_history;
+create policy dabbir_car_wash_history_member
+on public.dabbir_car_wash_booking_status_history
+for select to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_status_history.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_history_write on public.dabbir_car_wash_booking_status_history;
+create policy dabbir_car_wash_history_write
+on public.dabbir_car_wash_booking_status_history
+for insert to authenticated
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_status_history.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_photos_member on public.dabbir_car_wash_booking_photos;
+create policy dabbir_car_wash_photos_member
+on public.dabbir_car_wash_booking_photos
+for all to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_photos.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_photos.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_recurring_member on public.dabbir_car_wash_recurring_plans;
+create policy dabbir_car_wash_recurring_member
+on public.dabbir_car_wash_recurring_plans
+for all to authenticated
+using (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_recurring_plans.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1 from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_recurring_plans.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+-- Public booking is intentionally anonymous. Signed-in users do not need direct
+-- EXECUTE because DABBIR's public booking API calls these RPCs with the anon key.
+revoke execute on function public.dabbir_public_car_wash_book(text, uuid, text, timestamptz, text, text, numeric, numeric, text) from authenticated;
+revoke execute on function public.dabbir_public_car_wash_catalog(text) from authenticated;
+revoke execute on function public.dabbir_public_car_wash_slots(text, uuid, date, date) from authenticated;
+
+commit;

--- a/supabase/migrations/20260831194000_dabbir_car_wash_duplicate_index_cleanup_v1.sql
+++ b/supabase/migrations/20260831194000_dabbir_car_wash_duplicate_index_cleanup_v1.sql
@@ -1,0 +1,9 @@
+begin;
+
+-- Retain the canonical *_fk_idx indexes already present for these exact key shapes.
+drop index if exists public.dabbir_car_wash_booking_photos_business_idx;
+drop index if exists public.dabbir_car_wash_history_business_idx;
+drop index if exists public.dabbir_car_wash_recurring_offer_idx;
+drop index if exists public.dabbir_car_wash_recurring_vehicle_idx;
+
+commit;

--- a/test/dabbir-car-wash-duplicate-index-cleanup.test.mjs
+++ b/test/dabbir-car-wash-duplicate-index-cleanup.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const source=fs.readFileSync(path.join(root,'supabase/migrations/20260831194000_dabbir_car_wash_duplicate_index_cleanup_v1.sql'),'utf8');
+
+test('duplicate cleanup removes only redundant aliases',()=>{
+  for(const name of [
+    'dabbir_car_wash_booking_photos_business_idx',
+    'dabbir_car_wash_history_business_idx',
+    'dabbir_car_wash_recurring_offer_idx',
+    'dabbir_car_wash_recurring_vehicle_idx',
+  ]) assert.match(source,new RegExp(`drop index if exists public\\.${name}`,'i'));
+});
+
+test('canonical FK indexes are retained',()=>{
+  for(const name of [
+    'dabbir_car_wash_photos_business_fk_idx',
+    'dabbir_car_wash_history_business_fk_idx',
+    'dabbir_car_wash_recurring_offer_fk_idx',
+    'dabbir_car_wash_recurring_vehicle_fk_idx',
+  ]) assert.doesNotMatch(source,new RegExp(`drop index if exists public\\.${name}`,'i'));
+});

--- a/test/dabbir-car-wash-security-performance.test.mjs
+++ b/test/dabbir-car-wash-security-performance.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const source=fs.readFileSync(path.join(root,'supabase/migrations/20260831193000_dabbir_car_wash_security_performance_v1.sql'),'utf8');
+
+test('car wash foreign keys have covering indexes',()=>{
+  for(const marker of [
+    'dabbir_car_wash_booking_photos_business_idx',
+    'dabbir_car_wash_booking_photos_created_by_idx',
+    'dabbir_car_wash_booking_photos_vehicle_idx',
+    'dabbir_car_wash_booking_customer_fk_idx',
+    'dabbir_car_wash_booking_vehicle_fk_idx',
+    'dabbir_car_wash_history_business_idx',
+    'dabbir_car_wash_history_changed_by_idx',
+    'dabbir_car_wash_recurring_customer_fk_idx',
+    'dabbir_car_wash_recurring_offer_idx',
+    'dabbir_car_wash_recurring_vehicle_idx',
+  ]) assert.match(source,new RegExp(marker));
+});
+
+test('car wash RLS caches auth.uid once per statement',()=>{
+  const directAuthUid=(source.match(/m\.user_id\s*=\s*auth\.uid\(\)/g)||[]).length;
+  const selectedAuthUid=(source.match(/m\.user_id\s*=\s*\(select auth\.uid\(\)\)/g)||[]).length;
+  assert.equal(directAuthUid,0);
+  assert.ok(selectedAuthUid>=8);
+});
+
+test('signed-in users cannot directly execute public booking RPCs',()=>{
+  for(const fn of ['dabbir_public_car_wash_book','dabbir_public_car_wash_catalog','dabbir_public_car_wash_slots']){
+    assert.match(source,new RegExp(`revoke execute on function public\\.${fn}\\(`,'i'));
+  }
+  assert.match(source,/from authenticated/i);
+  assert.doesNotMatch(source,/revoke execute[^;]+from anon/i);
+});


### PR DESCRIPTION
Final internal stabilization tranche for the approved DABBIR release-hardening review.

- adds covering indexes for all new car-wash operational foreign keys flagged by Supabase Advisor
- rewrites car-wash RLS membership checks to evaluate `(select auth.uid())` once per statement
- removes unnecessary direct `authenticated` EXECUTE privilege from the three anonymous public-booking RPCs while retaining anon access required by the public booking API
- adds regression tests for indexes, RLS init-plan hardening, and RPC privilege narrowing

Merge only after DABBIR CI and Vercel preview are green; then apply the exact migration and rerun Supabase Advisors.