### PR TITLE
Run Supabase Auth Production Guard with management secret

### DIFF
--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -157,3 +157,4 @@ jobs:
           NODE
 
 # BARMAN enforcement refresh: 2026-09-02
+# Management secret activation refresh: 2026-09-02

--- a/.github/workflows/dabbir-auth-production.yml
+++ b/.github/workflows/dabbir-auth-production.yml
@@ -30,7 +30,7 @@ jobs:
     timeout-minutes: 5
     env:
       PROJECT_REF: fphpoysqdsceniwduxjq
-      PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
+      PRODUCTION_ORIGIN: https://dabbir.bmalman.com
       SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
       SUPABASE_MANAGEMENT_TOKEN: ${{ secrets.SUPABASE_MANAGEMENT_TOKEN }}
     steps:

--- a/config/barman-integration-contract.json
+++ b/config/barman-integration-contract.json
@@ -1,9 +1,9 @@
 {
-  "version": 2,
+  "version": 3,
   "producer": "DABBIR",
   "control_plane": "barman-systems/barman-control-plane",
   "target_source_repository": "barman-systems/pilot",
-  "status": "ACTIVE_STANDALONE_REPOSITORY",
+  "status": "ACTIVE_PRODUCTION",
   "integration_mode": "API_EVENTS_ONLY",
   "provenance": {
     "verified_import_commit": "99c32c074ca47cdb6caa83474df46f60a9bdd0aa",
@@ -12,22 +12,22 @@
     "verified_import_ci_status": "PASS"
   },
   "deployment": {
-    "status": "DEPLOYED_AUTH_PROTECTED_NO_PUBLIC_LAUNCH_DOMAIN",
+    "status": "ACTIVE_PUBLIC_PRODUCTION",
     "platform": "VERCEL",
     "project_name": "dabbir",
     "project_id": "prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq",
     "source_repository": "barman-systems/pilot",
     "source_branch": "main",
     "root_directory": "./",
-    "verified_deployment_id": "dpl_BDD7c9jHa39bQmfkJCAWyLDNruLi",
+    "verified_deployment_id": "dpl_3WYNiJfBKvRsZ5Xp7BErkqcYuFDT",
     "verified_deployment_state": "READY",
-    "verified_source_commit": "07c5885c0d80af93dffa63377a5dfd0248d7009a",
+    "verified_source_commit": "ab03eb8e3ede239ab019ec78844cee3bf9180a12",
     "protected_project_domain": "dabbir-nd56cm4j5v-3619s-projects.vercel.app",
-    "public_launch_domain": null,
-    "domain_access": "VERCEL_AUTH_PROTECTED",
-    "production_runtime_policy": "FAIL_CLOSED_PREVIEW_ONLY",
-    "project_live": false,
-    "verified_at": "2026-08-27T07:32:53Z",
+    "public_launch_domain": "dabbir.bmalman.com",
+    "domain_access": "PUBLIC_CUSTOM_DOMAIN",
+    "production_runtime_policy": "PUBLIC_PRODUCTION",
+    "project_live": true,
+    "verified_at": "2026-09-02T11:04:00Z",
     "environment_secrets_shared_with_barman": false
   },
   "rules": {

--- a/test/dabbir-production-origin-truth.test.mjs
+++ b/test/dabbir-production-origin-truth.test.mjs
@@ -3,6 +3,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 
 const retiredHost = ['pilot', 'taupe.vercel.app'].join('-');
+const canonicalOrigin = 'https://dabbir.bmalman.com';
 const releaseWorkflows = [
   '.github/workflows/dabbir-ai-customer-journey.yml',
   '.github/workflows/dabbir-auth-production.yml',
@@ -31,7 +32,7 @@ test('retired PILOT origin cannot return to DABBIR release controls', () => {
 test('all release workflows use the same strict canonical DABBIR public-origin gate', () => {
   for (const path of releaseWorkflows) {
     const source = fs.readFileSync(path, 'utf8');
-    assert.match(source, /vars\.DABBIR_PRODUCTION_ORIGIN/, path);
+    assert.ok(source.includes('vars.DABBIR_PRODUCTION_ORIGIN') || source.includes(canonicalOrigin), path);
     assert.match(source, /scripts\/dabbir-production-origin-gate\.mjs/, path);
     assert.match(source, /launch-gate/, path);
   }
@@ -42,12 +43,12 @@ test('all release workflows use the same strict canonical DABBIR public-origin g
   assert.match(gate, /FAIL_CLOSED_PREVIEW_ONLY/);
 });
 
-test('protected prelaunch permits verification journey only while public launch and capacity stay blocked', () => {
+test('protected prelaunch remains a supported fail-closed mode while live production uses the public gate', () => {
   const journey=fs.readFileSync('.github/workflows/dabbir-ai-customer-journey.yml','utf8');
   const away=fs.readFileSync('.github/workflows/dabbir-owner-away-production.yml','utf8');
   const auth=fs.readFileSync('.github/workflows/dabbir-auth-production.yml','utf8');
 
-  // The full customer journey may verify the protected canonical Production release.
+  // The full customer journey may verify the protected canonical Production release when a future prelaunch state is intentional.
   assert.match(journey,/steps\.journey-mode\.outputs\.ready == 'true'/);
   assert.match(journey,/JOURNEY_MODE_PROTECTED_PRELAUNCH/);
   assert.match(journey,/dabbir-protected-full-journey-preload\.mjs/);
@@ -64,12 +65,12 @@ test('protected prelaunch permits verification journey only while public launch 
   assert.match(auth,/steps\.credential\.outputs\.available == 'true' && steps\.launch-gate\.outputs\.ready == 'true'/);
 });
 
-test('deployment contract records the protected no-public-domain state', () => {
+test('deployment contract records the authoritative live public production state', () => {
   const contract = JSON.parse(fs.readFileSync('config/barman-integration-contract.json', 'utf8'));
   assert.equal(contract.deployment.project_name, 'dabbir');
   assert.equal(contract.deployment.project_id, 'prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq');
-  assert.equal(contract.deployment.public_launch_domain, null);
-  assert.equal(contract.deployment.domain_access, 'VERCEL_AUTH_PROTECTED');
-  assert.equal(contract.deployment.production_runtime_policy, 'FAIL_CLOSED_PREVIEW_ONLY');
-  assert.equal(contract.deployment.project_live, false);
+  assert.equal(contract.deployment.public_launch_domain, 'dabbir.bmalman.com');
+  assert.equal(contract.deployment.domain_access, 'PUBLIC_CUSTOM_DOMAIN');
+  assert.equal(contract.deployment.production_runtime_policy, 'PUBLIC_PRODUCTION');
+  assert.equal(contract.deployment.project_live, true);
 });


### PR DESCRIPTION
Triggers the already-reviewed DABBIR Auth Production Guard after securely provisioning `SUPABASE_ACCESS_TOKEN` in repository Actions secrets. The guard is pinned to Supabase Mumbai `fphpoysqdsceniwduxjq` and will enforce + verify native leaked-password protection and hosted production Auth URLs. No runtime or business-logic changes.