### PR TITLE
fix(dabbir): stop request storms and clean calendar error telemetry

### DIFF
--- a/api/calendar-connections.js
+++ b/api/calendar-connections.js
@@ -18,6 +18,15 @@ function calendarStorageConfigured(){
   return Boolean(key&&!key.startsWith('sb_publishable_'));
 }
 
+function logCalendarFailure(error,status){
+  const payload={
+    error:String(error?.message||'CALENDAR_CONNECTIONS_FAILED').slice(0,160),
+    code:status,
+  };
+  if(status>=500) console.error('dabbir_calendar_connections_failed',payload);
+  else if(status===429) console.warn('dabbir_calendar_connections_rate_limited',payload);
+}
+
 export default async function handler(req,res){
   try{
     if(req.method==='GET'){
@@ -50,7 +59,8 @@ export default async function handler(req,res){
     }
     return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
   }catch(error){
-    console.error('dabbir_calendar_connections_failed',{error:String(error?.message||'CALENDAR_CONNECTIONS_FAILED').slice(0,160),code:statusCode(error)});
-    return json(res,statusCode(error),{ok:false,error:String(error?.message||'CALENDAR_CONNECTIONS_FAILED').slice(0,160),detail:error?.detail||undefined});
+    const status=statusCode(error);
+    logCalendarFailure(error,status);
+    return json(res,status,{ok:false,error:String(error?.message||'CALENDAR_CONNECTIONS_FAILED').slice(0,160),detail:error?.detail||undefined});
   }
 }

--- a/api/dabbir-whatsapp-embedded-ui.js
+++ b/api/dabbir-whatsapp-embedded-ui.js
@@ -4,6 +4,8 @@ const script = String.raw`(()=>{
 
   const SESSION_TIMEOUT_MS=15*60*1000;
   const POST_LOGIN_SESSION_GRACE_MS=5000;
+  const CONFIG_CACHE_MS=60*1000;
+  const CONFIG_FAILURE_CACHE_MS=10*1000;
   const EMBEDDED_SIGNUP_VERSION='v4';
   const COEXISTENCE_FEATURE='whatsapp_business_app_onboarding';
   const META_FINISH_EVENTS=new Set([
@@ -31,6 +33,11 @@ const script = String.raw`(()=>{
   let sessionWaiters=[];
   let configCache=null;
   let configBusinessId=null;
+  let configFetchedAt=0;
+  let configFailureBusinessId='';
+  let configFailureAt=0;
+  let configInFlight=null;
+  let configInFlightBusinessId='';
   let busy=false;
 
   function ar(){return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')}
@@ -194,16 +201,52 @@ const script = String.raw`(()=>{
     return sdkPreparePromise;
   }
 
+  function resetConfigCache(){
+    configCache=null;
+    configBusinessId=null;
+    configFetchedAt=0;
+    configFailureBusinessId='';
+    configFailureAt=0;
+  }
+
   async function loadConfig(force=false){
     const bid=businessId();
     if(!bid) return null;
-    if(!force&&configCache&&configBusinessId===bid) return configCache;
-    const response=await fetch('/api/dabbir-whatsapp-embedded-config?business_id='+encodeURIComponent(bid),{cache:'no-store',headers:{accept:'application/json'}});
-    const payload=await response.json().catch(()=>({}));
-    if(!response.ok||!payload.ok) return null;
-    configBusinessId=bid;
-    configCache=payload;
-    return payload;
+    const now=Date.now();
+    if(!force&&configCache&&configBusinessId===bid&&now-configFetchedAt<CONFIG_CACHE_MS) return configCache;
+    if(!force&&configFailureBusinessId===bid&&now-configFailureAt<CONFIG_FAILURE_CACHE_MS) return null;
+    if(configInFlight&&configInFlightBusinessId===bid) return configInFlight;
+
+    configInFlightBusinessId=bid;
+    const request=(async()=>{
+      try{
+        const response=await fetch('/api/dabbir-whatsapp-embedded-config?business_id='+encodeURIComponent(bid),{cache:'no-store',headers:{accept:'application/json'}});
+        const payload=await response.json().catch(()=>({}));
+        if(!response.ok||!payload.ok){
+          configFailureBusinessId=bid;
+          configFailureAt=Date.now();
+          return null;
+        }
+        configBusinessId=bid;
+        configCache=payload;
+        configFetchedAt=Date.now();
+        configFailureBusinessId='';
+        configFailureAt=0;
+        return payload;
+      }catch{
+        configFailureBusinessId=bid;
+        configFailureAt=Date.now();
+        return null;
+      }
+    })();
+    configInFlight=request;
+    try{return await request}
+    finally{
+      if(configInFlight===request){
+        configInFlight=null;
+        configInFlightBusinessId='';
+      }
+    }
   }
 
   async function refreshTenantStatus(){
@@ -258,7 +301,7 @@ const script = String.raw`(()=>{
     }
     report('complete_ok',{stage:'server_complete',onboarding_mode:COEXISTENCE_FEATURE,has_waba:true,has_phone:true});
     if(typeof workspace!=='undefined'&&workspace) workspace.whatsapp={...(workspace.whatsapp||{}),...payload};
-    configCache=null;
+    resetConfigCache();
     await loadConfig(true).catch(()=>null);
     await refreshTenantStatus();
     tell(ar()?'تم ربط رقم WhatsApp Business بنجاح':'WhatsApp Business number connected successfully');
@@ -368,7 +411,7 @@ const script = String.raw`(()=>{
       });
       const payload=await response.json().catch(()=>({}));
       if(!response.ok||!payload.ok) throw new Error(payload.error||'WHATSAPP_DISCONNECT_FAILED');
-      configCache=null;
+      resetConfigCache();
       sdkReadyAppId=null;
       if(typeof workspace!=='undefined'&&workspace) workspace.whatsapp={connected:false,state:'NOT_CONFIGURED',phone:null,operational:false};
       try{if(typeof renderIntegrations==='function')renderIntegrations()}catch{}

--- a/test/dabbir-request-storm-regression.test.mjs
+++ b/test/dabbir-request-storm-regression.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('WhatsApp embedded signup coalesces concurrent config requests', async () => {
+  const source = await read('api/dabbir-whatsapp-embedded-ui.js');
+  assert.match(source, /let configInFlight=null;/);
+  assert.match(source, /if\(configInFlight&&configInFlightBusinessId===bid\) return configInFlight;/);
+  assert.match(source, /CONFIG_CACHE_MS=60\*1000/);
+  assert.match(source, /CONFIG_FAILURE_CACHE_MS=10\*1000/);
+});
+
+test('calendar connection endpoint only logs server failures as errors', async () => {
+  const source = await read('api/calendar-connections.js');
+  assert.match(source, /if\(status>=500\) console\.error\('dabbir_calendar_connections_failed'/);
+  assert.doesNotMatch(source, /catch\(error\)\{\s*console\.error\('dabbir_calendar_connections_failed'/);
+});


### PR DESCRIPTION
## What changed
- Coalesce concurrent `/api/dabbir-whatsapp-embedded-config` requests in the Embedded Signup UI.
- Cache successful config briefly and negative results briefly to prevent retry loops.
- Reset config cache only when connection state actually changes.
- Stop logging expected 4xx calendar authorization responses as production errors; retain 5xx error logging and 429 warnings.
- Add regression tests for both behaviors.

## Production evidence before fix
- Current production showed 58 successful calls to `/api/dabbir-whatsapp-embedded-config` in 15 minutes, with a same-user/database burst of repeated auth, membership and WhatsApp connection reads.
- Calendar 401 responses were being emitted as `console.error`, inflating the production error clusters.

## Safety
- No database schema changes.
- No WhatsApp credentials or Meta identifiers changed.
- No authorization behavior changed; only request deduplication and logging classification.