### PR TITLE
fix(dabbir): prevent customer number reuse after Mumbai restore

### DIFF
--- a/supabase/migrations/20260902075523_dabbir_customer_number_sequence_ledger_guard_v1.sql
+++ b/supabase/migrations/20260902075523_dabbir_customer_number_sequence_ledger_guard_v1.sql
@@ -1,0 +1,55 @@
+-- DABBIR customer number allocation must never reuse an immutable ledger number.
+-- Mumbai cutover evidence showed the restored sequence could lag behind the append-only
+-- identity ledger, causing onboarding to fail with SQLSTATE 23505.
+
+select setval(
+  'dabbir_private.dabbir_customer_number_seq'::regclass,
+  greatest(
+    (select last_value from dabbir_private.dabbir_customer_number_seq),
+    coalesce((
+      select max(substring(customer_no from 5)::bigint)
+      from dabbir_private.dabbir_customer_number_ledger
+      where customer_no ~ '^DAB-[0-9]+$'
+    ), 100000),
+    coalesce((
+      select max(substring(customer_no from 5)::bigint)
+      from public.dabbir_user_accounts
+      where customer_no ~ '^DAB-[0-9]+$'
+    ), 100000)
+  ),
+  true
+);
+
+create or replace function dabbir_private.next_customer_number()
+returns text
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private
+as $function$
+declare
+  v_no bigint;
+  v_candidate text;
+begin
+  loop
+    v_no := nextval('dabbir_private.dabbir_customer_number_seq');
+    v_candidate := 'DAB-' || v_no::text;
+
+    if not exists (
+      select 1
+      from dabbir_private.dabbir_customer_number_ledger l
+      where l.customer_no = v_candidate
+    ) and not exists (
+      select 1
+      from public.dabbir_user_accounts a
+      where a.customer_no = v_candidate
+    ) then
+      return v_candidate;
+    end if;
+  end loop;
+end;
+$function$;
+
+revoke all on function dabbir_private.next_customer_number() from public, anon, authenticated;
+
+comment on function dabbir_private.next_customer_number() is
+  'Allocates a monotonic DABBIR customer number while refusing to reuse any number reserved by the immutable ledger or active accounts, even after sequence restore drift.';

--- a/test/dabbir-customer-number-ledger-guard.test.mjs
+++ b/test/dabbir-customer-number-ledger-guard.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const sql = await readFile(new URL('../supabase/migrations/20260902075523_dabbir_customer_number_sequence_ledger_guard_v1.sql', import.meta.url), 'utf8');
+
+test('customer number sequence is advanced beyond both immutable ledger and active accounts', () => {
+  assert.match(sql, /select\s+setval\s*\(/i);
+  assert.match(sql, /greatest\s*\(/i);
+  assert.match(sql, /dabbir_customer_number_ledger/i);
+  assert.match(sql, /dabbir_user_accounts/i);
+});
+
+test('allocator refuses to return a number already present in ledger or accounts', () => {
+  assert.match(sql, /create\s+or\s+replace\s+function\s+dabbir_private\.next_customer_number\s*\(\s*\)/i);
+  assert.match(sql, /not\s+exists\s*\([\s\S]*dabbir_customer_number_ledger/i);
+  assert.match(sql, /and\s+not\s+exists\s*\([\s\S]*dabbir_user_accounts/i);
+  assert.match(sql, /nextval\s*\(\s*'dabbir_private\.dabbir_customer_number_seq'\s*\)/i);
+});

--- a/test/dabbir-protected-full-journey-preload.mjs
+++ b/test/dabbir-protected-full-journey-preload.mjs
@@ -3,6 +3,15 @@ import {
   installProtectedPlaywrightAccess,
 } from './support/dabbir-protected-journey-access.mjs';
 
+// Production data/auth and disposable QA identities were cut over to the Mumbai
+// DABBIR Supabase project. A release rollback restored the legacy Sydney project
+// ref in the workflow env, which created QA users in the wrong Auth tenant and
+// made the real Production login fail with INVALID_CREDENTIALS. Protected
+// journeys must therefore pin the canonical Mumbai QA project before the main
+// journey module is evaluated.
+const MUMBAI_QA_PROJECT_REF = 'fphpoysqdsceniwduxjq';
+process.env.SUPABASE_PROJECT_REF = MUMBAI_QA_PROJECT_REF;
+
 const origin = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 const bypass = String(process.env.VERCEL_AUTOMATION_BYPASS_SECRET || '').trim();
 const trustedOidc = String(process.env.VERCEL_TRUSTED_OIDC_TOKEN || '').trim();
@@ -214,3 +223,4 @@ webkit.launch = async (...launchArgs) => {
 };
 
 console.log(`DABBIR_PROTECTED_FULL_JOURNEY_ACCESS=${bypass ? 'automation_bypass' : 'trusted_oidc'}`);
+console.log('DABBIR_PROTECTED_QA_PROJECT=MUMBAI');

--- a/test/dabbir-protected-mumbai-qa-routing.test.mjs
+++ b/test/dabbir-protected-mumbai-qa-routing.test.mjs
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const preload = await readFile(new URL('./dabbir-protected-full-journey-preload.mjs', import.meta.url), 'utf8');
+const journey = await readFile(new URL('./ai-full-customer-journey-v2.mjs', import.meta.url), 'utf8');
+const isolation = await readFile(new URL('./dabbir-cross-tenant-isolation.mjs', import.meta.url), 'utf8');
+
+const MUMBAI = 'fphpoysqdsceniwduxjq';
+
+test('protected production journeys override stale workflow refs with canonical Mumbai QA project', () => {
+  assert.match(preload, new RegExp(`MUMBAI_QA_PROJECT_REF\\s*=\\s*['\"]${MUMBAI}['\"]`));
+  assert.match(preload, /process\.env\.SUPABASE_PROJECT_REF\s*=\s*MUMBAI_QA_PROJECT_REF/);
+});
+
+test('full and isolation journeys resolve QA control from SUPABASE_PROJECT_REF after preload', () => {
+  assert.match(journey, /process\.env\.SUPABASE_PROJECT_REF/);
+  assert.match(journey, /functions\/v1\/barman-qa-suite-runner/);
+  assert.match(isolation, /process\.env\.SUPABASE_PROJECT_REF/);
+  assert.match(isolation, /functions\/v1\/barman-qa-suite-runner/);
+});


### PR DESCRIPTION
Closed as obsolete cleanup noise. The customer-number ledger/sequence repair is already included in merged PR #262 and subsequently carried into current main. Keeping this duplicate PR open risks accidental reapplication of the same migration logic.