### PR TITLE
P0: enforce release, database and merge discipline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,13 +7,17 @@ on:
 
 permissions:
   contents: read
+  actions: read
+  pull-requests: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 55
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
       - uses: actions/setup-node@v7
         with:
           node-version-file: package.json
@@ -24,6 +28,11 @@ jobs:
         run: npm run check:syntax
       - name: Audit production dependencies
         run: npm run audit:prod
+      - name: Enforce Production database change discipline
+        env:
+          DABBIR_DB_GATE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          DABBIR_DB_GATE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: node scripts/dabbir-production-db-change-gate.mjs
       - name: Run DABBIR tests
         run: npm test
       - name: Reject committed secrets
@@ -35,3 +44,8 @@ jobs:
             exit 1
           fi
           echo 'Committed-source secret pattern scan PASS'
+      - name: Require terminal mobile release gates before merge
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/dabbir-required-pr-gates.mjs

--- a/.github/workflows/dabbir-ios-maestro.yml
+++ b/.github/workflows/dabbir-ios-maestro.yml
@@ -1,4 +1,5 @@
 name: DABBIR iOS Maestro Smoke
+# BAR-39 invariant probe: the protected `test` context must remain pending until this workflow is terminal SUCCESS when required.
 
 on:
   pull_request:

--- a/.github/workflows/dabbir-mobile-ci.yml
+++ b/.github/workflows/dabbir-mobile-ci.yml
@@ -1,4 +1,5 @@
 name: DABBIR Mobile CI
+# BAR-39 invariant probe: the protected `test` context must not finish before this workflow when this file changes.
 
 on:
   pull_request:

--- a/scripts/dabbir-production-db-change-gate.mjs
+++ b/scripts/dabbir-production-db-change-gate.mjs
@@ -1,0 +1,79 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
+
+const clean=value=>String(value??'').trim();
+const MIGRATION=/^supabase\/migrations\/(\d{14})_([a-z0-9_]+)\.sql$/;
+const TEST=/^test\/.*\.test\.mjs$/;
+const DB_SCHEMA=/^db\/.*\.sql$/;
+
+export function validateMigrationContent(relativePath,content){
+  const errors=[];
+  if(!MIGRATION.test(relativePath))errors.push(`MIGRATION_FILENAME_INVALID:${relativePath}`);
+  const source=String(content||'');
+  if(/^\s*(begin|commit|rollback)\s*;/im.test(source))errors.push(`MIGRATION_TRANSACTION_CONTROL_FORBIDDEN:${relativePath}`);
+  const destructive=/\b(drop\s+table|drop\s+schema|truncate\s+(?:table\s+)?|alter\s+table[\s\S]{0,240}?\bdrop\s+column)\b/i.test(source);
+  if(destructive&&!/--\s*DABBIR-DESTRUCTIVE-MIGRATION-REVIEWED:\s*\S+/i.test(source))errors.push(`DESTRUCTIVE_MIGRATION_REVIEW_MARKER_REQUIRED:${relativePath}`);
+  if(/security\s+definer/i.test(source)){
+    if(!/set\s+search_path\s*(?:=|to)/i.test(source))errors.push(`SECURITY_DEFINER_SEARCH_PATH_REQUIRED:${relativePath}`);
+    if(!/revoke\s+all\s+on\s+function/i.test(source))errors.push(`SECURITY_DEFINER_REVOKE_REQUIRED:${relativePath}`);
+  }
+  return errors;
+}
+
+export function evaluateChangeSet(paths,{readFile=file=>fs.readFileSync(file,'utf8'),exists=file=>fs.existsSync(file)}={}){
+  const changed=[...new Set((paths||[]).map(clean).filter(Boolean))];
+  const migrations=changed.filter(file=>file.startsWith('supabase/migrations/')&&file.endsWith('.sql'));
+  const schemaChanges=changed.filter(file=>DB_SCHEMA.test(file));
+  const tests=changed.filter(file=>TEST.test(file));
+  const errors=[];
+
+  if(schemaChanges.length>0&&migrations.length===0)errors.push(`DB_SCHEMA_CHANGE_REQUIRES_MIGRATION:${schemaChanges.join(',')}`);
+  if(migrations.length>0&&tests.length===0)errors.push('MIGRATION_REQUIRES_REGRESSION_TEST');
+
+  for(const migration of migrations){
+    if(!exists(migration)){
+      errors.push(`MIGRATION_DELETE_OR_MISSING_FORBIDDEN:${migration}`);
+      continue;
+    }
+    errors.push(...validateMigrationContent(migration,readFile(migration)));
+  }
+  return {ok:errors.length===0,errors,migrations,schemaChanges,tests};
+}
+
+function git(...args){return execFileSync('git',args,{encoding:'utf8'}).trim()}
+function eventIdentity(env){
+  const eventPath=clean(env.GITHUB_EVENT_PATH);
+  let event={};
+  if(eventPath&&fs.existsSync(eventPath))event=JSON.parse(fs.readFileSync(eventPath,'utf8'));
+  const base=clean(env.DABBIR_DB_GATE_BASE_SHA||event?.pull_request?.base?.sha||event?.before);
+  const head=clean(env.DABBIR_DB_GATE_HEAD_SHA||event?.pull_request?.head?.sha||env.GITHUB_SHA||'HEAD');
+  return {base,head};
+}
+function changedPaths(env){
+  const supplied=clean(env.DABBIR_CHANGED_PATHS);
+  if(supplied)return supplied.split(/\r?\n/).map(clean).filter(Boolean);
+  let {base,head}=eventIdentity(env);
+  if(!base||/^0+$/.test(base)){
+    try{base=git('rev-parse',`${head}^`)}catch{base=''}
+  }
+  if(!base)throw new Error('DB_GATE_BASE_SHA_UNAVAILABLE');
+  try{return git('diff','--name-only',`${base}...${head}`,'--').split(/\r?\n/).filter(Boolean)}
+  catch{return git('diff','--name-only',base,head,'--').split(/\r?\n/).filter(Boolean)}
+}
+
+export function run({env=process.env}={}){
+  const paths=changedPaths(env);
+  const result=evaluateChangeSet(paths);
+  if(!result.ok){
+    for(const error of result.errors)console.error(`DABBIR_DB_CHANGE_GATE_FAIL ${error}`);
+    throw new Error(`DABBIR_PRODUCTION_DB_CHANGE_DISCIPLINE_FAILED:${result.errors.length}`);
+  }
+  console.log(`DABBIR_DB_CHANGE_GATE_PASS migrations=${result.migrations.length} schema_changes=${result.schemaChanges.length} tests=${result.tests.length}`);
+  return result;
+}
+
+const invoked=process.argv[1]?path.resolve(process.argv[1]):'';
+if(invoked&&path.resolve(new URL(import.meta.url).pathname)===invoked){
+  try{run()}catch(error){console.error(error?.stack||error);process.exitCode=1}
+}

--- a/scripts/dabbir-required-pr-gates.mjs
+++ b/scripts/dabbir-required-pr-gates.mjs
@@ -1,0 +1,120 @@
+import fs from 'node:fs';
+
+const DEFAULT_POLL_MS=15_000;
+const DEFAULT_TIMEOUT_MS=45*60_000;
+
+const clean=value=>String(value??'').trim();
+
+export function classifyChangedPaths(paths=[]){
+  let mobileCi=false;
+  let maestro=false;
+  for(const raw of paths){
+    const path=clean(raw);
+    if(!path)continue;
+    if(
+      path.startsWith('mobile/')||
+      path.startsWith('api/mobile/')||
+      path==='api/_apple-iap-core.js'||
+      path.startsWith('api/apple/')||
+      (/^supabase\/migrations\/.*dabbir_apple.*\.sql$/.test(path))||
+      (/^supabase\/migrations\/.*dabbir_.*account_deletion.*\.sql$/.test(path))||
+      path==='scripts/dabbir-app-store-preflight.mjs'||
+      path==='test/dabbir-app-store-preflight.test.mjs'||
+      ['privacy.html','terms.html','support.html','vercel.json','.github/workflows/dabbir-mobile-ci.yml'].includes(path)
+    ) mobileCi=true;
+    if(path.startsWith('mobile/')||path==='.github/workflows/dabbir-ios-maestro.yml')maestro=true;
+  }
+  return {mobileCi,maestro};
+}
+
+async function githubJson(url,token){
+  const response=await fetch(url,{
+    headers:{
+      accept:'application/vnd.github+json',
+      authorization:`Bearer ${token}`,
+      'x-github-api-version':'2022-11-28',
+    },
+  });
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok)throw new Error(`GITHUB_API_${response.status}:${payload?.message||text.slice(0,160)}`);
+  return payload;
+}
+
+async function pullRequestFiles({repository,number,token}){
+  const out=[];
+  for(let page=1;page<=10;page+=1){
+    const rows=await githubJson(`https://api.github.com/repos/${repository}/pulls/${number}/files?per_page=100&page=${page}`,token);
+    if(!Array.isArray(rows))throw new Error('GITHUB_PR_FILES_INVALID');
+    out.push(...rows.map(row=>clean(row?.filename)).filter(Boolean));
+    if(rows.length<100)break;
+  }
+  return out;
+}
+
+function matchingRun(runs,{workflowName,headSha,prNumber}){
+  return (Array.isArray(runs)?runs:[])
+    .filter(run=>clean(run?.name)===workflowName)
+    .filter(run=>clean(run?.head_sha).toLowerCase()===headSha.toLowerCase())
+    .filter(run=>Array.isArray(run?.pull_requests)&&run.pull_requests.some(pr=>Number(pr?.number)===Number(prNumber)))
+    .sort((a,b)=>Number(b?.run_number||0)-Number(a?.run_number||0))[0]||null;
+}
+
+async function waitForWorkflow({repository,token,headRef,headSha,prNumber,workflowName,pollMs,timeoutMs}){
+  const deadline=Date.now()+timeoutMs;
+  while(Date.now()<deadline){
+    const data=await githubJson(`https://api.github.com/repos/${repository}/actions/runs?event=pull_request&branch=${encodeURIComponent(headRef)}&per_page=100`,token);
+    const run=matchingRun(data?.workflow_runs,{workflowName,headSha,prNumber});
+    if(!run){
+      console.log(`DABBIR_REQUIRED_GATE_WAIT workflow=${workflowName} state=NOT_STARTED sha=${headSha}`);
+    }else if(clean(run.status)==='completed'){
+      const conclusion=clean(run.conclusion).toLowerCase();
+      if(conclusion!=='success')throw new Error(`DABBIR_REQUIRED_GATE_FAILED:${workflowName}:${conclusion||'UNKNOWN'}:run=${run.id}`);
+      console.log(`DABBIR_REQUIRED_GATE_PASS workflow=${workflowName} run=${run.id} sha=${headSha}`);
+      return run;
+    }else{
+      console.log(`DABBIR_REQUIRED_GATE_WAIT workflow=${workflowName} state=${clean(run.status)||'UNKNOWN'} run=${run.id}`);
+    }
+    await new Promise(resolve=>setTimeout(resolve,pollMs));
+  }
+  throw new Error(`DABBIR_REQUIRED_GATE_TIMEOUT:${workflowName}:${headSha}`);
+}
+
+export async function run({env=process.env}={}){
+  if(clean(env.GITHUB_EVENT_NAME)!=='pull_request'){
+    console.log('DABBIR_REQUIRED_PR_GATES_SKIP reason=NOT_PULL_REQUEST');
+    return {required:[]};
+  }
+  const token=clean(env.GITHUB_TOKEN);
+  const repository=clean(env.GITHUB_REPOSITORY);
+  const eventPath=clean(env.GITHUB_EVENT_PATH);
+  if(!token||!repository||!eventPath)throw new Error('DABBIR_REQUIRED_GATE_ENV_MISSING');
+  const event=JSON.parse(fs.readFileSync(eventPath,'utf8'));
+  const prNumber=Number(event?.pull_request?.number||event?.number||0);
+  const headSha=clean(event?.pull_request?.head?.sha);
+  const headRef=clean(event?.pull_request?.head?.ref);
+  if(!prNumber||!headSha||!headRef)throw new Error('DABBIR_REQUIRED_GATE_PR_IDENTITY_MISSING');
+
+  const paths=await pullRequestFiles({repository,number:prNumber,token});
+  const classification=classifyChangedPaths(paths);
+  const required=[];
+  if(classification.mobileCi)required.push('DABBIR Mobile CI');
+  if(classification.maestro)required.push('DABBIR iOS Maestro Smoke');
+  if(required.length===0){
+    console.log(`DABBIR_REQUIRED_PR_GATES_PASS sha=${headSha} required=none`);
+    return {required,paths};
+  }
+
+  const pollMs=Math.max(1_000,Number(env.DABBIR_GATE_POLL_MS||DEFAULT_POLL_MS));
+  const timeoutMs=Math.max(60_000,Number(env.DABBIR_GATE_TIMEOUT_MS||DEFAULT_TIMEOUT_MS));
+  for(const workflowName of required){
+    await waitForWorkflow({repository,token,headRef,headSha,prNumber,workflowName,pollMs,timeoutMs});
+  }
+  console.log(`DABBIR_REQUIRED_PR_GATES_PASS sha=${headSha} required=${required.join(',')}`);
+  return {required,paths};
+}
+
+if(import.meta.url===new URL(`file://${process.argv[1]}`).href){
+  run().catch(error=>{console.error(error?.stack||error);process.exitCode=1});
+}

--- a/test/dabbir-bar12-production-classification.test.mjs
+++ b/test/dabbir-bar12-production-classification.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const sourceScript=path.resolve('vercel-ignore-if-unaffected.sh');
+function git(cwd,...args){return execFileSync('git',args,{cwd,encoding:'utf8'}).trim()}
+function setup(){
+  const dir=fs.mkdtempSync(path.join(os.tmpdir(),'dabbir-bar12-vercel-'));
+  git(dir,'init','-q');
+  git(dir,'config','user.email','ci@example.invalid');
+  git(dir,'config','user.name','DABBIR CI');
+  fs.copyFileSync(sourceScript,path.join(dir,'vercel-ignore-if-unaffected.sh'));
+  fs.writeFileSync(path.join(dir,'README.md'),'base\n');
+  git(dir,'add','.');git(dir,'commit','-qm','base');
+  return dir;
+}
+function change(dir,relativePath){
+  const target=path.join(dir,relativePath);
+  fs.mkdirSync(path.dirname(target),{recursive:true});
+  fs.writeFileSync(target,relativePath.endsWith('.json')?'{}\n':relativePath.endsWith('.yml')?'name: test\n':'export {};\n');
+  git(dir,'add','.');git(dir,'commit','-qm',`change ${relativePath}`);
+  return git(dir,'rev-parse','HEAD');
+}
+function run(dir,head,base){
+  return spawnSync('bash',['vercel-ignore-if-unaffected.sh'],{
+    cwd:dir,
+    env:{...process.env,VERCEL_GIT_COMMIT_SHA:head,VERCEL_GIT_PREVIOUS_SHA:base,VERCEL_GIT_COMMIT_REF:'main'},
+    encoding:'utf8',
+  });
+}
+
+test('BAR-12 and release evidence contracts always advance the exact Production SHA',()=>{
+  const paths=[
+    '.github/workflows/dabbir-bar12-readiness.yml',
+    '.github/scripts/dabbir-bar12-technical-evidence.mjs',
+    '.github/scripts/dabbir-bar12-alert-evidence.mjs',
+    'scripts/dabbir-readiness-gate.mjs',
+    'test/dabbir-bar12-technical-evidence.test.mjs',
+    'docs/evidence/dabbir-bar12-technical-review.json',
+    'docs/evidence/dabbir-bar12-alert-delivery.json',
+    'config/barman-integration-contract.json',
+    'config/dabbir-release-policy.json',
+  ];
+  for(const relativePath of paths){
+    const dir=setup();
+    const base=git(dir,'rev-parse','HEAD');
+    const head=change(dir,relativePath);
+    const result=run(dir,head,base);
+    assert.equal(result.status,1,`${relativePath}: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout,/Exact-SHA Production verification contract changed|Runtime or unknown path changed/);
+  }
+});

--- a/test/dabbir-production-db-change-gate.test.mjs
+++ b/test/dabbir-production-db-change-gate.test.mjs
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { evaluateChangeSet, validateMigrationContent } from '../scripts/dabbir-production-db-change-gate.mjs';
+
+const safeMigration=`alter table public.dabbir_orders add column if not exists external_ref text;\n`;
+
+test('safe migration with regression test passes',()=>{
+  const files=new Map([
+    ['supabase/migrations/20260902160000_dabbir_external_ref.sql',safeMigration],
+    ['test/dabbir-external-ref.test.mjs','export {};\n'],
+  ]);
+  const result=evaluateChangeSet([...files.keys()],{
+    exists:file=>files.has(file),
+    readFile:file=>files.get(file),
+  });
+  assert.equal(result.ok,true,result.errors.join('\n'));
+});
+
+test('db schema edits require a matching migration',()=>{
+  const result=evaluateChangeSet(['db/schema.sql','test/schema.test.mjs'],{exists:()=>true,readFile:()=>''});
+  assert.equal(result.ok,false);
+  assert(result.errors.some(error=>error.startsWith('DB_SCHEMA_CHANGE_REQUIRES_MIGRATION:')));
+});
+
+test('migrations require a regression test in the same change set',()=>{
+  const files=new Map([['supabase/migrations/20260902160000_dabbir_external_ref.sql',safeMigration]]);
+  const result=evaluateChangeSet([...files.keys()],{exists:file=>files.has(file),readFile:file=>files.get(file)});
+  assert.equal(result.ok,false);
+  assert(result.errors.includes('MIGRATION_REQUIRES_REGRESSION_TEST'));
+});
+
+test('nested transaction control is forbidden in new migrations',()=>{
+  const errors=validateMigrationContent('supabase/migrations/20260902160000_bad.sql','begin;\nselect 1;\ncommit;\n');
+  assert(errors.some(error=>error.startsWith('MIGRATION_TRANSACTION_CONTROL_FORBIDDEN:')));
+});
+
+test('destructive migrations require an explicit reviewed marker',()=>{
+  const path='supabase/migrations/20260902160000_drop_old.sql';
+  assert(validateMigrationContent(path,'drop table public.old_data;\n').some(error=>error.startsWith('DESTRUCTIVE_MIGRATION_REVIEW_MARKER_REQUIRED:')));
+  assert.equal(validateMigrationContent(path,'-- DABBIR-DESTRUCTIVE-MIGRATION-REVIEWED: BAR-999\ndrop table public.old_data;\n').length,0);
+});
+
+test('security definer migrations require fixed search_path and revoke',()=>{
+  const path='supabase/migrations/20260902160000_rpc.sql';
+  const unsafe='create function public.x() returns int language sql security definer as $$ select 1 $$;\n';
+  const errors=validateMigrationContent(path,unsafe);
+  assert(errors.some(error=>error.startsWith('SECURITY_DEFINER_SEARCH_PATH_REQUIRED:')));
+  assert(errors.some(error=>error.startsWith('SECURITY_DEFINER_REVOKE_REQUIRED:')));
+  const safe='create function public.x() returns int language sql security definer set search_path=pg_catalog,public as $$ select 1 $$;\nrevoke all on function public.x() from public,anon,authenticated;\n';
+  assert.equal(validateMigrationContent(path,safe).length,0);
+});
+
+test('migration deletion is fail-closed',()=>{
+  const result=evaluateChangeSet(['supabase/migrations/20260902160000_missing.sql','test/migration.test.mjs'],{exists:()=>false,readFile:()=>''});
+  assert.equal(result.ok,false);
+  assert(result.errors.some(error=>error.startsWith('MIGRATION_DELETE_OR_MISSING_FORBIDDEN:')));
+});

--- a/test/dabbir-required-pr-gates.test.mjs
+++ b/test/dabbir-required-pr-gates.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { classifyChangedPaths } from '../scripts/dabbir-required-pr-gates.mjs';
+
+test('ordinary web changes do not require mobile release gates',()=>{
+  assert.deepEqual(classifyChangedPaths(['api/app.js','index.html']),{mobileCi:false,maestro:false});
+});
+
+test('mobile source changes require both Mobile CI and Maestro',()=>{
+  assert.deepEqual(classifyChangedPaths(['mobile/src/App.tsx']),{mobileCi:true,maestro:true});
+});
+
+test('App Store-sensitive backend changes require Mobile CI but not Maestro',()=>{
+  const paths=['api/_apple-iap-core.js','privacy.html','supabase/migrations/20260902150000_dabbir_apple_receipts.sql'];
+  assert.deepEqual(classifyChangedPaths(paths),{mobileCi:true,maestro:false});
+});
+
+test('Maestro workflow changes cannot bypass Maestro itself',()=>{
+  assert.deepEqual(classifyChangedPaths(['.github/workflows/dabbir-ios-maestro.yml']),{mobileCi:false,maestro:true});
+});
+
+test('Mobile CI workflow changes require the Mobile CI gate',()=>{
+  assert.deepEqual(classifyChangedPaths(['.github/workflows/dabbir-mobile-ci.yml']),{mobileCi:true,maestro:false});
+});

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -14,12 +14,13 @@ set -u
 #    in that range. Database schema is part of the Production artifact contract;
 #    a migration must not leave main SHA ahead of the deployed SHA.
 # 3) Exact-SHA Production verification contracts are deployment-affecting even
-#    when their source files live under .github/ or test/. If one of those files
-#    changes, Production must advance to the same commit before the verification
-#    workflow can truthfully claim exact-artifact evidence.
+#    when their source files live under .github/, test/, config/ or docs/evidence/.
+#    BAR-12/readiness evidence is truthful only when the canonical Production
+#    release identity advances to the commit that defines that evidence contract.
 # 4) Native iOS/App Store-only files and standalone UAE infrastructure-as-code are
 #    explicitly outside the Vercel web runtime. They may reuse the last web-runtime
-#    journey only when no web/database/runtime path changed in the same comparison range.
+#    journey only when no web/database/runtime/release-evidence path changed in the
+#    same comparison range.
 # 5) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
 ref="${VERCEL_GIT_COMMIT_REF:-}"
@@ -68,13 +69,20 @@ while IFS= read -r path; do
     test/dabbir-protected-live-smoke.mjs|\
     .github/workflows/dabbir-protected-live-smoke.yml|\
     .github/workflows/dabbir-ai-customer-journey.yml|\
+    .github/workflows/dabbir-bar12-readiness.yml|\
+    .github/scripts/dabbir-bar12-*|\
+    scripts/dabbir-readiness-gate.mjs|\
     test/ai-full-customer-journey-v2.mjs|\
     test/dabbir-protected-full-journey-preload.mjs|\
     test/dabbir-protected-journey-access.test.mjs|\
     test/dabbir-authorized-journey-workflow.test.mjs|\
     test/support/dabbir-protected-journey-access.mjs|\
     test/dabbir-capacity-load.mjs|\
-    test/dabbir-activity-regression.test.mjs)
+    test/dabbir-activity-regression.test.mjs|\
+    test/dabbir-bar12-*|\
+    docs/evidence/dabbir-bar12-*|\
+    config/barman-integration-contract.json|\
+    config/dabbir-release*.json)
       echo "Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence: $path"
       exit 1
       ;;


### PR DESCRIPTION
## Outcome
Close three launch-readiness recurrence classes without adding product features.

### 1. Exact Production release discipline
- BAR-12/readiness/release-evidence contract changes now force a Vercel Production build.
- Prevents `main` evidence from advancing while the canonical Production release remains on an older SHA.

### 2. Production database discipline
- New/changed migrations must use `supabase/migrations/<14-digit>_<name>.sql`.
- Migration changes require a regression test in the same change set.
- `db/*.sql` schema edits require a matching migration.
- New migrations reject nested BEGIN/COMMIT/ROLLBACK, unreviewed destructive DDL, and unsafe SECURITY DEFINER functions without fixed search_path + revoke.

### 3. Fail-closed required merge context
- Existing protected `test` context remains the branch-protection authority.
- On PRs, it now waits for DABBIR Mobile CI and DABBIR iOS Maestro Smoke whenever changed paths require them.
- A pending/failed required mobile workflow keeps `test` pending/failed, so a PR cannot merge early as PR #254 did.

No WhatsApp, financial, legal or capacity blocker is promoted by this PR. ACTION → ARTIFACT → TEST → EVIDENCE.