### PR TITLE
Fail closed on direct main pushes

### DIFF
--- a/.github/workflows/dabbir-main-lineage-guard.yml
+++ b/.github/workflows/dabbir-main-lineage-guard.yml
@@ -1,0 +1,46 @@
+name: DABBIR Main Lineage Guard
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: dabbir-main-lineage-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  require-governed-main-lineage:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    env:
+      GH_TOKEN: ${{ github.token }}
+      HEAD_SHA: ${{ github.sha }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Require merged-PR lineage or Guardian rollback
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          subject="$(gh api "repos/${REPOSITORY}/commits/${HEAD_SHA}" --jq '.commit.message | split("\n")[0]')"
+          if [[ "$subject" == revert\(guardian\):* ]]; then
+            echo "Guardian rollback lineage accepted for ${HEAD_SHA}."
+            exit 0
+          fi
+
+          merged_pr_count="$(gh api \
+            -H 'Accept: application/vnd.github+json' \
+            "repos/${REPOSITORY}/commits/${HEAD_SHA}/pulls" \
+            --jq '[.[] | select(.base.ref == "main" and .merged_at != null)] | length')"
+
+          if [[ "$merged_pr_count" =~ ^[0-9]+$ ]] && [ "$merged_pr_count" -ge 1 ]; then
+            echo "Governed merged-PR lineage verified for ${HEAD_SHA}."
+            exit 0
+          fi
+
+          echo "::error::Direct or ungoverned push to main detected for ${HEAD_SHA}. A merged pull request is required."
+          exit 1

--- a/.github/workflows/dabbir-release-guardian.yml
+++ b/.github/workflows/dabbir-release-guardian.yml
@@ -8,6 +8,7 @@ on:
       - DABBIR Protected Live Smoke
       - DABBIR AI Full Customer Journey
       - DABBIR Auth Production Guard
+      - DABBIR Main Lineage Guard
     types: [completed]
 
 permissions:

--- a/test/dabbir-release-guardian.test.mjs
+++ b/test/dabbir-release-guardian.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 
 const buildGate=fs.readFileSync(new URL('../scripts/vercel-build-gate.mjs',import.meta.url),'utf8');
 const guardian=fs.readFileSync(new URL('../.github/workflows/dabbir-release-guardian.yml',import.meta.url),'utf8');
+const lineage=fs.readFileSync(new URL('../.github/workflows/dabbir-main-lineage-guard.yml',import.meta.url),'utf8');
 
 test('Vercel build gate fails closed on syntax, dependency audit, and full tests',()=>{
   assert.match(buildGate,/v4-fail-closed/);
@@ -20,6 +21,7 @@ test('release guardian auto-reverts failed main heads without stale rollback or 
     'DABBIR Protected Live Smoke',
     'DABBIR AI Full Customer Journey',
     'DABBIR Auth Production Guard',
+    'DABBIR Main Lineage Guard',
   ]) assert.ok(guardian.includes(`- ${workflow}`));
 
   assert.match(guardian,/permissions:[\s\S]*contents: write/);
@@ -28,4 +30,14 @@ test('release guardian auto-reverts failed main heads without stale rollback or 
   assert.match(guardian,/revert\\\(guardian\\\):/);
   assert.match(guardian,/git revert/);
   assert.match(guardian,/git push origin HEAD:main/);
+});
+
+test('main lineage guard requires a merged PR and only exempts Guardian rollback commits',()=>{
+  assert.match(lineage,/name: DABBIR Main Lineage Guard/);
+  assert.match(lineage,/push:[\s\S]*branches: \[main\]/);
+  assert.match(lineage,/pull-requests: read/);
+  assert.match(lineage,/commits\/\$\{HEAD_SHA\}\/pulls/);
+  assert.match(lineage,/\.base\.ref == "main" and \.merged_at != null/);
+  assert.match(lineage,/revert\\\(guardian\\\):/);
+  assert.match(lineage,/Direct or ungoverned push to main detected/);
 });


### PR DESCRIPTION
Rebased replacement for #291 on latest `main`.

Adds a compensating main-branch lineage control while native GitHub Rulesets/branch protection remain unavailable to the current integration.

- `DABBIR Main Lineage Guard` runs on every push to `main`.
- A main head is accepted only when GitHub reports lineage to a merged PR targeting `main`.
- The only non-PR exemption is a `revert(guardian):` rollback created by the Release Guardian.
- Release Guardian watches this gate and auto-reverts an ungoverned direct push if that head is still current.
- Regression tests lock the merged-PR check and narrow rollback exemption.

This is explicitly a compensating control, not a claim that native GitHub branch protection is enabled.