### PR TITLE
infra(dabbir): move Vercel Functions to Mumbai

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "fluid": true,
-  "regions": ["dub1"],
+  "regions": ["bom1"],
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "env": {
     "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"


### PR DESCRIPTION
## ACTION
Move DABBIR Vercel Function execution from Dubai (`dub1`) to Mumbai (`bom1`) so compute is colocated with Supabase Mumbai.

## ARTIFACT
- `vercel.json`: `regions` changed from `dub1` to `bom1`.
- No database, secret, financial, or ZAJEL change.

## TEST / EVIDENCE GATES
- Vercel preview must reach READY on exact commit `946b739d91e6e0c4a53291864330d6b15e245c72`.
- Live release and capability endpoints must pass.
- After merge, production response must prove Function region `bom1` via `x-vercel-id`.
- Runtime error scan must remain clean; rollback is the prior READY deployment `dpl_Ch6xqqrhwRY6GoBu4U1G2Lejeuqa`.