### PR TITLE
security(dabbir): track Auth staging containment

### DIFF
--- a/supabase/migrations/20260902015650_contain_auth_migration_staging_tables.sql
+++ b/supabase/migrations/20260902015650_contain_auth_migration_staging_tables.sql
@@ -1,0 +1,18 @@
+begin;
+
+revoke all privileges on table public.migration_auth_users_stage from public, anon, authenticated;
+revoke all privileges on table public.migration_auth_identities_stage from public, anon, authenticated;
+revoke all privileges on table public.migration_auth_mfa_factors_stage from public, anon, authenticated;
+
+alter table public.migration_auth_users_stage enable row level security;
+alter table public.migration_auth_identities_stage enable row level security;
+alter table public.migration_auth_mfa_factors_stage enable row level security;
+
+comment on table public.migration_auth_users_stage is
+  'Internal DABBIR Auth migration staging. Not accessible to anon/authenticated.';
+comment on table public.migration_auth_identities_stage is
+  'Internal DABBIR Auth identity migration staging. Not accessible to anon/authenticated.';
+comment on table public.migration_auth_mfa_factors_stage is
+  'Internal DABBIR MFA migration staging. Not accessible to anon/authenticated.';
+
+commit;


### PR DESCRIPTION
Tracks the already-applied Mumbai security containment migration.

Verified live:
- RLS enabled on all three Auth/MFA staging tables.
- `anon` and `authenticated` cannot SELECT.
- `service_role` retains SELECT.
- Supabase critical RLS-disabled advisory is cleared.

No rows were deleted and Sydney remains preserved.