### PR TITLE
Verify BAR-12 owner alert delivery

### DIFF
--- a/.github/scripts/dabbir-bar12-technical-evidence.mjs
+++ b/.github/scripts/dabbir-bar12-technical-evidence.mjs
@@ -5,6 +5,7 @@ const EVIDENCE_PATH=process.env.DABBIR_READINESS_EVIDENCE_PATH||'dabbir-bar12-li
 const REVIEW_PATH=process.env.DABBIR_BAR12_TECHNICAL_REVIEW_PATH||'docs/evidence/dabbir-bar12-technical-review.json';
 const MERGE_REPORT_PATH=process.env.DABBIR_BAR12_TECHNICAL_MERGE_PATH||'dabbir-bar12-technical-evidence-merge.json';
 const EXPECTED_PROJECT_REF='fphpoysqdsceniwduxjq';
+const EXPECTED_ALERT_CHANNEL='C0BRQQER3UH';
 const MAX_AGE_MS=24*60*60*1000;
 
 function readJson(path){return JSON.parse(fs.readFileSync(path,'utf8'))}
@@ -17,6 +18,7 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
   const expectedSha=String(evidence.expected_main_sha||'').trim();
   const deploymentId=String(deployment.id||'').trim();
   const monitoring=review?.runtime_monitoring||{};
+  const alert=review?.alert_delivery||{};
   const security=review?.security||{};
 
   const monitoringValid=
@@ -30,6 +32,25 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
     exactLevels(monitoring.levels_checked)&&
     fresh(monitoring.checked_at,now);
 
+  const alertLink=String(alert.message_link||'');
+  const alertTs=String(alert.message_ts||'');
+  const alertValid=
+    review?.schema_version==='dabbir_bar12_technical_review_v1'&&
+    Boolean(expectedSha)&&Boolean(deploymentId)&&
+    String(alert.source_commit||'')===expectedSha&&
+    String(alert.deployment_id||'')===deploymentId&&
+    String(alert.origin||'')==='https://dabbir.bmalman.com'&&
+    String(alert.provider||'')==='Slack'&&
+    String(alert.delivery_mode||'')==='BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL'&&
+    String(alert.channel_id||'')===EXPECTED_ALERT_CHANNEL&&
+    String(alert.channel_name||'')==='barman-executive-alerts'&&
+    /^\d{10,}\.\d{6}$/.test(alertTs)&&
+    alertLink.startsWith(`https://barman-global.slack.com/archives/${EXPECTED_ALERT_CHANNEL}/p`)&&
+    alert.readback_verified===true&&
+    alert.test_only===true&&
+    alert.contains_secrets_or_customer_data===false&&
+    fresh(alert.verified_at,now);
+
   evidence.monitoring={
     ...(evidence.monitoring||{}),
     runtime_errors_checked:monitoringValid,
@@ -41,6 +62,20 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
       levels_checked:['warning','error','fatal'],
       matching_logs:0,
       provider:String(monitoring.provider||'Vercel Runtime Logs'),
+    }:null,
+    alert_delivery_verified:alertValid,
+    alert_delivery:alertValid?{
+      source_commit:expectedSha,
+      deployment_id:deploymentId,
+      verified_at:alert.verified_at,
+      provider:'Slack',
+      delivery_mode:alert.delivery_mode,
+      channel_id:EXPECTED_ALERT_CHANNEL,
+      channel_name:'barman-executive-alerts',
+      message_ts:alertTs,
+      message_link:alertLink,
+      readback_verified:true,
+      test_only:true,
     }:null,
   };
 
@@ -83,8 +118,9 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
       expected_main_sha:expectedSha||null,
       deployment_id:deploymentId||null,
       runtime_monitoring:{valid:monitoringValid,reviewed_at:monitoring.checked_at||null},
+      alert_delivery:{valid:alertValid,verified_at:alert.verified_at||null,provider:alert.provider||null,channel_id:alert.channel_id||null,message_ts:alert.message_ts||null},
       critical_security:{valid:securityValid,reviewed_at:security.reviewed_at||null,project_ref:security.project_ref||null},
-      intentionally_unpromoted:{alert_delivery:true,financial:true,legal:true},
+      intentionally_unpromoted:{financial:true,legal:true,real_external_whatsapp:true},
     },
   };
 }
@@ -96,8 +132,9 @@ export function run(){
   fs.writeFileSync(EVIDENCE_PATH,JSON.stringify(merged.evidence,null,2));
   fs.writeFileSync(MERGE_REPORT_PATH,JSON.stringify(merged.report,null,2));
   if(!merged.report.runtime_monitoring.valid)throw new Error('BAR12_RUNTIME_MONITORING_REVIEW_INVALID_OR_STALE');
+  if(!merged.report.alert_delivery.valid)throw new Error('BAR12_ALERT_DELIVERY_REVIEW_INVALID_OR_STALE');
   if(!merged.report.critical_security.valid)throw new Error('BAR12_CRITICAL_SECURITY_REVIEW_INVALID_OR_STALE');
-  console.log(`BAR12_TECHNICAL_EVIDENCE_MERGED runtime_monitoring=PASS critical_security=PASS sha=${merged.report.expected_main_sha}`);
+  console.log(`BAR12_TECHNICAL_EVIDENCE_MERGED runtime_monitoring=PASS alert_delivery=PASS critical_security=PASS sha=${merged.report.expected_main_sha}`);
   return merged;
 }
 

--- a/docs/evidence/dabbir-bar12-technical-review.json
+++ b/docs/evidence/dabbir-bar12-technical-review.json
@@ -10,6 +10,22 @@
     "levels_checked": ["warning", "error", "fatal"],
     "matching_logs": 0
   },
+  "alert_delivery": {
+    "source_commit": "e5da322e56fc4903b5ee937e8a49686dc2d1de07",
+    "deployment_id": "dpl_A6cqCH6bW9ch9iDgye2FpKGCeEnQ",
+    "origin": "https://dabbir.bmalman.com",
+    "verified_at": "2026-09-02T12:49:28.186Z",
+    "provider": "Slack",
+    "delivery_mode": "BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL",
+    "channel_id": "C0BRQQER3UH",
+    "channel_name": "barman-executive-alerts",
+    "message_ts": "1788353368.186149",
+    "message_link": "https://barman-global.slack.com/archives/C0BRQQER3UH/p1788353368186149",
+    "readback_verified": true,
+    "test_only": true,
+    "contains_secrets_or_customer_data": false,
+    "notes": "A BAR-12 test alert containing only public release identity was delivered to the reserved owner-level operational alert channel and then read back from Slack with the same message timestamp. The channel is explicitly reserved for verified operational incidents, hard-gate failures, security events, and owner-level escalations."
+  },
   "security": {
     "source_commit": "e5da322e56fc4903b5ee937e8a49686dc2d1de07",
     "project_ref": "fphpoysqdsceniwduxjq",

--- a/test/dabbir-bar12-technical-evidence.test.mjs
+++ b/test/dabbir-bar12-technical-evidence.test.mjs
@@ -5,35 +5,56 @@ import { mergeTechnicalEvidence } from '../.github/scripts/dabbir-bar12-technica
 
 const SHA='e5da322e56fc4903b5ee937e8a49686dc2d1de07';
 const DEPLOY='dpl_A6cqCH6bW9ch9iDgye2FpKGCeEnQ';
-const NOW=Date.parse('2026-09-02T12:40:00.000Z');
+const NOW=Date.parse('2026-09-02T12:50:00.000Z');
 const base={expected_main_sha:SHA,production_deployment:{id:DEPLOY,state:'READY',source_commit:SHA},monitoring:{runtime_errors_checked:false,alert_delivery_verified:false},critical_gates:{security:null,financial:null,legal:null}};
-const review={schema_version:'dabbir_bar12_technical_review_v1',runtime_monitoring:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',checked_at:'2026-09-02T12:38:19.980Z',window_hours:24,provider:'Vercel Runtime Logs',levels_checked:['warning','error','fatal'],matching_logs:0},security:{source_commit:SHA,project_ref:'fphpoysqdsceniwduxjq',reviewed_at:'2026-09-02T12:38:59.130Z',verdict:'PASS',blocking_findings:0,advisor_max_level:'WARN',reviewed_warnings:['public.dabbir_public_car_wash_book','public.dabbir_public_car_wash_catalog','public.dabbir_public_car_wash_slots','public.dabbir_public_order_status'],review_basis:{security_advisor_rerun:true,public_definer_functions_reviewed:true,anonymous_direct_table_dml_for_booking_requests:false,booking_abuse_guard_trigger_present:true,public_catalog_is_bounded:true,public_slots_are_bounded:true,public_order_status_uses_unguessable_uuid_token:true}}};
+const review={schema_version:'dabbir_bar12_technical_review_v1',runtime_monitoring:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',checked_at:'2026-09-02T12:38:19.980Z',window_hours:24,provider:'Vercel Runtime Logs',levels_checked:['warning','error','fatal'],matching_logs:0},alert_delivery:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',verified_at:'2026-09-02T12:49:28.186Z',provider:'Slack',delivery_mode:'BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL',channel_id:'C0BRQQER3UH',channel_name:'barman-executive-alerts',message_ts:'1788353368.186149',message_link:'https://barman-global.slack.com/archives/C0BRQQER3UH/p1788353368186149',readback_verified:true,test_only:true,contains_secrets_or_customer_data:false},security:{source_commit:SHA,project_ref:'fphpoysqdsceniwduxjq',reviewed_at:'2026-09-02T12:38:59.130Z',verdict:'PASS',blocking_findings:0,advisor_max_level:'WARN',reviewed_warnings:['public.dabbir_public_car_wash_book','public.dabbir_public_car_wash_catalog','public.dabbir_public_car_wash_slots','public.dabbir_public_order_status'],review_basis:{security_advisor_rerun:true,public_definer_functions_reviewed:true,anonymous_direct_table_dml_for_booking_requests:false,booking_abuse_guard_trigger_present:true,public_catalog_is_bounded:true,public_slots_are_bounded:true,public_order_status_uses_unguessable_uuid_token:true}}};
 
-test('exact fresh technical evidence promotes only runtime monitoring and security',()=>{
+test('exact fresh technical evidence promotes runtime monitoring, owner alert delivery and security only',()=>{
   const {evidence,report}=mergeTechnicalEvidence(base,review,{now:NOW});
   assert.equal(report.runtime_monitoring.valid,true);
+  assert.equal(report.alert_delivery.valid,true);
   assert.equal(report.critical_security.valid,true);
   assert.equal(evidence.monitoring.runtime_errors_checked,true);
   assert.equal(evidence.monitoring.runtime_errors.matching_logs,0);
-  assert.equal(evidence.monitoring.alert_delivery_verified,false);
+  assert.equal(evidence.monitoring.alert_delivery_verified,true);
+  assert.equal(evidence.monitoring.alert_delivery.channel_id,'C0BRQQER3UH');
+  assert.equal(evidence.monitoring.alert_delivery.message_ts,'1788353368.186149');
   assert.equal(evidence.critical_gates.security,'PASS');
   assert.equal(evidence.critical_gates.financial,null);
   assert.equal(evidence.critical_gates.legal,null);
 });
 
-test('stale monitoring and security review fail closed',()=>{
-  const {evidence,report}=mergeTechnicalEvidence(base,review,{now:Date.parse('2026-09-04T12:40:00.000Z')});
+test('stale technical review fails closed for monitoring, alerting and security',()=>{
+  const {evidence,report}=mergeTechnicalEvidence(base,review,{now:Date.parse('2026-09-04T12:50:00.000Z')});
   assert.equal(report.runtime_monitoring.valid,false);
+  assert.equal(report.alert_delivery.valid,false);
   assert.equal(report.critical_security.valid,false);
   assert.equal(evidence.monitoring.runtime_errors_checked,false);
+  assert.equal(evidence.monitoring.alert_delivery_verified,false);
   assert.equal(evidence.critical_gates.security,null);
 });
 
-test('wrong release identity cannot inherit a prior technical PASS',()=>{
+test('wrong release identity cannot inherit a prior technical or alert PASS',()=>{
   const wrong={...base,expected_main_sha:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',production_deployment:{...base.production_deployment,id:'dpl_other',source_commit:'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'}};
   const {evidence}=mergeTechnicalEvidence(wrong,review,{now:NOW});
   assert.equal(evidence.monitoring.runtime_errors_checked,false);
+  assert.equal(evidence.monitoring.alert_delivery_verified,false);
   assert.equal(evidence.critical_gates.security,null);
+});
+
+test('alert PASS requires the reserved Slack channel, readback, safe payload and a real message identity',()=>{
+  for(const mutate of [
+    x=>{x.alert_delivery.channel_id='C_OTHER'},
+    x=>{x.alert_delivery.readback_verified=false},
+    x=>{x.alert_delivery.contains_secrets_or_customer_data=true},
+    x=>{x.alert_delivery.message_ts='not-a-message'},
+    x=>{x.alert_delivery.message_link='https://example.com/fake'},
+  ]){
+    const unsafe=structuredClone(review); mutate(unsafe);
+    const {evidence,report}=mergeTechnicalEvidence(base,unsafe,{now:NOW});
+    assert.equal(report.alert_delivery.valid,false);
+    assert.equal(evidence.monitoring.alert_delivery_verified,false);
+  }
 });
 
 test('security PASS requires all reviewed public-definer warnings and safety assertions',()=>{
@@ -44,7 +65,7 @@ test('security PASS requires all reviewed public-definer warnings and safety ass
   assert.equal(evidence.critical_gates.security,null);
 });
 
-test('BAR-12 workflow imports technical evidence before evaluation and keeps external gates fail closed',()=>{
+test('BAR-12 workflow imports technical evidence before evaluation and keeps external WhatsApp/financial/legal fail closed',()=>{
   const workflow=fs.readFileSync(new URL('../.github/workflows/dabbir-bar12-readiness.yml',import.meta.url),'utf8');
   const mergeAt=workflow.indexOf('Merge verified technical readiness evidence');
   const evaluateAt=workflow.indexOf('Evaluate BAR-12 readiness');
@@ -52,7 +73,6 @@ test('BAR-12 workflow imports technical evidence before evaluation and keeps ext
   assert.match(workflow,/\.github\/scripts\/dabbir-bar12-technical-evidence\.mjs/);
   assert.match(workflow,/docs\/evidence\/dabbir-bar12-technical-review\.json/);
   assert.match(workflow,/real_external_connection:false/);
-  assert.match(workflow,/alert_delivery_verified:false/);
   assert.match(workflow,/financial:null/);
   assert.match(workflow,/legal:null/);
 });


### PR DESCRIPTION
Close the BAR-12 alerting blocker with real delivery evidence, without promoting any external product gate.

- Delivered a test operational alert to the reserved private Slack channel #barman-executive-alerts and read it back with the same message timestamp.
- Evidence contains only public release identity; no secrets or customer data.
- Binds the alert to exact DABBIR Production SHA/deployment and expires after 24 hours.
- Fail-closed validation requires the exact reserved channel, Slack permalink, message identity, readback=true, safe payload, and release identity.
- Financial, legal, and real external WhatsApp remain unpromoted.
- Adds regression coverage for stale/tampered/wrong-release alert evidence.