### PR TITLE
fix(salon): make employee own assigned services in booking flow

### DIFF
--- a/api/calendar-performance-ui.js
+++ b/api/calendar-performance-ui.js
@@ -104,7 +104,7 @@ export default async function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=60');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-calendar-performance-ui','v4-salon-employee-first');
+  res.setHeader('x-dabbir-calendar-performance-ui','v3-calendar-correctness-event-scoped');
   return res.status(200).send(body);
 }
 

--- a/api/calendar-performance-ui.js
+++ b/api/calendar-performance-ui.js
@@ -1,4 +1,5 @@
 import calendarLiveHandler from './calendar-live-ui.js';
+import {applySalonProductModelPatches} from './salon-product-model-ui-patches.js';
 
 const PATCHES=[
   {
@@ -96,14 +97,14 @@ export default async function handler(req,res){
   await calendarLiveHandler(req,captured);
   if(captured.statusCode!==200||!captured.body)return res.status(500).end('Calendar UI unavailable');
   let body;
-  try{body=applyPerformancePatches(captured.body)}catch(error){
+  try{body=applySalonProductModelPatches(applyPerformancePatches(captured.body))}catch(error){
     console.error('dabbir_calendar_performance_patch_failed',String(error?.message||error));
     return res.status(500).end('Calendar performance guard unavailable');
   }
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=60');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-calendar-performance-ui','v3-calendar-correctness-event-scoped');
+  res.setHeader('x-dabbir-calendar-performance-ui','v4-salon-employee-first');
   return res.status(200).send(body);
 }
 

--- a/api/salon-product-model-ui-patches.js
+++ b/api/salon-product-model-ui-patches.js
@@ -1,0 +1,54 @@
+const SALON_PRODUCT_MODEL_PATCHES=[
+  {
+    name:'salon-copy-ar-employee-owns-services',
+    from:`appointmentDetails:'تفاصيل الموعد',serviceRequired:'أضيفي خدمة واربطيها بموظفة أولًا.',endOfDay:'ملخص اليوم'`,
+    to:`appointmentDetails:'تفاصيل الموعد',employeeRequired:'أضيفي موظفة أولًا.',serviceCatalogRequired:'أضيفي خدمة أولًا.',employeeServicesRequired:'أسندي خدمة واحدة على الأقل للموظفة من شاشة الموظفات.',serviceRequired:'اختاري الموظفة أولًا لعرض الخدمات التي تقدمها.',endOfDay:'ملخص اليوم'`,
+  },
+  {
+    name:'salon-copy-en-employee-owns-services',
+    from:`appointmentDetails:'Appointment details',serviceRequired:'Add a service and assign it to an employee first.',endOfDay:'End-of-day summary'`,
+    to:`appointmentDetails:'Appointment details',employeeRequired:'Add an employee first.',serviceCatalogRequired:'Add a service first.',employeeServicesRequired:'Assign at least one service to the employee from the Team screen.',serviceRequired:'Choose the employee first to show the services they provide.',endOfDay:'End-of-day summary'`,
+  },
+  {
+    name:'salon-month-range-stays-within-api-bound',
+    from:`    const from=plus(startDay(cursor),view==='month'?-10:view==='week'?-2:-2),to=plus(startDay(cursor),view==='month'?45:view==='week'?12:3);`,
+    to:`    const monthStart=startWeek(new Date(cursor.getFullYear(),cursor.getMonth(),1));\n    const from=view==='month'?monthStart:plus(startDay(cursor),-2),to=view==='month'?plus(monthStart,42):plus(startDay(cursor),view==='week'?12:3);`,
+  },
+  {
+    name:'salon-quick-book-readiness-is-explicit',
+    from:`    if(!services.length||!workers.length){notify(t.serviceRequired);return}`,
+    to:`    if(!workers.length){notify(t.employeeRequired);return}\n    if(!services.length){notify(t.serviceCatalogRequired);return}\n    if(!(data.worker_services||[]).some(x=>x.active&&workers.some(w=>w.id===x.worker_id)&&services.some(s=>s.id===x.service_id))){notify(t.employeeServicesRequired);return}`,
+  },
+  {
+    name:'salon-quick-book-employee-before-service',
+    from:`<div class="salonField"><label>'+esc(t.service)+'</label><select id="sqService" required><option value=""></option>'+services.map(s=>'<option value="'+esc(s.id)+'">'+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+' · '+money(s.price_aed)+'</option>').join('')+'</select></div><div class="salonField"><label>'+esc(t.employee)+'</label><select id="sqWorker" required><option value=""></option></select></div>`,
+    to:`<div class="salonField"><label>'+esc(t.employee)+'</label><select id="sqWorker" required><option value=""></option>'+workers.map(w=>'<option value="'+esc(w.id)+'">'+esc(w.display_name)+'</option>').join('')+'</select></div><div class="salonField"><label>'+esc(t.service)+'</label><select id="sqService" required><option value=""></option></select></div>`,
+  },
+  {
+    name:'salon-quick-book-services-follow-employee',
+    from:`    const syncWorkers=()=>{const sid=q('#sqService').value,allowed=new Set((data.worker_services||[]).filter(x=>x.service_id===sid&&x.active).map(x=>x.worker_id));q('#sqWorker').innerHTML='<option value=""></option>'+workers.filter(w=>allowed.has(w.id)).map(w=>'<option value="'+esc(w.id)+'">'+esc(w.display_name)+'</option>').join('')};q('#sqService').onchange=syncWorkers;`,
+    to:`    const syncServices=()=>{const wid=q('#sqWorker').value,allowed=new Set((data.worker_services||[]).filter(x=>x.worker_id===wid&&x.active).map(x=>x.service_id));q('#sqService').innerHTML='<option value=""></option>'+services.filter(s=>allowed.has(s.id)).map(s=>'<option value="'+esc(s.id)+'">'+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+' · '+money(s.price_aed)+'</option>').join('')};q('#sqWorker').onchange=syncServices;`,
+  },
+  {
+    name:'salon-new-employee-can-select-services',
+    from:`<div class="salonField"><label>'+esc(t.commissionValue)+'</label><input id="swCommission" type="number" min="0" value="0"></div></div><button class="salonBtn primary" type="submit">'+esc(t.addEmployee)+'</button>`,
+    to:`<div class="salonField"><label>'+esc(t.commissionValue)+'</label><input id="swCommission" type="number" min="0" value="0"></div></div><div class="salonField"><label>'+esc(t.assignedServices)+'</label><div class="salonChecks" id="swServices">'+((data.services||[]).filter(s=>s.active).map(s=>'<label class="salonCheck"><input type="checkbox" data-new-worker-service="'+esc(s.id)+'"> '+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+'</label>').join('')||'<span class="muted">'+esc(t.serviceCatalogRequired)+'</span>')+'</div></div><button class="salonBtn primary" type="submit">'+esc(t.addEmployee)+'</button>`,
+  },
+  {
+    name:'salon-new-employee-persists-selected-services',
+    from:`q('#salonWorkerForm').onsubmit=async e=>{e.preventDefault();try{await post({action:'save_worker',display_name:q('#swName').value,phone_e164:q('#swPhone').value,job_title:q('#swTitle').value,commission_type:q('#swCommissionType').value,commission_value:q('#swCommission').value});notify(t.saved);await load(true)}catch(error){notify(t.failed+' · '+error.message)}};`,
+    to:`q('#salonWorkerForm').onsubmit=async e=>{e.preventDefault();try{const saved=await post({action:'save_worker',display_name:q('#swName').value,phone_e164:q('#swPhone').value,job_title:q('#swTitle').value,commission_type:q('#swCommissionType').value,commission_value:q('#swCommission').value}),workerId=saved.worker?.id;if(workerId)for(const input of qa('[data-new-worker-service]:checked'))await post({action:'assign_worker_service',worker_id:workerId,service_id:input.dataset.newWorkerService,active:true});notify(t.saved);await load(true)}catch(error){notify(t.failed+' · '+error.message)}};`,
+  },
+];
+
+function applySalonProductModelPatches(source){
+  let body=String(source||'');
+  for(const patch of SALON_PRODUCT_MODEL_PATCHES){
+    if(!body.includes(patch.from))throw new Error('DABBIR_SALON_PRODUCT_MODEL_PATTERN_DRIFT_'+patch.name);
+    body=body.replace(patch.from,patch.to);
+    if(body.includes(patch.from))throw new Error('DABBIR_SALON_PRODUCT_MODEL_PATCH_INCOMPLETE_'+patch.name);
+  }
+  return body;
+}
+
+export {SALON_PRODUCT_MODEL_PATCHES,applySalonProductModelPatches};

--- a/test/dabbir-salon-employee-first-booking.test.mjs
+++ b/test/dabbir-salon-employee-first-booking.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import salonModeUiHandler from '../api/salon-mode-ui.js';
+import {applySalonProductModelPatches} from '../api/salon-product-model-ui-patches.js';
+
+const root=path.resolve(import.meta.dirname,'..');
+const read=file=>fs.readFileSync(path.join(root,file),'utf8');
+
+function captureResponse(){return {statusCode:200,headers:{},body:'',status(code){this.statusCode=Number(code);return this},setHeader(key,value){this.headers[String(key).toLowerCase()]=value;return this},send(body=''){this.body=String(body);return this},end(body=''){this.body=String(body);return this}}}
+function emittedSalon(){const res=captureResponse();salonModeUiHandler({method:'GET'},res);assert.equal(res.statusCode,200);return res.body}
+
+test('Salon data model keeps services standalone and assigns them to employees through worker_services',()=>{
+  const api=read('api/salon-operations.js');
+  const migration=read('supabase/migrations/20260831090000_dabbir_salon_mode_p0.sql');
+  assert.match(migration,/create table if not exists public\.dabbir_worker_services/);
+  assert.match(migration,/join public\.dabbir_worker_services ws[\s\S]+ws\.worker_id=p_worker_id[\s\S]+ws\.active/);
+  assert.match(api,/action==='assign_worker_service'/);
+  const serviceBlock=api.slice(api.indexOf("if(action==='save_service')"),api.indexOf("if(action==='save_waitlist')"));
+  assert.doesNotMatch(serviceBlock,/worker_id/,'creating a service must not require an employee');
+});
+
+test('Salon quick booking is employee-first and services are filtered by that employee',()=>{
+  const patched=applySalonProductModelPatches(emittedSalon());
+  const booking=patched.slice(patched.indexOf('function openQuickBooking()'),patched.indexOf('function transitionButtons'));
+  assert.ok(booking.indexOf('id="sqWorker"')<booking.indexOf('id="sqService"'),'employee selector must appear before service selector');
+  assert.match(booking,/q\('#sqWorker'\)\.onchange=syncServices/);
+  assert.match(booking,/x\.worker_id===wid&&x\.active/);
+  assert.match(booking,/services\.filter\(s=>allowed\.has\(s\.id\)\)/);
+  assert.doesNotMatch(booking,/q\('#sqService'\)\.onchange=syncWorkers/);
+});
+
+test('New employee form can assign multiple existing services at creation time',()=>{
+  const patched=applySalonProductModelPatches(emittedSalon());
+  const team=patched.slice(patched.indexOf('function renderTeam()'),patched.indexOf('function workerRow'));
+  assert.match(team,/data-new-worker-service=/);
+  assert.match(team,/qa\('\[data-new-worker-service\]:checked'\)/);
+  assert.match(team,/action:'assign_worker_service'/);
+  assert.match(team,/worker_id:workerId/);
+});
+
+test('Salon setup messages describe the real business state instead of reversing ownership',()=>{
+  const patched=applySalonProductModelPatches(emittedSalon());
+  assert.match(patched,/employeeRequired:'أضيفي موظفة أولًا\.'/);
+  assert.match(patched,/serviceCatalogRequired:'أضيفي خدمة أولًا\.'/);
+  assert.match(patched,/employeeServicesRequired:'أسندي خدمة واحدة على الأقل للموظفة من شاشة الموظفات\.'/);
+  assert.doesNotMatch(patched,/أضيفي خدمة واربطيها بموظفة أولًا/);
+});
+
+test('Salon month snapshot stays within the API 45-day maximum',()=>{
+  const patched=applySalonProductModelPatches(emittedSalon());
+  assert.match(patched,/const monthStart=startWeek\(new Date\(cursor\.getFullYear\(\),cursor\.getMonth\(\),1\)\)/);
+  assert.match(patched,/view==='month'\?plus\(monthStart,42\)/);
+  assert.doesNotMatch(patched,/view==='month'\?45/);
+});


### PR DESCRIPTION
Salon Mode already has the correct many-to-many data model through `dabbir_worker_services`; no schema rewrite is needed. This change aligns the product flow with that model.

Changes:
- Quick booking is employee-first: choose employee, then show only that employee's assigned services.
- Service creation remains independent and never requires an employee.
- Employee creation can optionally assign multiple existing services immediately.
- Empty/setup messages distinguish missing employees, missing service catalog, and missing employee-service assignments.
- Fix Salon month snapshot range from an invalid 55-day request to an exact 42-day calendar grid, eliminating the observed `INVALID_DATE_RANGE` failure.
- Preserve the existing calendar performance route contract and shell module count.

Evidence:
- Mumbai schema verified: `dabbir_worker_services` is the assignment authority.
- Preview `ddc362ef9f3401412f26955ac2e2edc107c8dd25` READY in `bom1`.
- Build gate: 751/751 tests PASS.
- Preview runtime confirms employee selector precedes service selector, services filter by selected employee, employee form exposes service checkboxes, and month range is 42 days.