### PR TITLE
Pin DABBIR Vercel functions to Sydney

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "regions": ["syd1"],
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "env": {
     "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"


### PR DESCRIPTION
Practical latency fix while Supabase remains in Sydney. Adds project-level Vercel Function region `syd1` so server-side API calls execute close to the existing Supabase database. No database migration or data changes. Reversible by removing the `regions` setting.