### PR TITLE
Bind DABBIR Auth production guard to Mumbai Supabase

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      PROJECT_REF: spohjzrsymsmzsseygtw
+      PROJECT_REF: fphpoysqdsceniwduxjq
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}

--- a/test/dabbir-no-retired-supabase-origin.test.mjs
+++ b/test/dabbir-no-retired-supabase-origin.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const apiRoot = path.join(root, 'api');
 const retiredRef = 'spohjzrsymsmzsseygtw';
+const mumbaiRef = 'fphpoysqdsceniwduxjq';
 const retiredPublishableKey = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
 
 function jsFiles(dir) {
@@ -25,6 +26,12 @@ test('runtime API cannot silently fall back to the retired Sydney Supabase proje
     }
   }
   assert.deepEqual(offenders, []);
+});
+
+test('production Auth guard is pinned to Mumbai and not the retired Sydney project', () => {
+  const source = fs.readFileSync(path.join(root, '.github', 'workflows', 'dabbir-auth-production.yml'), 'utf8');
+  assert.match(source, new RegExp(`PROJECT_REF:\\s*${mumbaiRef}`));
+  assert.doesNotMatch(source, new RegExp(`PROJECT_REF:\\s*${retiredRef}`));
 });
 
 test('auth core has no legacy Supabase origin constant', () => {


### PR DESCRIPTION
Fixes a production-governance drift in `dabbir-auth-production.yml`.

The Auth Production Guard was still hard-coded to the retired Sydney Supabase project `spohjzrsymsmzsseygtw`, even though DABBIR production has cut over to Mumbai `fphpoysqdsceniwduxjq`.

Changes:
- pin `PROJECT_REF` to the Mumbai production Supabase project;
- add regression coverage ensuring the Auth production workflow cannot drift back to the retired Sydney project.

This matters because, when a Supabase Management credential is present, the workflow enforces native leaked-password protection and production Auth URL settings. Those mutations must target the canonical Mumbai production project only.