### PR TITLE
P0: bind BAR-12 readiness to Mumbai production

### DIFF
--- a/.github/workflows/dabbir-bar12-readiness.yml
+++ b/.github/workflows/dabbir-bar12-readiness.yml
@@ -40,6 +40,7 @@ jobs:
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       EXPECTED_VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       EXPECTED_GIT_PROVIDER: github
       EXPECTED_GIT_REPOSITORY: barman-systems/pilot
@@ -71,17 +72,18 @@ jobs:
           token="$(jq -r '.value // empty' <<<"$token_json")"
           test -n "$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
-      - name: Fetch aggregate production evidence from Supabase
+      - name: Fetch aggregate production evidence from Mumbai Supabase
         shell: bash
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         run: |
           set -euo pipefail
+          test "$SUPABASE_PROJECT_REF" = 'fphpoysqdsceniwduxjq'
           curl --fail --silent --show-error \
             -X POST \
             -H "Authorization: Bearer $OIDC_TOKEN" \
             -H 'Content-Type: application/json' \
-            'https://spohjzrsymsmzsseygtw.supabase.co/functions/v1/barman-qa-suite-runner' \
+            "https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner" \
             -d '{"action":"dabbir_bar12_readiness"}' > dabbir-bar12-supabase-evidence.json
           jq -e '.ok == true and .evidence != null' dabbir-bar12-supabase-evidence.json >/dev/null
       - name: Prepare trusted Vercel access for protected prelaunch

--- a/test/dabbir-mumbai-qa-routing.test.mjs
+++ b/test/dabbir-mumbai-qa-routing.test.mjs
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const workflow=fs.readFileSync('.github/workflows/dabbir-ai-customer-journey.yml','utf8');
+const readinessWorkflow=fs.readFileSync('.github/workflows/dabbir-bar12-readiness.yml','utf8');
+const ownerAwayWorkflow=fs.readFileSync('.github/workflows/dabbir-owner-away-production.yml','utf8');
 const runner=fs.readFileSync('supabase/functions/dabbir-qa-suite-runner/index.ts','utf8');
 
 const MUMBAI='fphpoysqdsceniwduxjq';
@@ -11,6 +13,15 @@ const LEGACY='spohjzrsymsmzsseygtw';
 test('production customer journey creates disposable QA identities in the Mumbai production project',()=>{
   assert.match(workflow,new RegExp(`SUPABASE_PROJECT_REF: ${MUMBAI}`));
   assert.doesNotMatch(workflow,new RegExp(LEGACY));
+});
+
+test('all privileged production evidence workflows are pinned to Mumbai and cannot read the retired project',()=>{
+  for(const [name,source] of [['customer journey',workflow],['BAR-12 readiness',readinessWorkflow],['owner away',ownerAwayWorkflow]]){
+    assert.match(source,new RegExp(`SUPABASE_PROJECT_REF: ${MUMBAI}`),`${name} must pin Mumbai`);
+    assert.doesNotMatch(source,new RegExp(LEGACY),`${name} must not reference retired Supabase`);
+  }
+  assert.match(readinessWorkflow,/https:\/\/\$\{SUPABASE_PROJECT_REF\}\.supabase\.co\/functions\/v1\/barman-qa-suite-runner/);
+  assert.match(readinessWorkflow,/test "\$SUPABASE_PROJECT_REF" = 'fphpoysqdsceniwduxjq'/);
 });
 
 test('Mumbai QA runner is narrowly scoped and main-only',()=>{


### PR DESCRIPTION
Release Closure Mode P0.

Changes:
- BAR-12 aggregate production evidence now reads only from Mumbai Supabase `fphpoysqdsceniwduxjq`.
- Adds an explicit fail-closed Mumbai project assertion before the readiness fetch.
- Adds regression coverage preventing the retired Supabase project from returning to privileged production evidence workflows.

Production QA residue was separately cleaned and verified at 0 QA users / 0 QA businesses before this PR.

No product feature changes; release/readiness governance only.