### PR TITLE
Harden DABBIR Auth: enforce Supabase leaked-password protection

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -146,3 +146,5 @@ jobs:
           }
           console.log('DABBIR hosted Auth production URL configuration verified.');
           NODE
+
+# BARMAN enforcement refresh: 2026-09-02


### PR DESCRIPTION
Re-runs the existing DABBIR Auth Production Guard on `main` without changing its security semantics. The workflow uses the repository-managed Supabase Management credential only inside GitHub Actions, enables `password_hibp_enabled=true`, reads the Auth config back, and fails if native leaked-password protection is not actually enabled.

No secret values are exposed. This closes BAR-40 if the post-merge workflow and Supabase Security Advisor both pass.