### PR TITLE
Keep expected calendar auth failures out of error telemetry

### DIFF
--- a/api/calendar-oauth-callback.js
+++ b/api/calendar-oauth-callback.js
@@ -14,6 +14,12 @@ import { syncBusinessCalendars } from './_calendar-sync-core.js';
 
 function statusCode(error){const code=Number(error?.code||500);return [400,401,403,404,409,429,502,503].includes(code)?code:500}
 function redirect(res,location){res.statusCode=302;res.setHeader('location',location);res.setHeader('cache-control','no-store');res.end()}
+function logFailure(error,status){
+  const payload={error:String(error?.message||'CALENDAR_OAUTH_FAILED').slice(0,120),status};
+  if(status>=500)console.error('dabbir_calendar_oauth_callback_failed',payload);
+  else if(status===429)console.warn('dabbir_calendar_oauth_callback_rate_limited',payload);
+  else console.info('dabbir_calendar_oauth_callback_rejected',payload);
+}
 
 export default async function handler(req,res){
   const origin=(()=>{try{return requestOrigin(req)}catch{return null}})();
@@ -33,9 +39,9 @@ export default async function handler(req,res){
     if(origin)return redirect(res,`${origin}/?calendar=connected&provider=${encodeURIComponent(state.provider)}`);
     return json(res,200,{ok:true,provider:state.provider});
   }catch(error){
-    const code=String(error?.message||'CALENDAR_OAUTH_FAILED').slice(0,120);
-    console.error('dabbir_calendar_oauth_callback_failed',{error:code,status:statusCode(error)});
+    const status=statusCode(error),code=String(error?.message||'CALENDAR_OAUTH_FAILED').slice(0,120);
+    logFailure(error,status);
     if(origin)return redirect(res,`${origin}/?calendar=error&code=${encodeURIComponent(code)}`);
-    return json(res,statusCode(error),{ok:false,error:code});
+    return json(res,status,{ok:false,error:code});
   }
 }

--- a/api/calendar-oauth-start.js
+++ b/api/calendar-oauth-start.js
@@ -12,6 +12,12 @@ import {
 } from './_calendar-core.js';
 
 function statusCode(error){const code=Number(error?.code||500);return [400,401,403,404,409,429,502,503].includes(code)?code:500}
+function logFailure(error,status){
+  const payload={error:String(error?.message||'CALENDAR_OAUTH_START_FAILED').slice(0,160),code:status};
+  if(status>=500)console.error('dabbir_calendar_oauth_start_failed',payload);
+  else if(status===429)console.warn('dabbir_calendar_oauth_start_rate_limited',payload);
+  else console.info('dabbir_calendar_oauth_start_rejected',payload);
+}
 
 export default async function handler(req,res){
   try{
@@ -25,7 +31,8 @@ export default async function handler(req,res){
     const location=authorizationUrl(config,state);
     res.statusCode=302;res.setHeader('location',location);res.setHeader('cache-control','no-store');res.end();
   }catch(error){
-    console.error('dabbir_calendar_oauth_start_failed',{error:String(error?.message||'CALENDAR_OAUTH_START_FAILED').slice(0,160),code:statusCode(error)});
-    return json(res,statusCode(error),{ok:false,error:String(error?.message||'CALENDAR_OAUTH_START_FAILED').slice(0,160)});
+    const status=statusCode(error);
+    logFailure(error,status);
+    return json(res,status,{ok:false,error:String(error?.message||'CALENDAR_OAUTH_START_FAILED').slice(0,160)});
   }
 }

--- a/test/dabbir-request-query-safety.test.mjs
+++ b/test/dabbir-request-query-safety.test.mjs
@@ -46,6 +46,15 @@ test('calendar OAuth and connection endpoints use the guarded WHATWG parser', as
   }
 });
 
+test('calendar OAuth endpoints reserve error telemetry for server failures', async () => {
+  for (const path of ['api/calendar-oauth-start.js','api/calendar-oauth-callback.js']) {
+    const source = await readFile(new URL(path, root), 'utf8');
+    assert.match(source, /if\(status>=500\)console\.error/u, path);
+    assert.match(source, /else if\(status===429\)console\.warn/u, path);
+    assert.match(source, /else console\.info/u, path);
+  }
+});
+
 test('salon and clinic query helpers parse req.url with WHATWG URL semantics', async () => {
   for (const path of ['api/salon-operations.js','api/clinic-operations.js']) {
     const source = await readFile(new URL(path, root), 'utf8');


### PR DESCRIPTION
Fixes production observability pollution discovered after the DEP0169 closure.

`/api/calendar-oauth-start` and the OAuth callback were emitting expected 4xx client/auth rejections through `console.error`, causing Vercel to group normal `401 AUTH_REQUIRED` probes as production runtime errors.

This change:
- uses `console.error` only for >=500 calendar OAuth failures,
- uses `console.warn` for 429 rate limiting,
- uses `console.info` for expected 4xx rejections,
- adds regression assertions to the existing DABBIR request/query safety suite.

No auth, OAuth, calendar, session, redirect, or business behavior changes.