### PR TITLE
fix(dabbir): accept real iPhone navigation taps

### DIFF
--- a/api/dabbir-navigation-event-bridge-ui.js
+++ b/api/dabbir-navigation-event-bridge-ui.js
@@ -155,8 +155,10 @@ const script = String.raw`(()=>{
     const distance=Math.hypot(touch.clientX-start.x,touch.clientY-start.y);
     const duration=Date.now()-start.at;
     if(distance>MAX_TAP_DISTANCE||duration>MAX_TAP_DURATION) return;
-    const top=document.elementFromPoint(touch.clientX,touch.clientY);
-    if(!(top===node||node.contains(top))) return;
+    // On real iPhone Safari, elementFromPoint at touchend can resolve to a transient overlay,
+    // transformed ancestor, or composited layer even when the touch began and ended on the same
+    // navigation control. The same-node + distance + duration checks above already establish a tap.
+    // Do not add a second hit-test that can silently discard a valid user navigation action.
     const hit=resolve(node);
     if(!hit) return;
     event.preventDefault();
@@ -184,9 +186,11 @@ const script = String.raw`(()=>{
   document.addEventListener('touchcancel',()=>{touchStart=null},{capture:true,passive:true});
 
   window.__dabbirNavigationEventBridge={
-    version:'navigation-event-bridge-v5-conversation-ready',
+    version:'navigation-event-bridge-v6-real-iphone-touch',
     delegated_click:true,
     webkit_touch_fallback:true,
+    webkit_touch_same_node_validation:true,
+    redundant_touch_hit_test:false,
     safe_screen_fallback:true,
     visual_first:true,
     loaded_conversation_content_before_activation:true,
@@ -201,6 +205,6 @@ export default function handler(req,res){
   if(req.method!=='GET') return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=0, s-maxage=60, stale-while-revalidate=300');
-  res.setHeader('x-dabbir-navigation-event-bridge','v5-conversation-ready');
+  res.setHeader('x-dabbir-navigation-event-bridge','v6-real-iphone-touch');
   return res.status(200).send(script);
 }

--- a/test/dabbir-navigation-event-bridge.test.mjs
+++ b/test/dabbir-navigation-event-bridge.test.mjs
@@ -23,6 +23,17 @@ test('navigation bridge delegates primary destination choice to contextual routi
   assert.doesNotMatch(bridge, /createElement\(['"](?:button|nav)['"]\)/);
 });
 
+test('real iPhone touch navigation cannot be discarded by a redundant WebKit hit-test', () => {
+  const touchEnd = bridge.match(/document\.addEventListener\('touchend',event=>\{([\s\S]*?)\n  \},\{capture:true,passive:false\}\);/)?.[1] || '';
+  assert.match(touchEnd, /start\.node!==node/);
+  assert.match(touchEnd, /distance>MAX_TAP_DISTANCE\|\|duration>MAX_TAP_DURATION/);
+  assert.match(touchEnd, /const hit=resolve\(node\)/);
+  assert.match(touchEnd, /activate\(hit,'touchend'\)/);
+  assert.doesNotMatch(touchEnd, /elementFromPoint/);
+  assert.match(bridge, /version:'navigation-event-bridge-v6-real-iphone-touch'/);
+  assert.match(bridge, /redundant_touch_hit_test:false/);
+});
+
 test('store activity stays Operations even if a stale appointments call reaches showScreen', () => {
   assert.match(router, /setActivitySlot\(node,'operations',t\.operations\)/);
   assert.match(router, /authority:'primary-context-router'/);

--- a/test/dabbir-navigation-event-bridge.test.mjs
+++ b/test/dabbir-navigation-event-bridge.test.mjs
@@ -29,7 +29,7 @@ test('real iPhone touch navigation cannot be discarded by a redundant WebKit hit
   assert.match(touchEnd, /distance>MAX_TAP_DISTANCE\|\|duration>MAX_TAP_DURATION/);
   assert.match(touchEnd, /const hit=resolve\(node\)/);
   assert.match(touchEnd, /activate\(hit,'touchend'\)/);
-  assert.doesNotMatch(touchEnd, /elementFromPoint/);
+  assert.doesNotMatch(touchEnd, /document\.elementFromPoint\(/);
   assert.match(bridge, /version:'navigation-event-bridge-v6-real-iphone-touch'/);
   assert.match(bridge, /redundant_touch_hit_test:false/);
 });


### PR DESCRIPTION
## Production incident
Real iPhone Safari still reports non-responsive DABBIR tabs although WebKit click-based journey checks pass.

## Root cause
The navigation bridge had a touch-only second hit-test using `document.elementFromPoint()` after already verifying the same nav node on touchstart/touchend plus distance and duration. On real iPhone Safari, compositing/transformed/overlay layers can make `elementFromPoint()` return another top layer and silently discard a valid tap. Existing Playwright/WebKit checks use click activation and therefore did not exercise this rejection path.

## Fix
- Remove the redundant `elementFromPoint()` rejection from the real touch path.
- Preserve same-node, distance, duration, ghost-click suppression, contextual routing, visual-first paint and conversation pre-render safeguards.
- Add a regression test that fails if the redundant WebKit touch hit-test returns.

## Evidence required before merge
- full test suite
- Vercel preview build
- no regression to Context Router authority or conversation render readiness