### PR TITLE
fix(dabbir): stop Vercel build recursion

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "node --test test/*.test.mjs",
     "check:syntax": "git ls-files '*.js' '*.mjs' | xargs -r -n1 node --check",
     "audit:prod": "npm audit --omit=dev --audit-level=high",
-    "vercel-build": "node scripts/build-dabbir-ui-bundles.mjs && node scripts/vercel-build-gate.mjs"
+    "dabbir:build": "node scripts/build-dabbir-ui-bundles.mjs && node scripts/vercel-build-gate.mjs"
   },
   "dependencies": {
     "@apple/app-store-server-library": "3.1.0",

--- a/test/dabbir-production-deployment-gate.test.mjs
+++ b/test/dabbir-production-deployment-gate.test.mjs
@@ -4,12 +4,15 @@ import fs from 'node:fs';
 import { spawnSync } from 'node:child_process';
 
 const pkg = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 const ignore = fs.readFileSync(new URL('../vercel-ignore-if-unaffected.sh', import.meta.url), 'utf8');
 const gatePath = 'scripts/vercel-build-gate.mjs';
 const gate = fs.readFileSync(new URL(`../${gatePath}`, import.meta.url), 'utf8');
 
-test('Vercel uses the fail-closed DABBIR build gate without changing the Functions deployment contract', () => {
-  assert.equal(pkg.scripts?.['vercel-build'], 'node scripts/build-dabbir-ui-bundles.mjs && node scripts/vercel-build-gate.mjs');
+test('Vercel uses one explicit non-recursive DABBIR build command', () => {
+  assert.equal(vercel.buildCommand, 'npm run dabbir:build');
+  assert.equal(pkg.scripts?.['dabbir:build'], 'node scripts/build-dabbir-ui-bundles.mjs && node scripts/vercel-build-gate.mjs');
+  assert.equal(pkg.scripts?.['vercel-build'], undefined, 'reserved vercel-build hook must not coexist with explicit buildCommand');
   assert.equal(pkg.scripts?.test, 'node --test test/*.test.mjs');
   const parse = spawnSync(process.execPath, ['--check', gatePath], { encoding: 'utf8' });
   assert.equal(parse.status, 0, parse.stderr || parse.stdout);

--- a/vercel.json
+++ b/vercel.json
@@ -2,6 +2,7 @@
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "fluid": true,
   "regions": ["bom1"],
+  "buildCommand": "npm run dabbir:build",
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "env": {
     "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"


### PR DESCRIPTION
P0 release fix. Vercel repeatedly re-enters the reserved package.json `vercel-build` hook, leaving Production stuck BUILDING even after the fail-closed gate has already succeeded. Replace the reserved hook with `dabbir:build` and pin `vercel.json.buildCommand` to that explicit command. Preserve the same UI bundle build and fail-closed syntax/audit/test gate, with regression coverage preventing the reserved hook from returning.