### PR TITLE
Run DABBIR Auth Production Guard on PRs

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -10,6 +10,15 @@ on:
       - 'api/auth/**'
       - 'api/_password-breach-check.js'
       - 'test/dabbir-password-breach-check.test.mjs'
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/workflows/dabbir-auth-production.yml'
+      - 'scripts/dabbir-production-origin-gate.mjs'
+      - 'config/barman-integration-contract.json'
+      - 'api/auth/**'
+      - 'api/_password-breach-check.js'
+      - 'test/dabbir-password-breach-check.test.mjs'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Adds the existing Auth Production Guard to same-repository pull requests targeting `main`. This makes the native Supabase leaked-password enforcement observable before merge and keeps the guard fail-closed.

The workflow already uses repository-managed Supabase Management credentials without exposing their values. No product behavior changes.