### PR TITLE
Run native GitHub protection with admin secret

### DIFF
--- a/.github/workflows/dabbir-native-github-protection.yml
+++ b/.github/workflows/dabbir-native-github-protection.yml
@@ -69,3 +69,5 @@ jobs:
           if (protection?.required_conversation_resolution?.enabled !== true) throw new Error('Conversation resolution is not required');
           console.log('DABBIR native GitHub main protection verified.');
           NODE
+
+# BARMAN activation refresh after secure admin secret provisioning: 2026-09-02


### PR DESCRIPTION
Triggers the already-reviewed DABBIR Native GitHub Protection Bootstrap after securely provisioning `DABBIR_GITHUB_ADMIN_TOKEN` in repository Actions secrets. No protection contract changes; only an activation refresh comment so the workflow executes on `main` and verifies native protection.