### PR TITLE
fix(dabbir): include new files in source-control validation

### DIFF
--- a/.github/workflows/dabbir-autonomous-source-control.yml
+++ b/.github/workflows/dabbir-autonomous-source-control.yml
@@ -83,6 +83,8 @@ jobs:
             git apply /tmp/barman.patch
           fi
 
+          # Intent-to-add makes newly created files visible to git diff without staging content.
+          git add -N .
           mapfile -t files < <(git diff --name-only)
           ((${#files[@]} > 0)) || { echo 'Candidate produced no changes'; exit 1; }
           printf '%s\n' "${files[@]}" | tee /tmp/changed-files.txt


### PR DESCRIPTION
Fixes the Canary-discovered defect in the autonomous source-control executor.

Root cause: `git diff --name-only` does not include newly-created untracked files, so a valid new-file repair was incorrectly classified as no change.

Fix: use `git add -N .` (intent-to-add) before path enumeration. This exposes new files to diff without staging their content, preserving the existing sensitive-path guard and PR-only behavior.

No scheduler, no direct main push, no merge bypass.