### PR TITLE
Make DABBIR live production contract authoritative for release gates

### DIFF
--- a/.github/workflows/dabbir-owner-away-production.yml
+++ b/.github/workflows/dabbir-owner-away-production.yml
@@ -31,7 +31,7 @@ jobs:
     timeout-minutes: 12
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
-      SUPABASE_PROJECT_REF: spohjzrsymsmzsseygtw
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       AWAY_REPORT_PATH: dabbir-owner-away-production-report.json
     outputs:
       production_ready: ${{ steps.launch-gate.outputs.ready }}

--- a/scripts/dabbir-production-origin-gate.mjs
+++ b/scripts/dabbir-production-origin-gate.mjs
@@ -64,6 +64,9 @@ export function runGate({ origin = process.env.PRODUCTION_ORIGIN, contractPath =
   const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
   const result = classifyProductionOrigin({ origin, contract });
   append(process.env.GITHUB_OUTPUT, `ready=${result.ready ? 'true' : 'false'}\nstate=${result.state}\norigin=${result.origin || ''}\n`);
+  if (result.ready && result.origin) {
+    append(process.env.GITHUB_ENV, `PRODUCTION_ORIGIN=${result.origin}\nPUBLIC_PRODUCTION_ORIGIN=${result.origin}\n`);
+  }
   append(process.env.GITHUB_STEP_SUMMARY, `## DABBIR Production Origin Gate\n\n**State:** ${result.state}\n\n${result.reason}\n`);
   console.log(`${result.state}: ${result.reason}`);
   return result;

--- a/scripts/dabbir-production-origin-gate.mjs
+++ b/scripts/dabbir-production-origin-gate.mjs
@@ -5,9 +5,17 @@ const CONTRACT_PATH = 'config/barman-integration-contract.json';
 const HTTPS_ORIGIN_RE = /^https:\/\/[^/]+$/i;
 
 export function classifyProductionOrigin({ origin = '', contract }) {
-  const value = String(origin || '').trim().replace(/\/$/, '');
   const deployment = contract?.deployment || {};
   const launchDomain = String(deployment.public_launch_domain || '').trim().toLowerCase();
+  const explicit = String(origin || '').trim().replace(/\/$/, '');
+  const liveContractOrigin =
+    launchDomain &&
+    deployment.domain_access !== 'VERCEL_AUTH_PROTECTED' &&
+    deployment.production_runtime_policy !== 'FAIL_CLOSED_PREVIEW_ONLY' &&
+    deployment.project_live === true
+      ? `https://${launchDomain}`
+      : '';
+  const value = explicit || liveContractOrigin;
   const protectedPrelaunch =
     !launchDomain &&
     deployment.domain_access === 'VERCEL_AUTH_PROTECTED' &&
@@ -55,7 +63,7 @@ function append(file, text) {
 export function runGate({ origin = process.env.PRODUCTION_ORIGIN, contractPath = CONTRACT_PATH } = {}) {
   const contract = JSON.parse(fs.readFileSync(contractPath, 'utf8'));
   const result = classifyProductionOrigin({ origin, contract });
-  append(process.env.GITHUB_OUTPUT, `ready=${result.ready ? 'true' : 'false'}\nstate=${result.state}\n`);
+  append(process.env.GITHUB_OUTPUT, `ready=${result.ready ? 'true' : 'false'}\nstate=${result.state}\norigin=${result.origin || ''}\n`);
   append(process.env.GITHUB_STEP_SUMMARY, `## DABBIR Production Origin Gate\n\n**State:** ${result.state}\n\n${result.reason}\n`);
   console.log(`${result.state}: ${result.reason}`);
   return result;

--- a/test/dabbir-production-origin-gate.test.mjs
+++ b/test/dabbir-production-origin-gate.test.mjs
@@ -21,11 +21,14 @@ test('protected DABBIR prelaunch is BLOCKED_PRELAUNCH rather than a false produc
   assert.match(result.reason,/no public launch domain/i);
 });
 
-test('missing production origin fails once the contract says DABBIR is no longer protected prelaunch', () => {
-  assert.throws(
-    ()=>classifyProductionOrigin({origin:'',contract:contract({public_launch_domain:'dabbir.example',domain_access:'PUBLIC',production_runtime_policy:'LIVE',project_live:true})}),
-    /DABBIR_PRODUCTION_ORIGIN must be configured/
-  );
+test('live DABBIR contract supplies the canonical production origin when CI variable is absent', () => {
+  const result=classifyProductionOrigin({
+    origin:'',
+    contract:contract({public_launch_domain:'dabbir.example',domain_access:'PUBLIC',production_runtime_policy:'LIVE',project_live:true}),
+  });
+  assert.equal(result.ready,true);
+  assert.equal(result.state,'PUBLIC_PRODUCTION_READY');
+  assert.equal(result.origin,'https://dabbir.example');
 });
 
 test('an origin cannot be configured before a public launch domain is approved', () => {


### PR DESCRIPTION
Fixes the post-launch release-gate drift exposed after enabling native GitHub protection and Supabase Auth hardening.

Changes:
- production-origin gate now derives the canonical HTTPS origin from the approved live integration contract when the Actions variable is absent;
- prelaunch remains fail-closed and explicit mismatched origins still fail;
- the resolved live origin is propagated to downstream workflow steps;
- Owner Away production routing is corrected from the retired Sydney Supabase ref to DABBIR Mumbai `fphpoysqdsceniwduxjq`;
- regression coverage locks the live-contract fallback.

This restores Full Customer Journey / Owner Away / BAR-12 gates without weakening launch validation or branch protection.