### PR TITLE
P0: make live release evidence the only runtime authority

### DIFF
--- a/config/barman-integration-contract.json
+++ b/config/barman-integration-contract.json
@@ -1,5 +1,5 @@
 {
-  "version": 3,
+  "version": 4,
   "producer": "DABBIR",
   "control_plane": "barman-systems/barman-control-plane",
   "target_source_repository": "barman-systems/pilot",
@@ -19,6 +19,17 @@
     "source_repository": "barman-systems/pilot",
     "source_branch": "main",
     "root_directory": "./",
+    "release_authority": {
+      "kind": "LIVE_RELEASE_EVIDENCE_ENDPOINT",
+      "endpoint": "https://dabbir.bmalman.com/api/release-evidence",
+      "runtime_identity_must_be_read_live": true,
+      "historical_snapshot_fields": [
+        "verified_deployment_id",
+        "verified_deployment_state",
+        "verified_source_commit",
+        "verified_at"
+      ]
+    },
     "verified_deployment_id": "dpl_3WYNiJfBKvRsZ5Xp7BErkqcYuFDT",
     "verified_deployment_state": "READY",
     "verified_source_commit": "ab03eb8e3ede239ab019ec78844cee3bf9180a12",

--- a/test/dabbir-live-release-authority.test.mjs
+++ b/test/dabbir-live-release-authority.test.mjs
@@ -1,0 +1,23 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const contract=JSON.parse(fs.readFileSync('config/barman-integration-contract.json','utf8'));
+const workflow=fs.readFileSync('.github/workflows/dabbir-bar12-readiness.yml','utf8');
+
+test('integration contract declares the live release endpoint as runtime authority',()=>{
+  const authority=contract.deployment.release_authority;
+  assert.equal(authority?.kind,'LIVE_RELEASE_EVIDENCE_ENDPOINT');
+  assert.equal(authority?.endpoint,'https://dabbir.bmalman.com/api/release-evidence');
+  assert.equal(authority?.runtime_identity_must_be_read_live,true);
+  assert.deepEqual(authority?.historical_snapshot_fields,[
+    'verified_deployment_id','verified_deployment_state','verified_source_commit','verified_at'
+  ]);
+});
+
+test('BAR-12 reads live release evidence instead of trusting historical verified snapshot fields',()=>{
+  assert.match(workflow,/\/api\/release-evidence\?t=/);
+  assert.match(workflow,/initial_sha="\$\(jq -r '\.commit_sha'/);
+  assert.doesNotMatch(workflow,/verified_source_commit/);
+  assert.doesNotMatch(workflow,/verified_deployment_id/);
+});


### PR DESCRIPTION
Release Closure Mode governance fix.

- Marks historical `verified_*` deployment fields as snapshots only.
- Declares the live public `/api/release-evidence` endpoint as the authoritative Production runtime identity.
- Adds regression coverage preventing BAR-12 from trusting stale snapshot SHA/deployment fields.

No product behavior or database change.