### PR TITLE
Remove Vercel legacy query parsing from DABBIR APIs

### DIFF
--- a/api/calendar-connections.js
+++ b/api/calendar-connections.js
@@ -1,4 +1,5 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 import {
   calendarError,
   disconnectConnection,
@@ -30,7 +31,7 @@ function logCalendarFailure(error,status){
 export default async function handler(req,res){
   try{
     if(req.method==='GET'){
-      const businessId=safeBusinessId(req.query?.business_id);
+      const businessId=safeBusinessId(singleQueryValue(req,'business_id'));
       await requireCalendarMember(req,businessId);
       const google=providerConfig('google',req),outlook=providerConfig('outlook',req);
       const securityReady=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24&&String(process.env.DABBIR_CALENDAR_STATE_SECRET||process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24;

--- a/api/calendar-oauth-callback.js
+++ b/api/calendar-oauth-callback.js
@@ -1,4 +1,5 @@
 import { json } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 import {
   calendarError,
   exchangeAuthorizationCode,
@@ -18,10 +19,10 @@ export default async function handler(req,res){
   const origin=(()=>{try{return requestOrigin(req)}catch{return null}})();
   try{
     if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
-    const providerError=String(req.query?.error||'').trim();
-    const state=verifyOauthState(req.query?.state);
+    const providerError=String(singleQueryValue(req,'error')||'').trim();
+    const state=verifyOauthState(singleQueryValue(req,'state'));
     if(providerError)throw calendarError(`CALENDAR_PROVIDER_${providerError.toUpperCase().replace(/[^A-Z0-9_]/g,'_')}`,400);
-    const code=String(req.query?.code||'').trim();if(!code)throw calendarError('CALENDAR_AUTHORIZATION_CODE_MISSING',400);
+    const code=String(singleQueryValue(req,'code')||'').trim();if(!code)throw calendarError('CALENDAR_AUTHORIZATION_CODE_MISSING',400);
     const ctx=await requireCalendarMember(req,state.business_id,{manage:true});
     if(String(ctx.user.id)!==String(state.user_id))throw calendarError('CALENDAR_OAUTH_USER_MISMATCH',403);
     const config=providerConfig(state.provider,req);

--- a/api/calendar-oauth-start.js
+++ b/api/calendar-oauth-start.js
@@ -1,5 +1,6 @@
 import crypto from 'node:crypto';
 import { json } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 import {
   authorizationUrl,
   calendarError,
@@ -15,7 +16,7 @@ function statusCode(error){const code=Number(error?.code||500);return [400,401,4
 export default async function handler(req,res){
   try{
     if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
-    const businessId=safeBusinessId(req.query?.business_id),provider=safeProvider(req.query?.provider);
+    const businessId=safeBusinessId(singleQueryValue(req,'business_id')),provider=safeProvider(singleQueryValue(req,'provider'));
     if(!provider)throw calendarError('INVALID_CALENDAR_PROVIDER',400);
     const ctx=await requireCalendarMember(req,businessId,{manage:true});
     const config=providerConfig(provider,req);

--- a/api/calendar-sync.js
+++ b/api/calendar-sync.js
@@ -1,4 +1,5 @@
 import { accessTokenFromRequest, json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 import { calendarError, requireCalendarMember, safeBusinessId } from './_calendar-core.js';
 import { syncBusinessCalendars } from './_calendar-sync-core.js';
 
@@ -22,7 +23,7 @@ async function userRestJson(path,accessToken,fallback){
 export default async function handler(req,res){
   try{
     if(req.method==='GET'){
-      const businessId=safeBusinessId(req.query?.business_id);
+      const businessId=safeBusinessId(singleQueryValue(req,'business_id'));
       const ctx=await requireCalendarMember(req,businessId);
       const busy=await userRestJson(
         `dabbir_calendar_busy_blocks?select=id,connection_id,provider_event_id,starts_at,ends_at,summary,provider_updated_at&business_id=eq.${encodeURIComponent(businessId)}&order=starts_at.asc&limit=500`,

--- a/api/clinic-operations.js
+++ b/api/clinic-operations.js
@@ -12,7 +12,7 @@ const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a
 const clean=(value,max=240)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
 const safeId=value=>UUID_RE.test(clean(value,60))?clean(value,60):null;
 const enc=value=>encodeURIComponent(String(value));
-const queryValue=(req,key)=>{const value=req?.query?.[key];return Array.isArray(value)?value[0]:value};
+const queryValue=(req,key)=>{try{const values=new URL(String(req?.url||'/'),'https://dabbir.invalid').searchParams.getAll(key);return values.length===1?values[0]:null}catch{return null}};
 const number=(value,{min=0,max=1e7,fallback=0}={})=>{const n=Number(value);return Number.isFinite(n)&&n>=min&&n<=max?n:fallback};
 const isoDate=(value)=>{const d=new Date(value);return Number.isNaN(d.getTime())?null:d.toISOString()};
 

--- a/api/salon-operations.js
+++ b/api/salon-operations.js
@@ -16,7 +16,7 @@ const ALL_STATUSES=new Set([...ACTIVE_STATUSES,'completed','cancelled','no_show'
 const PAYMENT_METHODS=new Set(['cash','card','payment_link','other','unpaid']);
 const clean=(value,max=240)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
 const safeId=value=>UUID_RE.test(clean(value,60))?clean(value,60):null;
-const queryValue=(req,key)=>{const value=req?.query?.[key];return Array.isArray(value)?value[0]:value};
+const queryValue=(req,key)=>{try{const values=new URL(String(req?.url||'/'),'https://dabbir.invalid').searchParams.getAll(key);return values.length===1?values[0]:null}catch{return null}};
 const enc=value=>encodeURIComponent(String(value));
 
 async function readData(response,fallback){

--- a/api/service-catalog.js
+++ b/api/service-catalog.js
@@ -7,6 +7,7 @@ import {
   requireSameOrigin,
   supabaseRest,
 } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
@@ -37,7 +38,7 @@ export default async function handler(req,res){
   if(!ctx)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
   try{
     if(req.method==='GET'){
-      const businessId=safeId(req.query?.business_id);
+      const businessId=safeId(singleQueryValue(req,'business_id'));
       const membership=membershipFor(ctx,businessId);
       if(!businessId||!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
       const services=await rest(ctx.token,`dabbir_services?select=id,name,price_aed,duration_minutes,active,metadata&business_id=eq.${businessId}&order=name.asc&limit=200`,{},'SERVICES_LOOKUP_FAILED');

--- a/test/dabbir-request-query-safety.test.mjs
+++ b/test/dabbir-request-query-safety.test.mjs
@@ -15,7 +15,14 @@ const guardedFiles = [
   "api/dabbir-runtime.js",
   "api/dabbir-whatsapp-status.js",
   "api/dabbir-whatsapp-webhook.js",
-  "api/owner-action-center.js"
+  "api/owner-action-center.js",
+  "api/calendar-oauth-start.js",
+  "api/calendar-oauth-callback.js",
+  "api/calendar-sync.js",
+  "api/calendar-connections.js",
+  "api/service-catalog.js",
+  "api/clinic-operations.js",
+  "api/salon-operations.js"
 ];
 
 test('singleQueryValue uses WHATWG parsing and fails closed for duplicate or invalid values', () => {
@@ -29,6 +36,21 @@ test('DABBIR runtime endpoints do not access Vercel legacy req.query', async () 
   for (const path of guardedFiles) {
     const source = await readFile(new URL(path, root), 'utf8');
     assert.doesNotMatch(source, /req\.query/, path);
+  }
+});
+
+test('calendar OAuth and connection endpoints use the guarded WHATWG parser', async () => {
+  for (const path of ['api/calendar-oauth-start.js','api/calendar-oauth-callback.js','api/calendar-sync.js','api/calendar-connections.js']) {
+    const source = await readFile(new URL(path, root), 'utf8');
+    assert.match(source, /singleQueryValue\(req,/u, path);
+  }
+});
+
+test('salon and clinic query helpers parse req.url with WHATWG URL semantics', async () => {
+  for (const path of ['api/salon-operations.js','api/clinic-operations.js']) {
+    const source = await readFile(new URL(path, root), 'utf8');
+    assert.match(source, /new URL\(String\(req\?\.url\|\|'\/'\),'https:\/\/dabbir\.invalid'\)/u, path);
+    assert.match(source, /searchParams\.getAll\(key\)/u, path);
   }
 });
 


### PR DESCRIPTION
Eliminates all remaining direct `req.query` access from DABBIR production API endpoints that were still triggering Node 24 `DEP0169` warnings through Vercel's legacy query parser.

Changes:
- calendar OAuth start/callback, calendar sync/connections, and service catalog now use the existing fail-closed `singleQueryValue()` WHATWG parser.
- salon and clinic operations parse `req.url` with WHATWG `URL` semantics and reject duplicate values.
- expands `dabbir-request-query-safety` coverage from 11 to 18 runtime endpoints so legacy `req.query` cannot regress.

Scope is query parsing only; no booking, payment, calendar sync, salon, clinic, or authorization business logic was changed.

Post-merge verification will explicitly exercise `/api/calendar-connections` with a synthetic business UUID and inspect Vercel runtime logs for fresh `DEP0169` entries.