### PR TITLE
Align Owner Away QA cleanup contract

### DIFF
--- a/test/dabbir-owner-away-production-journey.mjs
+++ b/test/dabbir-owner-away-production-journey.mjs
@@ -8,7 +8,7 @@ const QA_CONTROL_URL=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-
 const OIDC_AUDIENCE='dabbir-ai-qa';
 const REPORT_PATH=process.env.AWAY_REPORT_PATH||'dabbir-owner-away-production-report.json';
 const RUN_ID=`${Date.now()}-${crypto.randomBytes(3).toString('hex')}`;
-const RUN_LABEL=`DABBIR Away QA ${RUN_ID}`;
+const RUN_LABEL=`DABBIR AI QA ${RUN_ID}`;
 
 const report={run_id:RUN_ID,journey:'DABBIR_OWNER_AWAY_PRODUCTION',production_origin:ORIGIN,started_at:new Date().toISOString(),completed_at:null,verdict:'RUNNING',required_failures:0,steps:[],cleanup:[]};
 let owner=null,employee=null,businessId=null,oidcToken=null;


### PR DESCRIPTION
Owner Away production journey now uses the same canonical `DABBIR AI QA <run_id>` fixture name enforced by the BARMAN QA broker cleanup scope. This fixes the only remaining post-journey cleanup failure without broadening deletion authority. The previous production rerun already proved all 10 Owner Away functional steps pass; only cleanup was rejected by the stricter name contract.