### PR TITLE
fix(dabbir): restore contextual navigation authority

### DIFF
--- a/api/dabbir-navigation-event-bridge-ui.js
+++ b/api/dabbir-navigation-event-bridge-ui.js
@@ -14,18 +14,10 @@ const script = String.raw`(()=>{
     return target?.closest?.(NAV_ITEM_SELECTOR)||null;
   }
 
-  function normalizeName(name){
-    try{
-      if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') return 'dashboard';
-    }catch{}
-    return name;
-  }
-
   function resolve(node){
     if(!node) return null;
-    const rawName=String(node.dataset?.screen||'').trim();
-    if(!rawName) return null;
-    const name=normalizeName(rawName);
+    const name=String(node.dataset?.screen||'').trim();
+    if(!name) return null;
     const screen=document.getElementById('screen-'+name);
     if(!screen) return null;
     return {node,name,screen};
@@ -136,12 +128,13 @@ const script = String.raw`(()=>{
   document.addEventListener('touchcancel',()=>{touchStart=null},{capture:true,passive:true});
 
   window.__dabbirNavigationEventBridge={
-    version:'navigation-event-bridge-v2-instant-paint-dub1',
+    version:'navigation-event-bridge-v3-router-authority',
     delegated_click:true,
     webkit_touch_fallback:true,
     safe_screen_fallback:true,
     visual_first:true,
     deferred_render:true,
+    destination_authority:'context-router',
   };
 })();`;
 
@@ -149,6 +142,6 @@ export default function handler(req,res){
   if(req.method!=='GET') return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=0, s-maxage=60, stale-while-revalidate=300');
-  res.setHeader('x-dabbir-navigation-event-bridge','v2-instant-paint-dub1');
+  res.setHeader('x-dabbir-navigation-event-bridge','v3-router-authority');
   return res.status(200).send(script);
 }

--- a/test/dabbir-navigation-event-bridge.test.mjs
+++ b/test/dabbir-navigation-event-bridge.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 
 const root = new URL('../', import.meta.url);
 const bridge = fs.readFileSync(new URL('api/dabbir-navigation-event-bridge-ui.js', root), 'utf8');
+const router = fs.readFileSync(new URL('api/dabbir-contextual-navigation-ui.js', root), 'utf8');
 const bundles = JSON.parse(fs.readFileSync(new URL('config/dabbir-ui-bundles.json', root), 'utf8'));
 const recovery = fs.readFileSync(new URL('api/app-recovery.js', root), 'utf8');
 
@@ -13,8 +14,18 @@ test('navigation bridge delegates existing primary nav without owning destinatio
   assert.match(bridge, /document\.addEventListener\('touchend'/);
   assert.match(bridge, /typeof showScreen==='function'/);
   assert.match(bridge, /safeFallback/);
+  assert.match(bridge, /destination_authority:'context-router'/);
+  assert.doesNotMatch(bridge, /function normalizeName\(/);
+  assert.doesNotMatch(bridge, /name==='appointments'/);
+  assert.doesNotMatch(bridge, /name='dashboard'/);
   assert.doesNotMatch(bridge, /dataset\.screen\s*=(?!=)/);
   assert.doesNotMatch(bridge, /createElement\(['"](?:button|nav)['"]\)/);
+});
+
+test('store activity destination remains Operations under the contextual router', () => {
+  assert.match(router, /setActivitySlot\(node,'operations',t\.operations\)/);
+  assert.match(router, /authority:'primary-context-router'/);
+  assert.match(bridge, /const name=String\(node\.dataset\?\.screen\|\|''\)\.trim\(\)/);
 });
 
 test('tab feedback paints before deferred screen rendering', () => {


### PR DESCRIPTION
## Root cause
The mobile navigation event bridge was normalizing store `appointments` to `dashboard`, while the contextual router owns that primary slot and maps it to `operations`. On WebKit/iPhone the capture-phase bridge could therefore override the contextual destination.

## Fix
- remove destination normalization from the touch/click bridge
- make the bridge resolve the current `data-screen` target verbatim
- mark `context-router` as the bridge destination authority
- bump bridge runtime evidence to `v3-router-authority`
- add regression coverage that rejects route ownership in the bridge and locks store activity routing to Operations

## Expected behavior
For store workspaces, the contextual router maps the activity slot to `operations`, and the touch bridge delegates that target unchanged instead of redirecting to Dashboard.