### PR TITLE
fix(dabbir): surface customer feedback in owner dashboard

### DIFF
--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -7,7 +7,7 @@ import {
 
 const OWNER_USERNAME = 'barmanadmin';
 const OWNER_EMAIL = process.env.DABBIR_OWNER_LOGIN_EMAIL || 'barman2013@icloud.com';
-const BROKER_URL = 'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/bm-secret-broker';
+const BROKER_URL = 'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/dabbir-owner-broker';
 const OTP_RE = /^\d{6}$/;
 const CHALLENGE_COOKIE = '__Host-dabbir_owner_otp_challenge';
 const SESSION_COOKIE = '__Host-dabbir_owner_session';
@@ -45,7 +45,7 @@ async function broker(body) {
 export default async function handler(req, res) {
   res.setHeader('cache-control', 'no-store, max-age=0');
   res.setHeader('pragma', 'no-cache');
-  res.setHeader('x-dabbir-owner-auth', 'brokered-resend-otp-v6');
+  res.setHeader('x-dabbir-owner-auth', 'brokered-resend-otp-v7');
 
   if (req.method !== 'POST') {
     return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });

--- a/api/owner-dashboard-data.js
+++ b/api/owner-dashboard-data.js
@@ -1,7 +1,7 @@
 import { json, parseCookies } from './_auth-core.js';
 import { singleQueryValue } from './_request-query.js';
 
-const BROKER_URL='https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/bm-secret-broker';
+const BROKER_URL='https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/dabbir-owner-broker';
 const SESSION_COOKIE='__Host-dabbir_owner_session';
 
 async function broker(body){

--- a/api/owner-dashboard-gateway.js
+++ b/api/owner-dashboard-gateway.js
@@ -1,7 +1,7 @@
 import dashboard from './owner-command-center-v21.js';
 import { parseCookies } from './_auth-core.js';
 
-const BROKER_URL = 'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/bm-secret-broker';
+const BROKER_URL = 'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/dabbir-owner-broker';
 const SESSION_COOKIE = '__Host-dabbir_owner_session';
 
 function redirectToOwner(res, clear = false) {

--- a/supabase/functions/dabbir-owner-broker/index.ts
+++ b/supabase/functions/dabbir-owner-broker/index.ts
@@ -1,0 +1,87 @@
+const SUPABASE_URL=Deno.env.get('SUPABASE_URL')||'';
+const SERVICE_KEY=Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')||'';
+const JSON_HEADERS={'content-type':'application/json','cache-control':'no-store'};
+const sbHeaders=()=>({'apikey':SERVICE_KEY,'authorization':`Bearer ${SERVICE_KEY}`,'content-type':'application/json'});
+const reply=(status:number,body:unknown)=>new Response(JSON.stringify(body),{status,headers:JSON_HEADERS});
+const bytesToHex=(bytes:Uint8Array)=>Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('');
+async function sha(value:string){return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256',new TextEncoder().encode(value))))}
+async function otpHash(id:string,otp:string){return sha(`${SERVICE_KEY}:dabbir-owner-otp:${id}:${otp}`)}
+async function tokenHash(token:string){return sha(`${SERVICE_KEY}:dabbir-owner-session:${token}`)}
+function randomToken(bytes=36){const data=new Uint8Array(bytes);crypto.getRandomValues(data);return btoa(String.fromCharCode(...data)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
+function randomOtp(){const x=new Uint32Array(1);crypto.getRandomValues(x);return String(x[0]%1000000).padStart(6,'0')}
+function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let out=0;for(let i=0;i<a.length;i++)out|=a.charCodeAt(i)^b.charCodeAt(i);return out===0}
+async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
+async function activeAdmin(){
+ const r=await sb('/rest/v1/dabbir_platform_admins?active=eq.true&select=user_id&order=created_at.asc&limit=1');
+ if(!r.ok)return null;const rows=await r.json().catch(()=>[]);return Array.isArray(rows)&&rows[0]?.user_id?String(rows[0].user_id):null;
+}
+async function adminEmail(userId:string){
+ const r=await sb(`/auth/v1/admin/users/${encodeURIComponent(userId)}`);
+ if(!r.ok)return null;const u=await r.json().catch(()=>null);return u?.email?String(u.email):null;
+}
+async function verifySession(token:string){
+ if(!token||token.length<24||token.length>256)return null;
+ const h=await tokenHash(token);
+ const r=await sb('/rest/v1/rpc/dabbir_owner_session_verify_v1',{method:'POST',body:JSON.stringify({p_token_hash:h})});
+ if(!r.ok)return null;const p=await r.json().catch(()=>null);return p?.authenticated===true&&p?.role==='platform_owner'&&p?.actor_user_id?p:null;
+}
+async function requestOtp(body:any){
+ const resendKey=String(body?.resend_key||'').trim();
+ if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+ const since=new Date(Date.now()-10*60*1000).toISOString();
+ const countRes=await sb(`/rest/v1/dabbir_owner_otp_challenges?created_at=gte.${encodeURIComponent(since)}&select=id`,{headers:{prefer:'count=exact'}});
+ if(countRes.ok){const range=countRes.headers.get('content-range')||'';const total=Number(range.split('/')[1]);if(Number.isFinite(total)&&total>=3)return reply(429,{ok:false,error:'OTP_RATE_LIMITED'})}
+ const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});
+ const email=await adminEmail(actor);if(!email)return reply(503,{ok:false,error:'PLATFORM_OWNER_EMAIL_NOT_CONFIGURED'});
+ const id=crypto.randomUUID(),otp=randomOtp(),expires=new Date(Date.now()+10*60*1000).toISOString();
+ const insert=await sb('/rest/v1/dabbir_owner_otp_challenges',{method:'POST',headers:{prefer:'return=minimal'},body:JSON.stringify({id,otp_hash:await otpHash(id,otp),token_hash:await sha(`${SERVICE_KEY}:challenge:${id}:${randomToken(18)}`),expires_at:expires,attempts:0})});
+ if(!insert.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});
+ const from=String(Deno.env.get('DABBIR_RESEND_FROM')||'DABBIR <onboarding@resend.dev>');
+ const sent=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${resendKey}`,'content-type':'application/json'},body:JSON.stringify({from,to:[email],subject:'DABBIR owner verification code',text:`رمز دخول مالك دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR owner verification code: ${otp}\nExpires in 10 minutes.`})});
+ if(!sent.ok){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}`,{method:'DELETE'});return reply(503,{ok:false,error:'OWNER_OTP_DELIVERY_FAILED'})}
+ return reply(200,{ok:true,challenge_id:id,otp_required:true});
+}
+async function verifyOtp(body:any){
+ const id=String(body?.challenge_id||'').trim(),otp=String(body?.otp||'').trim();
+ if(!/^[0-9a-f-]{36}$/i.test(id)||!/^\d{6}$/.test(otp))return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});
+ const r=await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&select=id,otp_hash,expires_at,attempts,consumed_at&limit=1`);
+ if(!r.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});const rows=await r.json().catch(()=>[]),row=Array.isArray(rows)?rows[0]:null;
+ if(!row||row.consumed_at||new Date(row.expires_at).getTime()<=Date.now()||Number(row.attempts||0)>=5)return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});
+ const good=safeEqual(String(row.otp_hash||''),await otpHash(id,otp));
+ if(!good){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({attempts:Number(row.attempts||0)+1})});return reply(401,{ok:false,error:'INVALID_OWNER_OTP'})}
+ const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});
+ const sessionToken=randomToken(48),h=await tokenHash(sessionToken),expiresIn=43200,sessionExpires=new Date(Date.now()+expiresIn*1000).toISOString();
+ const issue=await sb('/rest/v1/rpc/dabbir_owner_session_issue_v1',{method:'POST',body:JSON.stringify({p_actor_user_id:actor,p_token_hash:h,p_expires_at:sessionExpires})});
+ if(!issue.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});
+ await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({consumed_at:new Date().toISOString(),attempts:Number(row.attempts||0)+1})});
+ return reply(200,{ok:true,authenticated:true,role:'platform_owner',session_token:sessionToken,expires_in:expiresIn});
+}
+async function ownerData(body:any){
+ const session=await verifySession(String(body?.session_token||''));if(!session)return reply(401,{ok:false,error:'OWNER_SESSION_REQUIRED'});
+ const action=String(body?.data_action||'overview').trim().toLowerCase();
+ if(action==='overview'){
+  const r=await sb('/rest/v1/rpc/dabbir_platform_owner_overview',{method:'POST',body:JSON.stringify({p_actor_user_id:session.actor_user_id})});
+  if(!r.ok)return reply(503,{ok:false,error:'OWNER_DATA_FAILED'});const payload=await r.json().catch(()=>null);return reply(200,{ok:true,payload});
+ }
+ if(action==='search'){
+  const q=String(body?.q||'').trim().slice(0,160);
+  const r=await sb('/rest/v1/rpc/dabbir_platform_customer_search',{method:'POST',body:JSON.stringify({p_actor_user_id:session.actor_user_id,p_query:q,p_limit:50})});
+  if(!r.ok)return reply(503,{ok:false,error:'OWNER_SEARCH_FAILED'});const rows=await r.json().catch(()=>[]);return reply(200,{ok:true,payload:{accounts:Array.isArray(rows)?rows:[]}});
+ }
+ return reply(400,{ok:false,error:'UNKNOWN_OWNER_DATA_ACTION'});
+}
+Deno.serve(async(req:Request)=>{
+ if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
+ if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_BROKER_NOT_CONFIGURED'});
+ let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
+ const action=String(body?.action||'').trim().toLowerCase();
+ try{
+  if(action==='owner_otp_request')return requestOtp(body);
+  if(action==='owner_otp_verify')return verifyOtp(body);
+  if(action==='owner_session_verify'){
+   const session=await verifySession(String(body?.session_token||''));return session?reply(200,{ok:true,authenticated:true,role:'platform_owner',actor_user_id:session.actor_user_id,expires_at:session.expires_at}):reply(401,{ok:false,authenticated:false,error:'OWNER_SESSION_REQUIRED'});
+  }
+  if(action==='owner_data')return ownerData(body);
+  return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
+ }catch{return reply(503,{ok:false,error:'OWNER_BROKER_UNAVAILABLE'})}
+});

--- a/supabase/migrations/20260831192500_dabbir_owner_sessions_v1.sql
+++ b/supabase/migrations/20260831192500_dabbir_owner_sessions_v1.sql
@@ -1,0 +1,25 @@
+begin;
+
+create table if not exists dabbir_private.owner_sessions (
+  id uuid primary key default gen_random_uuid(),
+  actor_user_id uuid not null,
+  token_hash text not null unique,
+  expires_at timestamptz not null,
+  created_at timestamptz not null default now(),
+  last_seen_at timestamptz,
+  revoked_at timestamptz
+);
+
+alter table dabbir_private.owner_sessions enable row level security;
+alter table dabbir_private.owner_sessions force row level security;
+
+revoke all on table dabbir_private.owner_sessions from public;
+revoke all on table dabbir_private.owner_sessions from anon;
+revoke all on table dabbir_private.owner_sessions from authenticated;
+grant select, insert, update, delete on table dabbir_private.owner_sessions to service_role;
+
+create index if not exists dabbir_owner_sessions_expiry_idx
+  on dabbir_private.owner_sessions (expires_at)
+  where revoked_at is null;
+
+commit;

--- a/supabase/migrations/20260831192600_dabbir_owner_session_rpc_v1.sql
+++ b/supabase/migrations/20260831192600_dabbir_owner_session_rpc_v1.sql
@@ -1,0 +1,63 @@
+begin;
+
+create or replace function public.dabbir_owner_session_issue_v1(
+  p_actor_user_id uuid,
+  p_token_hash text,
+  p_expires_at timestamptz
+)
+returns void
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','dabbir_private'
+as $$
+begin
+  if p_actor_user_id is null or nullif(trim(p_token_hash),'') is null or p_expires_at <= now() then
+    raise exception 'INVALID_OWNER_SESSION';
+  end if;
+  if not exists(select 1 from public.dabbir_platform_admins where user_id=p_actor_user_id and active=true) then
+    raise exception 'PLATFORM_ADMIN_REQUIRED';
+  end if;
+  delete from dabbir_private.owner_sessions where expires_at <= now() or revoked_at is not null;
+  insert into dabbir_private.owner_sessions(actor_user_id,token_hash,expires_at,last_seen_at)
+  values(p_actor_user_id,p_token_hash,p_expires_at,now());
+end;
+$$;
+
+create or replace function public.dabbir_owner_session_verify_v1(p_token_hash text)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','dabbir_private'
+as $$
+declare
+  v_session dabbir_private.owner_sessions%rowtype;
+begin
+  select * into v_session
+  from dabbir_private.owner_sessions
+  where token_hash=p_token_hash
+    and revoked_at is null
+    and expires_at>now()
+  limit 1;
+  if not found then
+    return jsonb_build_object('authenticated',false);
+  end if;
+  if not exists(select 1 from public.dabbir_platform_admins where user_id=v_session.actor_user_id and active=true) then
+    update dabbir_private.owner_sessions set revoked_at=now() where id=v_session.id;
+    return jsonb_build_object('authenticated',false);
+  end if;
+  update dabbir_private.owner_sessions set last_seen_at=now() where id=v_session.id;
+  return jsonb_build_object(
+    'authenticated',true,
+    'role','platform_owner',
+    'actor_user_id',v_session.actor_user_id,
+    'expires_at',v_session.expires_at
+  );
+end;
+$$;
+
+revoke all on function public.dabbir_owner_session_issue_v1(uuid,text,timestamptz) from public, anon, authenticated;
+revoke all on function public.dabbir_owner_session_verify_v1(text) from public, anon, authenticated;
+grant execute on function public.dabbir_owner_session_issue_v1(uuid,text,timestamptz) to service_role;
+grant execute on function public.dabbir_owner_session_verify_v1(text) to service_role;
+
+commit;

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -4,12 +4,12 @@ import { readFile } from 'node:fs/promises';
 
 const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
-test('owner authentication is username + brokered Resend OTP with a signed owner session', async () => {
+test('owner authentication is username + brokered Resend OTP with an isolated owner session', async () => {
   const source = await read('api/auth/owner-otp.js');
   assert.match(source, /OWNER_USERNAME\s*=\s*'barmanadmin'/);
   assert.match(source, /requireSameOrigin\(req\)/);
   assert.match(source, /RESEND_API_KEY/);
-  assert.match(source, /bm-secret-broker/);
+  assert.match(source, /dabbir-owner-broker/);
   assert.match(source, /owner_otp_request/);
   assert.match(source, /owner_otp_verify/);
   assert.match(source, /challenge_id/);
@@ -41,8 +41,9 @@ test('canonical owner routes use the OTP gate and authenticated dashboard gatewa
   assert.equal(dashboardRoute?.dest, '/api/owner-dashboard-gateway');
 });
 
-test('dashboard gateway validates the signed owner session fail-closed through the broker', async () => {
+test('dashboard gateway validates the owner session fail-closed through the DABBIR broker', async () => {
   const source = await read('api/owner-dashboard-gateway.js');
+  assert.match(source, /dabbir-owner-broker/);
   assert.match(source, /__Host-dabbir_owner_session/);
   assert.match(source, /owner_session_verify/);
   assert.match(source, /payload\?\.authenticated === true/);


### PR DESCRIPTION
Routes DABBIR owner OTP/session/data through an isolated DABBIR-only broker instead of the offline Barman broker. Persists the owner-session schema/RPC source, preserves the existing owner feedback inbox UI, and restores `overview.feedback` from the protected platform-owner overview function. Barman and ZAJEL systems remain untouched/offline.