### PR TITLE
fix(dabbir): prevent customer number reuse after Mumbai restore drift

### DIFF
--- a/supabase/migrations/20260902081000_dabbir_customer_number_sequence_ledger_guard_v1.sql
+++ b/supabase/migrations/20260902081000_dabbir_customer_number_sequence_ledger_guard_v1.sql
@@ -1,0 +1,58 @@
+-- DABBIR customer number allocation must never reuse an immutable ledger number.
+-- Mumbai cutover evidence showed the restored sequence could lag behind the append-only
+-- identity ledger, causing onboarding to fail with SQLSTATE 23505.
+
+-- First align the sequence with every number already reserved in either truth surface.
+select setval(
+  'dabbir_private.dabbir_customer_number_seq'::regclass,
+  greatest(
+    (select last_value from dabbir_private.dabbir_customer_number_seq),
+    coalesce((
+      select max(substring(customer_no from 5)::bigint)
+      from dabbir_private.dabbir_customer_number_ledger
+      where customer_no ~ '^DAB-[0-9]+$'
+    ), 100000),
+    coalesce((
+      select max(substring(customer_no from 5)::bigint)
+      from public.dabbir_user_accounts
+      where customer_no ~ '^DAB-[0-9]+$'
+    ), 100000)
+  ),
+  true
+);
+
+-- Defense in depth: even if a future restore/cutover regresses the sequence again,
+-- skip every number already present in the immutable ledger or active account table.
+create or replace function dabbir_private.next_customer_number()
+returns text
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private
+as $function$
+declare
+  v_no bigint;
+  v_candidate text;
+begin
+  loop
+    v_no := nextval('dabbir_private.dabbir_customer_number_seq');
+    v_candidate := 'DAB-' || v_no::text;
+
+    if not exists (
+      select 1
+      from dabbir_private.dabbir_customer_number_ledger l
+      where l.customer_no = v_candidate
+    ) and not exists (
+      select 1
+      from public.dabbir_user_accounts a
+      where a.customer_no = v_candidate
+    ) then
+      return v_candidate;
+    end if;
+  end loop;
+end;
+$function$;
+
+revoke all on function dabbir_private.next_customer_number() from public, anon, authenticated;
+
+comment on function dabbir_private.next_customer_number() is
+  'Allocates a monotonic DABBIR customer number while refusing to reuse any number reserved by the immutable ledger or active accounts, even after sequence restore drift.';

--- a/test/dabbir-customer-number-sequence-ledger-guard.test.mjs
+++ b/test/dabbir-customer-number-sequence-ledger-guard.test.mjs
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration = fs.readFileSync(
+  new URL('../supabase/migrations/20260902081000_dabbir_customer_number_sequence_ledger_guard_v1.sql', import.meta.url),
+  'utf8',
+);
+
+test('customer number sequence is realigned against immutable ledger and active accounts', () => {
+  assert.match(migration, /select setval\(/);
+  assert.match(migration, /dabbir_private\.dabbir_customer_number_seq/);
+  assert.match(migration, /from dabbir_private\.dabbir_customer_number_ledger/);
+  assert.match(migration, /from public\.dabbir_user_accounts/);
+  assert.match(migration, /greatest\(/);
+});
+
+test('allocator skips any number already reserved in either truth surface', () => {
+  assert.match(migration, /create or replace function dabbir_private\.next_customer_number\(\)/);
+  assert.match(migration, /loop[\s\S]*nextval\('dabbir_private\.dabbir_customer_number_seq'\)/);
+  assert.match(migration, /where l\.customer_no = v_candidate/);
+  assert.match(migration, /where a\.customer_no = v_candidate/);
+  assert.match(migration, /return v_candidate/);
+});
+
+test('allocator remains privileged and documents restore-drift protection', () => {
+  assert.match(migration, /revoke all on function dabbir_private\.next_customer_number\(\) from public, anon, authenticated/);
+  assert.match(migration, /immutable ledger or active accounts/);
+  assert.match(migration, /sequence restore drift/);
+});


### PR DESCRIPTION
## Root cause
Production full-customer journey reached Mumbai successfully but business onboarding failed with PostgreSQL `23505`. Postgres logs identified `dabbir_customer_number_ledger_customer_no_key`: the restored sequence was at 100367 while the immutable ledger already reserved DAB-100368.

## Fix
- realign the customer-number sequence against both immutable ledger and active accounts
- harden `next_customer_number()` to skip any already-reserved number even if a future restore regresses the sequence
- add regression tests for sequence realignment, collision skipping, and privilege posture

## Production evidence
The identical migration has already been applied fail-closed to the Mumbai project `fphpoysqdsceniwduxjq`; sequence is aligned to ledger max and the hardened function is live. This PR restores source-of-truth parity and gates recurrence through CI.