### PR TITLE
fix(dabbir): align production QA with Mumbai and restore fail-closed guards

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -1,5 +1,5 @@
 name: DABBIR AI Full Customer Journey
-# Real production journey. Before public launch, the same broker-authorized workflow tests the protected canonical Vercel Production release without widening Supabase OIDC policy.
+# Canonical main-only production journey. During protected prelaunch the exact Vercel Production release is verified through trusted OIDC. QA identities are created in the Mumbai Supabase production project.
 
 on:
   workflow_dispatch:
@@ -24,6 +24,7 @@ on:
       - 'test/dabbir-protected-full-journey-preload.mjs'
       - 'test/dabbir-protected-journey-access.test.mjs'
       - 'test/dabbir-authorized-journey-workflow.test.mjs'
+      - 'test/dabbir-mumbai-qa-routing.test.mjs'
       - 'test/support/dabbir-protected-journey-access.mjs'
       - 'test/dabbir-capacity-load.mjs'
       - 'test/dabbir-activity-regression.test.mjs'
@@ -32,6 +33,7 @@ on:
       - '.github/workflows/dabbir-ai-customer-journey.yml'
       - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
+      - 'supabase/functions/dabbir-qa-suite-runner/**'
       - 'db/dabbir*.sql'
       - 'api/**'
       - 'api/auth/**'
@@ -70,14 +72,13 @@ jobs:
       PUBLIC_PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
-      SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report.json
       ISOLATION_REPORT_PATH: dabbir-cross-tenant-isolation-report.json
       EXPECTED_VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       EXPECTED_GIT_PROVIDER: github
       EXPECTED_GIT_REPOSITORY: barman-systems/pilot
     outputs:
-      # Capacity remains locked until a real public launch origin exists.
       production_ready: ${{ steps.launch-gate.outputs.ready }}
       production_state: ${{ steps.launch-gate.outputs.state }}
       journey_ready: ${{ steps.journey-mode.outputs.ready }}
@@ -86,7 +87,6 @@ jobs:
       verified_deployment_id: ${{ steps.release-before.outputs.deployment }}
     steps:
       - uses: actions/checkout@v7
-
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
@@ -117,12 +117,10 @@ jobs:
             echo 'JOURNEY_MODE_PUBLIC'
             exit 0
           fi
-
           if [ "${{ steps.launch-gate.outputs.state }}" != 'BLOCKED_PRELAUNCH' ]; then
             echo "UNEXPECTED_PRODUCTION_GATE_STATE=${{ steps.launch-gate.outputs.state }}"
             exit 2
           fi
-
           echo "PRODUCTION_ORIGIN=${PROTECTED_QA_ORIGIN}" >> "$GITHUB_ENV"
           echo 'ready=true' >> "$GITHUB_OUTPUT"
           echo 'mode=protected' >> "$GITHUB_OUTPUT"
@@ -137,31 +135,18 @@ jobs:
           set -euo pipefail
           request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
           request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
-          if [ -z "$request_url" ] || [ -z "$request_token" ]; then
-            echo 'GITHUB_TRUSTED_OIDC_CONTEXT_REQUIRED'
-            exit 2
-          fi
-
-          oidc_response="$(curl --fail-with-body --silent --show-error \
-            -H "Authorization: Bearer ${request_token}" \
-            "$request_url")"
+          test -n "$request_url"
+          test -n "$request_token"
+          oidc_response="$(curl --fail-with-body --silent --show-error -H "Authorization: Bearer ${request_token}" "$request_url")"
           oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
-          if [ -z "$oidc_token" ]; then
-            echo 'GITHUB_TRUSTED_OIDC_TOKEN_MISSING'
-            exit 3
-          fi
+          test -n "$oidc_token"
           echo "::add-mask::$oidc_token"
-
           probe_body="$(mktemp)"
-          probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' \
-            -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" \
-            -H 'accept: text/html' \
-            "$PROTECTED_QA_ORIGIN/")"
+          probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" -H 'accept: text/html' "$PROTECTED_QA_ORIGIN/")"
           if [ "$probe_status" != '200' ] || ! grep -qi 'DABBIR' "$probe_body"; then
             echo "VERCEL_TRUSTED_OIDC_REJECTED_HTTP_${probe_status}"
             exit 4
           fi
-
           echo "VERCEL_TRUSTED_OIDC_TOKEN=$oidc_token" >> "$GITHUB_ENV"
           echo 'ready=true' >> "$GITHUB_OUTPUT"
           echo 'TRUSTED_VERCEL_OIDC_READY'
@@ -177,15 +162,9 @@ jobs:
             test -n "${VERCEL_TRUSTED_OIDC_TOKEN:-}"
             auth_args+=( -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" )
           fi
-
-          body=''
-          sha=''
-          deployment=''
+          body=''; sha=''; deployment=''
           for attempt in $(seq 1 60); do
-            body="$(curl --silent --show-error \
-              "${auth_args[@]}" \
-              -H 'accept: application/json' \
-              "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
+            body="$(curl --silent --show-error "${auth_args[@]}" -H 'accept: application/json' "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
             sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty' 2>/dev/null || true)"
             deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty' 2>/dev/null || true)"
             environment="$(printf '%s' "$body" | jq -r '.environment // empty' 2>/dev/null || true)"
@@ -193,18 +172,8 @@ jobs:
             git_provider="$(printf '%s' "$body" | jq -r '.git_provider // empty' 2>/dev/null || true)"
             repository="$(printf '%s' "$body" | jq -r '.repository // empty' 2>/dev/null || true)"
             ok="$(printf '%s' "$body" | jq -r '.ok // false' 2>/dev/null || true)"
-            if [ "$ok" = 'true' ] \
-              && [ "$sha" = "$GITHUB_SHA" ] \
-              && [ "$environment" = 'production' ] \
-              && [ "$project_id" = "$EXPECTED_VERCEL_PROJECT_ID" ] \
-              && [ "$git_provider" = "$EXPECTED_GIT_PROVIDER" ] \
-              && [ "$repository" = "$EXPECTED_GIT_REPOSITORY" ] \
-              && [[ "$deployment" == dpl_* ]]; then
-              break
-            fi
-            sha=''
-            deployment=''
-            sleep 5
+            if [ "$ok" = 'true' ] && [ "$sha" = "$GITHUB_SHA" ] && [ "$environment" = 'production' ] && [ "$project_id" = "$EXPECTED_VERCEL_PROJECT_ID" ] && [ "$git_provider" = "$EXPECTED_GIT_PROVIDER" ] && [ "$repository" = "$EXPECTED_GIT_REPOSITORY" ] && [[ "$deployment" == dpl_* ]]; then break; fi
+            sha=''; deployment=''; sleep 5
           done
           if [ -z "$sha" ]; then
             echo "EXACT_PRODUCTION_RELEASE_UNVERIFIED expected_sha=$GITHUB_SHA body=${body:0:500}"
@@ -265,32 +234,17 @@ jobs:
             test -n "${VERCEL_TRUSTED_OIDC_TOKEN:-}"
             auth_args+=( -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" )
           fi
-          body=''
-          sha=''
-          deployment=''
+          body=''; sha=''; deployment=''
           for attempt in $(seq 1 12); do
-            body="$(curl --silent --show-error \
-              "${auth_args[@]}" \
-              -H 'accept: application/json' \
-              "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
+            body="$(curl --silent --show-error "${auth_args[@]}" -H 'accept: application/json' "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
             sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty' 2>/dev/null || true)"
             deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty' 2>/dev/null || true)"
             environment="$(printf '%s' "$body" | jq -r '.environment // empty' 2>/dev/null || true)"
             project_id="$(printf '%s' "$body" | jq -r '.project_id // empty' 2>/dev/null || true)"
             git_provider="$(printf '%s' "$body" | jq -r '.git_provider // empty' 2>/dev/null || true)"
             repository="$(printf '%s' "$body" | jq -r '.repository // empty' 2>/dev/null || true)"
-            if [ "$sha" = "$GITHUB_SHA" ] \
-              && [ "$sha" = "${{ steps.release-before.outputs.sha }}" ] \
-              && [ "$deployment" = "${{ steps.release-before.outputs.deployment }}" ] \
-              && [ "$environment" = 'production' ] \
-              && [ "$project_id" = "$EXPECTED_VERCEL_PROJECT_ID" ] \
-              && [ "$git_provider" = "$EXPECTED_GIT_PROVIDER" ] \
-              && [ "$repository" = "$EXPECTED_GIT_REPOSITORY" ]; then
-              break
-            fi
-            sha=''
-            deployment=''
-            sleep 5
+            if [ "$sha" = "$GITHUB_SHA" ] && [ "$sha" = "${{ steps.release-before.outputs.sha }}" ] && [ "$deployment" = "${{ steps.release-before.outputs.deployment }}" ] && [ "$environment" = 'production' ] && [ "$project_id" = "$EXPECTED_VERCEL_PROJECT_ID" ] && [ "$git_provider" = "$EXPECTED_GIT_PROVIDER" ] && [ "$repository" = "$EXPECTED_GIT_REPOSITORY" ]; then break; fi
+            sha=''; deployment=''; sleep 5
           done
           if [ -z "$sha" ]; then
             echo "EXACT_PRODUCTION_RELEASE_DRIFT_OR_UNAVAILABLE expected_sha=$GITHUB_SHA body=${body:0:500}"
@@ -300,37 +254,11 @@ jobs:
           echo "deployment=$deployment" >> "$GITHUB_OUTPUT"
           echo "STABLE_EXACT_PRODUCTION_SHA=$sha deployment=$deployment"
 
-      - name: Publish journey summary
-        if: ${{ always() && steps.journey-mode.outputs.ready == 'true' }}
-        shell: bash
-        run: |
-          echo '## DABBIR AI Full Customer Journey' >> "$GITHUB_STEP_SUMMARY"
-          echo '' >> "$GITHUB_STEP_SUMMARY"
-          echo "**Mode:** ${{ steps.journey-mode.outputs.mode }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Expected SHA:** $GITHUB_SHA" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Production SHA before:** ${{ steps.release-before.outputs.sha || 'UNVERIFIED' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Production SHA after:** ${{ steps.release-after.outputs.sha || 'UNVERIFIED' }}" >> "$GITHUB_STEP_SUMMARY"
-          echo "**Deployment:** ${{ steps.release-before.outputs.deployment || 'UNAVAILABLE' }}" >> "$GITHUB_STEP_SUMMARY"
-          if [ -f "$JOURNEY_REPORT_PATH" ]; then
-            echo "**Verdict:** $(jq -r '.verdict' "$JOURNEY_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Required failures:** $(jq -r '.required_failures' "$JOURNEY_REPORT_PATH")" >> "$GITHUB_STEP_SUMMARY"
-            echo '| Step | Status | Duration ms | Detail |' >> "$GITHUB_STEP_SUMMARY"
-            echo '|---|---:|---:|---|' >> "$GITHUB_STEP_SUMMARY"
-            jq -r '.steps[] | "| \(.name) | \(.status) | \(.duration_ms // 0) | \((.detail // "") | gsub("\\|"; "\\|")) |"' "$JOURNEY_REPORT_PATH" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo '**Verdict:** NO_REPORT' >> "$GITHUB_STEP_SUMMARY"
-          fi
-          if [ -f "$ISOLATION_REPORT_PATH" ]; then
-            echo "**Cross-tenant isolation:** $(jq -r '.verdict' "$ISOLATION_REPORT_PATH") ($(jq -r '.checks | length' "$ISOLATION_REPORT_PATH") checks)" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo '**Cross-tenant isolation:** NO_REPORT' >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload journey evidence
-        if: ${{ always() && steps.journey-mode.outputs.ready == 'true' }}
+      - name: Upload full journey evidence
+        if: always()
         uses: actions/upload-artifact@v6
         with:
-          name: dabbir-ai-customer-journey-evidence
+          name: dabbir-ai-full-customer-journey-evidence
           path: |
             dabbir-ai-customer-journey-report.json
             dabbir-ai-customer-journey-screenshot.png
@@ -346,7 +274,7 @@ jobs:
     timeout-minutes: 25
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
-      SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '300'
       RUN_RUNTIME: 'false'
@@ -358,22 +286,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-      - name: Run clean AI concurrency test
-        run: node test/dabbir-capacity-load.mjs
-      - name: Publish AI capacity summary
+      - run: node test/dabbir-capacity-load.mjs
+      - uses: actions/upload-artifact@v6
         if: always()
-        shell: bash
-        run: |
-          if [ -f dabbir-ai-capacity-report.json ]; then
-            echo '## DABBIR AI Capacity' >> "$GITHUB_STEP_SUMMARY"
-            echo "**AI concurrency passed:** $(jq -r '.capacity.ai_concurrency' dabbir-ai-capacity-report.json)" >> "$GITHUB_STEP_SUMMARY"
-            echo '| Concurrent | Error rate | AI reply rate | p95 ms | Pass |' >> "$GITHUB_STEP_SUMMARY"
-            echo '|---:|---:|---:|---:|---:|' >> "$GITHUB_STEP_SUMMARY"
-            jq -r '.ai_stages[] | "| \(.concurrency) | \(.error_rate) | \(.ai_reply_rate // 0) | \(.p95_ms) | \(.pass) |"' dabbir-ai-capacity-report.json >> "$GITHUB_STEP_SUMMARY"
-          fi
-      - name: Upload AI capacity evidence
-        if: always()
-        uses: actions/upload-artifact@v6
         with:
           name: dabbir-ai-capacity-evidence
           path: dabbir-ai-capacity-report.json
@@ -388,7 +303,7 @@ jobs:
     timeout-minutes: 30
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
-      SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '1000'
       RUN_RUNTIME: 'true'
@@ -400,24 +315,9 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '24'
-      - name: Run 1000-customer runtime capacity test
-        run: node test/dabbir-capacity-load.mjs
-      - name: Publish runtime capacity summary
+      - run: node test/dabbir-capacity-load.mjs
+      - uses: actions/upload-artifact@v6
         if: always()
-        shell: bash
-        run: |
-          if [ -f dabbir-runtime-capacity-report.json ]; then
-            echo '## DABBIR Runtime Capacity' >> "$GITHUB_STEP_SUMMARY"
-            echo "**Customers created:** $(jq -r '.customer_count' dabbir-runtime-capacity-report.json)" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Strict UX concurrency:** $(jq -r '.capacity.infrastructure_stable_concurrency' dabbir-runtime-capacity-report.json)" >> "$GITHUB_STEP_SUMMARY"
-            echo "**Available concurrency:** $(jq -r '.capacity.infrastructure_available_concurrency' dabbir-runtime-capacity-report.json)" >> "$GITHUB_STEP_SUMMARY"
-            echo '| Concurrent | Error rate | p95 ms | p99 ms | Stable | Available |' >> "$GITHUB_STEP_SUMMARY"
-            echo '|---:|---:|---:|---:|---:|---:|' >> "$GITHUB_STEP_SUMMARY"
-            jq -r '.runtime_stages[] | "| \(.concurrency) | \(.error_rate) | \(.p95_ms) | \(.p99_ms) | \(.stable) | \(.available) |"' dabbir-runtime-capacity-report.json >> "$GITHUB_STEP_SUMMARY"
-          fi
-      - name: Upload runtime capacity evidence
-        if: always()
-        uses: actions/upload-artifact@v6
         with:
           name: dabbir-runtime-capacity-evidence
           path: dabbir-runtime-capacity-report.json

--- a/.github/workflows/dabbir-release-guardian.yml
+++ b/.github/workflows/dabbir-release-guardian.yml
@@ -1,0 +1,66 @@
+name: DABBIR Release Guardian
+
+on:
+  workflow_run:
+    workflows:
+      - DABBIR CI
+      - DABBIR Mobile CI
+      - DABBIR Protected Live Smoke
+      - DABBIR AI Full Customer Journey
+      - DABBIR Auth Production Guard
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: dabbir-release-guardian-main
+  cancel-in-progress: false
+
+jobs:
+  revert-failed-main:
+    if: >-
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      contains(fromJSON('["failure","timed_out","cancelled","action_required","startup_failure"]'), github.event.workflow_run.conclusion)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      FAILED_SHA: ${{ github.event.workflow_run.head_sha }}
+      FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}
+      FAILED_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 20
+      - name: Fail closed by reverting the failing head if it is still current
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch origin main --prune
+          current_sha="$(git rev-parse origin/main)"
+          if [ "$current_sha" != "$FAILED_SHA" ]; then
+            echo "Guardian observed $FAILED_SHA failure, but main is already $current_sha; no stale rollback attempted."
+            exit 0
+          fi
+
+          subject="$(git show -s --format=%s "$FAILED_SHA")"
+          if [[ "$subject" == revert\(guardian\):* ]]; then
+            echo "Guardian revert itself failed validation; refusing an automatic re-revert loop."
+            exit 1
+          fi
+
+          git config user.name 'dabbir-release-guardian'
+          git config user.email 'dabbir-release-guardian@users.noreply.github.com'
+
+          parent_count="$(git rev-list --parents -n 1 "$FAILED_SHA" | awk '{print NF-1}')"
+          if [ "$parent_count" -gt 1 ]; then
+            git revert -m 1 --no-edit "$FAILED_SHA"
+          else
+            git revert --no-edit "$FAILED_SHA"
+          fi
+
+          git commit --amend -m "revert(guardian): ${FAILED_WORKFLOW} ${FAILED_CONCLUSION} on ${FAILED_SHA}"
+          git push origin HEAD:main
+          echo "Fail-closed rollback pushed for $FAILED_SHA after ${FAILED_WORKFLOW}=${FAILED_CONCLUSION}."

--- a/scripts/vercel-build-gate.mjs
+++ b/scripts/vercel-build-gate.mjs
@@ -3,7 +3,7 @@ import { existsSync, openSync, closeSync, writeFileSync, unlinkSync } from 'node
 import os from 'node:os';
 import path from 'node:path';
 
-const gateVersion = 'v3-final';
+const gateVersion = 'v4-fail-closed';
 const rawSha = String(process.env.VERCEL_GIT_COMMIT_SHA || process.env.GITHUB_SHA || 'local').trim();
 const rawDeploymentId = String(process.env.VERCEL_DEPLOYMENT_ID || `pid-${process.pid}`).trim();
 const safeSha = rawSha.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 80) || 'local';
@@ -19,24 +19,31 @@ function sleep(milliseconds) {
   Atomics.wait(new Int32Array(buffer), 0, 0, milliseconds);
 }
 
-function runTests() {
-  console.log(`[dabbir-build-gate:${gateVersion}] verifying deployment ${safeDeploymentId} commit ${safeSha}`);
-  const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test'], {
+function runNpm(args,label) {
+  console.log(`[dabbir-build-gate:${gateVersion}] ${label}`);
+  const result = spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', args, {
     stdio: 'inherit',
     env: process.env,
   });
   if (result.error) throw result.error;
   if (result.status !== 0) {
-    const error = new Error(`DABBIR_TEST_GATE_FAILED_${result.status ?? 1}`);
+    const error = new Error(`DABBIR_BUILD_GATE_${label.replace(/[^A-Z0-9]+/gi,'_').toUpperCase()}_FAILED_${result.status ?? 1}`);
     error.exitCode = result.status ?? 1;
     throw error;
   }
+}
+
+function runTests() {
+  console.log(`[dabbir-build-gate:${gateVersion}] verifying deployment ${safeDeploymentId} commit ${safeSha}`);
+  runNpm(['run','check:syntax'],'syntax');
+  runNpm(['run','audit:prod'],'dependency-audit');
+  runNpm(['test'],'test-suite');
   writeFileSync(marker, `${new Date().toISOString()}\n`, { encoding: 'utf8', mode: 0o600 });
   console.log(`[dabbir-build-gate:${gateVersion}] verified deployment ${safeDeploymentId} commit ${safeSha}`);
 }
 
 if (existsSync(marker)) {
-  console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} already verified; skipping duplicate test run`);
+  console.log(`[dabbir-build-gate:${gateVersion}] deployment ${safeDeploymentId} commit ${safeSha} already verified; skipping duplicate gate run`);
   process.exit(0);
 }
 

--- a/supabase/functions/dabbir-qa-suite-runner/index.ts
+++ b/supabase/functions/dabbir-qa-suite-runner/index.ts
@@ -1,0 +1,64 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2.112.2";
+
+const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,{auth:{persistSession:false}});
+const GH_ISSUER='https://token.actions.githubusercontent.com';
+const GH_REPOSITORY='barman-systems/pilot';
+const GH_REF='refs/heads/main';
+const GH_WORKFLOW='barman-systems/pilot/.github/workflows/dabbir-ai-customer-journey.yml@refs/heads/main';
+const GH_AUDIENCE='dabbir-ai-qa';
+const GH_EVENTS=new Set(['push','schedule','workflow_dispatch']);
+const ACTIONS=new Set(['dabbir_ai_qa_bootstrap','dabbir_ai_qa_seed_order','dabbir_ai_qa_cleanup']);
+
+function b64urlDecode(value:string){const padded=value.replaceAll('-','+').replaceAll('_','/')+'='.repeat((4-value.length%4)%4);const binary=atob(padded);return Uint8Array.from(binary,c=>c.charCodeAt(0))}
+function decodeJsonPart(value:string){return JSON.parse(new TextDecoder().decode(b64urlDecode(value)))}
+async function verifyGitHubOidc(req:Request){
+  const auth=req.headers.get('authorization')||'';
+  if(!auth.startsWith('Bearer '))throw new Error('OIDC_REQUIRED');
+  const token=auth.slice(7).trim(),parts=token.split('.');
+  if(parts.length!==3)throw new Error('OIDC_FORMAT_INVALID');
+  const header=decodeJsonPart(parts[0]),payload=decodeJsonPart(parts[1]);
+  if(header?.alg!=='RS256'||!header?.kid)throw new Error('OIDC_ALG_INVALID');
+  const jwksResponse=await fetch('https://token.actions.githubusercontent.com/.well-known/jwks',{headers:{accept:'application/json'},signal:AbortSignal.timeout(10000)});
+  if(!jwksResponse.ok)throw new Error('OIDC_JWKS_UNAVAILABLE');
+  const jwks=await jwksResponse.json(),jwk=(jwks?.keys||[]).find((k:any)=>k.kid===header.kid&&k.kty==='RSA');
+  if(!jwk)throw new Error('OIDC_KEY_NOT_FOUND');
+  const key=await crypto.subtle.importKey('jwk',jwk,{name:'RSASSA-PKCS1-v1_5',hash:'SHA-256'},false,['verify']);
+  const valid=await crypto.subtle.verify('RSASSA-PKCS1-v1_5',key,b64urlDecode(parts[2]),new TextEncoder().encode(`${parts[0]}.${parts[1]}`));
+  if(!valid)throw new Error('OIDC_SIGNATURE_INVALID');
+  const now=Math.floor(Date.now()/1000),aud=Array.isArray(payload.aud)?payload.aud:[payload.aud];
+  if(payload.iss!==GH_ISSUER)throw new Error('OIDC_ISSUER_DENIED');
+  if(!aud.includes(GH_AUDIENCE))throw new Error('OIDC_AUDIENCE_DENIED');
+  if(Number(payload.exp||0)<=now||Number(payload.nbf||0)>now+30)throw new Error('OIDC_TIME_INVALID');
+  if(payload.repository!==GH_REPOSITORY||payload.ref!==GH_REF||payload.workflow_ref!==GH_WORKFLOW)throw new Error('OIDC_SOURCE_DENIED');
+  if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
+  return payload;
+}
+function runId(value:any){const v=String(value||'').trim();if(!/^[A-Za-z0-9-]{6,90}$/.test(v))throw new Error('INVALID_RUN_ID');return v}
+function password(){const bytes=crypto.getRandomValues(new Uint8Array(24));const base=btoa(String.fromCharCode(...bytes)).replaceAll('+','-').replaceAll('/','_').replaceAll('=','');return `Dabbir-QA-${base}!Aa9`}
+async function createUser(email:string,pw:string,rid:string,label:string){const {data,error}=await db.auth.admin.createUser({email,password:pw,email_confirm:true,user_metadata:{dabbir_qa:true,dabbir_qa_run_id:rid,role_label:label}});if(error||!data?.user?.id)throw new Error(`AUTH_USER_CREATE_FAILED:${error?.message||'missing_id'}`);return {id:data.user.id,email,password:pw}}
+async function scopedUser(id:string,rid:string){const {data,error}=await db.auth.admin.getUserById(id);if(error||!data?.user||data.user.user_metadata?.dabbir_qa!==true||data.user.user_metadata?.dabbir_qa_run_id!==rid)throw new Error('QA_USER_SCOPE_DENIED')}
+async function deleteUser(id:string,rid:string){await scopedUser(id,rid);const {error:t}=await db.from('account_access_state').upsert({user_id:id,status:'deleted',reason:'DABBIR_QA_CLEANUP',updated_at:new Date().toISOString()},{onConflict:'user_id'});if(t)throw new Error(`QA_USER_TOMBSTONE_FAILED:${t.message}`);const {error:a}=await db.from('dabbir_user_accounts').delete().eq('user_id',id);if(a)throw new Error(`QA_USER_ACCOUNT_DELETE_FAILED:${a.message}`);const {error}=await db.auth.admin.deleteUser(id);if(error)throw new Error(`AUTH_USER_DELETE_FAILED:${error.message}`);return {deleted:true,user_id:id}}
+async function assertBusiness(id:string,rid:string){const {data,error}=await db.from('dabbir_businesses').select('id,name').eq('id',id).maybeSingle();if(error||!data||data.name!==`DABBIR AI QA ${rid}`)throw new Error('QA_BUSINESS_SCOPE_DENIED')}
+async function bootstrap(rid:string){const suffix=`${rid.toLowerCase()}-${crypto.randomUUID().slice(0,8)}`;let owner:any=null,employee:any=null;try{owner=await createUser(`dabbir-qa-owner-${suffix}@example.com`,password(),rid,'owner');employee=await createUser(`dabbir-qa-employee-${suffix}@example.com`,password(),rid,'employee');return {owner,employee}}catch(e){if(employee?.id)await deleteUser(employee.id,rid).catch(()=>{});if(owner?.id)await deleteUser(owner.id,rid).catch(()=>{});throw e}}
+async function cleanup(rid:string,b:any){const out:any={};if(b.business_id){await assertBusiness(String(b.business_id),rid);const {data,error}=await db.rpc('dabbir_qa_cleanup_business',{p_business_id:String(b.business_id)});if(error)throw new Error(`QA_BUSINESS_CLEANUP_FAILED:${error.message}`);out.business=data}if(b.employee_user_id)out.employee=await deleteUser(String(b.employee_user_id),rid);if(b.owner_user_id)out.owner=await deleteUser(String(b.owner_user_id),rid);return out}
+function errorResponse(e:unknown){const m=String(e instanceof Error?e.message:e).slice(0,500);return Response.json({ok:false,error:m},{status:m.startsWith('OIDC_')?401:400,headers:{'cache-control':'no-store'}})}
+
+Deno.serve(async(req:Request)=>{
+  if(req.method!=='POST')return new Response('method not allowed',{status:405});
+  try{
+    const claims=await verifyGitHubOidc(req);
+    const b=await req.json().catch(()=>({})),action=String(b.action||''),rid=runId(b.run_id);
+    if(!ACTIONS.has(action))return Response.json({ok:false,error:'unknown_action'},{status:400});
+    if(action==='dabbir_ai_qa_bootstrap')return Response.json({ok:true,action,run_id:rid,identities:await bootstrap(rid),github_run_id:claims.run_id||null},{headers:{'cache-control':'no-store'}});
+    if(action==='dabbir_ai_qa_seed_order'){
+      const businessId=String(b.business_id||''),customerId=String(b.customer_id||'');
+      if(!businessId||!customerId)return Response.json({ok:false,error:'business_id_customer_id_required'},{status:400});
+      await assertBusiness(businessId,rid);
+      const {data,error}=await db.from('dabbir_orders').insert({business_id:businessId,customer_id:customerId,status:'draft',total_aed:125,simulated:false}).select('id,status,total_aed,simulated').single();
+      if(error||!data?.id)throw new Error(`QA_ORDER_CREATE_FAILED:${error?.message||'missing_id'}`);
+      return Response.json({ok:true,action,run_id:rid,order:data},{headers:{'cache-control':'no-store'}});
+    }
+    return Response.json({ok:true,action,run_id:rid,cleanup:await cleanup(rid,b)},{headers:{'cache-control':'no-store'}});
+  }catch(e){return errorResponse(e)}
+});

--- a/supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql
+++ b/supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql
@@ -1,0 +1,56 @@
+-- Prevent concurrent booking/calendar writes for the same business from bypassing
+-- the existing appointment conflict checks. The lock is transaction-scoped and
+-- shared by appointments, external busy blocks, worker schedules, and time off.
+
+create or replace function dabbir_private.lock_booking_calendar_business()
+returns trigger
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_new_business uuid;
+  v_old_business uuid;
+  v_first text;
+  v_second text;
+begin
+  if tg_op <> 'DELETE' then v_new_business := new.business_id; end if;
+  if tg_op <> 'INSERT' then v_old_business := old.business_id; end if;
+
+  if v_new_business is not null and v_old_business is not null and v_new_business <> v_old_business then
+    v_first := least(v_new_business::text, v_old_business::text);
+    v_second := greatest(v_new_business::text, v_old_business::text);
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || v_first, 0));
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || v_second, 0));
+  elsif coalesce(v_new_business,v_old_business) is not null then
+    perform pg_advisory_xact_lock(hashtextextended('dabbir:booking-calendar:' || coalesce(v_new_business,v_old_business)::text, 0));
+  end if;
+
+  return case when tg_op='DELETE' then old else new end;
+end;
+$$;
+
+revoke all on function dabbir_private.lock_booking_calendar_business() from public,anon,authenticated;
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_appointments;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_appointments
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_calendar_busy_blocks;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_calendar_busy_blocks
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_worker_schedules;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_worker_schedules
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+drop trigger if exists dabbir_00_booking_calendar_lock on public.dabbir_worker_time_off;
+create trigger dabbir_00_booking_calendar_lock
+before insert or update or delete on public.dabbir_worker_time_off
+for each row execute function dabbir_private.lock_booking_calendar_business();
+
+comment on function dabbir_private.lock_booking_calendar_business() is
+  'Serializes booking-calendar writes per business so concurrent appointment, busy-block, schedule, and time-off transactions cannot bypass conflict checks.';

--- a/test/dabbir-booking-calendar-lock.test.mjs
+++ b/test/dabbir-booking-calendar-lock.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration=fs.readFileSync(new URL('../supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql',import.meta.url),'utf8');
+
+const requiredTables=[
+  'public.dabbir_appointments',
+  'public.dabbir_calendar_busy_blocks',
+  'public.dabbir_worker_schedules',
+  'public.dabbir_worker_time_off',
+];
+
+test('booking calendar writes are serialized per business with a transaction lock',()=>{
+  assert.match(migration,/pg_advisory_xact_lock\(hashtextextended\('dabbir:booking-calendar:' \|\|/);
+  assert.match(migration,/create or replace function dabbir_private\.lock_booking_calendar_business\(\)/);
+  assert.match(migration,/revoke all on function dabbir_private\.lock_booking_calendar_business\(\) from public,anon,authenticated/);
+});
+
+test('all scheduling truth surfaces share the same lock trigger',()=>{
+  for(const table of requiredTables){
+    assert.match(migration,new RegExp(`create trigger dabbir_00_booking_calendar_lock[\\s\\S]+?on ${table.replaceAll('.','\\.')}[\\s\\S]+?lock_booking_calendar_business\\(\\)`));
+  }
+});
+
+test('lock trigger sorts before the appointment conflict guard',()=>{
+  assert.ok('dabbir_00_booking_calendar_lock'.localeCompare('dabbir_appointment_calendar_conflict_guard') < 0);
+});

--- a/test/dabbir-mumbai-qa-routing.test.mjs
+++ b/test/dabbir-mumbai-qa-routing.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const workflow=fs.readFileSync('.github/workflows/dabbir-ai-customer-journey.yml','utf8');
+const runner=fs.readFileSync('supabase/functions/dabbir-qa-suite-runner/index.ts','utf8');
+
+const MUMBAI='fphpoysqdsceniwduxjq';
+const LEGACY='spohjzrsymsmzsseygtw';
+
+test('production customer journey creates disposable QA identities in the Mumbai production project',()=>{
+  assert.match(workflow,new RegExp(`SUPABASE_PROJECT_REF: ${MUMBAI}`));
+  assert.doesNotMatch(workflow,new RegExp(LEGACY));
+});
+
+test('Mumbai QA runner is narrowly scoped and main-only',()=>{
+  assert.match(runner,/GH_REF='refs\/heads\/main'/);
+  assert.match(runner,/dabbir-ai-customer-journey\.yml@refs\/heads\/main/);
+  assert.match(runner,/GH_AUDIENCE='dabbir-ai-qa'/);
+  assert.match(runner,/dabbir_ai_qa_bootstrap/);
+  assert.match(runner,/dabbir_ai_qa_seed_order/);
+  assert.match(runner,/dabbir_ai_qa_cleanup/);
+  assert.doesNotMatch(runner,/x-barman-worker-secret/);
+  assert.doesNotMatch(runner,/barman_create_qa_suite_v2/);
+});
+
+test('journey keeps exact-release and cross-tenant gates while using Mumbai QA',()=>{
+  assert.match(workflow,/EXACT_PRODUCTION_RELEASE_UNVERIFIED/);
+  assert.match(workflow,/EXACT_PRODUCTION_RELEASE_DRIFT_OR_UNAVAILABLE/);
+  assert.match(workflow,/CROSS_TENANT_ISOLATION_PASS/);
+  assert.match(workflow,/FULL_JOURNEY_PASS/);
+});

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -15,16 +15,18 @@ test('Vercel uses the fail-closed DABBIR build gate without changing the Functio
   assert.equal(parse.status, 0, parse.stderr || parse.stdout);
 });
 
-test('cached build evidence is scoped to deployment plus commit and written only after tests succeed', () => {
+test('cached build evidence is scoped to deployment plus commit and written only after every fail-closed verification succeeds', () => {
   assert.match(gate, /VERCEL_DEPLOYMENT_ID/);
   assert.match(gate, /VERCEL_GIT_COMMIT_SHA/);
   assert.match(gate, /const evidenceKey = `\$\{safeDeploymentId\}-\$\{safeSha\}`/);
   assert.match(gate, /dabbir-vercel-tests-passed-/);
-  assert.match(gate, /spawnSync[\s\S]*\['test'\]/);
-  const testRun = gate.indexOf("spawnSync(process.platform === 'win32' ? 'npm.cmd' : 'npm', ['test']");
+  assert.match(gate, /runNpm\(\['run','check:syntax'\],'syntax'\)/);
+  assert.match(gate, /runNpm\(\['run','audit:prod'\],'dependency-audit'\)/);
+  assert.match(gate, /runNpm\(\['test'\],'test-suite'\)/);
+  const testRun = gate.indexOf("runNpm(['test'],'test-suite')");
   const markerWrite = gate.indexOf('writeFileSync(marker');
-  assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the test process');
-  assert.match(gate, /DABBIR_TEST_GATE_FAILED_/);
+  assert.ok(testRun >= 0 && markerWrite > testRun, 'success evidence must be written only after the final verification process');
+  assert.match(gate, /DABBIR_BUILD_GATE_/);
 });
 
 test('failure cleanup cannot leave a stale success path', () => {

--- a/test/dabbir-release-guardian.test.mjs
+++ b/test/dabbir-release-guardian.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const buildGate=fs.readFileSync(new URL('../scripts/vercel-build-gate.mjs',import.meta.url),'utf8');
+const guardian=fs.readFileSync(new URL('../.github/workflows/dabbir-release-guardian.yml',import.meta.url),'utf8');
+
+test('Vercel build gate fails closed on syntax, dependency audit, and full tests',()=>{
+  assert.match(buildGate,/v4-fail-closed/);
+  assert.match(buildGate,/runNpm\(\['run','check:syntax'\],'syntax'\)/);
+  assert.match(buildGate,/runNpm\(\['run','audit:prod'\],'dependency-audit'\)/);
+  assert.match(buildGate,/runNpm\(\['test'\],'test-suite'\)/);
+  assert.match(buildGate,/process\.exit\(exitCode\)/);
+});
+
+test('release guardian auto-reverts failed main heads without stale rollback or loops',()=>{
+  for(const workflow of [
+    'DABBIR CI',
+    'DABBIR Mobile CI',
+    'DABBIR Protected Live Smoke',
+    'DABBIR AI Full Customer Journey',
+    'DABBIR Auth Production Guard',
+  ]) assert.ok(guardian.includes(`- ${workflow}`));
+
+  assert.match(guardian,/permissions:[\s\S]*contents: write/);
+  assert.match(guardian,/current_sha=.*origin\/main/);
+  assert.match(guardian,/current_sha.*FAILED_SHA/);
+  assert.match(guardian,/revert\\\(guardian\\\):/);
+  assert.match(guardian,/git revert/);
+  assert.match(guardian,/git push origin HEAD:main/);
+});


### PR DESCRIPTION
## Root cause
The exact-production customer journey created disposable QA users in the retired Sydney Supabase project (`spoh...`) while DABBIR Production authenticates against Mumbai (`fphp...`). The release guardian correctly detected the resulting login failure and reverted the prior release.

## Fix
- restore the fail-closed Vercel build gate, booking-calendar transaction lock source migration, and release guardian
- keep the already-applied live Mumbai booking lock represented in source control
- route DABBIR production customer-journey QA to Mumbai `fphpoysqdsceniwduxjq`
- add the narrowly scoped `dabbir-qa-suite-runner` source, pinned to GitHub OIDC from the canonical main-only journey
- add a regression test that forbids the retired `spoh...` project from the production customer-journey workflow
- preserve exact-release locking, cross-tenant isolation, full-journey evidence, and manual-only capacity gates

## Live infrastructure evidence
- Mumbai `dabbir-qa-suite-runner` ACTIVE
- Mumbai compatibility slug `barman-qa-suite-runner` ACTIVE and DABBIR-only
- booking calendar lock: 4 protected scheduling surfaces, 0 current overlap pairs
- previous bad release was automatically reverted by the guardian, proving fail-closed recovery works

## Merge rule
Do not merge until branch CI and Vercel Preview are green. After merge, require the exact Production SHA to pass the full customer journey, cross-tenant/WhatsApp isolation, auth guard, protected smoke, and zero recent 5xx/error/fatal runtime logs.