### PR TITLE
fix(dabbir): authenticate reminder cron with Supabase secret keys

### DIFF
--- a/api/salon-reminders-cron.js
+++ b/api/salon-reminders-cron.js
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from 'node:crypto';
-import { json, SUPABASE_URL, supabaseRpc } from './_auth-core.js';
+import { json, SUPABASE_URL } from './_auth-core.js';
 import { loadBusinessConnection } from './_whatsapp-embedded-core.js';
 import { sendMetaTemplate } from './_whatsapp-live-core.js';
 
@@ -7,6 +7,21 @@ const clean=(value,max=500)=>String(value??'').trim().replace(/[\u0000-\u001f\u0
 const serviceKey=()=>clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
 const EXPECTED_SCHEDULE='*/5 * * * *';
 const EDGE_WORKER_URL=`${SUPABASE_URL}/functions/v1/dabbir-salon-reminder-worker`;
+
+export function adminRpcHeaders(key){
+  const headers={apikey:key,accept:'application/json','content-type':'application/json',prefer:'return=representation'};
+  // Supabase secret keys (sb_secret_*) authenticate through apikey. Sending
+  // them as Bearer tokens makes PostgREST parse them as JWTs and fail.
+  if(!String(key).startsWith('sb_secret_'))headers.authorization=`Bearer ${key}`;
+  return headers;
+}
+async function adminRpc(key,name,params){
+  return fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{
+    method:'POST',cache:'no-store',redirect:'manual',
+    headers:adminRpcHeaders(key),
+    body:JSON.stringify(params),
+  });
+}
 
 function sameSecret(left,right){
   const a=Buffer.from(String(left||''));const b=Buffer.from(String(right||''));
@@ -28,7 +43,7 @@ async function readRpc(response,fallback){
   if(!response.ok)throw Object.assign(new Error(payload?.message||payload?.code||fallback),{status:response.status});
   return payload;
 }
-async function rpc(key,name,params){return readRpc(await supabaseRpc(name,key,params),`${name.toUpperCase()}_FAILED`)}
+async function rpc(key,name,params){return readRpc(await adminRpc(key,name,params),`${name.toUpperCase()}_FAILED`)}
 async function edge(req,action,payload={}){
   const token=clean(req.headers?.['x-vercel-oidc-token'],16384);
   if(!token)throw Object.assign(new Error('VERCEL_OIDC_TOKEN_REQUIRED'),{status:503});

--- a/test/dabbir-salon-mode.test.mjs
+++ b/test/dabbir-salon-mode.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
-import { cronAuthMode } from '../api/salon-reminders-cron.js';
+import { adminRpcHeaders, cronAuthMode } from '../api/salon-reminders-cron.js';
 
 const root=path.resolve(import.meta.dirname,'..');
 const read=file=>fs.readFileSync(path.join(root,file),'utf8');
@@ -120,6 +120,15 @@ test('Vercel Pro cron is configured every five minutes with secret-first authent
   assert.equal(cronAuthMode({headers:officialHeaders},{VERCEL_ENV:'preview'}),null);
   assert.equal(cronAuthMode({headers:{...officialHeaders,'user-agent':'browser'}},{VERCEL_ENV:'production'}),null);
   assert.equal(cronAuthMode({headers:{...officialHeaders,'x-vercel-cron-schedule':'0 * * * *'}},{VERCEL_ENV:'production'}),null);
+});
+
+test('reminder cron never sends Supabase secret keys as JWT bearer tokens',()=>{
+  const secretHeaders=adminRpcHeaders('sb_secret_example');
+  assert.equal(secretHeaders.apikey,'sb_secret_example');
+  assert.equal(secretHeaders.authorization,undefined);
+  const legacyHeaders=adminRpcHeaders('legacy.jwt.value');
+  assert.equal(legacyHeaders.apikey,'legacy.jwt.value');
+  assert.equal(legacyHeaders.authorization,'Bearer legacy.jwt.value');
 });
 
 test('legacy appointment writers remain compatible during the Salon Mode rollout',()=>{


### PR DESCRIPTION
## Incident
Production salon reminder cron fails every five minutes with `Expected 3 parts in JWT; got 1`.

## Root cause
The Mumbai runtime uses a current `sb_secret_*` Supabase server key. The cron sent it as `Authorization: Bearer`, so PostgREST attempted JWT parsing.

## Change
- Send `sb_secret_*` through `apikey` only.
- Preserve Bearer auth for legacy JWT service-role keys.
- Add a regression test for both formats.

## Verification
- Reviewable and reversible code-only change.
- No database mutation and no new spend.
- Merge only after GitHub checks pass.