### PR TITLE
fix(dabbir): unblock Vercel deploy without Enterprise

### DIFF
--- a/supabase/migrations/20260901214926_contain_public_migration_helper_privilege_chain.sql
+++ b/supabase/migrations/20260901214926_contain_public_migration_helper_privilege_chain.sql
@@ -1,0 +1,27 @@
+begin;
+
+revoke all privileges
+  on table public.migration_auth_fk_specs
+  from public, anon, authenticated;
+
+alter table public.migration_auth_fk_specs enable row level security;
+
+revoke execute
+  on function public.migration_apply_auth_fks_v1()
+  from public, anon, authenticated;
+
+grant select
+  on table public.migration_auth_fk_specs
+  to service_role;
+
+grant execute
+  on function public.migration_apply_auth_fks_v1()
+  to service_role;
+
+comment on table public.migration_auth_fk_specs is
+  'Internal DABBIR migration metadata. Not accessible to anon/authenticated.';
+
+comment on function public.migration_apply_auth_fks_v1() is
+  'Internal DABBIR migration helper. Execution restricted to service_role and privileged database roles.';
+
+commit;

--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,6 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "fluid": true,
   "regions": ["dub1"],
-  "functionFailoverRegions": ["fra1"],
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "env": {
     "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"


### PR DESCRIPTION
## Outcome

Unblocks DABBIR deployments without purchasing Vercel Enterprise and records the production security containment already applied to DABBIR Mumbai.

## Changes

- Remove `functionFailoverRegions` from `vercel.json`; keep the primary function region `dub1` and Fluid Compute.
- Add the exact Supabase migration `20260901214926_contain_public_migration_helper_privilege_chain.sql` so repository history matches the applied DABBIR Mumbai database state.

## Verified before PR

- `vercel.json` parses as valid JSON.
- Supabase migration applied successfully.
- `anon` and `authenticated` have no table DML or helper EXECUTE.
- `service_role` retains required SELECT/EXECUTE.
- Supabase security advisor no longer reports the migration privilege-chain warning/error.

No payment or plan upgrade is required. ZAJEL is untouched.