### PR TITLE
fix(dabbir): stop salon reminder service key JWT parsing

### DIFF
--- a/api/_whatsapp-service-connection.js
+++ b/api/_whatsapp-service-connection.js
@@ -1,0 +1,45 @@
+import { SUPABASE_DATA_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
+
+const WHATSAPP_DATA_TIMEOUT_MS = 10_000;
+const CONNECTION_SELECT = 'id,business_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error';
+
+function storageError(code, response, payload = null) {
+  const error = new Error(String(payload?.message || payload?.code || code));
+  error.code = code;
+  error.status = Number(response?.status || 502);
+  return error;
+}
+
+export async function loadBusinessConnectionWithServiceKey(serviceKey, businessId, options = {}) {
+  const key = String(serviceKey || '').trim();
+  const id = String(businessId || '').trim();
+  if (!key) throw Object.assign(new Error('WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED'), { status: 503 });
+  if (!id) throw Object.assign(new Error('BUSINESS_ID_REQUIRED'), { status: 400 });
+
+  const path = `dabbir_whatsapp_connections?select=${CONNECTION_SELECT}&business_id=eq.${encodeURIComponent(id)}&limit=1`;
+  return withServerReadTimeout(async signal => {
+    const response = await fetch(`${SUPABASE_DATA_URL}/rest/v1/${path}`, {
+      method: 'GET',
+      cache: 'no-store',
+      redirect: 'manual',
+      signal,
+      headers: supabaseKeyHeaders(key, { accept: 'application/json' }),
+    });
+    const text = await response.text();
+    let rows = null;
+    try { rows = text ? JSON.parse(text) : null; } catch {}
+    if (!response.ok) throw storageError('WHATSAPP_CONNECTION_SERVICE_READ_FAILED', response, rows);
+    if (!Array.isArray(rows) || rows.length > 1) throw storageError('WHATSAPP_CONNECTION_SERVICE_RESPONSE_MALFORMED', response);
+    const row = rows[0] || null;
+    if (row && (typeof row !== 'object' || Array.isArray(row) || String(row.business_id || '') !== id)) {
+      throw storageError('WHATSAPP_CONNECTION_SERVICE_RESPONSE_MALFORMED', response);
+    }
+    return row;
+  }, {
+    label: 'WHATSAPP_CONNECTION_SERVICE_READ',
+    errorCode: 'WHATSAPP_CONNECTION_SERVICE_READ_TIMEOUT',
+    timeoutMs: options.timeoutMs ?? WHATSAPP_DATA_TIMEOUT_MS,
+  });
+}

--- a/api/salon-reminders-cron.js
+++ b/api/salon-reminders-cron.js
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import { json, SUPABASE_URL } from './_auth-core.js';
-import { loadBusinessConnection } from './_whatsapp-embedded-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+import { loadBusinessConnectionWithServiceKey } from './_whatsapp-service-connection.js';
 import { sendMetaTemplate } from './_whatsapp-live-core.js';
 
 const clean=(value,max=500)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
@@ -9,11 +10,7 @@ const EXPECTED_SCHEDULE='*/5 * * * *';
 const EDGE_WORKER_URL=`${SUPABASE_URL}/functions/v1/dabbir-salon-reminder-worker`;
 
 export function adminRpcHeaders(key){
-  const headers={apikey:key,accept:'application/json','content-type':'application/json',prefer:'return=representation'};
-  // Supabase secret keys (sb_secret_*) authenticate through apikey. Sending
-  // them as Bearer tokens makes PostgREST parse them as JWTs and fail.
-  if(!String(key).startsWith('sb_secret_'))headers.authorization=`Bearer ${key}`;
-  return headers;
+  return supabaseKeyHeaders(key,{accept:'application/json','content-type':'application/json',prefer:'return=representation'});
 }
 async function adminRpc(key,name,params){
   return fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{
@@ -86,7 +83,7 @@ async function finalize(req,key,item,status,providerMessageId=null,error=null){
 }
 async function deliver(req,key,item){
   try{
-    const connection=key?await loadBusinessConnection(key,item.business_id):item.connection;
+    const connection=key?await loadBusinessConnectionWithServiceKey(key,item.business_id):item.connection;
     if(!connection||connection.status!=='connected'){
       await finalize(req,key,item,'failed',null,'WHATSAPP_TENANT_NOT_LINKED');
       return {id:item.notification_id,status:'failed',error:'WHATSAPP_TENANT_NOT_LINKED'};

--- a/test/dabbir-salon-mode.test.mjs
+++ b/test/dabbir-salon-mode.test.mjs
@@ -11,6 +11,7 @@ const compatibility=read('supabase/migrations/20260831091000_dabbir_salon_legacy
 const api=read('api/salon-operations.js');
 const ui=read('api/salon-mode-ui.js');
 const cron=read('api/salon-reminders-cron.js');
+const serviceConnection=read('api/_whatsapp-service-connection.js');
 const whatsapp=read('api/_whatsapp-live-core.js');
 const edgeWorker=read('supabase/functions/dabbir-salon-reminder-worker/index.ts');
 
@@ -74,7 +75,7 @@ test('scenario 7: tenant isolation is enforced with business-scoped foreign keys
 
 test('scenario 8: WhatsApp reminders are claimed concurrently and never automatically duplicated',()=>{
   hasAll(migration,['unique (business_id,idempotency_key)','for update skip locked',"status='processing'","status='ambiguous'",'STALE_PROCESSING_REQUIRES_RECONCILIATION','dabbir_claim_workflow_notifications','dabbir_finalize_workflow_notification']);
-  hasAll(cron,['CRON_SECRET','dabbir_claim_workflow_notifications','sendMetaTemplate',"error?.ambiguous===true?'ambiguous':'failed'",'dabbir_finalize_workflow_notification','x-vercel-oidc-token','dabbir-salon-reminder-worker']);
+  hasAll(cron,['CRON_SECRET','dabbir_claim_workflow_notifications','sendMetaTemplate',"error?.ambiguous===true?'ambiguous':'failed'",'dabbir_finalize_workflow_notification','x-vercel-oidc-token','dabbir-salon-reminder-worker','loadBusinessConnectionWithServiceKey']);
   hasAll(whatsapp,["type: 'template'",'providerMessageId','META_WHATSAPP_TEMPLATE_TIMEOUT_AMBIGUOUS']);
   hasAll(edgeWorker,['createRemoteJWKSet','jwtVerify','EXPECTED_AUDIENCE','EXPECTED_SUBJECT','owner_id !== OWNER_ID','project_id !== PROJECT_ID','environment !== "production"','dabbir_claim_workflow_notifications','dabbir_finalize_workflow_notification','CONNECTION_COLUMNS']);
   assert.doesNotMatch(edgeWorker,/dabbir_(salon_quick_book|salon_transition_appointment|salon_rebook)/);
@@ -122,13 +123,20 @@ test('Vercel Pro cron is configured every five minutes with secret-first authent
   assert.equal(cronAuthMode({headers:{...officialHeaders,'x-vercel-cron-schedule':'0 * * * *'}},{VERCEL_ENV:'production'}),null);
 });
 
-test('reminder cron never sends Supabase secret keys as JWT bearer tokens',()=>{
+test('reminder cron keeps opaque service keys out of user JWT bearer paths',()=>{
   const secretHeaders=adminRpcHeaders('sb_secret_example');
   assert.equal(secretHeaders.apikey,'sb_secret_example');
   assert.equal(secretHeaders.authorization,undefined);
+  const opaqueHeaders=adminRpcHeaders('opaque-service-key');
+  assert.equal(opaqueHeaders.apikey,'opaque-service-key');
+  assert.equal(opaqueHeaders.authorization,undefined);
   const legacyHeaders=adminRpcHeaders('legacy.jwt.value');
   assert.equal(legacyHeaders.apikey,'legacy.jwt.value');
   assert.equal(legacyHeaders.authorization,'Bearer legacy.jwt.value');
+  assert.match(serviceConnection,/supabaseKeyHeaders\(key/);
+  assert.doesNotMatch(serviceConnection,/\bsupabaseRest\(/);
+  assert.match(cron,/loadBusinessConnectionWithServiceKey\(key,item\.business_id\)/);
+  assert.doesNotMatch(cron,/\bloadBusinessConnection\(key,item\.business_id\)/);
 });
 
 test('legacy appointment writers remain compatible during the Salon Mode rollout',()=>{

--- a/test/dabbir-salon-reminder-service-key.test.mjs
+++ b/test/dabbir-salon-reminder-service-key.test.mjs
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { adminRpcHeaders } from '../api/salon-reminders-cron.js';
+
+const cron=fs.readFileSync(new URL('../api/salon-reminders-cron.js',import.meta.url),'utf8');
+const serviceConnection=fs.readFileSync(new URL('../api/_whatsapp-service-connection.js',import.meta.url),'utf8');
+
+test('opaque Supabase service keys never enter user JWT bearer paths',()=>{
+  const opaque=adminRpcHeaders('opaque-service-key');
+  assert.equal(opaque.apikey,'opaque-service-key');
+  assert.equal(opaque.authorization,undefined);
+  assert.match(serviceConnection,/supabaseKeyHeaders\(key/);
+  assert.doesNotMatch(serviceConnection,/\bsupabaseRest\(/);
+  assert.match(cron,/loadBusinessConnectionWithServiceKey\(key,item\.business_id\)/);
+  assert.doesNotMatch(cron,/\bloadBusinessConnection\(key,item\.business_id\)/);
+});
+
+test('legacy JWT-shaped service keys retain compatibility only when actually JWT-shaped',()=>{
+  const legacy=adminRpcHeaders('legacy.jwt.value');
+  assert.equal(legacy.authorization,'Bearer legacy.jwt.value');
+});


### PR DESCRIPTION
## Confirmed production failure
Vercel runtime errors show `/api/salon-reminders-cron` failing with `Expected 3 parts in JWT; got 1`.

## Root cause
The cron correctly used modern service-key headers for its own RPCs, but then passed the service key into `loadBusinessConnection()`. That helper is intentionally a user/RLS path and calls `supabaseRest()`, which always sends its access token as `Authorization: Bearer ...`. An opaque Supabase service key was therefore parsed as a user JWT.

## Fix
- add a dedicated server-only WhatsApp connection reader using `supabaseKeyHeaders`
- keep user `supabaseRest()` semantics unchanged
- route Salon reminder connection reads through the service-key reader
- use the shared modern-key helper for reminder RPC headers
- retain the existing Vercel OIDC fallback, queue claim/finalize, idempotency, and Meta send behavior
- add regression coverage for generic opaque service keys and forbid the cron from re-entering the user bearer path

## Release proof required
Do not consider this resolved until CI and Preview pass, Production is READY on the merged SHA, and a real scheduled Production cron run no longer emits the JWT parsing failure.