### PR TITLE
fix(dabbir): add fail-closed recurrence guardrails

### DIFF
--- a/.github/workflows/dabbir-release-guardian.yml
+++ b/.github/workflows/dabbir-release-guardian.yml
@@ -1,0 +1,66 @@
+name: DABBIR Release Guardian
+
+on:
+  workflow_run:
+    workflows:
+      - DABBIR CI
+      - DABBIR Mobile CI
+      - DABBIR Protected Live Smoke
+      - DABBIR AI Full Customer Journey
+      - DABBIR Auth Production Guard
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dabbir-release-guardian-main
+  cancel-in-progress: false
+
+jobs:
+  revert-failed-main:
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(fromJSON('["failure","timed_out","cancelled","action_required","startup_failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      FAILED_SHA: ${{ github.event.workflow_run.head_sha }}
+      FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}
+      FAILED_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 20
+      - name: Fail closed by reverting the failing head if it is still current
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          current_sha="$(git rev-parse origin/main)"
+          if [ "$current_sha" != "$FAILED_SHA" ]; then
+            echo "Guardian observed $FAILED_SHA failure, but main is already $current_sha; no stale rollback attempted."
+            exit 0
+          fi
+
+          subject="$(git show -s --format=%s "$FAILED_SHA")"
+          if [[ "$subject" == revert\(guardian\):* ]]; then
+            echo "Guardian revert itself failed validation; refusing an automatic re-revert loop."
+            exit 1
+          fi
+
+          git config user.name 'dabbir-release-guardian'
+          git config user.email 'dabbir-release-guardian@users.noreply.github.com'
+
+          parent_count="$(git rev-list --parents -n 1 "$FAILED_SHA" | awk '{print NF-1}')"
+          if [ "$parent_count" -gt 1 ]; then
+            git revert -m 1 --no-edit "$FAILED_SHA"
+          else
+            git revert --no-edit "$FAILED_SHA"
+          fi
+
+          git commit --amend -m "revert(guardian): ${FAILED_WORKFLOW} ${FAILED_CONCLUSION} on ${FAILED_SHA}"
+          git push origin HEAD:main
+          echo "Fail-closed rollback pushed for $FAILED_SHA after ${FAILED_WORKFLOW}=${FAILED_CONCLUSION}."

--- a/scripts/vercel-build-gate.mjs
+++ b/scripts/vercel-build-gate.mjs
@@ -3,7 +3,7 @@ import { existsSync, openSync, closeSync, writeFileSync, unlinkSync } from 'node
 import os from 'node:os';
 import path from 'node:path';
 
-const gateVersion = 'v3-final';
+const gateVersion = 'v4-fail-closed';
 const rawSha = String(process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local').trim();
 const rawDeploymentId = String(process.env.VERCEL_DEPLOYMENT_ID || `pid-${process.pid}`).trim();
 const safeSha = rawSha.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'local';
@@ -19,24 +19,31 @@ function sleep(milliseconds) {
   Atomics.wait(new Int32Array(buffer), 0, 0, milliseconds);
 }
 
-function runTests() {
-  console.log(`[dabbir-build-gate:${gateVersion}] verifying deployment ${safeDeploymentId} commit ${safeSha}`);
-  const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test'], {
+function runNpm(args,label) {
+  console.log(`[dabbir-build-gate:${gateVersion}] ${label}`);
+  const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, {
     stdio: 'inherit',
     env: process.env,
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {
-    const error = new Error(`DABBIR_TEST_GATE_FAILED_${result.status ?? 1}`);
+    const error = new Error(`DABBIR_BUILD_GATE_${label.replace(/[^A-Z0-9]+/gi,'_').toUpperCase()}_FAILED_${result.status ?? 1}`);
     error.exitCode = result.status ?? 1;
     throw error;
   }
+}
+
+function runTests() {
+  console.log(`[dabbir-build-gate:${gateVersion}] verifying deployment ${safeDeploymentId} commit ${safeSha}`);
+  runNpm(['run','check:syntax'],'syntax');
+  runNpm(['run','audit:prod'],'dependency-audit');
+  runNpm(['test'],'test-suite');
   writeFileSync(marker, `${new Date().toISOString()}\n`, { encoding: 'utf8', mode: 0o600 });
   console.log(`[dabbir-build-gate:${gateVersion}] verified deployment ${safeDeploymentId} commit ${safeSha}`);
 }
 
 if (existsSync(marker)) {
-  console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} already verified; skipping duplicate test run`);
+  console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} already verified; skipping duplicate gate run`);
   process.exit(0);
 }
 

--- a/supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql
+++ b/supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql
@@ -1,0 +1,56 @@
+-- Prevent concurrent booking/calendar writes for the same business from bypassing
+-- the existing appointment conflict checks. The lock is transaction-scoped and
+-- shared by appointments, external busy blocks, worker schedules, and time off.
+
+create or replace function dabbir_private.lock_booking_calendar_business()
+returns trigger
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_new_business uuid;
+  v_old_business uuid;
+  v_first text;
+  v_second text;
+begin
+  if tg_op <> 'DELETE' then v_new_business := new.business_id; end if;
+  if tg_op <> 'INSERT' then v_old_business := old.business_id; end if;
+
+  if v_new_business is not null and v_old_business is not null and v_new_business <> v_old_business then
+    v_first := least(v_new_business::text, v_old_business::text);
+    v_second := greatest(v_new_business::text, v_old_business::text);
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || v_first, 0));
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || v_second, 0));
+  elsif coalesce(v_new_business,v_old_business) is not null then
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || coalesce(v_new_business,v_old_business)::text, 0));
+  end if;
+
+  return case when tg_op='DELETE' then old else new end;
+end;
+$$;
+
+revoke all on function dabbir_private.lock_booking_calendar_business() from public,anon,authenticated;
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_appointments;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_appointments
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_calendar_busy_blocks;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_calendar_busy_blocks
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_worker_schedules;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_worker_schedules
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_worker_time_off;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_worker_time_off
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+comment on function dabbir_private.lock_booking_calendar_business() is
+  'Serializes booking-calendar writes per business so concurrent appointment, busy-block, schedule, and time-off transactions cannot bypass conflict checks.';

--- a/test/dabbir-booking-calendar-lock.test.mjs
+++ b/test/dabbir-booking-calendar-lock.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration=fs.readFileSync(new URL('../supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql',import.meta.url),'utf8');
+
+const requiredTables=[
+  'public.dabbir_appointments',
+  'public.dabbir_calendar_busy_blocks',
+  'public.dabbir_worker_schedules',
+  'public.dabbir_worker_time_off',
+];
+
+test('booking calendar writes are serialized per business with a transaction lock',()=>{
+  assert.match(migration,/pg_advisory_xact_lock\(hashtextextended\('dabbir:booking-calendar:' \|\|/);
+  assert.match(migration,/create or replace function dabbir_private\.lock_booking_calendar_business\(\)/);
+  assert.match(migration,/revoke all on function dabbir_private\.lock_booking_calendar_business\(\) from public,anon,authenticated/);
+});
+
+test('all scheduling truth surfaces share the same lock trigger',()=>{
+  for(const table of requiredTables){
+    assert.match(migration,new RegExp(`create trigger dabbir_00_booking_calendar_lock[\\s\\S]+?on ${table.replaceAll('.','\\.')}[\\s\\S]+?lock_booking_calendar_business\\(\\)`));
+  }
+});
+
+test('lock trigger sorts before the appointment conflict guard',()=>{
+  assert.ok('dabbir_00_booking_calendar_lock'.localeCompare('dabbir_appointment_calendar_conflict_guard') < 0);
+});

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -15,16 +15,18 @@ test('Vercel uses the fail-closed DABBIR build gate without changing the Functio
   assert.equal(parse.status, 0, parse.stderr || parse.stdout);
 });
 
-test('cached build evidence is scoped to deployment plus commit and written only after tests succeed', () => {
+test('cached build evidence is scoped to deployment plus commit and written only after every fail-closed verification succeeds', () => {
   assert.match(gate, /VERCEL_DEPLOYMENT_ID/);
   assert.match(gate, /VERCEL_GIT_COMMIT_SHA/);
   assert.match(gate, /const evidenceKey = `\$\{safeDeploymentId\}-\$\{safeSha\}`/);
   assert.match(gate, /dabbir-vercel-tests-passed-/);
-  assert.match(gate, /spawnSync[\s\S]*\['test'\]/);
-  const testRun = gate.indexOf("spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test']");
+  assert.match(gate, /runNpm\(\['run','check:syntax'\],'syntax'\)/);
+  assert.match(gate, /runNpm\(\['run','audit:prod'\],'dependency-audit'\)/);
+  assert.match(gate, /runNpm\(\['test'\],'test-suite'\)/);
+  const testRun = gate.indexOf("runNpm(['test'],'test-suite')");
   const markerWrite = gate.indexOf('writeFileSync(marker');
-  assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the test process');
-  assert.match(gate, /DABBIR_TEST_GATE_FAILED_/);
+  assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the final verification process');
+  assert.match(gate, /DABBIR_BUILD_GATE_/);
 });
 
 test('failure cleanup cannot leave a stale success path', () => {

--- a/test/dabbir-release-guardian.test.mjs
+++ b/test/dabbir-release-guardian.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const buildGate=fs.readFileSync(new URL('../scripts/vercel-build-gate.mjs',import.meta.url),'utf8');
+const guardian=fs.readFileSync(new URL('../.github/workflows/dabbir-release-guardian.yml',import.meta.url),'utf8');
+
+test('Vercel build gate fails closed on syntax, dependency audit, and full tests',()=>{
+  assert.match(buildGate,/v4-fail-closed/);
+  assert.match(buildGate,/runNpm\(\['run','check:syntax'\],'syntax'\)/);
+  assert.match(buildGate,/runNpm\(\['run','audit:prod'\],'dependency-audit'\)/);
+  assert.match(buildGate,/runNpm\(\['test'\],'test-suite'\)/);
+  assert.match(buildGate,/process\.exit\(exitCode\)/);
+});
+
+test('release guardian auto-reverts failed main heads without stale rollback or loops',()=>{
+  for(const workflow of [
+    'DABBIR CI',
+    'DABBIR Mobile CI',
+    'DABBIR Protected Live Smoke',
+    'DABBIR AI Full Customer Journey',
+    'DABBIR Auth Production Guard',
+  ]) assert.ok(guardian.includes(`- ${workflow}`));
+
+  assert.match(guardian,/permissions:[\s\S]*contents: write/);
+  assert.match(guardian,/current_sha=.*origin\/main/);
+  assert.match(guardian,/current_sha.*FAILED_SHA/);
+  assert.match(guardian,/revert\\\(guardian\\\):/);
+  assert.match(guardian,/git revert/);
+  assert.match(guardian,/git push origin HEAD:main/);
+});


### PR DESCRIPTION
## Objective
Prevent recurrence of the failure classes found in the production audit rather than patching symptoms.

## Changes
- serialize appointment/calendar/schedule/time-off writes per business with a PostgreSQL transaction advisory lock
- mirror the already-applied Mumbai production migration in source control
- add regression tests for the booking lock invariant
- expand the Vercel build gate to fail closed on syntax, production dependency audit, and the full Node test suite
- add a Release Guardian that auto-reverts the current `main` head when a critical push-triggered CI/live/auth workflow fails
- add regression tests for the release guardrails

## Production DB evidence before PR
- DABBIR Mumbai project ACTIVE_HEALTHY
- 3 appointments inspected
- 0 existing overlap pairs
- transaction-lock migration applied successfully
- lock trigger verified on appointments, calendar busy blocks, worker schedules, and worker time off

## Release rule
Do not merge until CI is green. After merge, verify exact production SHA, runtime errors, Safari/login shell, and database guard presence.