### PR TITLE
Align DABBIR production authority with Mumbai

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -29,8 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      PROJECT_REF: spohjzrsymsmzsseygtw
-      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
+      PROJECT_REF: fphpoysqdsceniwduxjq
+      PRODUCTION_ORIGIN: https://dabbir.bmalman.com
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
     steps:

--- a/config/barman-integration-contract.json
+++ b/config/barman-integration-contract.json
@@ -1,9 +1,9 @@
 {
-  "version": 2,
+  "version": 3,
   "producer": "DABBIR",
   "control_plane": "barman-systems/barman-control-plane",
   "target_source_repository": "barman-systems/pilot",
-  "status": "ACTIVE_STANDALONE_REPOSITORY",
+  "status": "ACTIVE_PRODUCTION",
   "integration_mode": "API_EVENTS_ONLY",
   "provenance": {
     "verified_import_commit": "99c32c074ca47cdb6caa83474df46f60a9bdd0aa",
@@ -12,23 +12,33 @@
     "verified_import_ci_status": "PASS"
   },
   "deployment": {
-    "status": "DEPLOYED_AUTH_PROTECTED_NO_PUBLIC_LAUNCH_DOMAIN",
+    "status": "DEPLOYED_PRODUCTION_READY",
     "platform": "VERCEL",
     "project_name": "dabbir",
     "project_id": "prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq",
     "source_repository": "barman-systems/pilot",
     "source_branch": "main",
     "root_directory": "./",
-    "verified_deployment_id": "dpl_BDD7c9jHa39bQmfkJCAWyLDNruLi",
+    "verified_deployment_id": "dpl_99zcU5cT6f1rkL4jmrN3t85PzZsr",
     "verified_deployment_state": "READY",
-    "verified_source_commit": "07c5885c0d80af93dffa63377a5dfd0248d7009a",
+    "verified_source_commit": "f48011f68e1ed2cc2fa4a368e6d37608d1b0b5fa",
+    "production_region": "bom1",
     "protected_project_domain": "dabbir-nd56cm4j5v-3619s-projects.vercel.app",
-    "public_launch_domain": null,
-    "domain_access": "VERCEL_AUTH_PROTECTED",
-    "production_runtime_policy": "FAIL_CLOSED_PREVIEW_ONLY",
-    "project_live": false,
-    "verified_at": "2026-08-27T07:32:53Z",
+    "public_launch_domain": "https://dabbir.bmalman.com",
+    "domain_access": "PUBLIC_PRODUCTION",
+    "production_runtime_policy": "ACTIVE_FAIL_CLOSED",
+    "project_live": true,
+    "verified_at": "2026-09-02T08:52:01Z",
     "environment_secrets_shared_with_barman": false
+  },
+  "database": {
+    "platform": "SUPABASE",
+    "project_name": "DABBIR Mumbai",
+    "project_ref": "fphpoysqdsceniwduxjq",
+    "region": "ap-south-1",
+    "status": "ACTIVE_HEALTHY",
+    "retired_runtime_source_ref": "spohjzrsymsmzsseygtw",
+    "retired_runtime_source_policy": "NO_RUNTIME_FALLBACK"
   },
   "rules": {
     "source_code_imports_across_boundary": false,
@@ -37,6 +47,7 @@
     "authenticated_requests_required": true,
     "separate_deployment_identity": true,
     "separate_environment_configuration": true,
-    "separate_ci_release_lifecycle": true
+    "separate_ci_release_lifecycle": true,
+    "retired_supabase_runtime_fallback_allowed": false
   }
 }

--- a/config/barman-integration-contract.json
+++ b/config/barman-integration-contract.json
@@ -24,7 +24,7 @@
     "verified_source_commit": "f48011f68e1ed2cc2fa4a368e6d37608d1b0b5fa",
     "production_region": "bom1",
     "protected_project_domain": "dabbir-nd56cm4j5v-3619s-projects.vercel.app",
-    "public_launch_domain": "https://dabbir.bmalman.com",
+    "public_launch_domain": "dabbir.bmalman.com",
     "domain_access": "PUBLIC_PRODUCTION",
     "production_runtime_policy": "ACTIVE_FAIL_CLOSED",
     "project_live": true,

--- a/test/dabbir-production-origin-truth.test.mjs
+++ b/test/dabbir-production-origin-truth.test.mjs
@@ -31,10 +31,17 @@ test('retired PILOT origin cannot return to DABBIR release controls', () => {
 test('all release workflows use the same strict canonical DABBIR public-origin gate', () => {
   for (const path of releaseWorkflows) {
     const source = fs.readFileSync(path, 'utf8');
-    assert.match(source, /vars\.DABBIR_PRODUCTION_ORIGIN/, path);
+    assert.match(source, /PRODUCTION_ORIGIN:/, path);
     assert.match(source, /scripts\/dabbir-production-origin-gate\.mjs/, path);
     assert.match(source, /launch-gate/, path);
   }
+
+  // The auth guard is account-security critical, so it pins the currently
+  // verified production origin rather than depending on an unset repository var.
+  const auth = fs.readFileSync('.github/workflows/dabbir-auth-production.yml', 'utf8');
+  assert.match(auth, /PRODUCTION_ORIGIN: https:\/\/dabbir\.bmalman\.com/);
+  assert.match(auth, /PROJECT_REF: fphpoysqdsceniwduxjq/);
+
   const gate=fs.readFileSync('scripts/dabbir-production-origin-gate.mjs','utf8');
   assert.match(gate, /DABBIR_PRODUCTION_ORIGIN must be configured as the canonical public HTTPS origin/);
   assert.match(gate, /BLOCKED_PRELAUNCH/);
@@ -64,12 +71,19 @@ test('protected prelaunch permits verification journey only while public launch 
   assert.match(auth,/steps\.credential\.outputs\.available == 'true' && steps\.launch-gate\.outputs\.ready == 'true'/);
 });
 
-test('deployment contract records the protected no-public-domain state', () => {
+test('deployment contract records the live Mumbai production state', () => {
   const contract = JSON.parse(fs.readFileSync('config/barman-integration-contract.json', 'utf8'));
+  assert.equal(contract.status, 'ACTIVE_PRODUCTION');
   assert.equal(contract.deployment.project_name, 'dabbir');
   assert.equal(contract.deployment.project_id, 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq');
-  assert.equal(contract.deployment.public_launch_domain, null);
-  assert.equal(contract.deployment.domain_access, 'VERCEL_AUTH_PROTECTED');
-  assert.equal(contract.deployment.production_runtime_policy, 'FAIL_CLOSED_PREVIEW_ONLY');
-  assert.equal(contract.deployment.project_live, false);
+  assert.equal(contract.deployment.public_launch_domain, 'dabbir.bmalman.com');
+  assert.equal(contract.deployment.domain_access, 'PUBLIC_PRODUCTION');
+  assert.equal(contract.deployment.production_runtime_policy, 'ACTIVE_FAIL_CLOSED');
+  assert.equal(contract.deployment.project_live, true);
+  assert.equal(contract.deployment.production_region, 'bom1');
+  assert.equal(contract.database.project_ref, 'fphpoysqdsceniwduxjq');
+  assert.equal(contract.database.region, 'ap-south-1');
+  assert.equal(contract.database.retired_runtime_source_ref, 'spohjzrsymsmzsseygtw');
+  assert.equal(contract.database.retired_runtime_source_policy, 'NO_RUNTIME_FALLBACK');
+  assert.equal(contract.rules.retired_supabase_runtime_fallback_allowed, false);
 });


### PR DESCRIPTION
Corrects stale production governance after the Mumbai cutover.

- DABBIR Auth Production Guard now targets Supabase project `fphpoysqdsceniwduxjq` (DABBIR Mumbai) instead of retired Sydney/control source `spohjzrsymsmzsseygtw`.
- Canonical production origin is pinned to `https://dabbir.bmalman.com` instead of an unset repository variable.
- `config/barman-integration-contract.json` is refreshed to ACTIVE_PRODUCTION with the verified Vercel production deployment `dpl_99zcU5cT6f1rkL4jmrN3t85PzZsr`, source commit `f48011f68e1ed2cc2fa4a368e6d37608d1b0b5fa`, region `bom1`, public domain `dabbir.bmalman.com`, and Supabase Mumbai ref.
- Explicitly records that the retired Sydney project is not an allowed runtime fallback.

No secrets are changed or exposed. Native Supabase leaked-password protection remains dependent on a Management API credential; the application-level HIBP guard remains active meanwhile.