### PR TITLE
P0: unify generic service bookings into real calendar

### DIFF
--- a/api/appointment-management-ui.js
+++ b/api/appointment-management-ui.js
@@ -4,28 +4,33 @@ const script=String.raw`(()=>{
   const q=s=>document.querySelector(s);
   const ar=()=>document.documentElement.lang!=='en';
   const ws=()=>{try{return typeof workspace!=='undefined'?workspace:null}catch{return null}};
-  const esc=value=>String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  const esc=value=>String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot',"'":'&#39;'}[c]));
   const copy=()=>ar()?{
     title:'إدارة الحجوزات',desc:'يمكنك تعديل موعد العميل أو حذفه. أي تغيير يُحفظ في دبّر ويُزامن مع التقويم المرتبط.',
     customer:'العميل',time:'الموعد',status:'الحالة',edit:'تعديل',del:'حذف',save:'حفظ التعديل',cancel:'إلغاء',
     editTitle:'تعديل الموعد',deleteTitle:'حذف الموعد؟',deleteBody:'سيتم حذف الموعد من دبّر ومن التقويمات المرتبطة إن وُجدت.',
     requested:'مطلوب',confirmed:'مؤكد',rescheduled:'أعيدت جدولته',completed:'مكتمل',cancelled:'ملغي',
     saved:'تم تعديل الموعد.',deleted:'تم حذف الموعد.',deletePending:'تم إلغاء الموعد، لكن حذف التقويم الخارجي يحتاج إعادة مزامنة.',
-    failed:'تعذر إكمال العملية.',past:'لا يمكن تعديل موعد مضى وقته.',empty:'لا توجد حجوزات لإدارتها.'
+    failed:'تعذر إكمال العملية.',past:'لا يمكن تعديل موعد مضى وقته.',empty:'لا توجد حجوزات لإدارتها.',
+    calendar:'التقويم',day:'يومي',week:'أسبوعي',month:'شهري',today:'اليوم',previous:'السابق',next:'التالي',noBookings:'لا توجد حجوزات في هذه الفترة',more:'أخرى'
   }:{
     title:'Manage bookings',desc:'Edit or delete a customer booking. Changes are saved in DABBIR and synced to connected calendars.',
     customer:'Customer',time:'Booking',status:'Status',edit:'Edit',del:'Delete',save:'Save changes',cancel:'Cancel',
     editTitle:'Edit booking',deleteTitle:'Delete booking?',deleteBody:'The booking will be removed from DABBIR and connected calendars when available.',
     requested:'Requested',confirmed:'Confirmed',rescheduled:'Rescheduled',completed:'Completed',cancelled:'Cancelled',
     saved:'Booking updated.',deleted:'Booking deleted.',deletePending:'Booking was cancelled, but the external calendar delete still needs reconciliation.',
-    failed:'Could not complete the action.',past:'Past bookings cannot be rescheduled.',empty:'No bookings to manage.'
+    failed:'Could not complete the action.',past:'Past bookings cannot be rescheduled.',empty:'No bookings to manage.',
+    calendar:'Calendar',day:'Day',week:'Week',month:'Month',today:'Today',previous:'Previous',next:'Next',noBookings:'No bookings in this period',more:'more'
   };
 
   const style=document.createElement('style');
-  style.textContent='.dabbirApptManage{border:1px solid var(--line);background:#111315;border-radius:18px;padding:12px;margin-top:12px}.dabbirApptManageHead{display:flex;justify-content:space-between;gap:10px;align-items:flex-start;margin-bottom:10px}.dabbirApptManageHead h3{font-size:13px;margin:0 0 4px}.dabbirApptManageHead p{font-size:9px;color:var(--muted);margin:0;line-height:1.55}.dabbirApptManageList{display:grid;gap:7px}.dabbirApptManageRow{display:grid;grid-template-columns:minmax(120px,1.2fr) minmax(135px,1fr) 90px auto;gap:8px;align-items:center;border:1px solid #292f34;background:#15181b;border-radius:11px;padding:9px}.dabbirApptManageRow b{font-size:10px}.dabbirApptManageRow span{font-size:9px;color:var(--muted)}.dabbirApptManageActions{display:flex;gap:6px;justify-content:flex-end}.dabbirApptManageActions button{min-height:34px;border-radius:9px;padding:6px 9px;font-size:9px;font-weight:850}.dabbirApptEdit{border:1px solid #414d2a;background:#252c1d;color:#fff}.dabbirApptDelete{border:1px solid #5b2b2b;background:#32191a;color:#ffb9b9}.dabbirApptEdit:disabled{opacity:.45}.dabbirApptEmpty{border:1px dashed #31363c;border-radius:11px;padding:16px;text-align:center;color:var(--muted);font-size:9px}.dabbirApptModal{position:fixed;inset:0;z-index:90;background:#000b;display:none;align-items:center;justify-content:center;padding:18px}.dabbirApptModal.open{display:flex}.dabbirApptModalBox{width:min(430px,100%);background:#131518;border:1px solid #343940;border-radius:18px;padding:16px}.dabbirApptModalBox h3{margin:0 0 10px;font-size:14px}.dabbirApptField{display:grid;gap:5px;margin-top:9px}.dabbirApptField label{font-size:9px;color:var(--muted)}.dabbirApptField input,.dabbirApptField select{width:100%;border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:9px;min-height:42px}.dabbirApptModalActions{display:flex;gap:7px;justify-content:flex-end;margin-top:13px}.dabbirApptModalActions button{border-radius:10px;padding:8px 11px;font-weight:850}.dabbirApptModalActions .save{border:0;background:var(--accent);color:#10130b}.dabbirApptModalActions .cancel{border:1px solid var(--line);background:#181b1f;color:#fff}@media(max-width:700px){.dabbirApptManageRow{grid-template-columns:1fr}.dabbirApptManageActions{justify-content:stretch}.dabbirApptManageActions button{flex:1}.dabbirApptManageHead{display:block}}';
+  style.textContent='.dabbirApptManage{border:1px solid var(--line);background:#111315;border-radius:18px;padding:12px;margin-top:12px}.dabbirApptManageHead{display:flex;justify-content:space-between;gap:10px;align-items:flex-start;margin-bottom:10px}.dabbirApptManageHead h3{font-size:13px;margin:0 0 4px}.dabbirApptManageHead p{font-size:9px;color:var(--muted);margin:0;line-height:1.55}.dabbirApptManageList{display:grid;gap:7px}.dabbirApptManageRow{display:grid;grid-template-columns:minmax(120px,1.2fr) minmax(135px,1fr) 90px auto;gap:8px;align-items:center;border:1px solid #292f34;background:#15181b;border-radius:11px;padding:9px}.dabbirApptManageRow b{font-size:10px}.dabbirApptManageRow span{font-size:9px;color:var(--muted)}.dabbirApptManageActions{display:flex;gap:6px;justify-content:flex-end}.dabbirApptManageActions button{min-height:34px;border-radius:9px;padding:6px 9px;font-size:9px;font-weight:850}.dabbirApptEdit{border:1px solid #414d2a;background:#252c1d;color:#fff}.dabbirApptDelete{border:1px solid #5b2b2b;background:#32191a;color:#ffb9b9}.dabbirApptEdit:disabled{opacity:.45}.dabbirApptEmpty{border:1px dashed #31363c;border-radius:11px;padding:16px;text-align:center;color:var(--muted);font-size:9px}.dabbirApptModal{position:fixed;inset:0;z-index:90;background:#000b;display:none;align-items:center;justify-content:center;padding:18px}.dabbirApptModal.open{display:flex}.dabbirApptModalBox{width:min(430px,100%);background:#131518;border:1px solid #343940;border-radius:18px;padding:16px}.dabbirApptModalBox h3{margin:0 0 10px;font-size:14px}.dabbirApptField{display:grid;gap:5px;margin-top:9px}.dabbirApptField label{font-size:9px;color:var(--muted)}.dabbirApptField input,.dabbirApptField select{width:100%;border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:9px;min-height:42px}.dabbirApptModalActions{display:flex;gap:7px;justify-content:flex-end;margin-top:13px}.dabbirApptModalActions button{border-radius:10px;padding:8px 11px;font-weight:850}.dabbirApptModalActions .save{border:0;background:var(--accent);color:#10130b}.dabbirApptModalActions .cancel{border:1px solid var(--line);background:#181b1f;color:#fff}.dabbirGenericCalendar{border:1px solid var(--line);background:#111315;border-radius:18px;padding:12px;margin-top:12px}.dabbirGenericCalendar[hidden]{display:none}.dabbirGenericCalendarHead{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap;margin-bottom:10px}.dabbirGenericCalendarTitle{font-size:13px;font-weight:900}.dabbirGenericCalendarControls,.dabbirGenericCalendarViews{display:flex;gap:5px;align-items:center;flex-wrap:wrap}.dabbirGenericCalendar button{border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:9px;min-height:36px;padding:6px 9px;font-size:9px;font-weight:850}.dabbirGenericCalendar button.on{background:var(--accent);color:#10130b;border-color:transparent}.dabbirGenericRange{font-size:9px;color:var(--muted);font-weight:800}.dabbirGenericDay{display:grid;gap:8px}.dabbirGenericTimelineRow{display:grid;grid-template-columns:74px 1fr;gap:8px;align-items:start}.dabbirGenericTimelineTime{font-size:9px;color:var(--muted);padding-top:10px}.dabbirGenericEvent{width:100%;border:1px solid #415d76!important;background:#142c43!important;color:#eaf5ff!important;text-align:start;border-radius:10px!important;padding:9px!important;min-height:48px!important}.dabbirGenericEvent.completed{border-color:#366346!important;background:#17311f!important}.dabbirGenericEvent.cancelled{border-color:#6a3434!important;background:#34191b!important}.dabbirGenericEvent b{display:block;font-size:10px}.dabbirGenericEvent small{display:block;margin-top:4px;opacity:.8;font-size:8px}.dabbirGenericWeek{display:grid;grid-template-columns:repeat(7,minmax(150px,1fr));gap:6px;min-width:1050px}.dabbirGenericWeekWrap,.dabbirGenericMonthWrap{overflow:auto}.dabbirGenericWeekDay{border:1px solid #292f34;background:#15181b;border-radius:11px;padding:7px;min-height:160px}.dabbirGenericWeekHead{font-size:9px;font-weight:900;margin-bottom:7px}.dabbirGenericWeekEvents{display:grid;gap:5px}.dabbirGenericWeekEvents .dabbirGenericEvent{min-height:42px!important;padding:7px!important}.dabbirGenericMonth{display:grid;grid-template-columns:repeat(7,minmax(105px,1fr));gap:5px;min-width:735px}.dabbirGenericMonthDay{border:1px solid #292f34;background:#15181b;border-radius:10px;min-height:105px;padding:6px}.dabbirGenericMonthDay.out{opacity:.42}.dabbirGenericMonthDay.today{border-color:var(--accent)}.dabbirGenericMonthDate{font-size:9px;font-weight:900;margin-bottom:4px}.dabbirGenericMonthEvent{display:block;width:100%;border:0!important;background:#142c43!important;color:#fff!important;border-radius:6px!important;min-height:0!important;padding:4px!important;margin-top:3px;text-align:start;font-size:8px!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}.dabbirGenericEmpty{border:1px dashed #31363c;border-radius:11px;padding:18px;text-align:center;color:var(--muted);font-size:9px}@media(max-width:700px){.dabbirApptManageRow{grid-template-columns:1fr}.dabbirApptManageActions{justify-content:stretch}.dabbirApptManageActions button{flex:1}.dabbirApptManageHead{display:block}.dabbirGenericCalendarHead{align-items:flex-start}.dabbirGenericTimelineRow{grid-template-columns:58px 1fr}}';
   document.head.append(style);
 
   let signature='',editingId=null,busy=false;
+  let calendarView=localStorage.getItem('dabbir_generic_calendar_view')||'week';
+  if(!['day','week','month'].includes(calendarView))calendarView='week';
+  let calendarCursor=new Date();
   function customerName(id){
     const row=(ws()?.customers||[]).find(x=>x.id===id);
     return row?.display_name||(ar()?'عميل':'Customer');
@@ -47,6 +52,47 @@ const script=String.raw`(()=>{
     if(!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(raw))return null;
     const d=new Date(raw+':00+04:00');
     return Number.isNaN(d.getTime())?null:d.toISOString();
+  }
+  function businessType(){return String(ws()?.business?.business_type||'').toLowerCase()}
+  function genericCalendarEnabled(){return !['store','creator','real_estate','salon'].includes(businessType())}
+  function calendarDayKey(value){const raw=dubaiLocalMinute(value instanceof Date?value:new Date(value));return raw.slice(0,10)}
+  function calendarWallDate(value){const key=calendarDayKey(value);const d=new Date(key+'T12:00:00');return Number.isNaN(d.getTime())?new Date(value):d}
+  function startDay(value){const d=calendarWallDate(value);d.setHours(12,0,0,0);return d}
+  function addDays(value,n){const d=new Date(value);d.setDate(d.getDate()+n);return d}
+  function startWeek(value){const d=startDay(value),dow=(d.getDay()+6)%7;return addDays(d,-dow)}
+  function startMonth(value){const d=startDay(value);d.setDate(1);return d}
+  function sameDay(a,b){return calendarDayKey(a)===calendarDayKey(b)}
+  function dayLabel(value,weekday=true){try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{weekday:weekday?'short':undefined,month:'short',day:'numeric'}).format(value)}catch{return calendarDayKey(value)}}
+  function monthLabel(value){try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{month:'long',year:'numeric'}).format(value)}catch{return calendarDayKey(value).slice(0,7)}}
+  function timeLabel(value){try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{hour:'numeric',minute:'2-digit'}).format(new Date(value))}catch{return ''}}
+  function activeRows(){return [...(ws()?.appointments||[])].filter(a=>a?.id&&a?.starts_at&&!['cancelled','canceled'].includes(String(a.status||'').toLowerCase())).sort((a,b)=>new Date(a.starts_at)-new Date(b.starts_at))}
+  function eventClass(a){const s=String(a.status||'requested').toLowerCase();return s==='completed'?' completed':(s==='cancelled'||s==='canceled'?' cancelled':'')}
+  function eventButton(a,compact=false){const name=customerName(a.customer_id),meta=timeLabel(a.starts_at)+' · '+statusLabel(a.status);return '<button type="button" class="'+(compact?'dabbirGenericMonthEvent':'dabbirGenericEvent'+eventClass(a))+'" data-calendar-appt="'+esc(a.id)+'" title="'+esc(fmt(a.starts_at))+'"><b>'+esc(name)+'</b>'+(compact?'':'<small>'+esc(meta)+'</small>')+'</button>'}
+  function bindCalendarEvents(host){host.querySelectorAll('[data-calendar-appt]').forEach(btn=>btn.onclick=()=>openEdit(btn.dataset.calendarAppt))}
+  function ensureCalendar(){
+    const screen=q('#screen-appointments');if(!screen)return null;
+    let panel=q('#dabbirGenericCalendar');
+    if(!panel){panel=document.createElement('section');panel.id='dabbirGenericCalendar';panel.className='dabbirGenericCalendar';const table=q('#appointmentsTable');if(table?.parentNode)table.parentNode.insertBefore(panel,table);else screen.append(panel)}
+    return panel;
+  }
+  function renderDayCalendar(rows){const c=copy(),key=calendarDayKey(calendarCursor),dayRows=rows.filter(a=>calendarDayKey(a.starts_at)===key);return dayRows.length?'<div class="dabbirGenericDay">'+dayRows.map(a=>'<div class="dabbirGenericTimelineRow"><div class="dabbirGenericTimelineTime">'+esc(timeLabel(a.starts_at))+'</div>'+eventButton(a)+'</div>').join('')+'</div>':'<div class="dabbirGenericEmpty">'+esc(c.noBookings)+'</div>'}
+  function renderWeekCalendar(rows){const c=copy(),start=startWeek(calendarCursor),days=Array.from({length:7},(_,i)=>addDays(start,i));return '<div class="dabbirGenericWeekWrap"><div class="dabbirGenericWeek">'+days.map(day=>{const key=calendarDayKey(day),dayRows=rows.filter(a=>calendarDayKey(a.starts_at)===key);return '<div class="dabbirGenericWeekDay"><div class="dabbirGenericWeekHead">'+esc(dayLabel(day))+'</div><div class="dabbirGenericWeekEvents">'+(dayRows.length?dayRows.map(a=>eventButton(a)).join(''):'<div class="dabbirGenericEmpty">'+esc(c.noBookings)+'</div>')+'</div></div>'}).join('')+'</div></div>'}
+  function renderMonthCalendar(rows){const c=copy(),month=startMonth(calendarCursor),gridStart=startWeek(month),todayKey=calendarDayKey(new Date());const cells=Array.from({length:42},(_,i)=>addDays(gridStart,i));return '<div class="dabbirGenericMonthWrap"><div class="dabbirGenericMonth">'+cells.map(day=>{const key=calendarDayKey(day),dayRows=rows.filter(a=>calendarDayKey(a.starts_at)===key),outside=day.getMonth()!==month.getMonth(),shown=dayRows.slice(0,3),more=Math.max(0,dayRows.length-shown.length);return '<div class="dabbirGenericMonthDay'+(outside?' out':'')+(key===todayKey?' today':'')+'"><div class="dabbirGenericMonthDate">'+esc(String(day.getDate()))+'</div>'+shown.map(a=>eventButton(a,true)).join('')+(more?'<div class="dabbirGenericRange">+'+more+' '+esc(c.more)+'</div>':'')+'</div>'}).join('')+'</div></div>'}
+  function calendarRangeLabel(){if(calendarView==='day')return dayLabel(calendarCursor);if(calendarView==='month')return monthLabel(calendarCursor);const start=startWeek(calendarCursor),end=addDays(start,6);return dayLabel(start,false)+' – '+dayLabel(end,false)}
+  function moveCalendar(delta){if(calendarView==='day')calendarCursor=addDays(calendarCursor,delta);else if(calendarView==='week')calendarCursor=addDays(calendarCursor,delta*7);else{const d=startDay(calendarCursor);d.setMonth(d.getMonth()+delta,1);calendarCursor=d}signature='';render()}
+  function renderCalendar(rows){
+    const panel=ensureCalendar();if(!panel)return;
+    const enabled=genericCalendarEnabled();panel.hidden=!enabled;
+    const table=q('#appointmentsTable');if(table)table.style.display=enabled?'none':'';
+    if(!enabled)return;
+    const c=copy();
+    const body=calendarView==='day'?renderDayCalendar(rows):(calendarView==='month'?renderMonthCalendar(rows):renderWeekCalendar(rows));
+    panel.innerHTML='<div class="dabbirGenericCalendarHead"><div><div class="dabbirGenericCalendarTitle">'+esc(c.calendar)+'</div><div class="dabbirGenericRange">'+esc(calendarRangeLabel())+'</div></div><div class="dabbirGenericCalendarViews"><button type="button" data-calendar-view="day" class="'+(calendarView==='day'?'on':'')+'">'+esc(c.day)+'</button><button type="button" data-calendar-view="week" class="'+(calendarView==='week'?'on':'')+'">'+esc(c.week)+'</button><button type="button" data-calendar-view="month" class="'+(calendarView==='month'?'on':'')+'">'+esc(c.month)+'</button></div><div class="dabbirGenericCalendarControls"><button type="button" data-calendar-nav="prev" aria-label="'+esc(c.previous)+'">‹</button><button type="button" data-calendar-nav="today">'+esc(c.today)+'</button><button type="button" data-calendar-nav="next" aria-label="'+esc(c.next)+'">›</button></div></div>'+body;
+    panel.querySelectorAll('[data-calendar-view]').forEach(btn=>btn.onclick=()=>{calendarView=btn.dataset.calendarView;localStorage.setItem('dabbir_generic_calendar_view',calendarView);signature='';render()});
+    panel.querySelector('[data-calendar-nav="prev"]')?.addEventListener('click',()=>moveCalendar(-1));
+    panel.querySelector('[data-calendar-nav="next"]')?.addEventListener('click',()=>moveCalendar(1));
+    panel.querySelector('[data-calendar-nav="today"]')?.addEventListener('click',()=>{calendarCursor=new Date();signature='';render()});
+    bindCalendarEvents(panel);
   }
   function ensurePanel(){
     const screen=q('#screen-appointments');if(!screen)return null;
@@ -70,9 +116,10 @@ const script=String.raw`(()=>{
       const an=new Date(a.starts_at).getTime(),bn=new Date(b.starts_at).getTime(),now=Date.now();
       const af=an>=now,bf=bn>=now;if(af!==bf)return af?-1:1;return af?an-bn:bn-an;
     });
-    const nextSig=(ar()?'ar':'en')+'|'+rows.map(a=>[a.id,a.starts_at,a.status].join(':')).join('|');
+    const nextSig=(ar()?'ar':'en')+'|'+calendarView+'|'+calendarDayKey(calendarCursor)+'|'+businessType()+'|'+rows.map(a=>[a.id,a.starts_at,a.status].join(':')).join('|');
     if(nextSig===signature&&panel.dataset.ready==='1')return;
     signature=nextSig;panel.dataset.ready='1';
+    renderCalendar(activeRows());
     const c=copy();
     panel.innerHTML='<div class="dabbirApptManageHead"><div><h3>'+esc(c.title)+'</h3><p>'+esc(c.desc)+'</p></div></div><div class="dabbirApptManageList">'+(rows.length?rows.map(a=>{
       const future=new Date(a.starts_at).getTime()>=Date.now();
@@ -135,13 +182,13 @@ const script=String.raw`(()=>{
   setInterval(()=>{if(q('#screen-appointments')?.classList.contains('active'))render()},1500);
   document.addEventListener('keydown',e=>{if(e.key==='Escape'&&q('#dabbirApptEditModal.open'))closeModal()});
   setTimeout(render,500);
-  window.__dabbirAppointmentManagement={render,version:'appointment-management-v1'};
+  window.__dabbirAppointmentManagement={render,version:'appointment-management-v2-generic-calendar'};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-appointment-management-ui','v1');
+  res.setHeader('x-dabbir-appointment-management-ui','v2-generic-calendar');
   return res.status(200).send(script);
 }

--- a/test/dabbir-generic-service-calendar.test.mjs
+++ b/test/dabbir-generic-service-calendar.test.mjs
@@ -15,7 +15,7 @@ test('generic service bookings render a real day week month calendar over the ca
   assert.match(ui,/data-calendar-view="day"/);
   assert.match(ui,/data-calendar-view="week"/);
   assert.match(ui,/data-calendar-view="month"/);
-  assert.match(ui,/workspace\?\.appointments/);
+  assert.match(ui,/ws\(\)\?\.appointments/);
   assert.match(index,/id="screen-appointments"/);
   assert.match(index,/id="appointmentsTable"/);
 });

--- a/test/dabbir-generic-service-calendar.test.mjs
+++ b/test/dabbir-generic-service-calendar.test.mjs
@@ -12,9 +12,9 @@ test('generic service bookings render a real day week month calendar over the ca
   assert.match(ui,/renderDayCalendar/);
   assert.match(ui,/renderWeekCalendar/);
   assert.match(ui,/renderMonthCalendar/);
-  assert.match(ui,/data-calendar-view=\\"day\\"/);
-  assert.match(ui,/data-calendar-view=\\"week\\"/);
-  assert.match(ui,/data-calendar-view=\\"month\\"/);
+  assert.match(ui,/data-calendar-view="day"/);
+  assert.match(ui,/data-calendar-view="week"/);
+  assert.match(ui,/data-calendar-view="month"/);
   assert.match(ui,/workspace\?\.appointments/);
   assert.match(index,/id="screen-appointments"/);
   assert.match(index,/id="appointmentsTable"/);

--- a/test/dabbir-generic-service-calendar.test.mjs
+++ b/test/dabbir-generic-service-calendar.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const ui=fs.readFileSync('api/appointment-management-ui.js','utf8');
+const performance=fs.readFileSync('api/calendar-performance-ui.js','utf8');
+const index=fs.readFileSync('index.html','utf8');
+
+test('generic service bookings render a real day week month calendar over the canonical appointment screen',()=>{
+  assert.match(ui,/dabbirGenericCalendar/);
+  assert.match(ui,/calendarView.*'week'/);
+  assert.match(ui,/renderDayCalendar/);
+  assert.match(ui,/renderWeekCalendar/);
+  assert.match(ui,/renderMonthCalendar/);
+  assert.match(ui,/data-calendar-view=\\"day\\"/);
+  assert.match(ui,/data-calendar-view=\\"week\\"/);
+  assert.match(ui,/data-calendar-view=\\"month\\"/);
+  assert.match(ui,/workspace\?\.appointments/);
+  assert.match(index,/id="screen-appointments"/);
+  assert.match(index,/id="appointmentsTable"/);
+});
+
+test('generic calendar does not create a parallel booking model and keeps Salon as its richer owner',()=>{
+  assert.doesNotMatch(ui,/fetch\(['"]\/api\/generic-calendar/);
+  assert.match(ui,/!\['store','creator','real_estate','salon'\]\.includes\(businessType\(\)\)/);
+  assert.match(ui,/\/api\/appointment-management/);
+  assert.doesNotMatch(ui,/create_appointment/);
+});
+
+test('calendar events edit the same persisted appointment and cancelled items stay out of active calendar',()=>{
+  assert.match(ui,/data-calendar-appt/);
+  assert.match(ui,/openEdit\(btn\.dataset\.calendarAppt\)/);
+  assert.match(ui,/action:'update'.*appointment_id:editingId/);
+  assert.match(ui,/action:'delete'.*appointment_id:id/);
+  assert.match(ui,/!\['cancelled','canceled'\]\.includes/);
+});
+
+test('event-scoped performance wrapper remains the only shipped calendar bundle and patches business timezone',()=>{
+  assert.match(performance,/import calendarLiveHandler from '\.\/calendar-live-ui\.js'/);
+  assert.match(performance,/appointment-management-business-timezone/);
+  assert.match(performance,/appointment-management-global-observer-and-poll/);
+  assert.match(ui,/appointment-management-v2-generic-calendar/);
+});


### PR DESCRIPTION
Release Closure Mode calendar P0.

- Keeps `dabbir_appointments` as the single booking source of truth.
- Adds day/week/month calendar presentation for generic service-like businesses on the existing appointments screen.
- Salon keeps its richer employee-aware calendar; no parallel booking model is introduced.
- Calendar events edit/delete the same appointment-management API.
- Existing Google/Outlook live sync and business-timezone performance wrapper remain authoritative.
- Adds regression tests for calendar views, source-of-truth reuse, cancelled filtering and performance wrapper ownership.