### PR TITLE
Pin DABBIR Auth Production Guard to Mumbai

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      PROJECT_REF: spohjzrsymsmzsseygtw
+      PROJECT_REF: fphpoysqdsceniwduxjq
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}

--- a/test/dabbir-no-retired-supabase-origin.test.mjs
+++ b/test/dabbir-no-retired-supabase-origin.test.mjs
@@ -7,6 +7,7 @@ import { fileURLToPath } from 'node:url';
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const apiRoot = path.join(root, 'api');
 const retiredRef = 'spohjzrsymsmzsseygtw';
+const mumbaiRef = 'fphpoysqdsceniwduxjq';
 const retiredPublishableKey = 'sb_publishable_WPxhwNf08BW1FgBptkinWg_3j75O4O3';
 
 function jsFiles(dir) {
@@ -25,6 +26,12 @@ test('runtime API cannot silently fall back to the retired Sydney Supabase proje
     }
   }
   assert.deepEqual(offenders, []);
+});
+
+test('production Auth guard is pinned to Mumbai and not the retired Sydney project', () => {
+  const source = fs.readFileSync(path.join(root, '.github', 'workflows', 'dabbir-auth-production.yml'), 'utf8');
+  assert.match(source, new RegExp(`PROJECT_REF:\\s*${mumbaiRef}`));
+  assert.doesNotMatch(source, new RegExp(`PROJECT_REF:\\s*${retiredRef}`));
 });
 
 test('auth core has no legacy Supabase origin constant', () => {


### PR DESCRIPTION
Fixes a production-control-plane drift discovered after the DABBIR Mumbai cutover.

The Auth Production Guard still targeted the retired Sydney Supabase ref `spohjzrsymsmzsseygtw`. This PR pins its Management API operations to the authoritative Mumbai project `fphpoysqdsceniwduxjq` and adds regression coverage that rejects a future return to the retired ref.

This is governance/security wiring only; no customer runtime or business logic changes.