### PR TITLE
Close DABBIR readiness evidence gaps for capacity and bilingual iPhone

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -20,6 +20,7 @@ on:
       - 'package-lock.json'
       - 'vercel-ignore-if-unaffected.sh'
       - 'test/ai-full-customer-journey-v2.mjs'
+      - 'test/run-ai-full-customer-journey-en.mjs'
       - 'test/dabbir-cross-tenant-isolation.mjs'
       - 'test/dabbir-protected-full-journey-preload.mjs'
       - 'test/dabbir-protected-journey-access.test.mjs'
@@ -200,6 +201,22 @@ jobs:
             node test/ai-full-customer-journey-v2.mjs
           fi
 
+      - name: Run English iPhone WebKit owner journey against exact Production
+        if: steps.journey-mode.outputs.ready == 'true'
+        shell: bash
+        env:
+          JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report-en.json
+        run: |
+          set -euo pipefail
+          if [ "${{ steps.journey-mode.outputs.mode }}" = 'protected' ]; then
+            node --import ./test/dabbir-protected-full-journey-preload.mjs test/run-ai-full-customer-journey-en.mjs
+          else
+            node test/run-ai-full-customer-journey-en.mjs
+          fi
+          test -s dabbir-ai-customer-journey-report-en.json
+          jq -e '.verdict == "PASS" and .required_failures == 0 and any(.steps[]; .name == "25_mobile_webkit_owner_journey" and .status == "PASS")' dabbir-ai-customer-journey-report-en.json >/dev/null
+          echo 'ENGLISH_IPHONE_WEBKIT_JOURNEY_PASS'
+
       - name: Run cross-tenant and WhatsApp isolation attack
         if: steps.journey-mode.outputs.ready == 'true'
         shell: bash
@@ -261,6 +278,7 @@ jobs:
           name: dabbir-ai-full-customer-journey-evidence
           path: |
             dabbir-ai-customer-journey-report.json
+            dabbir-ai-customer-journey-report-en.json
             dabbir-ai-customer-journey-screenshot.png
             dabbir-cross-tenant-isolation-report.json
           if-no-files-found: warn

--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -275,7 +275,8 @@ jobs:
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
-      PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
+      CAPACITY_TARGET: production
+      CAPACITY_PRODUCTION_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '300'
       RUN_RUNTIME: 'false'
       RUN_AI: 'true'
@@ -304,7 +305,8 @@ jobs:
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
-      PRODUCTION_CAPACITY_LOAD_ACK: ${{ inputs.production_capacity_ack }}
+      CAPACITY_TARGET: production
+      CAPACITY_PRODUCTION_ACK: ${{ inputs.production_capacity_ack }}
       CUSTOMER_COUNT: '1000'
       RUN_RUNTIME: 'true'
       RUN_AI: 'false'

--- a/.github/workflows/dabbir-bar12-readiness.yml
+++ b/.github/workflows/dabbir-bar12-readiness.yml
@@ -14,6 +14,7 @@ on:
       - 'api/dabbir-whatsapp-*.js'
       - 'api/_whatsapp-*.js'
       - 'test/ai-full-customer-journey-v2.mjs'
+      - 'test/run-ai-full-customer-journey-en.mjs'
       - 'test/dabbir-cross-tenant-isolation.mjs'
       - '.github/workflows/dabbir-ai-customer-journey.yml'
       - '.github/workflows/dabbir-bar12-readiness.yml'
@@ -248,21 +249,28 @@ jobs:
           mkdir -p bar12-journey-evidence
           gh run download "$journey_run" \
             --repo "$GITHUB_REPOSITORY" \
-            --name dabbir-ai-customer-journey-evidence \
+            --name dabbir-ai-full-customer-journey-evidence \
             --dir bar12-journey-evidence
 
           report='bar12-journey-evidence/dabbir-ai-customer-journey-report.json'
+          report_en='bar12-journey-evidence/dabbir-ai-customer-journey-report-en.json'
           isolation='bar12-journey-evidence/dabbir-cross-tenant-isolation-report.json'
           screenshot='bar12-journey-evidence/dabbir-ai-customer-journey-screenshot.png'
           test -s "$report"
+          test -s "$report_en"
           test -s "$isolation"
           test -s "$screenshot"
           jq -e \
             --arg origin "$RUNTIME_ORIGIN" \
             '.verdict == "PASS" and .required_failures == 0 and .production_origin == $origin and any(.steps[]; .name == "25_mobile_webkit_owner_journey" and .status == "PASS")' \
             "$report" >/dev/null
+          jq -e \
+            --arg origin "$RUNTIME_ORIGIN" \
+            '.verdict == "PASS" and .required_failures == 0 and .production_origin == $origin and any(.steps[]; .name == "25_mobile_webkit_owner_journey" and .status == "PASS")' \
+            "$report_en" >/dev/null
           jq -e '.verdict == "PASS" and .required_failures == 0 and (.checks | length) >= 9' "$isolation" >/dev/null
           grep -q "locale: 'ar-AE'" test/ai-full-customer-journey-v2.mjs
+          grep -q "locale: 'en-US'" test/run-ai-full-customer-journey-en.mjs
           echo "run_id=$journey_run" >> "$GITHUB_OUTPUT"
           echo "source_sha=$journey_sha" >> "$GITHUB_OUTPUT"
           echo "mode=$journey_mode" >> "$GITHUB_OUTPUT"
@@ -297,7 +305,7 @@ jobs:
               production_deployment:{state:"READY",source_commit:$runtime_sha,id:$deployment_id,environment:"production",evidence:("live_release_endpoint+full_journey_run:"+$journey_run_id)},
               end_to_end_journey:{verdict:"PASS",source_commit:$runtime_sha,journey_source_commit:$journey_source_sha,evidence_mode:$journey_evidence_mode,run_id:$journey_run_id,web_owner_journey_verified:true,cross_tenant_isolation_verified:true,real_external_connection:false,real_inbound_message:false,approved_reply_verified:false,external_scope:"UNVERIFIED"},
               iphone_safari_ar:{verdict:"PASS",source_commit:$runtime_sha,journey_source_commit:$journey_source_sha,evidence_mode:$journey_evidence_mode,evidence:"25_mobile_webkit_owner_journey+ar-AE_fixture+screenshot"},
-              iphone_safari_en:null,
+              iphone_safari_en:{verdict:"PASS",source_commit:$runtime_sha,journey_source_commit:$journey_source_sha,evidence_mode:$journey_evidence_mode,evidence:"25_mobile_webkit_owner_journey+en-US_fixture"},
               monitoring:{runtime_errors_checked:false,alert_delivery_verified:false},
               critical_gates:{security:null,financial:null,legal:null}
             }' > dabbir-bar12-live-evidence.json
@@ -315,6 +323,7 @@ jobs:
             dabbir-bar12-runtime-classification.log
             dabbir-bar12-journey-equivalence.log
             bar12-journey-evidence/dabbir-ai-customer-journey-report.json
+            bar12-journey-evidence/dabbir-ai-customer-journey-report-en.json
             bar12-journey-evidence/dabbir-cross-tenant-isolation-report.json
             bar12-journey-evidence/dabbir-ai-customer-journey-screenshot.png
           if-no-files-found: warn

--- a/test/dabbir-bar12-live-evidence-ingestion.test.mjs
+++ b/test/dabbir-bar12-live-evidence-ingestion.test.mjs
@@ -4,6 +4,8 @@ import fs from 'node:fs';
 
 const workflow = fs.readFileSync(new URL('../.github/workflows/dabbir-bar12-readiness.yml', import.meta.url), 'utf8');
 const journey = fs.readFileSync(new URL('./ai-full-customer-journey-v2.mjs', import.meta.url), 'utf8');
+const englishJourney = fs.readFileSync(new URL('./run-ai-full-customer-journey-en.mjs', import.meta.url), 'utf8');
+const producer = fs.readFileSync(new URL('../.github/workflows/dabbir-ai-customer-journey.yml', import.meta.url), 'utf8');
 
 test('BAR-12 reads the authoritative deployed runtime instead of assuming repository HEAD is deployed', () => {
   assert.match(workflow, /fetch-depth:\s*0/);
@@ -31,16 +33,24 @@ test('BAR-12 imports only an exact or proven runtime-equivalent successful Full 
   assert.match(workflow, /journey_mode='exact_sha'/);
   assert.match(workflow, /journey_mode='runtime_equivalent'/);
   assert.match(workflow, /gh run download "\$journey_run"/);
-  assert.match(workflow, /--name dabbir-ai-customer-journey-evidence/);
+  assert.match(producer, /name:\s*dabbir-ai-full-customer-journey-evidence/);
+  assert.match(workflow, /--name dabbir-ai-full-customer-journey-evidence/);
+  assert.doesNotMatch(workflow, /--name dabbir-ai-customer-journey-evidence/);
   assert.match(workflow, /FULL_JOURNEY_RUNTIME_EVIDENCE_PASS/);
 });
 
-test('Arabic iPhone evidence is tied to the real WebKit step and Arabic journey fixture', () => {
+test('Arabic and English iPhone evidence are tied to real WebKit journeys', () => {
   assert.match(journey, /locale:\s*'ar-AE'/);
+  assert.match(englishJourney, /locale:\s*'en-US'/);
+  assert.match(englishJourney, /ai-full-customer-journey-v2\.mjs/);
+  assert.match(producer, /Run English iPhone WebKit owner journey against exact Production/);
+  assert.match(producer, /dabbir-ai-customer-journey-report-en\.json/);
   assert.match(workflow, /25_mobile_webkit_owner_journey/);
   assert.match(workflow, /dabbir-ai-customer-journey-screenshot\.png/);
+  assert.match(workflow, /dabbir-ai-customer-journey-report-en\.json/);
   assert.match(workflow, /iphone_safari_ar:\{verdict:"PASS"/);
-  assert.match(workflow, /iphone_safari_en:null/);
+  assert.match(workflow, /iphone_safari_en:\{verdict:"PASS"/);
+  assert.doesNotMatch(workflow, /iphone_safari_en:null/);
 });
 
 test('BAR-12 preserves external WhatsApp fail-closed truth while importing internal journey evidence', () => {

--- a/test/dabbir-journey-workflow-safety.test.mjs
+++ b/test/dabbir-journey-workflow-safety.test.mjs
@@ -35,8 +35,12 @@ test('capacity never runs automatically on push or schedule',()=>{
   must(/runtime-capacity-1000:\n    name:[^\n]*\n    needs: \[full-customer-journey, ai-capacity\]\n    if: \$\{\{[^\n]*github\.event_name == 'workflow_dispatch'[^\n]*needs\.ai-capacity\.result == 'success'[^\n]*needs\.full-customer-journey\.outputs\.production_ready == 'true'[^\n]*\}\}/,'runtime capacity must require both successful AI capacity and the explicit public-production-ready gate');
 });
 
-test('production capacity retains exact fail-closed acknowledgement',()=>{
+test('production capacity retains exact fail-closed acknowledgement and explicit target',()=>{
   const ack='ALLOW_CAPACITY_LOAD_ON_PRODUCTION';
   assert.ok(workflow.includes(ack),'workflow must require the exact production acknowledgement');
-  must(/PRODUCTION_CAPACITY_LOAD_ACK:\s*\$\{\{ inputs\.production_capacity_ack \}\}/,'the verified manual acknowledgement must reach the capacity safety guard');
+  const ackWiring=/CAPACITY_PRODUCTION_ACK:\s*\$\{\{ inputs\.production_capacity_ack \}\}/g;
+  assert.equal((workflow.match(ackWiring)||[]).length,2,'both production capacity jobs must pass the acknowledgement using the variable consumed by dabbir-capacity-load');
+  const targetWiring=/CAPACITY_TARGET:\s*production/g;
+  assert.equal((workflow.match(targetWiring)||[]).length,2,'both capacity jobs must explicitly declare the production target');
+  mustNot(/PRODUCTION_CAPACITY_LOAD_ACK:/,'obsolete unused acknowledgement variable must not return');
 });

--- a/test/run-ai-full-customer-journey-en.mjs
+++ b/test/run-ai-full-customer-journey-en.mjs
@@ -1,0 +1,24 @@
+import fs from 'node:fs';
+
+const sourceUrl = new URL('./ai-full-customer-journey-v2.mjs', import.meta.url);
+const generatedUrl = new URL('./.dabbir-ai-full-customer-journey-en.generated.mjs', import.meta.url);
+const source = fs.readFileSync(sourceUrl, 'utf8');
+const arabicLocale = "locale: 'ar-AE',";
+
+if ((source.match(/locale:\s*'ar-AE',/g) || []).length !== 1) {
+  throw new Error('ENGLISH_WEBKIT_SOURCE_LOCALE_CONTRACT_CHANGED');
+}
+
+const englishSource = source.replace(arabicLocale, "locale: 'en-US',");
+if (!englishSource.includes("locale: 'en-US',")) {
+  throw new Error('ENGLISH_WEBKIT_LOCALE_REWRITE_FAILED');
+}
+
+process.env.JOURNEY_REPORT_PATH = process.env.JOURNEY_REPORT_PATH || 'dabbir-ai-customer-journey-report-en.json';
+fs.writeFileSync(generatedUrl, englishSource, 'utf8');
+
+try {
+  await import(`${generatedUrl.href}?run=${Date.now()}`);
+} finally {
+  fs.rmSync(generatedUrl, { force: true });
+}


### PR DESCRIPTION
CEO report execution closeout for technical readiness gaps.

- Fix production capacity gate env wiring to the exact variables consumed by dabbir-capacity-load.mjs, while preserving workflow_dispatch-only + explicit production acknowledgement.
- Produce an English en-US iPhone-size WebKit production journey using the authoritative full journey implementation and disposable QA cleanup.
- Upload Arabic + English journey reports in the authoritative full-journey artifact.
- Fix BAR-12 artifact-name mismatch and ingest/validate both mobile reports.
- Preserve fail-closed truth for real external WhatsApp, alerting, and critical legal/financial/security gates; this PR does not fake those as PASS.
- Add regression tests for capacity wiring and bilingual artifact ingestion.