### PR TITLE
fix(dabbir): recover Safari from stale UI bundle cache

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,0 +1,37 @@
+import appRecoveryHandler from './app-recovery.js';
+
+const UI_CACHE_BUST = '20260902-p0-safari-v1';
+
+function bustUiAssetVersion(body) {
+  if (typeof body !== 'string') return body;
+  return body
+    .replace(/(\/dabbir-ui-critical\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
+    .replace(/(\/dabbir-ui-deferred\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
+    .replace(/(\/api\/dabbir-owner-first-ui\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`);
+}
+
+export default function handler(req, res) {
+  const headers = new Map();
+  const proxy = {
+    statusCode: 200,
+    setHeader(name, value) {
+      headers.set(String(name), value);
+      return proxy;
+    },
+    getHeader(name) {
+      return headers.get(String(name));
+    },
+    removeHeader(name) {
+      headers.delete(String(name));
+    },
+    end(body = '') {
+      for (const [name, value] of headers.entries()) res.setHeader(name, value);
+      res.setHeader('cache-control', 'no-store, max-age=0');
+      res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
+      res.statusCode = Number(proxy.statusCode || 200);
+      return res.end(bustUiAssetVersion(body));
+    },
+  };
+
+  return appRecoveryHandler(req, proxy);
+}

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const recovery = fs.readFileSync(new URL('../api/app-safari-recovery.js', import.meta.url), 'utf8');
+const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+
+test('root shell bypasses stale Safari UI bundle versions', () => {
+  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v1'/);
+  assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
+  assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
+  assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
+  assert.match(recovery, /x-dabbir-ui-cache-bust/);
+});
+
+test('root route uses Safari recovery shell and includes index.html', () => {
+  const rootRoute = vercel.routes.find((route) => route.src === '^/$');
+  const rootRewrite = vercel.rewrites.find((rewrite) => rewrite.source === '/');
+  assert.equal(rootRoute?.dest, '/api/app-safari-recovery');
+  assert.equal(rootRewrite?.destination, '/api/app-safari-recovery');
+  assert.equal(vercel.functions?.['api/app-safari-recovery.js']?.includeFiles, 'index.html');
+});
+
+test('generated DABBIR UI bundles cannot remain fresh in Safari after a deployment', () => {
+  const uiHeader = vercel.headers.find((entry) => entry.source.includes('dabbir-ui-(critical|deferred)'));
+  const cacheControl = uiHeader?.headers?.find((header) => String(header.key).toLowerCase() === 'cache-control');
+  assert.equal(cacheControl?.value, 'no-store, max-age=0');
+});

--- a/test/dabbir-stability-audit.test.mjs
+++ b/test/dabbir-stability-audit.test.mjs
@@ -5,6 +5,7 @@ import { access, readFile } from 'node:fs/promises';
 const root = new URL('../', import.meta.url);
 const platformApi = await readFile(new URL('api/platform-customers.js', root), 'utf8');
 const shell = await readFile(new URL('api/app-recovery.js', root), 'utf8');
+const safariShell = await readFile(new URL('api/app-safari-recovery.js', root), 'utf8');
 const uiBundles = JSON.parse(await readFile(new URL('config/dabbir-ui-bundles.json', root), 'utf8'));
 const whatsappStatus = await readFile(new URL('api/dabbir-whatsapp-status.js', root), 'utf8');
 
@@ -54,6 +55,8 @@ test('root routing remains pinned to the recovery-authoritative shell', async ()
   const vercel = JSON.parse(await readFile(new URL('vercel.json', root), 'utf8'));
   assert.ok(Array.isArray(vercel.routes));
   assert.ok(Array.isArray(vercel.rewrites));
-  assert.ok(vercel.routes.some(route => route?.src === '^/$' && route?.dest === '/api/app-recovery'));
-  assert.ok(vercel.rewrites.some(rewrite => rewrite?.source === '/' && rewrite?.destination === '/api/app-recovery'));
+  assert.ok(vercel.routes.some(route => route?.src === '^/$' && route?.dest === '/api/app-safari-recovery'));
+  assert.ok(vercel.rewrites.some(rewrite => rewrite?.source === '/' && rewrite?.destination === '/api/app-safari-recovery'));
+  assert.match(safariShell, /import appRecoveryHandler from '\.\/app-recovery\.js'/);
+  assert.match(safariShell, /x-dabbir-ui-cache-bust/);
 });

--- a/test/production-ai-chat.test.mjs
+++ b/test/production-ai-chat.test.mjs
@@ -5,6 +5,7 @@ import fs from 'node:fs';
 const runtime = fs.readFileSync(new URL('../api/dabbir-runtime.js', import.meta.url), 'utf8');
 const app = fs.readFileSync(new URL('../api/app.js', import.meta.url), 'utf8');
 const recoveryShell = fs.readFileSync(new URL('../api/app-recovery.js', import.meta.url), 'utf8');
+const safariRecoveryShell = fs.readFileSync(new URL('../api/app-safari-recovery.js', import.meta.url), 'utf8');
 const recoveryUi = fs.readFileSync(new URL('../api/auth/recovery-ui.js', import.meta.url), 'utf8');
 const html = fs.readFileSync(new URL('../index.html', import.meta.url), 'utf8');
 const vercel = fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8');
@@ -28,13 +29,16 @@ test('unified conversation uses the real persisted DABBIR runtime', () => {
 
 test('root route serves the authoritative DABBIR interface with recovery enhancement only', () => {
   const config = JSON.parse(vercel);
-  assert.ok(config.rewrites.some(rule => rule.source === '/' && rule.destination === '/api/app-recovery'));
+  assert.ok(config.rewrites.some(rule => rule.source === '/' && rule.destination === '/api/app-safari-recovery'));
   assert.equal(config.functions['api/app.js'].includeFiles, 'index.html');
   assert.equal(config.functions['api/app-recovery.js'].includeFiles, 'index.html');
+  assert.equal(config.functions['api/app-safari-recovery.js'].includeFiles, 'index.html');
   assert.match(app, /x-dabbir-interface/);
   assert.doesNotMatch(app, /source\.replace/);
   assert.doesNotMatch(app, /dabbir-ai/);
   assert.match(recoveryShell, /import appHandler from '\.\/app\.js'/);
+  assert.match(safariRecoveryShell, /import appRecoveryHandler from '\.\/app-recovery\.js'/);
+  assert.match(safariRecoveryShell, /UI_CACHE_BUST/);
   assert.match(recoveryShell, /\/api\/auth\/recovery-ui/);
   assert.match(recoveryUi, /نسيت كلمة المرور/);
   assert.match(recoveryUi, /\/api\/auth\/forgot-password/);

--- a/vercel.json
+++ b/vercel.json
@@ -22,6 +22,9 @@
     "api/app-recovery.js": {
       "includeFiles": "index.html"
     },
+    "api/app-safari-recovery.js": {
+      "includeFiles": "index.html"
+    },
     "api/car-wash-booking.js": {
       "includeFiles": "booking.html"
     },
@@ -64,7 +67,7 @@
     },
     {
       "src": "^/$",
-      "dest": "/api/app-recovery"
+      "dest": "/api/app-safari-recovery"
     }
   ],
   "rewrites": [
@@ -98,14 +101,14 @@
     },
     {
       "source": "/",
-      "destination": "/api/app-recovery"
+      "destination": "/api/app-safari-recovery"
     }
   ],
   "headers": [
     {
       "source": "/dabbir-ui-(critical|deferred)\\.js",
       "headers": [
-        { "key": "Cache-Control", "value": "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400" }
+        { "key": "Cache-Control", "value": "no-store, max-age=0" }
       ]
     },
     {


### PR DESCRIPTION
## P0 Safari blank-screen recovery

The production shell was returning HTTP 200 and the runtime endpoint was executing, but iPhone Safari could remain on a black screen after deployment because generated UI bundles changed while their cache-busting query token stayed unchanged.

### Fix
- route `/` through a small recovery wrapper
- force a new UI asset version token for critical/deferred/owner-first UI assets
- set generated UI bundle cache policy to `no-store, max-age=0`
- keep `index.html` bundled into the recovery function
- add regression tests locking the root route and cache policy

### Evidence target
Production must serve `x-dabbir-ui-cache-bust: 20260902-p0-safari-v1` and UI bundles must return `Cache-Control: no-store, max-age=0`.