### PR TITLE
Split DABBIR owner customers/support into tabs

### DIFF
--- a/api/owner-command-center-v25.js
+++ b/api/owner-command-center-v25.js
@@ -1,0 +1,41 @@
+import base from './owner-command-center-v24.js';
+
+const PATCH=String.raw`<style>
+.ownerTabs25{position:sticky;top:0;z-index:40;display:flex;gap:7px;overflow-x:auto;overscroll-behavior-x:contain;padding:7px;margin:0 0 10px;border:1px solid #2e414c;border-radius:14px;background:#0b1115f2;backdrop-filter:blur(12px);-webkit-backdrop-filter:blur(12px);scrollbar-width:none}.ownerTabs25::-webkit-scrollbar{display:none}.ownerTab25{flex:0 0 auto;min-height:42px;border:1px solid #31434d;background:#121b20;color:#aebbc3;border-radius:11px;padding:8px 13px;font-size:10px;font-weight:850;cursor:pointer}.ownerTab25[aria-selected="true"]{background:#d7ff5f;color:#10130b;border-color:#d7ff5f}.ownerTabHidden25{display:none!important}.ownerTab25:focus-visible{outline:3px solid #d7ff5f;outline-offset:2px}@media(max-width:520px){.ownerTabs25{margin-inline:-2px;padding:6px;border-radius:12px}.ownerTab25{min-height:44px;padding:8px 12px}}
+</style><script>(()=>{
+const host=document.querySelector('#customers');if(!host)return;
+const classify=el=>{
+ if(el.id==='barmanExecutiveOsCeo'||el.classList?.contains('ceo24'))return'ceo';
+ if(el.id==='ownerExecutiveV23'||el.classList?.contains('oc23')||el.classList?.contains('oc22'))return'executive';
+ if(el.classList?.contains('oc20')||el.classList?.contains('oc16')||el.classList?.contains('oc15diag'))return'support';
+ if(el.classList?.contains('oc21'))return'feedback';
+ return'customers';
+};
+let nav=null,active='ceo';
+function apply(){
+ if(!nav)return;
+ [...host.children].forEach(el=>{if(el===nav)return;const key=classify(el);el.dataset.ownerTab25=key;el.classList.toggle('ownerTabHidden25',key!==active)});
+ nav.querySelectorAll('[data-tab25]').forEach(b=>b.setAttribute('aria-selected',String(b.dataset.tab25===active)));
+ try{sessionStorage.setItem('dabbir_owner_tab25',active)}catch{}
+}
+function setTab(key){active=key;apply();host.scrollIntoView({behavior:'smooth',block:'start'});}
+function setup(){
+ nav=document.createElement('nav');nav.className='ownerTabs25';nav.setAttribute('aria-label','تبويبات مركز مالك دبّر');
+ const tabs=[['ceo','CEO'],['executive','الإدارة'],['customers','العملاء'],['support','الدعم'],['feedback','الملاحظات']];
+ nav.innerHTML=tabs.map(([k,l])=>'<button type="button" class="ownerTab25" data-tab25="'+k+'" aria-selected="false">'+l+'</button>').join('');
+ host.prepend(nav);
+ nav.addEventListener('click',e=>{const b=e.target.closest('[data-tab25]');if(b)setTab(b.dataset.tab25)});
+ let saved='';try{saved=sessionStorage.getItem('dabbir_owner_tab25')||''}catch{};
+ active=tabs.some(x=>x[0]===saved)?saved:'ceo';
+ apply();
+ new MutationObserver(()=>apply()).observe(host,{childList:true});
+ window.__dabbirOwnerTabs={version:'v25',open:setTab,current:()=>active};
+}
+setup();
+})();</script>`;
+
+export default function handler(req,res){
+ const end=res.end.bind(res);let body='';
+ res.end=(chunk,...args)=>{body+=chunk?String(chunk):'';return end(body.includes('</body>')?body.replace('</body>',PATCH+'</body>'):body,...args)};
+ return base(req,res);
+}

--- a/api/owner-dashboard-gateway.js
+++ b/api/owner-dashboard-gateway.js
@@ -1,5 +1,5 @@
-// v24 adds the BARMAN Executive OS CEO center while preserving owner-command-center-v23.js and owner-command-center-v22.js truth layers.
-import dashboard from './owner-command-center-v24.js';
+// v25 adds tabbed owner navigation while preserving owner-command-center-v24.js, owner-command-center-v23.js and owner-command-center-v22.js truth layers.
+import dashboard from './owner-command-center-v25.js';
 import { parseCookies } from './_auth-core.js';
 
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '');

--- a/test/dabbir-owner-tabs-v25.test.mjs
+++ b/test/dabbir-owner-tabs-v25.test.mjs
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const ui=fs.readFileSync(new URL('../api/owner-command-center-v25.js',import.meta.url),'utf8');
+const gateway=fs.readFileSync(new URL('../api/owner-dashboard-gateway.js',import.meta.url),'utf8');
+
+test('owner dashboard routes through v25 tabs while preserving CEO v24',()=>{
+  assert.match(gateway,/owner-command-center-v25\.js/);
+  assert.match(gateway,/owner-command-center-v24\.js/);
+  assert.match(ui,/owner-command-center-v24\.js/);
+});
+
+test('owner customers workspace is split into clear tabs with CEO first',()=>{
+  for(const token of ["['ceo','CEO']","['executive','الإدارة']","['customers','العملاء']","['support','الدعم']","['feedback','الملاحظات']"]) assert.match(ui,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+  assert.match(ui,/active='ceo'/);
+  assert.match(ui,/ownerTabs25/);
+  assert.match(ui,/aria-label','تبويبات مركز مالك دبّر'/);
+});
+
+test('long customer and support modules are assigned to separate panels',()=>{
+  assert.match(ui,/oc20/);
+  assert.match(ui,/oc16/);
+  assert.match(ui,/oc15diag/);
+  assert.match(ui,/return'support'/);
+  assert.match(ui,/return'customers'/);
+  assert.match(ui,/ownerTabHidden25/);
+});
+
+test('tabs are mobile friendly and remember current tab without weakening owner auth',()=>{
+  assert.match(ui,/overflow-x:auto/);
+  assert.match(ui,/@media\(max-width:520px\)/);
+  assert.match(ui,/sessionStorage\.setItem\('dabbir_owner_tab25'/);
+  assert.doesNotMatch(ui,/SUPABASE_SERVICE_ROLE_KEY|service_role|apikey/i);
+});


### PR DESCRIPTION
Owner Dashboard v25: makes BARMAN Executive OS the first/default tab and splits the long owner workspace into CEO, Executive, Customers, Support, and Feedback tabs. Preserves v24/v23/v22 layers and owner OTP/session protection. Includes mobile horizontal tabs and regression coverage.