### PR TITLE
fix(dabbir): stop passive calendar request storms

### DIFF
--- a/api/calendar-live-ui.js
+++ b/api/calendar-live-ui.js
@@ -7,7 +7,11 @@ import businessActivityProfileUiHandler from './business-activity-profile-ui.js'
 const liveScript=String.raw`(()=>{
   if(window.__dabbirCalendarLiveUi)return;
   const q=s=>document.querySelector(s);
-  let busy=false,lastBusiness=null,lastSyncAt=0,lastBusy=[];
+  const PASSIVE_CACHE_MS=60*1000;
+  const AUTH_BACKOFF_MS=60*1000;
+  let busy=false,lastBusiness=null,lastSyncAt=0,lastBusy=[],lastBusyLoadAt=0;
+  let lastConnectionState=null,lastConnectionCheckAt=0,connectionBlockedUntil=0,connectionBlockedError='';
+  let syncInFlight=null,forceQueued=false,passiveSyncTimer=null;
   const ar=()=>document.documentElement.lang!=='en';
   const esc=value=>String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
   const businessId=()=>{try{return workspace?.business?.id||null}catch{return null}};
@@ -42,52 +46,114 @@ const liveScript=String.raw`(()=>{
     panel.innerHTML='<h4>'+(ar()?'الأوقات المشغولة من Google / Outlook':'Busy time from Google / Outlook')+'</h4>'+(rows.length?'<div class="dabbirExternalBusyList">'+rows.map(row=>'<div class="dabbirExternalBusyRow"><b>'+esc(row.summary||(ar()?'مشغول':'Busy'))+'</b><span>'+esc(fmt(row.starts_at))+'</span></div>').join('')+'</div>':'<div style="font-size:8px;color:var(--muted)">'+(ar()?'لا توجد أوقات خارجية مشغولة قادمة.':'No upcoming external busy time.')+'</div>');
   }
 
-  async function connectionState(id){
+  function httpError(response,body,fallback){
+    const error=new Error(body?.error||fallback);
+    error.status=Number(response?.status||0);
+    return error;
+  }
+
+  function resetPassiveState(id){
+    lastBusiness=id;
+    lastSyncAt=0;
+    lastBusy=[];
+    lastBusyLoadAt=0;
+    lastConnectionState=null;
+    lastConnectionCheckAt=0;
+    connectionBlockedUntil=0;
+    connectionBlockedError='';
+  }
+
+  async function connectionState(id,force=false){
+    const now=Date.now();
+    if(!force&&connectionBlockedUntil>now){
+      const error=new Error(connectionBlockedError||'AUTH_REQUIRED');
+      error.status=401;
+      throw error;
+    }
+    if(!force&&lastConnectionState&&lastBusiness===id&&now-lastConnectionCheckAt<PASSIVE_CACHE_MS)return lastConnectionState;
     const response=await fetch('/api/calendar-connections?business_id='+encodeURIComponent(id),{credentials:'same-origin',cache:'no-store',headers:{accept:'application/json'}});
-    const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw new Error(body?.error||'CALENDAR_CONNECTIONS_FAILED');
+    const body=await response.json().catch(()=>null);
+    if(!response.ok||!body?.ok){
+      const error=httpError(response,body,'CALENDAR_CONNECTIONS_FAILED');
+      if(error.status===401||error.status===403){
+        connectionBlockedUntil=Date.now()+AUTH_BACKOFF_MS;
+        connectionBlockedError=String(error.message||'AUTH_REQUIRED');
+      }
+      throw error;
+    }
+    lastConnectionState=body;
+    lastConnectionCheckAt=Date.now();
+    connectionBlockedUntil=0;
+    connectionBlockedError='';
     return body;
   }
 
-  async function loadBusy(id){
+  async function loadBusy(id,force=false){
+    const now=Date.now();
+    if(!force&&lastBusiness===id&&lastBusyLoadAt&&now-lastBusyLoadAt<PASSIVE_CACHE_MS){renderBusy();removeCancelledFromActiveCalendar();return}
     const response=await fetch('/api/calendar-sync?business_id='+encodeURIComponent(id),{credentials:'same-origin',cache:'no-store',headers:{accept:'application/json'}});
-    const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw new Error(body?.error||'CALENDAR_BUSY_FAILED');
-    lastBusy=Array.isArray(body.busy_blocks)?body.busy_blocks:[];renderBusy();removeCancelledFromActiveCalendar();
+    const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw httpError(response,body,'CALENDAR_BUSY_FAILED');
+    lastBusy=Array.isArray(body.busy_blocks)?body.busy_blocks:[];
+    lastBusyLoadAt=Date.now();
+    renderBusy();removeCancelledFromActiveCalendar();
   }
 
-  async function sync(force=false){
-    const id=businessId();if(!id||busy)return;
+  async function runSync(force=false){
+    const id=businessId();if(!id)return;
     ensureUi();
-    if(id!==lastBusiness){lastBusiness=id;lastSyncAt=0;lastBusy=[]}
+    if(id!==lastBusiness)resetPassiveState(id);
     try{
-      const connections=await connectionState(id),active=(connections.connections||[]).filter(c=>c.status==='active'&&c.sync_enabled!==false);
-      if(!active.length){lastBusy=[];renderBusy();removeCancelledFromActiveCalendar();return}
+      const connections=await connectionState(id,force),active=(connections.connections||[]).filter(c=>c.status==='active'&&c.sync_enabled!==false);
+      if(!active.length){lastBusy=[];lastBusyLoadAt=Date.now();renderBusy();removeCancelledFromActiveCalendar();return}
       const due=force||Date.now()-lastSyncAt>5*60*1000;
       if(due){
         busy=true;ensureUi();
         const response=await fetch('/api/calendar-sync',{method:'POST',credentials:'same-origin',headers:{'content-type':'application/json',accept:'application/json'},body:JSON.stringify({business_id:id})});
-        const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw new Error(body?.error||'CALENDAR_SYNC_FAILED');
+        const body=await response.json().catch(()=>null);if(!response.ok||!body?.ok)throw httpError(response,body,'CALENDAR_SYNC_FAILED');
         lastSyncAt=Date.now();
+        lastBusyLoadAt=0;
         try{window.__dabbirActivityProfile?.refresh?.()}catch{}
       }
-      await loadBusy(id);
+      await loadBusy(id,due||force);
       removeCancelledFromActiveCalendar();
       if(force)try{toast(ar()?'تمت مزامنة التقويم':'Calendar synced')}catch{}
     }catch(error){
-      console.error('dabbir_calendar_live_ui_failed',String(error?.message||error).slice(0,120));
+      const status=Number(error?.status||0);
+      if(force||status>=500||status===0)console.error('dabbir_calendar_live_ui_failed',String(error?.message||error).slice(0,120));
       if(force)try{toast(ar()?'تعذرت مزامنة التقويم':'Calendar sync failed')}catch{}
     }finally{busy=false;ensureUi();removeCancelledFromActiveCalendar()}
   }
 
-  const observer=new MutationObserver(()=>{if(screenActive()&&businessId()){ensureUi();sync(false)}});
+  async function sync(force=false){
+    if(!businessId())return;
+    if(syncInFlight){if(force)forceQueued=true;return syncInFlight}
+    const request=runSync(force);
+    syncInFlight=request;
+    try{return await request}
+    finally{
+      if(syncInFlight===request)syncInFlight=null;
+      if(forceQueued){forceQueued=false;setTimeout(()=>sync(true),0)}
+    }
+  }
+
+  function schedulePassiveSync(){
+    if(passiveSyncTimer)return;
+    passiveSyncTimer=setTimeout(()=>{
+      passiveSyncTimer=null;
+      if(screenActive()&&businessId()){ensureUi();void sync(false)}
+    },150);
+  }
+
+  const observer=new MutationObserver(schedulePassiveSync);
   observer.observe(document.body,{subtree:true,attributes:true,attributeFilter:['class']});
   const calendarScreen=q('#screen-appointments');
   if(calendarScreen){
     const calendarObserver=new MutationObserver(()=>setTimeout(removeCancelledFromActiveCalendar,0));
     calendarObserver.observe(calendarScreen,{subtree:true,childList:true});
   }
-  setInterval(()=>{if(screenActive()&&businessId()){removeCancelledFromActiveCalendar();sync(false)}},60000);
-  setTimeout(()=>{if(screenActive()&&businessId()){removeCancelledFromActiveCalendar();sync(false)}},1200);
-  window.__dabbirCalendarLiveUi={sync:()=>sync(true),refreshBusy:()=>businessId()?loadBusy(businessId()):Promise.resolve(),sanitize:removeCancelledFromActiveCalendar,version:'calendar-live-v4-free-cancelled'};
+  setInterval(()=>{if(screenActive()&&businessId()){removeCancelledFromActiveCalendar();void sync(false)}},60000);
+  setTimeout(()=>{if(screenActive()&&businessId()){removeCancelledFromActiveCalendar();void sync(false)}},1200);
+  window.__dabbirCalendarLiveUi={sync:()=>sync(true),refreshBusy:()=>businessId()?loadBusy(businessId(),true):Promise.resolve(),sanitize:removeCancelledFromActiveCalendar,version:'calendar-live-v5-request-coalescing'};
 })();`;
 
 function captureResponse(){
@@ -119,6 +185,6 @@ export default async function handler(req,res){
   if(businessActivityCaptured.statusCode!==200||!businessActivityCaptured.body) return res.status(500).end('Business activity profile UI unavailable');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-calendar-live-ui','v7-clinic-mode');
+  res.setHeader('x-dabbir-calendar-live-ui','v8-request-coalescing');
   return res.status(200).send(activityCaptured.body+'\n'+liveScript+'\n'+managementCaptured.body+'\n'+salonCaptured.body+'\n'+clinicCaptured.body+'\n'+businessActivityCaptured.body);
 }

--- a/test/dabbir-request-storm-regression.test.mjs
+++ b/test/dabbir-request-storm-regression.test.mjs
@@ -17,3 +17,13 @@ test('calendar connection endpoint only logs server failures as errors', async (
   assert.match(source, /if\(status>=500\) console\.error\('dabbir_calendar_connections_failed'/);
   assert.doesNotMatch(source, /catch\(error\)\{\s*console\.error\('dabbir_calendar_connections_failed'/);
 });
+
+test('calendar live UI coalesces passive sync and backs off expected auth failures', async () => {
+  const source = await read('api/calendar-live-ui.js');
+  assert.match(source, /AUTH_BACKOFF_MS=60\*1000/);
+  assert.match(source, /let syncInFlight=null,forceQueued=false,passiveSyncTimer=null;/);
+  assert.match(source, /if\(syncInFlight\)\{if\(force\)forceQueued=true;return syncInFlight\}/);
+  assert.match(source, /connectionBlockedUntil=Date\.now\(\)\+AUTH_BACKOFF_MS/);
+  assert.match(source, /const observer=new MutationObserver\(schedulePassiveSync\)/);
+  assert.match(source, /lastBusyLoadAt<PASSIVE_CACHE_MS/);
+});


### PR DESCRIPTION
## What changed
- Coalesce overlapping passive calendar sync work into one in-flight request.
- Cache passive connection state and busy-time reads for 60 seconds.
- Back off expected 401/403 calendar checks for 60 seconds instead of retrying on DOM mutations.
- Throttle MutationObserver-triggered passive checks.
- Keep manual Sync Now able to force a refresh.
- Add regression coverage for the request coalescing/backoff contract.

## Production evidence before fix
- Production recorded 2,648 `/api/calendar-connections` AUTH_REQUIRED responses from one user within ~10 seconds.
- The existing MutationObserver called `sync(false)` on class mutations before any in-flight guard was set.

## Safety
- No database or authorization changes.
- No calendar provider credentials changed.
- Manual sync behavior remains available and explicit.