### PR TITLE
fix(dabbir): make WebKit journey wait for rendered conversations

### DIFF
--- a/test/dabbir-protected-full-journey-preload.mjs
+++ b/test/dabbir-protected-full-journey-preload.mjs
@@ -113,6 +113,19 @@ webkit.launch = async (...launchArgs) => {
           if (tracked) checkpoint('wait_start', selectorText);
           try {
             const result = await protectedWaitFor(options);
+            if (selectorText === '#screen-conversations.active') {
+              // The iPhone/WebKit navigation bridge intentionally paints the active
+              // screen immediately, then calls showScreen/renderChats after two
+              // requestAnimationFrame ticks. Treat the screen as ready only after
+              // its conversation rows have actually rendered, not merely when the
+              // visual-first `active` class appears.
+              await protectedWaitForFunction(
+                () => document.querySelectorAll('#chatList .chatContact').length > 0,
+                null,
+                { timeout: 10_000 },
+              );
+              checkpoint('content_ready', '#chatList .chatContact');
+            }
             if (tracked) checkpoint('wait_pass', selectorText);
             return result;
           } catch (error) {

--- a/test/dabbir-webkit-deferred-render-readiness.test.mjs
+++ b/test/dabbir-webkit-deferred-render-readiness.test.mjs
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const bridge = await readFile(new URL('../api/dabbir-navigation-event-bridge-ui.js', import.meta.url), 'utf8');
+const preload = await readFile(new URL('./dabbir-protected-full-journey-preload.mjs', import.meta.url), 'utf8');
+
+test('navigation bridge is visual-first and defers the actual screen render', () => {
+  assert.match(bridge, /visual_first:true/);
+  assert.match(bridge, /deferred_render:true/);
+  assert.match(bridge, /requestAnimationFrame\(\(\)=>requestAnimationFrame\(callback\)\)/);
+});
+
+test('WebKit journey waits for conversation rows after the visual-first active state', () => {
+  assert.match(preload, /selectorText === '#screen-conversations\.active'/);
+  assert.match(preload, /#chatList \.chatContact/);
+  assert.match(preload, /content_ready/);
+});


### PR DESCRIPTION
Closed as superseded by merged PR #265. Production SHA `d5f89a012bc3ba543c49e0f341483bfa7eacfd0c` has now passed the exact-production WebKit Full Customer Journey, cross-tenant/WhatsApp isolation, and stable-release verification. No second competing render-readiness implementation should be merged.