### PR TITLE
fix: refresh conversations after first Safari paint

### DIFF
--- a/api/dabbir-navigation-event-bridge-ui.js
+++ b/api/dabbir-navigation-event-bridge-ui.js
@@ -9,6 +9,8 @@ const script = String.raw`(()=>{
   let suppressClickNode=null;
   let suppressClickUntil=0;
   let navigationEpoch=0;
+  let conversationRefreshInFlight=null;
+  let conversationRefreshBusinessId=null;
 
   function itemFrom(target){
     return target?.closest?.(NAV_ITEM_SELECTOR)||null;
@@ -71,6 +73,34 @@ const script = String.raw`(()=>{
     };
   }
 
+  function refreshConversationWorkspace(){
+    const businessId=String(workspace?.business?.id||'').trim();
+    if(!businessId||typeof loadRuntime!=='function') return Promise.resolve({ok:false,reason:'RUNTIME_REFRESH_UNAVAILABLE'});
+    if(conversationRefreshInFlight&&conversationRefreshBusinessId===businessId) return conversationRefreshInFlight;
+
+    const before=workspace;
+    const conversationId=typeof selectedConversationId!=='undefined'?selectedConversationId:null;
+    conversationRefreshBusinessId=businessId;
+    conversationRefreshInFlight=Promise.resolve()
+      .then(()=>loadRuntime(businessId,conversationId))
+      .then(()=>{
+        const ok=workspace!==before&&String(workspace?.business?.id||'')===businessId;
+        const result={ok,reason:ok?'SERVER_REFRESHED':'NO_FRESH_RUNTIME'};
+        window.__dabbirLastConversationRefresh={...result,business_id:businessId,at:new Date().toISOString()};
+        return result;
+      })
+      .catch(error=>{
+        const result={ok:false,reason:'RUNTIME_REFRESH_FAILED'};
+        window.__dabbirLastConversationRefresh={...result,business_id:businessId,error:String(error?.message||error),at:new Date().toISOString()};
+        return result;
+      })
+      .finally(()=>{
+        conversationRefreshInFlight=null;
+        conversationRefreshBusinessId=null;
+      });
+    return conversationRefreshInFlight;
+  }
+
   function paint(hit){
     try{current=hit.name}catch{}
     document.querySelectorAll('.screen').forEach(screen=>screen.classList.toggle('active',screen===hit.screen));
@@ -105,33 +135,45 @@ const script = String.raw`(()=>{
     const epoch=++navigationEpoch;
     const started=typeof performance!=='undefined'&&performance.now?performance.now():Date.now();
 
-    // Conversation data is already present in the authenticated workspace. Render that local
-    // state synchronously so WebKit never exposes an activated but empty conversation screen.
-    // Network/data refresh work remains deferred with showScreen below.
+    // Render the authenticated local workspace immediately so WebKit never shows a blank chat.
+    // Then refresh canonical server state after first paint so newly-created conversations appear.
     renderLoadedScreen(hit);
     paint(hit);
 
     afterPaint(()=>{
       if(epoch!==navigationEpoch) return;
-      let error=null;
-      try{
-        if(typeof showScreen==='function') showScreen(hit.name);
-      }catch(caught){
-        error=caught;
-      }
-      if(epoch!==navigationEpoch) return;
-      if(!hit.screen.classList.contains('active')) safeFallback(hit,source,error||new Error('SCREEN_NOT_ACTIVATED'));
-      else if(error) safeFallback(hit,source,error);
-      const finished=typeof performance!=='undefined'&&performance.now?performance.now():Date.now();
-      window.__dabbirLastNavigationTiming={
-        target:hit.name,
-        source,
-        visual_first:true,
-        loaded_content_before_activation:hit.name==='conversations',
-        deferred_render:true,
-        total_ms:Math.max(0,Math.round((finished-started)*10)/10),
-        at:new Date().toISOString(),
+
+      const finish=(conversationRefresh=null)=>{
+        if(epoch!==navigationEpoch) return;
+        if(hit.name==='conversations'&&!workspace?.business?.id) return;
+        let error=null;
+        try{
+          if(typeof showScreen==='function') showScreen(hit.name);
+        }catch(caught){
+          error=caught;
+        }
+        if(epoch!==navigationEpoch) return;
+        if(!hit.screen.classList.contains('active')) safeFallback(hit,source,error||new Error('SCREEN_NOT_ACTIVATED'));
+        else if(error) safeFallback(hit,source,error);
+        const finished=typeof performance!=='undefined'&&performance.now?performance.now():Date.now();
+        window.__dabbirLastNavigationTiming={
+          target:hit.name,
+          source,
+          visual_first:true,
+          loaded_content_before_activation:hit.name==='conversations',
+          server_refresh_after_first_paint:hit.name==='conversations',
+          conversation_refreshed:conversationRefresh?.ok===true,
+          deferred_render:true,
+          total_ms:Math.max(0,Math.round((finished-started)*10)/10),
+          at:new Date().toISOString(),
+        };
       };
+
+      if(hit.name==='conversations'){
+        refreshConversationWorkspace().then(finish).catch(()=>finish({ok:false,reason:'RUNTIME_REFRESH_FAILED'}));
+        return;
+      }
+      finish();
     });
   }
 
@@ -194,6 +236,9 @@ const script = String.raw`(()=>{
     safe_screen_fallback:true,
     visual_first:true,
     loaded_conversation_content_before_activation:true,
+    server_conversation_refresh_after_first_paint:true,
+    repeated_refresh_coalescing:true,
+    stale_navigation_response_guard:true,
     deferred_render:true,
     destination_authority:'context-router',
     context_resync_before_navigation:true,

--- a/test/dabbir-conversation-navigation-freshness.test.mjs
+++ b/test/dabbir-conversation-navigation-freshness.test.mjs
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const bridge=fs.readFileSync(new URL('../api/dabbir-navigation-event-bridge-ui.js',import.meta.url),'utf8');
+const manifest=JSON.parse(fs.readFileSync(new URL('../config/dabbir-ui-bundles.json',import.meta.url),'utf8'));
+
+test('conversation freshness reuses the existing navigation bridge without growing shell modules',()=>{
+  assert.equal(manifest.critical.at(-1),'/api/auth-session-stability-ui');
+  assert.ok(!manifest.critical.includes('/api/dabbir-conversation-freshness-ui'));
+  assert.ok(!manifest.deferred.includes('/api/dabbir-conversation-freshness-ui'));
+  assert.equal([...manifest.critical,...manifest.deferred].length,26);
+  assert.match(bridge,/server_conversation_refresh_after_first_paint:true/);
+});
+
+test('WebKit keeps immediate local conversation rendering then refreshes canonical server runtime',()=>{
+  const activate=bridge.match(/function activate\(hit,source\)\{([\s\S]*?)\n  \}/)?.[1]||'';
+  const localRender=activate.indexOf('renderLoadedScreen(hit)');
+  const paint=activate.indexOf('paint(hit)');
+  const refresh=activate.indexOf('refreshConversationWorkspace().then(finish)');
+  const canonical=activate.indexOf('showScreen(hit.name)');
+  assert.ok(localRender>=0&&paint>localRender,'loaded workspace must render before first paint');
+  assert.ok(refresh>paint,'server refresh must wait until after immediate visual feedback');
+  assert.ok(canonical>paint,'canonical screen render must remain deferred after first paint');
+  assert.match(bridge,/loadRuntime\(businessId,conversationId\)/);
+  assert.match(bridge,/workspace!==before/);
+});
+
+test('conversation refresh coalesces repeated taps and ignores stale navigation responses',()=>{
+  assert.match(bridge,/if\(conversationRefreshInFlight&&conversationRefreshBusinessId===businessId\) return conversationRefreshInFlight/);
+  assert.match(bridge,/const epoch=\+\+navigationEpoch/);
+  assert.match(bridge,/if\(epoch!==navigationEpoch\) return/);
+  assert.match(bridge,/repeated_refresh_coalescing:true/);
+  assert.match(bridge,/stale_navigation_response_guard:true/);
+});
+
+test('conversation freshness preserves the real iPhone touch acceptance fix',()=>{
+  const touchEnd=bridge.match(/document\.addEventListener\('touchend',event=>\{([\s\S]*?)\n  \},\{capture:true,passive:false\}\);/)?.[1]||'';
+  assert.doesNotMatch(touchEnd,/document\.elementFromPoint\(/);
+  assert.match(bridge,/redundant_touch_hit_test:false/);
+  assert.match(bridge,/version:'navigation-event-bridge-v6-real-iphone-touch'/);
+});


### PR DESCRIPTION
Fixes the remaining WebKit/Safari stale conversation-list failure without increasing the shell UI-module count. Keeps the existing immediate local conversation render from #265, then refreshes the canonical server runtime after the first paint, coalesces repeated taps, and ignores stale responses after the user navigates away. Includes a regression test that preserves the critical-module ceiling and auth-session authority.