### PR TITLE
fix(dabbir): stop navigation render storms on iPhone Safari

### DIFF
--- a/api/calendar-performance-ui.js
+++ b/api/calendar-performance-ui.js
@@ -1,0 +1,85 @@
+import calendarLiveHandler from './calendar-live-ui.js';
+
+const PATCHES=[
+  {
+    name:'activity-profile-navigation-observer',
+    from:`  const observer=new MutationObserver(()=>{if(workspace?.business?.id){setTimeout(applyProfile,0);load(false)}});\n  observer.observe(document.body,{subtree:true,attributes:true,attributeFilter:['class']});`,
+    to:`  let profileApplyQueued=false;\n  function scheduleProfileApply(){\n    if(profileApplyQueued)return;\n    profileApplyQueued=true;\n    const run=()=>{profileApplyQueued=false;if(workspace?.business?.id)void load(false)};\n    if(typeof requestAnimationFrame==='function')requestAnimationFrame(run);else setTimeout(run,0);\n  }\n  const profileLanguageObserver=new MutationObserver(scheduleProfileApply);\n  profileLanguageObserver.observe(document.documentElement,{attributes:true,attributeFilter:['lang','dir']});\n  try{\n    const baseRenderAllProfile=renderAll;\n    renderAll=function(){const result=baseRenderAllProfile.apply(this,arguments);scheduleProfileApply();return result};\n  }catch{}`,
+  },
+  {
+    name:'activity-profile-business-polling',
+    from:`  setInterval(()=>{if(workspace?.business?.id&&workspace.business.id!==lastBusiness)load(true)},1200);`,
+    to:`  // Business changes are driven by renderAll; do not poll the owner shell every 1.2 seconds.`,
+  },
+  {
+    name:'calendar-live-navigation-observer',
+    from:`  const observer=new MutationObserver(schedulePassiveSync);\n  observer.observe(document.body,{subtree:true,attributes:true,attributeFilter:['class']});\n  const calendarScreen=q('#screen-appointments');`,
+    to:`  const calendarScreen=q('#screen-appointments');\n  if(calendarScreen){\n    const activationObserver=new MutationObserver(schedulePassiveSync);\n    activationObserver.observe(calendarScreen,{attributes:true,attributeFilter:['class']});\n  }`,
+  },
+  {
+    name:'appointment-management-global-observer-and-poll',
+    from:`  const observer=new MutationObserver(()=>{if(q('#screen-appointments')?.classList.contains('active'))setTimeout(render,0)});\n  observer.observe(document.body,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});\n  setInterval(()=>{if(q('#screen-appointments')?.classList.contains('active'))render()},1500);`,
+    to:`  const appointmentScreen=q('#screen-appointments');\n  if(appointmentScreen){\n    const screenObserver=new MutationObserver(()=>{if(appointmentScreen.classList.contains('active'))setTimeout(render,0)});\n    screenObserver.observe(appointmentScreen,{attributes:true,attributeFilter:['class']});\n  }\n  const appointmentTable=q('#appointmentsTable');\n  if(appointmentTable){\n    const tableObserver=new MutationObserver(()=>{if(q('#screen-appointments')?.classList.contains('active'))setTimeout(render,0)});\n    tableObserver.observe(appointmentTable,{childList:true});\n  }`,
+  },
+  {
+    name:'clinic-loading-state',
+    from:`  let D=null,busy=false;`,
+    to:`  let D=null,busy=false,loading=false;`,
+  },
+  {
+    name:'clinic-load-coalescing',
+    from:`  async function load(){if(!isClinic()||!bid()||busy)return;try{D=await api();render()}catch(e){console.error('clinic_mode_load',e)}}`,
+    to:`  async function load(){if(!isClinic()||!bid()||busy||loading)return;loading=true;try{D=await api();render()}catch(e){console.error('clinic_mode_load',e)}finally{loading=false}}`,
+  },
+  {
+    name:'clinic-global-observer',
+    from:`  const mo=new MutationObserver(()=>{if(isClinic()&&$('#screen-appointments')?.classList.contains('active'))load()});mo.observe(document.body,{subtree:true,attributes:true,attributeFilter:['class'],childList:true});setTimeout(load,700);window.__dabbirClinicMode={refresh:load,version:'beauty-laser-v1-no-images'};`,
+    to:`  const clinicScreen=$('#screen-appointments');\n  if(clinicScreen){\n    const clinicActivationObserver=new MutationObserver(()=>{if(isClinic()&&clinicScreen.classList.contains('active'))load()});\n    clinicActivationObserver.observe(clinicScreen,{attributes:true,attributeFilter:['class']});\n  }\n  try{\n    const baseRenderAllClinic=renderAll;\n    renderAll=function(){const result=baseRenderAllClinic.apply(this,arguments);if(isClinic()&&clinicScreen?.classList.contains('active'))setTimeout(load,0);return result};\n  }catch{}\n  setTimeout(load,700);window.__dabbirClinicMode={refresh:load,version:'beauty-laser-v2-event-scoped'};`,
+  },
+  {
+    name:'business-activity-global-observer',
+    from:`  const observer=new MutationObserver(()=>{if(genericCard()&&business()?.id)setTimeout(enforce,0)});\n  observer.observe(document.body,{subtree:true,childList:true});\n  try{const baseRenderAll=renderAll;renderAll=function(){const result=baseRenderAll.apply(this,arguments);setTimeout(enforce,0);return result}}catch{}\n  try{const baseApplyLang=applyLang;applyLang=function(){const result=baseApplyLang.apply(this,arguments);lastRenderKey='';setTimeout(enforce,0);return result}}catch{}`,
+    to:`  let businessProfileQueued=false;\n  function scheduleBusinessProfileEnforce(){\n    if(businessProfileQueued)return;\n    businessProfileQueued=true;\n    const run=()=>{businessProfileQueued=false;if(genericCard()&&business()?.id)enforce()};\n    if(typeof requestAnimationFrame==='function')requestAnimationFrame(run);else setTimeout(run,0);\n  }\n  const settingsProfileScreen=q('#screen-settings');\n  if(settingsProfileScreen){\n    const observer=new MutationObserver(scheduleBusinessProfileEnforce);\n    observer.observe(settingsProfileScreen,{subtree:true,childList:true});\n  }\n  try{const baseRenderAll=renderAll;renderAll=function(){const result=baseRenderAll.apply(this,arguments);scheduleBusinessProfileEnforce();return result}}catch{}\n  try{const baseApplyLang=applyLang;applyLang=function(){const result=baseApplyLang.apply(this,arguments);lastRenderKey='';scheduleBusinessProfileEnforce();return result}}catch{}`,
+  },
+];
+
+function captureResponse(){
+  return {
+    statusCode:200,
+    headers:{},
+    body:'',
+    status(code){this.statusCode=Number(code||200);return this},
+    setHeader(key,value){this.headers[String(key).toLowerCase()]=value;return this},
+    send(body=''){this.body=String(body);return this},
+    end(body=''){this.body=String(body);return this},
+  };
+}
+
+function applyPerformancePatches(source){
+  let body=String(source||'');
+  for(const patch of PATCHES){
+    if(!body.includes(patch.from))throw new Error('DABBIR_NAV_PERFORMANCE_PATTERN_DRIFT_'+patch.name);
+    body=body.replace(patch.from,patch.to);
+    if(body.includes(patch.from))throw new Error('DABBIR_NAV_PERFORMANCE_PATCH_INCOMPLETE_'+patch.name);
+  }
+  return body;
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  const captured=captureResponse();
+  await calendarLiveHandler(req,captured);
+  if(captured.statusCode!==200||!captured.body)return res.status(500).end('Calendar UI unavailable');
+  let body;
+  try{body=applyPerformancePatches(captured.body)}catch(error){
+    console.error('dabbir_calendar_performance_patch_failed',String(error?.message||error));
+    return res.status(500).end('Calendar performance guard unavailable');
+  }
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=60');
+  res.setHeader('x-content-type-options','nosniff');
+  res.setHeader('x-dabbir-calendar-performance-ui','v2-navigation-event-scoped');
+  return res.status(200).send(body);
+}
+
+export {applyPerformancePatches};

--- a/config/dabbir-ui-bundles.json
+++ b/config/dabbir-ui-bundles.json
@@ -14,7 +14,7 @@
     "/api/translation-ui",
     "/api/owner-operations-ui",
     "/api/service-operations-ui",
-    "/api/calendar-live-ui",
+    "/api/calendar-performance-ui",
     "/api/owner-action-center-ui",
     "/api/dabbir-owner-away-ui",
     "/api/dabbir-owner-decision-memory-ui",

--- a/test/dabbir-navigation-performance.test.mjs
+++ b/test/dabbir-navigation-performance.test.mjs
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import handler from '../api/calendar-performance-ui.js';
+
+const root=new URL('../',import.meta.url);
+const bundles=JSON.parse(fs.readFileSync(new URL('config/dabbir-ui-bundles.json',root),'utf8'));
+
+function response(){
+  return {
+    statusCode:200,
+    headers:{},
+    body:'',
+    status(code){this.statusCode=Number(code);return this},
+    setHeader(key,value){this.headers[String(key).toLowerCase()]=value;return this},
+    send(body=''){this.body=String(body);return this},
+    end(body=''){this.body=String(body);return this},
+  };
+}
+
+test('owner bundle uses the event-scoped calendar performance route',()=>{
+  assert.ok(bundles.deferred.includes('/api/calendar-performance-ui'));
+  assert.equal(bundles.deferred.includes('/api/calendar-live-ui'),false);
+});
+
+test('calendar performance route removes navigation-wide render and request storms',async()=>{
+  const res=response();
+  await handler({method:'GET'},res);
+  assert.equal(res.statusCode,200);
+  assert.equal(res.headers['x-dabbir-calendar-performance-ui'],'v2-navigation-event-scoped');
+
+  const body=res.body;
+  assert.doesNotMatch(body,/observer\.observe\(document\.body,\{subtree:true,attributes:true,attributeFilter:\['class'\]\}\)/);
+  assert.doesNotMatch(body,/observer\.observe\(document\.body,\{subtree:true,childList:true,attributes:true,attributeFilter:\['class'\]\}\)/);
+  assert.doesNotMatch(body,/mo\.observe\(document\.body,\{subtree:true,attributes:true,attributeFilter:\['class'\],childList:true\}\)/);
+  assert.doesNotMatch(body,/observer\.observe\(document\.body,\{subtree:true,childList:true\}\)/);
+  assert.doesNotMatch(body,/setInterval\(\(\)=>\{if\(workspace\?\.business\?\.id&&workspace\.business\.id!==lastBusiness\)load\(true\)\},1200\)/);
+  assert.doesNotMatch(body,/setInterval\(\(\)=>\{if\(q\('#screen-appointments'\)\?\.classList\.contains\('active'\)\)render\(\)\},1500\)/);
+
+  assert.match(body,/profileLanguageObserver\.observe\(document\.documentElement,\{attributes:true,attributeFilter:\['lang','dir'\]\}\)/);
+  assert.match(body,/baseRenderAllProfile/);
+  assert.match(body,/activationObserver\.observe\(calendarScreen,\{attributes:true,attributeFilter:\['class'\]\}\)/);
+  assert.match(body,/screenObserver\.observe\(appointmentScreen,\{attributes:true,attributeFilter:\['class'\]\}\)/);
+  assert.match(body,/tableObserver\.observe\(appointmentTable,\{childList:true\}\)/);
+  assert.match(body,/clinicActivationObserver\.observe\(clinicScreen,\{attributes:true,attributeFilter:\['class'\]\}\)/);
+  assert.match(body,/busy\|\|loading/);
+  assert.match(body,/finally\{loading=false\}/);
+  assert.match(body,/settingsProfileScreen=q\('#screen-settings'\)/);
+  assert.match(body,/observer\.observe\(settingsProfileScreen,\{subtree:true,childList:true\}\)/);
+  assert.match(body,/scheduleBusinessProfileEnforce/);
+});

--- a/test/dabbir-salon-mode.test.mjs
+++ b/test/dabbir-salon-mode.test.mjs
@@ -86,8 +86,11 @@ test('calendar UI provides day, week, month, employee columns, drag/drop and dur
   hasAll(ui,["view==='day'","view==='week'",'monthCalendar','salonDayGrid','data-worker','ondragstart','ondrop','data-resize','duration_minutes','quickBooking']);
   const manifest=JSON.parse(read('config/dabbir-ui-bundles.json'));
   const calendarOwner=read('api/calendar-live-ui.js');
+  const calendarPerformance=read('api/calendar-performance-ui.js');
   assert.equal(manifest.deferred.includes('/api/salon-mode-ui'),false);
-  assert.ok(manifest.deferred.includes('/api/calendar-live-ui'));
+  assert.ok(manifest.deferred.includes('/api/calendar-performance-ui'));
+  assert.equal(manifest.deferred.includes('/api/calendar-live-ui'),false);
+  assert.match(calendarPerformance,/import calendarLiveHandler from '\.\/calendar-live-ui\.js'/);
   assert.match(calendarOwner,/import salonModeUiHandler from '\.\/salon-mode-ui\.js'/);
   assert.match(calendarOwner,/managementCaptured\.body\+'\\n'\+salonCaptured\.body/);
 });


### PR DESCRIPTION
## Production incident
DABBIR primary navigation becomes progressively slow on real iPhone Safari and can freeze the owner shell.

## Confirmed causes
- Activity Profile observed every class mutation under `document.body`; every navigation tap triggered profile/calendar work, and its cached load path applied the profile twice.
- Calendar Live observed all body class mutations.
- Appointment Management observed all body class/child mutations and also polled every 1.5 seconds.
- Clinic Mode observed the whole body and had no in-flight load guard, allowing overlapping requests while the appointments screen was active.
- Business Activity Profile observed all body child mutations, scheduling repeated enforce/load callbacks.

## Fix
- Keep the existing calendar stack unchanged and wrap it with a fail-closed performance adapter.
- Scope calendar/appointment/clinic observers to the appointments screen/table only.
- Scope business profile DOM observation to Settings only.
- Remove 1.2s/1.5s legacy polling loops.
- Coalesce clinic network loads and UI refreshes.
- Preserve Salon Mode, Clinic Mode, Google/Outlook sync, booking management, and contextual navigation.
- Add regression coverage that fails if the broad render/request storms return.

## Release evidence required
- Full CI green.
- Vercel preview READY.
- Preview performance route returns `x-dabbir-calendar-performance-ui: v2-navigation-event-scoped`.
- Production iPhone smoke green after merge.