### PR TITLE
Stabilize car-wash database performance

### DIFF
--- a/supabase/migrations/20260831195000_dabbir_car_wash_rls_fk_perf_v1.sql
+++ b/supabase/migrations/20260831195000_dabbir_car_wash_rls_fk_perf_v1.sql
@@ -1,0 +1,153 @@
+-- DABBIR car-wash database stabilization.
+-- Keeps the existing tenant/role authorization semantics while avoiding
+-- per-row auth.uid() re-evaluation and covering all car-wash foreign keys.
+
+-- RLS policy init-plan optimization: cache auth.uid() once per statement.
+drop policy if exists dabbir_car_wash_booking_operations_update on public.dabbir_car_wash_booking_requests;
+create policy dabbir_car_wash_booking_operations_update on public.dabbir_car_wash_booking_requests
+for update to authenticated
+using (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_requests.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_requests.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_vehicles_member on public.dabbir_car_wash_vehicles;
+create policy dabbir_car_wash_vehicles_member on public.dabbir_car_wash_vehicles
+for all to authenticated
+using (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_vehicles.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_vehicles.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_history_member on public.dabbir_car_wash_booking_status_history;
+create policy dabbir_car_wash_history_member on public.dabbir_car_wash_booking_status_history
+for select to authenticated
+using (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_status_history.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_history_write on public.dabbir_car_wash_booking_status_history;
+create policy dabbir_car_wash_history_write on public.dabbir_car_wash_booking_status_history
+for insert to authenticated
+with check (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_status_history.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_photos_member on public.dabbir_car_wash_booking_photos;
+create policy dabbir_car_wash_photos_member on public.dabbir_car_wash_booking_photos
+for all to authenticated
+using (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_photos.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_booking_photos.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+drop policy if exists dabbir_car_wash_recurring_member on public.dabbir_car_wash_recurring_plans;
+create policy dabbir_car_wash_recurring_member on public.dabbir_car_wash_recurring_plans
+for all to authenticated
+using (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_recurring_plans.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+)
+with check (
+  exists (
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id = dabbir_car_wash_recurring_plans.business_id
+      and m.user_id = (select auth.uid())
+      and m.status = 'active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  )
+);
+
+-- Cover foreign-key lookup paths used by cascades, joins, and tenant operations.
+create index if not exists dabbir_car_wash_booking_requests_customer_fk_idx
+  on public.dabbir_car_wash_booking_requests (business_id, customer_id);
+create index if not exists dabbir_car_wash_booking_requests_vehicle_fk_idx
+  on public.dabbir_car_wash_booking_requests (vehicle_id);
+
+create index if not exists dabbir_car_wash_history_business_fk_idx
+  on public.dabbir_car_wash_booking_status_history (business_id);
+create index if not exists dabbir_car_wash_history_changed_by_fk_idx
+  on public.dabbir_car_wash_booking_status_history (changed_by);
+
+create index if not exists dabbir_car_wash_photos_business_fk_idx
+  on public.dabbir_car_wash_booking_photos (business_id);
+create index if not exists dabbir_car_wash_photos_vehicle_fk_idx
+  on public.dabbir_car_wash_booking_photos (vehicle_id);
+create index if not exists dabbir_car_wash_photos_created_by_fk_idx
+  on public.dabbir_car_wash_booking_photos (created_by);
+
+create index if not exists dabbir_car_wash_recurring_customer_fk_idx
+  on public.dabbir_car_wash_recurring_plans (business_id, customer_id);
+create index if not exists dabbir_car_wash_recurring_vehicle_fk_idx
+  on public.dabbir_car_wash_recurring_plans (vehicle_id);
+create index if not exists dabbir_car_wash_recurring_offer_fk_idx
+  on public.dabbir_car_wash_recurring_plans (offer_id);

--- a/supabase/migrations/20260831195500_dabbir_car_wash_duplicate_index_cleanup_v1.sql
+++ b/supabase/migrations/20260831195500_dabbir_car_wash_duplicate_index_cleanup_v1.sql
@@ -1,0 +1,7 @@
+-- Remove only exact duplicate car-wash indexes introduced by concurrent hardening.
+-- Canonical full covering indexes created by dabbir_car_wash_security_performance_v1 remain.
+
+drop index if exists public.dabbir_car_wash_photos_business_fk_idx;
+drop index if exists public.dabbir_car_wash_history_business_fk_idx;
+drop index if exists public.dabbir_car_wash_recurring_offer_fk_idx;
+drop index if exists public.dabbir_car_wash_recurring_vehicle_fk_idx;

--- a/supabase/migrations/20260831200000_dabbir_car_wash_perf_reconcile_v2.sql
+++ b/supabase/migrations/20260831200000_dabbir_car_wash_perf_reconcile_v2.sql
@@ -1,0 +1,26 @@
+begin;
+
+-- Reconcile a concurrent live hardening migration with the repository source of truth.
+-- Keep one canonical full index for each exact FK shape that needs full coverage.
+create index if not exists dabbir_car_wash_photos_business_fk_idx
+  on public.dabbir_car_wash_booking_photos (business_id);
+create index if not exists dabbir_car_wash_history_business_fk_idx
+  on public.dabbir_car_wash_booking_status_history (business_id);
+create index if not exists dabbir_car_wash_recurring_offer_fk_idx
+  on public.dabbir_car_wash_recurring_plans (offer_id);
+create index if not exists dabbir_car_wash_recurring_vehicle_fk_idx
+  on public.dabbir_car_wash_recurring_plans (vehicle_id);
+
+-- Remove only exact full-index aliases created by the concurrent migration.
+drop index if exists public.dabbir_car_wash_booking_photos_business_idx;
+drop index if exists public.dabbir_car_wash_history_business_idx;
+drop index if exists public.dabbir_car_wash_recurring_offer_idx;
+drop index if exists public.dabbir_car_wash_recurring_vehicle_idx;
+
+-- Public booking remains intentionally anonymous. Authenticated application users
+-- go through DABBIR's protected APIs and do not need direct EXECUTE on these RPCs.
+revoke execute on function public.dabbir_public_car_wash_book(text, uuid, text, timestamptz, text, text, numeric, numeric, text) from authenticated;
+revoke execute on function public.dabbir_public_car_wash_catalog(text) from authenticated;
+revoke execute on function public.dabbir_public_car_wash_slots(text, uuid, date, date) from authenticated;
+
+commit;

--- a/test/dabbir-car-wash-db-perf.test.mjs
+++ b/test/dabbir-car-wash-db-perf.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const migrationPath='supabase/migrations/20260831195000_dabbir_car_wash_rls_fk_perf_v1.sql';
+const source=readFileSync(migrationPath,'utf8');
+
+test('car wash RLS policies use statement-stable auth uid lookup',()=>{
+  const directAuthUid=(source.match(/m\.user_id\s*=\s*auth\.uid\(\)/g)||[]).length;
+  const stableAuthUid=(source.match(/m\.user_id\s*=\s*\(select auth\.uid\(\)\)/g)||[]).length;
+  assert.equal(directAuthUid,0);
+  assert.ok(stableAuthUid>=8);
+  for(const policy of [
+    'dabbir_car_wash_booking_operations_update',
+    'dabbir_car_wash_vehicles_member',
+    'dabbir_car_wash_history_member',
+    'dabbir_car_wash_history_write',
+    'dabbir_car_wash_photos_member',
+    'dabbir_car_wash_recurring_member'
+  ]) assert.match(source,new RegExp(`create policy ${policy}`));
+});
+
+test('car wash foreign keys have covering indexes',()=>{
+  for(const indexName of [
+    'dabbir_car_wash_booking_requests_customer_fk_idx',
+    'dabbir_car_wash_booking_requests_vehicle_fk_idx',
+    'dabbir_car_wash_history_business_fk_idx',
+    'dabbir_car_wash_history_changed_by_fk_idx',
+    'dabbir_car_wash_photos_business_fk_idx',
+    'dabbir_car_wash_photos_vehicle_fk_idx',
+    'dabbir_car_wash_photos_created_by_fk_idx',
+    'dabbir_car_wash_recurring_customer_fk_idx',
+    'dabbir_car_wash_recurring_vehicle_fk_idx',
+    'dabbir_car_wash_recurring_offer_fk_idx'
+  ]) assert.match(source,new RegExp(`create index if not exists ${indexName}`));
+});

--- a/test/dabbir-car-wash-db-perf.test.mjs
+++ b/test/dabbir-car-wash-db-perf.test.mjs
@@ -3,7 +3,9 @@ import assert from 'node:assert/strict';
 import { readFileSync } from 'node:fs';
 
 const migrationPath='supabase/migrations/20260831195000_dabbir_car_wash_rls_fk_perf_v1.sql';
+const cleanupPath='supabase/migrations/20260831195500_dabbir_car_wash_duplicate_index_cleanup_v1.sql';
 const source=readFileSync(migrationPath,'utf8');
+const cleanup=readFileSync(cleanupPath,'utf8');
 
 test('car wash RLS policies use statement-stable auth uid lookup',()=>{
   const directAuthUid=(source.match(/m\.user_id\s*=\s*auth\.uid\(\)/g)||[]).length;
@@ -33,4 +35,22 @@ test('car wash foreign keys have covering indexes',()=>{
     'dabbir_car_wash_recurring_vehicle_fk_idx',
     'dabbir_car_wash_recurring_offer_fk_idx'
   ]) assert.match(source,new RegExp(`create index if not exists ${indexName}`));
+});
+
+test('concurrent duplicate car wash indexes are removed without dropping canonical coverage',()=>{
+  for(const indexName of [
+    'dabbir_car_wash_photos_business_fk_idx',
+    'dabbir_car_wash_history_business_fk_idx',
+    'dabbir_car_wash_recurring_offer_fk_idx',
+    'dabbir_car_wash_recurring_vehicle_fk_idx'
+  ]) assert.match(cleanup,new RegExp(`drop index if exists public\\.${indexName}`));
+
+  for(const indexName of [
+    'dabbir_car_wash_booking_requests_customer_fk_idx',
+    'dabbir_car_wash_booking_requests_vehicle_fk_idx',
+    'dabbir_car_wash_history_changed_by_fk_idx',
+    'dabbir_car_wash_photos_vehicle_fk_idx',
+    'dabbir_car_wash_photos_created_by_fk_idx',
+    'dabbir_car_wash_recurring_customer_fk_idx'
+  ]) assert.ok(!cleanup.includes(`drop index if exists public.${indexName}`));
 });

--- a/test/dabbir-car-wash-db-perf.test.mjs
+++ b/test/dabbir-car-wash-db-perf.test.mjs
@@ -4,8 +4,10 @@ import { readFileSync } from 'node:fs';
 
 const migrationPath='supabase/migrations/20260831195000_dabbir_car_wash_rls_fk_perf_v1.sql';
 const cleanupPath='supabase/migrations/20260831195500_dabbir_car_wash_duplicate_index_cleanup_v1.sql';
+const reconcilePath='supabase/migrations/20260831200000_dabbir_car_wash_perf_reconcile_v2.sql';
 const source=readFileSync(migrationPath,'utf8');
 const cleanup=readFileSync(cleanupPath,'utf8');
+const reconcile=readFileSync(reconcilePath,'utf8');
 
 test('car wash RLS policies use statement-stable auth uid lookup',()=>{
   const directAuthUid=(source.match(/m\.user_id\s*=\s*auth\.uid\(\)/g)||[]).length;
@@ -37,20 +39,30 @@ test('car wash foreign keys have covering indexes',()=>{
   ]) assert.match(source,new RegExp(`create index if not exists ${indexName}`));
 });
 
-test('concurrent duplicate car wash indexes are removed without dropping canonical coverage',()=>{
+test('final reconciliation restores canonical full indexes and removes only exact aliases',()=>{
   for(const indexName of [
     'dabbir_car_wash_photos_business_fk_idx',
     'dabbir_car_wash_history_business_fk_idx',
     'dabbir_car_wash_recurring_offer_fk_idx',
     'dabbir_car_wash_recurring_vehicle_fk_idx'
-  ]) assert.match(cleanup,new RegExp(`drop index if exists public\\.${indexName}`));
+  ]) {
+    assert.match(cleanup,new RegExp(`drop index if exists public\\.${indexName}`));
+    assert.match(reconcile,new RegExp(`create index if not exists ${indexName}`));
+  }
 
-  for(const indexName of [
-    'dabbir_car_wash_booking_requests_customer_fk_idx',
-    'dabbir_car_wash_booking_requests_vehicle_fk_idx',
-    'dabbir_car_wash_history_changed_by_fk_idx',
-    'dabbir_car_wash_photos_vehicle_fk_idx',
-    'dabbir_car_wash_photos_created_by_fk_idx',
-    'dabbir_car_wash_recurring_customer_fk_idx'
-  ]) assert.ok(!cleanup.includes(`drop index if exists public.${indexName}`));
+  for(const alias of [
+    'dabbir_car_wash_booking_photos_business_idx',
+    'dabbir_car_wash_history_business_idx',
+    'dabbir_car_wash_recurring_offer_idx',
+    'dabbir_car_wash_recurring_vehicle_idx'
+  ]) assert.match(reconcile,new RegExp(`drop index if exists public\\.${alias}`));
+});
+
+test('authenticated access is removed from anonymous public booking RPCs',()=>{
+  for(const fn of [
+    'dabbir_public_car_wash_book',
+    'dabbir_public_car_wash_catalog',
+    'dabbir_public_car_wash_slots'
+  ]) assert.match(reconcile,new RegExp(`revoke execute on function public\\.${fn}\\(`));
+  assert.doesNotMatch(reconcile,/from anon\s*;/i);
 });


### PR DESCRIPTION
Stabilizes the DABBIR car-wash data path after the latest operations release.

- Optimizes car-wash RLS policies to use statement-stable `(select auth.uid())` lookups.
- Adds full covering indexes for car-wash foreign-key paths that were still flagged by the database linter.
- Removes only exact duplicate indexes created by a concurrent hardening migration while preserving canonical/required coverage.
- Adds regression tests for RLS optimization, FK coverage, and duplicate-index cleanup.

Live database verification already completed: no duplicate indexes remain across `public.dabbir_car_wash_%`; the car-wash policies no longer contain direct per-row `auth.uid()` evaluation; public booking RPCs remain executable by `anon` and are no longer executable by `authenticated`.