### PR TITLE
Index DABBIR executive foreign keys on Mumbai

### DIFF
--- a/supabase/migrations/20260902090657_dabbir_executive_fk_indexes_20260902.sql
+++ b/supabase/migrations/20260902090657_dabbir_executive_fk_indexes_20260902.sql
@@ -1,0 +1,29 @@
+create index if not exists executive_actions_run_id_idx
+  on dabbir_private.executive_actions (run_id);
+
+create index if not exists executive_actions_event_id_idx
+  on dabbir_private.executive_actions (event_id);
+
+create index if not exists executive_actions_goal_id_idx
+  on dabbir_private.executive_actions (goal_id);
+
+create index if not exists executive_escalations_action_id_idx
+  on dabbir_private.executive_escalations (action_id);
+
+create index if not exists executive_escalations_event_id_idx
+  on dabbir_private.executive_escalations (event_id);
+
+create index if not exists executive_hypotheses_domain_key_idx
+  on dabbir_private.executive_hypotheses (domain_key);
+
+create index if not exists executive_hypothesis_insights_insight_id_idx
+  on dabbir_private.executive_hypothesis_insights (insight_id);
+
+create index if not exists executive_insight_sources_source_id_idx
+  on dabbir_private.executive_insight_sources (source_id);
+
+create index if not exists executive_insights_cycle_id_idx
+  on dabbir_private.executive_insights (cycle_id);
+
+create index if not exists executive_principles_hypothesis_id_idx
+  on dabbir_private.executive_principles (hypothesis_id);


### PR DESCRIPTION
Synchronizes the already-applied Mumbai production migration `20260902090657_dabbir_executive_fk_indexes_20260902` into source control.

Adds covering btree indexes for the 10 DABBIR Executive OS foreign keys identified by the Supabase performance advisor. The production migration is already live on `fphpoysqdsceniwduxjq` and post-migration performance advisor no longer reports any `unindexed_foreign_keys` findings for `dabbir_private.executive_*`.

No existing indexes are removed. `unused_index` notices are intentionally left untouched because Mumbai is newly cut over and usage history is insufficient for safe deletion decisions. Security advisor shows no new finding caused by this migration.