### PR TITLE
fix(dabbir): make Safari auth fail-open unconditional

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260902-p0-safari-v3';
+const UI_CACHE_BUST = '20260902-p0-safari-v4';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/dabbir-safari-auth-fail-open-ui.js
+++ b/api/dabbir-safari-auth-fail-open-ui.js
@@ -1,9 +1,8 @@
 const script = String.raw`(()=>{
-  if(window.__dabbirSafariAuthFailOpenV1) return;
-  window.__dabbirSafariAuthFailOpenV1=true;
+  if(window.__dabbirSafariAuthFailOpenV2) return;
+  window.__dabbirSafariAuthFailOpenV2=true;
 
-  var VERSION='safari-auth-fail-open-v1';
-  var probeRunning=false;
+  var VERSION='safari-auth-fail-open-v2';
   var recovered=false;
 
   function node(id){return document.getElementById(id)}
@@ -16,47 +15,46 @@ const script = String.raw`(()=>{
     window.__dabbirSafariAuthFailOpen={version:VERSION,recovered:recovered,reason:reason||null,status:Number(status||0),updated_at:new Date().toISOString()};
     try{document.body.dataset.dabbirSafariAuthRecovery=recovered?'recovered':'armed'}catch(_e){}
   }
-  function revealAuth(reason){
+  function installAbortSignalTimeoutFallback(){
+    try{
+      if(globalThis.AbortSignal&&typeof globalThis.AbortSignal.timeout!=='function'&&globalThis.AbortController){
+        globalThis.AbortSignal.timeout=function(ms){
+          var controller=new AbortController();
+          setTimeout(function(){try{controller.abort()}catch(_e){}},Math.max(0,Number(ms)||0));
+          return controller.signal;
+        };
+      }
+    }catch(_e){}
+  }
+  function revealAuth(reason,status){
     if(!gateMissing()) return false;
     try{
-      if(typeof window.showGate==='function'){
-        window.showGate('auth');
-      }else{
-        var loading=node('loading');
-        var auth=node('authGate');
-        var onboarding=node('onboardingGate');
-        var app=node('appShell');
-        var bottom=node('bottomNav');
-        if(loading) loading.hidden=true;
-        if(auth){auth.hidden=false;auth.classList.remove('hidden')}
-        if(onboarding){onboarding.hidden=true;onboarding.classList.add('hidden')}
-        if(app){app.hidden=true;app.classList.add('hidden')}
-        if(bottom) bottom.classList.add('hidden');
-      }
+      var loading=node('loading');
+      var auth=node('authGate');
+      var onboarding=node('onboardingGate');
+      var app=node('appShell');
+      var bottom=node('bottomNav');
+      if(loading){loading.hidden=true;loading.classList.add('hidden');loading.style.display='none'}
+      if(auth){auth.hidden=false;auth.classList.remove('hidden');auth.style.removeProperty('display')}
+      if(onboarding){onboarding.hidden=true;onboarding.classList.add('hidden')}
+      if(app){app.hidden=true;app.classList.add('hidden')}
+      if(bottom) bottom.classList.add('hidden');
       recovered=true;
-      publish(reason,401);
+      publish(reason,status||0);
       return true;
     }catch(_e){return false}
   }
-  function probe(reason){
-    if(probeRunning||recovered||!gateMissing()) return;
-    probeRunning=true;
-    var timeout=new Promise(function(resolve){setTimeout(function(){resolve(null)},4000)});
-    var request;
-    try{
-      request=fetch('/api/dabbir-runtime-fast?summary=1',{credentials:'same-origin',cache:'no-store'}).catch(function(){return null});
-    }catch(_e){request=Promise.resolve(null)}
-    Promise.race([request,timeout]).then(function(response){
-      if(response&&response.status===401&&gateMissing()) revealAuth(reason||'AUTH_REQUIRED_RECOVERY');
-      else publish(reason||'PROBE_COMPLETE',response&&response.status);
-    }).finally(function(){probeRunning=false});
+  function watchdog(reason){
+    if(!gateMissing()) return;
+    revealAuth(reason||'BOOT_STALL_FAIL_OPEN',0);
   }
 
+  installAbortSignalTimeoutFallback();
   publish('ARMED',0);
-  setTimeout(function(){probe('BOOT_WATCHDOG')},1200);
-  setTimeout(function(){probe('BOOT_WATCHDOG_RETRY')},3200);
-  window.addEventListener('error',function(){setTimeout(function(){probe('WINDOW_ERROR')},0)});
-  window.addEventListener('unhandledrejection',function(){setTimeout(function(){probe('UNHANDLED_REJECTION')},0)});
+  setTimeout(function(){watchdog('BOOT_STALL_FAIL_OPEN')},900);
+  setTimeout(function(){watchdog('BOOT_STALL_FAIL_OPEN_RETRY')},2200);
+  window.addEventListener('error',function(){setTimeout(function(){watchdog('WINDOW_ERROR_FAIL_OPEN')},0)});
+  window.addEventListener('unhandledrejection',function(){setTimeout(function(){watchdog('UNHANDLED_REJECTION_FAIL_OPEN')},0)});
 })();`;
 
 export default function handler(req,res){
@@ -64,6 +62,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store, max-age=0');
   res.setHeader('surrogate-control','no-store');
-  res.setHeader('x-dabbir-safari-auth-fail-open','v1');
+  res.setHeader('x-dabbir-safari-auth-fail-open','v2');
   res.status(200).send(script);
 }

--- a/test-trigger.txt
+++ b/test-trigger.txt
@@ -1,1 +1,0 @@
-safari-v4

--- a/test-trigger.txt
+++ b/test-trigger.txt
@@ -1,0 +1,1 @@
+safari-v4

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v3'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260902-p0-safari-v4'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
@@ -18,11 +18,13 @@ test('root shell bypasses stale Safari UI bundle versions', () => {
 test('root shell injects an independent Safari auth fail-open watchdog', () => {
   assert.match(recovery, /dabbir-safari-auth-fail-open-ui/);
   assert.match(recovery, /injectSafariAuthFailOpen/);
-  assert.match(failOpen, /BOOT_WATCHDOG/);
-  assert.match(failOpen, /response\.status===401/);
-  assert.match(failOpen, /typeof window\.showGate==='function'/);
+  assert.match(failOpen, /BOOT_STALL_FAIL_OPEN/);
+  assert.match(failOpen, /typeof globalThis\.AbortSignal\.timeout!=='function'/);
+  assert.match(failOpen, /globalThis\.AbortSignal\.timeout=function/);
   assert.match(failOpen, /auth\.classList\.remove\('hidden'\)/);
-  assert.doesNotMatch(failOpen, /AbortSignal\.timeout/);
+  assert.match(failOpen, /loading\.style\.display='none'/);
+  assert.doesNotMatch(failOpen, /response\.status===401/);
+  assert.doesNotMatch(failOpen, /Promise\.race/);
 });
 
 test('fail-open never replaces a healthy visible gate', () => {
@@ -30,7 +32,7 @@ test('fail-open never replaces a healthy visible gate', () => {
   assert.match(failOpen, /isHidden\(node\('authGate'\)\)/);
   assert.match(failOpen, /isHidden\(node\('onboardingGate'\)\)/);
   assert.match(failOpen, /isHidden\(node\('appShell'\)\)/);
-  assert.match(failOpen, /status===401&&gateMissing\(\)/);
+  assert.match(failOpen, /if\(!gateMissing\(\)\) return/);
 });
 
 test('canonical root strips legacy store navigation overrides before delivery', () => {


### PR DESCRIPTION
P0 Safari recovery. The canonical custom domain can remain on the loading shell when main boot JavaScript stalls before showing any gate. This change makes the independent auth watchdog reveal the login gate without waiting for a runtime 401, adds an AbortSignal.timeout fallback for Safari, and bumps the root recovery cache generation to safari-v4. Includes regression coverage.