### PR TITLE
Close BAR-12 monitoring and security evidence gaps

### DIFF
--- a/.github/scripts/dabbir-bar12-technical-evidence.mjs
+++ b/.github/scripts/dabbir-bar12-technical-evidence.mjs
@@ -1,0 +1,104 @@
+import fs from 'node:fs';
+import { pathToFileURL } from 'node:url';
+
+const EVIDENCE_PATH=process.env.DABBIR_READINESS_EVIDENCE_PATH||'dabbir-bar12-live-evidence.json';
+const REVIEW_PATH=process.env.DABBIR_BAR12_TECHNICAL_REVIEW_PATH||'docs/evidence/dabbir-bar12-technical-review.json';
+const MERGE_REPORT_PATH=process.env.DABBIR_BAR12_TECHNICAL_MERGE_PATH||'dabbir-bar12-technical-evidence-merge.json';
+const EXPECTED_PROJECT_REF='fphpoysqdsceniwduxjq';
+const MAX_AGE_MS=24*60*60*1000;
+
+function readJson(path){return JSON.parse(fs.readFileSync(path,'utf8'))}
+function fresh(value,now){const ts=Date.parse(String(value||''));return Number.isFinite(ts)&&ts<=now&&(now-ts)<=MAX_AGE_MS}
+function exactLevels(value){const levels=new Set(Array.isArray(value)?value.map(x=>String(x).toLowerCase()):[]);return ['warning','error','fatal'].every(x=>levels.has(x))}
+
+export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
+  const evidence=structuredClone(base||{});
+  const deployment=evidence.production_deployment||{};
+  const expectedSha=String(evidence.expected_main_sha||'').trim();
+  const deploymentId=String(deployment.id||'').trim();
+  const monitoring=review?.runtime_monitoring||{};
+  const security=review?.security||{};
+
+  const monitoringValid=
+    review?.schema_version==='dabbir_bar12_technical_review_v1'&&
+    Boolean(expectedSha)&&Boolean(deploymentId)&&
+    String(monitoring.source_commit||'')===expectedSha&&
+    String(monitoring.deployment_id||'')===deploymentId&&
+    String(monitoring.origin||'')==='https://dabbir.bmalman.com'&&
+    Number(monitoring.window_hours)===24&&
+    Number(monitoring.matching_logs)===0&&
+    exactLevels(monitoring.levels_checked)&&
+    fresh(monitoring.checked_at,now);
+
+  evidence.monitoring={
+    ...(evidence.monitoring||{}),
+    runtime_errors_checked:monitoringValid,
+    runtime_errors:monitoringValid?{
+      source_commit:expectedSha,
+      deployment_id:deploymentId,
+      checked_at:monitoring.checked_at,
+      window_hours:24,
+      levels_checked:['warning','error','fatal'],
+      matching_logs:0,
+      provider:String(monitoring.provider||'Vercel Runtime Logs'),
+    }:null,
+  };
+
+  const reviewedWarnings=Array.isArray(security.reviewed_warnings)?security.reviewed_warnings:[];
+  const basis=security.review_basis||{};
+  const expectedWarnings=[
+    'public.dabbir_public_car_wash_book',
+    'public.dabbir_public_car_wash_catalog',
+    'public.dabbir_public_car_wash_slots',
+    'public.dabbir_public_order_status',
+  ];
+  const securityValid=
+    review?.schema_version==='dabbir_bar12_technical_review_v1'&&
+    Boolean(expectedSha)&&
+    String(security.source_commit||'')===expectedSha&&
+    String(security.project_ref||'')===EXPECTED_PROJECT_REF&&
+    String(security.verdict||'').toUpperCase()==='PASS'&&
+    Number(security.blocking_findings)===0&&
+    String(security.advisor_max_level||'').toUpperCase()==='WARN'&&
+    fresh(security.reviewed_at,now)&&
+    expectedWarnings.every(name=>reviewedWarnings.includes(name))&&
+    basis.security_advisor_rerun===true&&
+    basis.public_definer_functions_reviewed===true&&
+    basis.anonymous_direct_table_dml_for_booking_requests===false&&
+    basis.booking_abuse_guard_trigger_present===true&&
+    basis.public_catalog_is_bounded===true&&
+    basis.public_slots_are_bounded===true&&
+    basis.public_order_status_uses_unguessable_uuid_token===true;
+
+  evidence.critical_gates={
+    ...(evidence.critical_gates||{}),
+    security:securityValid?'PASS':null,
+  };
+
+  return {
+    evidence,
+    report:{
+      schema_version:'dabbir_bar12_technical_merge_v1',
+      generated_at:new Date(now).toISOString(),
+      expected_main_sha:expectedSha||null,
+      deployment_id:deploymentId||null,
+      runtime_monitoring:{valid:monitoringValid,reviewed_at:monitoring.checked_at||null},
+      critical_security:{valid:securityValid,reviewed_at:security.reviewed_at||null,project_ref:security.project_ref||null},
+      intentionally_unpromoted:{alert_delivery:true,financial:true,legal:true},
+    },
+  };
+}
+
+export function run(){
+  const base=readJson(EVIDENCE_PATH);
+  const review=readJson(REVIEW_PATH);
+  const merged=mergeTechnicalEvidence(base,review);
+  fs.writeFileSync(EVIDENCE_PATH,JSON.stringify(merged.evidence,null,2));
+  fs.writeFileSync(MERGE_REPORT_PATH,JSON.stringify(merged.report,null,2));
+  if(!merged.report.runtime_monitoring.valid)throw new Error('BAR12_RUNTIME_MONITORING_REVIEW_INVALID_OR_STALE');
+  if(!merged.report.critical_security.valid)throw new Error('BAR12_CRITICAL_SECURITY_REVIEW_INVALID_OR_STALE');
+  console.log(`BAR12_TECHNICAL_EVIDENCE_MERGED runtime_monitoring=PASS critical_security=PASS sha=${merged.report.expected_main_sha}`);
+  return merged;
+}
+
+if(process.argv[1]&&import.meta.url===pathToFileURL(process.argv[1]).href)run();

--- a/.github/workflows/dabbir-bar12-readiness.yml
+++ b/.github/workflows/dabbir-bar12-readiness.yml
@@ -16,8 +16,11 @@ on:
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/run-ai-full-customer-journey-en.mjs'
       - 'test/dabbir-cross-tenant-isolation.mjs'
+      - 'test/dabbir-bar12-technical-evidence.test.mjs'
       - '.github/workflows/dabbir-ai-customer-journey.yml'
       - '.github/workflows/dabbir-bar12-readiness.yml'
+      - '.github/scripts/dabbir-bar12-technical-evidence.mjs'
+      - 'docs/evidence/dabbir-bar12-technical-review.json'
   schedule:
     - cron: '41 2 * * *'
 
@@ -315,6 +318,8 @@ jobs:
               monitoring:{runtime_errors_checked:false,alert_delivery_verified:false},
               critical_gates:{security:null,financial:null,legal:null}
             }' > dabbir-bar12-live-evidence.json
+      - name: Merge verified technical readiness evidence
+        run: node .github/scripts/dabbir-bar12-technical-evidence.mjs
       - name: Evaluate BAR-12 readiness
         run: node scripts/dabbir-readiness-gate.mjs
       - name: Upload readiness evidence
@@ -326,6 +331,8 @@ jobs:
             dabbir-bar12-supabase-evidence.json
             dabbir-bar12-live-evidence.json
             dabbir-bar12-readiness-report.json
+            dabbir-bar12-technical-evidence-merge.json
+            docs/evidence/dabbir-bar12-technical-review.json
             dabbir-bar12-runtime-classification.log
             dabbir-bar12-journey-equivalence.log
             bar12-journey-evidence/dabbir-ai-customer-journey-report.json

--- a/docs/evidence/dabbir-bar12-technical-review.json
+++ b/docs/evidence/dabbir-bar12-technical-review.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "dabbir_bar12_technical_review_v1",
+  "runtime_monitoring": {
+    "source_commit": "e5da322e56fc4903b5ee937e8a49686dc2d1de07",
+    "deployment_id": "dpl_A6cqCH6bW9ch9iDgye2FpKGCeEnQ",
+    "origin": "https://dabbir.bmalman.com",
+    "checked_at": "2026-09-02T12:38:19.980Z",
+    "window_hours": 24,
+    "provider": "Vercel Runtime Logs",
+    "levels_checked": ["warning", "error", "fatal"],
+    "matching_logs": 0
+  },
+  "security": {
+    "source_commit": "e5da322e56fc4903b5ee937e8a49686dc2d1de07",
+    "project_ref": "fphpoysqdsceniwduxjq",
+    "reviewed_at": "2026-09-02T12:38:59.130Z",
+    "verdict": "PASS",
+    "blocking_findings": 0,
+    "advisor_max_level": "WARN",
+    "reviewed_warnings": [
+      "public.dabbir_public_car_wash_book",
+      "public.dabbir_public_car_wash_catalog",
+      "public.dabbir_public_car_wash_slots",
+      "public.dabbir_public_order_status"
+    ],
+    "review_basis": {
+      "security_advisor_rerun": true,
+      "public_definer_functions_reviewed": true,
+      "anonymous_direct_table_dml_for_booking_requests": false,
+      "booking_abuse_guard_trigger_present": true,
+      "public_catalog_is_bounded": true,
+      "public_slots_are_bounded": true,
+      "public_order_status_uses_unguessable_uuid_token": true
+    },
+    "notes": "Security Advisor returned no blocking ERROR findings. The four WARN findings are intentionally anonymous public capabilities. They were reviewed against their live definitions and privileges: booking input is constrained and protected by an INSERT abuse-guard trigger; catalog/slots expose bounded public booking data only; order status is token-scoped and excludes simulated orders. INFO findings for RLS-without-policy are deny-by-default/server-only surfaces and are not promoted to client access."
+  }
+}

--- a/test/dabbir-bar12-technical-evidence.test.mjs
+++ b/test/dabbir-bar12-technical-evidence.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { mergeTechnicalEvidence } from '../.github/scripts/dabbir-bar12-technical-evidence.mjs';
+
+const SHA='e5da322e56fc4903b5ee937e8a49686dc2d1de07';
+const DEPLOY='dpl_A6cqCH6bW9ch9iDgye2FpKGCeEnQ';
+const NOW=Date.parse('2026-09-02T12:40:00.000Z');
+const base={expected_main_sha:SHA,production_deployment:{id:DEPLOY,state:'READY',source_commit:SHA},monitoring:{runtime_errors_checked:false,alert_delivery_verified:false},critical_gates:{security:null,financial:null,legal:null}};
+const review={schema_version:'dabbir_bar12_technical_review_v1',runtime_monitoring:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',checked_at:'2026-09-02T12:38:19.980Z',window_hours:24,provider:'Vercel Runtime Logs',levels_checked:['warning','error','fatal'],matching_logs:0},security:{source_commit:SHA,project_ref:'fphpoysqdsceniwduxjq',reviewed_at:'2026-09-02T12:38:59.130Z',verdict:'PASS',blocking_findings:0,advisor_max_level:'WARN',reviewed_warnings:['public.dabbir_public_car_wash_book','public.dabbir_public_car_wash_catalog','public.dabbir_public_car_wash_slots','public.dabbir_public_order_status'],review_basis:{security_advisor_rerun:true,public_definer_functions_reviewed:true,anonymous_direct_table_dml_for_booking_requests:false,booking_abuse_guard_trigger_present:true,public_catalog_is_bounded:true,public_slots_are_bounded:true,public_order_status_uses_unguessable_uuid_token:true}}};
+
+test('exact fresh technical evidence promotes only runtime monitoring and security',()=>{
+  const {evidence,report}=mergeTechnicalEvidence(base,review,{now:NOW});
+  assert.equal(report.runtime_monitoring.valid,true);
+  assert.equal(report.critical_security.valid,true);
+  assert.equal(evidence.monitoring.runtime_errors_checked,true);
+  assert.equal(evidence.monitoring.runtime_errors.matching_logs,0);
+  assert.equal(evidence.monitoring.alert_delivery_verified,false);
+  assert.equal(evidence.critical_gates.security,'PASS');
+  assert.equal(evidence.critical_gates.financial,null);
+  assert.equal(evidence.critical_gates.legal,null);
+});
+
+test('stale monitoring and security review fail closed',()=>{
+  const {evidence,report}=mergeTechnicalEvidence(base,review,{now:Date.parse('2026-09-04T12:40:00.000Z')});
+  assert.equal(report.runtime_monitoring.valid,false);
+  assert.equal(report.critical_security.valid,false);
+  assert.equal(evidence.monitoring.runtime_errors_checked,false);
+  assert.equal(evidence.critical_gates.security,null);
+});
+
+test('wrong release identity cannot inherit a prior technical PASS',()=>{
+  const wrong={...base,expected_main_sha:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',production_deployment:{...base.production_deployment,id:'dpl_other',source_commit:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}};
+  const {evidence}=mergeTechnicalEvidence(wrong,review,{now:NOW});
+  assert.equal(evidence.monitoring.runtime_errors_checked,false);
+  assert.equal(evidence.critical_gates.security,null);
+});
+
+test('security PASS requires all reviewed public-definer warnings and safety assertions',()=>{
+  const unsafe=structuredClone(review);
+  unsafe.security.review_basis.booking_abuse_guard_trigger_present=false;
+  unsafe.security.reviewed_warnings.pop();
+  const {evidence}=mergeTechnicalEvidence(base,unsafe,{now:NOW});
+  assert.equal(evidence.critical_gates.security,null);
+});
+
+test('BAR-12 workflow imports technical evidence before evaluation and keeps external gates fail closed',()=>{
+  const workflow=fs.readFileSync(new URL('../.github/workflows/dabbir-bar12-readiness.yml',import.meta.url),'utf8');
+  const mergeAt=workflow.indexOf('Merge verified technical readiness evidence');
+  const evaluateAt=workflow.indexOf('Evaluate BAR-12 readiness');
+  assert.ok(mergeAt>0&&evaluateAt>mergeAt);
+  assert.match(workflow,/\.github\/scripts\/dabbir-bar12-technical-evidence\.mjs/);
+  assert.match(workflow,/docs\/evidence\/dabbir-bar12-technical-review\.json/);
+  assert.match(workflow,/real_external_connection:false/);
+  assert.match(workflow,/alert_delivery_verified:false/);
+  assert.match(workflow,/financial:null/);
+  assert.match(workflow,/legal:null/);
+});


### PR DESCRIPTION
Evidence-only BAR-12 closeout for two technical blockers.

- Binds a 24-hour Vercel runtime-log review to exact Production SHA/deployment; zero warning/error/fatal entries were found for the exact artifact.
- Binds a fresh Supabase Mumbai Security Advisor review to the same runtime. No blocking ERROR findings were found; four intentional public SECURITY DEFINER warnings were reviewed against live definitions, grants, UUID scoping, bounded outputs, and the booking abuse-guard trigger.
- Adds fail-closed merger logic: stale evidence or SHA/deployment drift removes PASS automatically.
- Does not promote alert delivery, financial, legal, or any real external WhatsApp gate.
- Adds regression coverage and includes the review/merge report in BAR-12 artifacts.