### PR TITLE
fix(dabbir): fail open to auth on Safari boot failure

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,7 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260902-p0-safari-v1';
+const UI_CACHE_BUST = '20260902-p0-safari-v2';
+const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -8,6 +9,11 @@ function bustUiAssetVersion(body) {
     .replace(/(\/dabbir-ui-critical\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
     .replace(/(\/dabbir-ui-deferred\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
     .replace(/(\/api\/dabbir-owner-first-ui\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`);
+}
+
+function injectSafariAuthFailOpen(body) {
+  if (typeof body !== 'string' || body.includes('/api/dabbir-safari-auth-fail-open-ui')) return body;
+  return body.replace('</body>', `<script src="${SAFARI_AUTH_FAIL_OPEN}"></script>\n</body>`);
 }
 
 export default function handler(req, res) {
@@ -29,7 +35,7 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.statusCode = Number(proxy.statusCode || 200);
-      return res.end(bustUiAssetVersion(body));
+      return res.end(injectSafariAuthFailOpen(bustUiAssetVersion(body)));
     },
   };
 

--- a/api/dabbir-safari-auth-fail-open-ui.js
+++ b/api/dabbir-safari-auth-fail-open-ui.js
@@ -1,0 +1,69 @@
+const script = String.raw`(()=>{
+  if(window.__dabbirSafariAuthFailOpenV1) return;
+  window.__dabbirSafariAuthFailOpenV1=true;
+
+  var VERSION='safari-auth-fail-open-v1';
+  var probeRunning=false;
+  var recovered=false;
+
+  function node(id){return document.getElementById(id)}
+  function isHidden(el){return !el||el.hidden===true||el.classList.contains('hidden')}
+  function gateMissing(){
+    var loading=node('loading');
+    return Boolean(loading&&!isHidden(loading)&&isHidden(node('authGate'))&&isHidden(node('onboardingGate'))&&isHidden(node('appShell')));
+  }
+  function publish(reason,status){
+    window.__dabbirSafariAuthFailOpen={version:VERSION,recovered:recovered,reason:reason||null,status:Number(status||0),updated_at:new Date().toISOString()};
+    try{document.body.dataset.dabbirSafariAuthRecovery=recovered?'recovered':'armed'}catch(_e){}
+  }
+  function revealAuth(reason){
+    if(!gateMissing()) return false;
+    try{
+      if(typeof window.showGate==='function'){
+        window.showGate('auth');
+      }else{
+        var loading=node('loading');
+        var auth=node('authGate');
+        var onboarding=node('onboardingGate');
+        var app=node('appShell');
+        var bottom=node('bottomNav');
+        if(loading) loading.hidden=true;
+        if(auth){auth.hidden=false;auth.classList.remove('hidden')}
+        if(onboarding){onboarding.hidden=true;onboarding.classList.add('hidden')}
+        if(app){app.hidden=true;app.classList.add('hidden')}
+        if(bottom) bottom.classList.add('hidden');
+      }
+      recovered=true;
+      publish(reason,401);
+      return true;
+    }catch(_e){return false}
+  }
+  function probe(reason){
+    if(probeRunning||recovered||!gateMissing()) return;
+    probeRunning=true;
+    var timeout=new Promise(function(resolve){setTimeout(function(){resolve(null)},4000)});
+    var request;
+    try{
+      request=fetch('/api/dabbir-runtime-fast?summary=1',{credentials:'same-origin',cache:'no-store'}).catch(function(){return null});
+    }catch(_e){request=Promise.resolve(null)}
+    Promise.race([request,timeout]).then(function(response){
+      if(response&&response.status===401&&gateMissing()) revealAuth(reason||'AUTH_REQUIRED_RECOVERY');
+      else publish(reason||'PROBE_COMPLETE',response&&response.status);
+    }).finally(function(){probeRunning=false});
+  }
+
+  publish('ARMED',0);
+  setTimeout(function(){probe('BOOT_WATCHDOG')},1200);
+  setTimeout(function(){probe('BOOT_WATCHDOG_RETRY')},3200);
+  window.addEventListener('error',function(){setTimeout(function(){probe('WINDOW_ERROR')},0)});
+  window.addEventListener('unhandledrejection',function(){setTimeout(function(){probe('UNHANDLED_REJECTION')},0)});
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET') return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','no-store, max-age=0');
+  res.setHeader('surrogate-control','no-store');
+  res.setHeader('x-dabbir-safari-auth-fail-open','v1');
+  res.status(200).send(script);
+}

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -3,14 +3,33 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const recovery = fs.readFileSync(new URL('../api/app-safari-recovery.js', import.meta.url), 'utf8');
+const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui.js', import.meta.url), 'utf8');
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v1'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v2'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
+});
+
+test('root shell injects an independent Safari auth fail-open watchdog', () => {
+  assert.match(recovery, /dabbir-safari-auth-fail-open-ui/);
+  assert.match(recovery, /injectSafariAuthFailOpen/);
+  assert.match(failOpen, /BOOT_WATCHDOG/);
+  assert.match(failOpen, /response\.status===401/);
+  assert.match(failOpen, /typeof window\.showGate==='function'/);
+  assert.match(failOpen, /auth\.classList\.remove\('hidden'\)/);
+  assert.doesNotMatch(failOpen, /AbortSignal\.timeout/);
+});
+
+test('fail-open never replaces a healthy visible gate', () => {
+  assert.match(failOpen, /gateMissing\(\)/);
+  assert.match(failOpen, /isHidden\(node\('authGate'\)\)/);
+  assert.match(failOpen, /isHidden\(node\('onboardingGate'\)\)/);
+  assert.match(failOpen, /isHidden\(node\('appShell'\)\)/);
+  assert.match(failOpen, /status===401&&gateMissing\(\)/);
 });
 
 test('root route uses Safari recovery shell and includes index.html', () => {


### PR DESCRIPTION
P0 Safari recovery hardening.

- Adds an independent auth fail-open watchdog loaded from the root Safari recovery shell.
- The watchdog only reveals the auth gate when all gates are hidden, loading is still active, and the live runtime explicitly returns HTTP 401.
- Does not depend on AbortSignal.timeout or the base boot path.
- Bumps the Safari cache-bust token to 20260902-p0-safari-v2 so iPhone Safari cannot reuse the previous release-specific asset URLs.
- Adds regression coverage for healthy-gate isolation and 401-only recovery.