### PR TITLE
Authorize Owner Away QA OIDC source explicitly

### DIFF
--- a/supabase/functions/dabbir-qa-suite-runner/index.ts
+++ b/supabase/functions/dabbir-qa-suite-runner/index.ts
@@ -5,7 +5,10 @@ const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVI
 const GH_ISSUER='https://token.actions.githubusercontent.com';
 const GH_REPOSITORY='barman-systems/pilot';
 const GH_REF='refs/heads/main';
-const GH_WORKFLOW='barman-systems/pilot/.github/workflows/dabbir-ai-customer-journey.yml@refs/heads/main';
+const GH_WORKFLOWS=new Set([
+  'barman-systems/pilot/.github/workflows/dabbir-ai-customer-journey.yml@refs/heads/main',
+  'barman-systems/pilot/.github/workflows/dabbir-owner-away-production.yml@refs/heads/main',
+]);
 const GH_AUDIENCE='dabbir-ai-qa';
 const GH_EVENTS=new Set(['push','schedule','workflow_dispatch']);
 const ACTIONS=new Set(['dabbir_ai_qa_bootstrap','dabbir_ai_qa_seed_order','dabbir_ai_qa_cleanup']);
@@ -30,7 +33,7 @@ async function verifyGitHubOidc(req:Request){
   if(payload.iss!==GH_ISSUER)throw new Error('OIDC_ISSUER_DENIED');
   if(!aud.includes(GH_AUDIENCE))throw new Error('OIDC_AUDIENCE_DENIED');
   if(Number(payload.exp||0)<=now||Number(payload.nbf||0)>now+30)throw new Error('OIDC_TIME_INVALID');
-  if(payload.repository!==GH_REPOSITORY||payload.ref!==GH_REF||payload.workflow_ref!==GH_WORKFLOW)throw new Error('OIDC_SOURCE_DENIED');
+  if(payload.repository!==GH_REPOSITORY||payload.ref!==GH_REF||!GH_WORKFLOWS.has(String(payload.workflow_ref||'')))throw new Error('OIDC_SOURCE_DENIED');
   if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
   return payload;
 }

--- a/test/dabbir-qa-oidc-source-allowlist.test.mjs
+++ b/test/dabbir-qa-oidc-source-allowlist.test.mjs
@@ -1,0 +1,12 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const source = await readFile(new URL('../supabase/functions/dabbir-qa-suite-runner/index.ts', import.meta.url), 'utf8');
+
+test('QA runner accepts only the two authorized main workflows', () => {
+  assert.match(source, /dabbir-ai-customer-journey\.yml@refs\/heads\/main/u);
+  assert.match(source, /dabbir-owner-away-production\.yml@refs\/heads\/main/u);
+  assert.match(source, /GH_WORKFLOWS\.has\(String\(payload\.workflow_ref\|\|''\)\)/u);
+  assert.doesNotMatch(source, /workflow_ref\.includes|workflow_ref\.startsWith|\*\.yml/u);
+});


### PR DESCRIPTION
Fixes the Owner Away production journey bootstrap after the live-origin gate was restored.

The QA Edge Function previously accepted only the Full Customer Journey workflow_ref. This PR changes that single-source check to an exact two-entry allowlist:
- DABBIR AI Full Customer Journey on main
- DABBIR Owner Away Production Gate on main

Repository, ref, audience, issuer, event, signature, and time checks remain unchanged. Regression coverage rejects wildcard/prefix workflow matching.