### PR TITLE
fix(dabbir): enforce one contextual navigation authority

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,7 +1,9 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260902-p0-safari-v2';
+const UI_CACHE_BUST = '20260902-p0-safari-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
+const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
+const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -9,6 +11,13 @@ function bustUiAssetVersion(body) {
     .replace(/(\/dabbir-ui-critical\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
     .replace(/(\/dabbir-ui-deferred\.js\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`)
     .replace(/(\/api\/dabbir-owner-first-ui\?v=)[^"'\s<]+/g, `$1${UI_CACHE_BUST}`);
+}
+
+function stripLegacyNavigationOverrides(body) {
+  if (typeof body !== 'string') return body;
+  return body
+    .split(LEGACY_STORE_SLOT_HIDE).join('')
+    .split(LEGACY_STORE_APPOINTMENT_REDIRECT).join('');
 }
 
 function injectSafariAuthFailOpen(body) {
@@ -34,8 +43,11 @@ export default function handler(req, res) {
       for (const [name, value] of headers.entries()) res.setHeader(name, value);
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
+      res.setHeader('x-dabbir-navigation-authority', 'context-router');
       res.statusCode = Number(proxy.statusCode || 200);
-      return res.end(injectSafariAuthFailOpen(bustUiAssetVersion(body)));
+      const fresh = bustUiAssetVersion(body);
+      const canonical = stripLegacyNavigationOverrides(fresh);
+      return res.end(injectSafariAuthFailOpen(canonical));
     },
   };
 

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -3,11 +3,12 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const recovery = fs.readFileSync(new URL('../api/app-safari-recovery.js', import.meta.url), 'utf8');
+const app = fs.readFileSync(new URL('../api/app.js', import.meta.url), 'utf8');
 const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui.js', import.meta.url), 'utf8');
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v2'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v3'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
@@ -30,6 +31,18 @@ test('fail-open never replaces a healthy visible gate', () => {
   assert.match(failOpen, /isHidden\(node\('onboardingGate'\)\)/);
   assert.match(failOpen, /isHidden\(node\('appShell'\)\)/);
   assert.match(failOpen, /status===401&&gateMissing\(\)/);
+});
+
+test('canonical root strips legacy store navigation overrides before delivery', () => {
+  assert.match(app, /el\.style\.display=isStore\?'none':''/);
+  assert.match(app, /name==='appointments'.*name='dashboard'/);
+  assert.match(recovery, /LEGACY_STORE_SLOT_HIDE/);
+  assert.match(recovery, /LEGACY_STORE_APPOINTMENT_REDIRECT/);
+  assert.match(recovery, /stripLegacyNavigationOverrides/);
+  assert.match(recovery, /split\(LEGACY_STORE_SLOT_HIDE\)\.join\(''\)/);
+  assert.match(recovery, /split\(LEGACY_STORE_APPOINTMENT_REDIRECT\)\.join\(''\)/);
+  assert.match(recovery, /x-dabbir-navigation-authority/);
+  assert.match(recovery, /context-router/);
 });
 
 test('root route uses Safari recovery shell and includes index.html', () => {


### PR DESCRIPTION
Navigation hardening after the Safari recovery release.

- Removes the legacy emitted store-only `appointments -> dashboard` redirect from the canonical root shell.
- Removes the legacy early hide of the appointments/activity slot so Context Router owns the slot from first paint.
- Keeps the existing navigation event bridge as the transport/delegation layer, not a destination owner.
- Bumps the Safari shell release token to v3 so iPhone Safari cannot retain the prior emitted shell.
- Adds an explicit `x-dabbir-navigation-authority: context-router` production header and regression coverage.