### PR TITLE
Fix BAR-12 evidence release cycle

### DIFF
--- a/test/dabbir-bar12-production-classification.test.mjs
+++ b/test/dabbir-bar12-production-classification.test.mjs
@@ -32,15 +32,13 @@ function run(dir,head,base){
   });
 }
 
-test('BAR-12 and release evidence contracts always advance the exact Production SHA',()=>{
+test('executable BAR-12 and release contracts advance the exact Production SHA',()=>{
   const paths=[
     '.github/workflows/dabbir-bar12-readiness.yml',
     '.github/scripts/dabbir-bar12-technical-evidence.mjs',
     '.github/scripts/dabbir-bar12-alert-evidence.mjs',
     'scripts/dabbir-readiness-gate.mjs',
     'test/dabbir-bar12-technical-evidence.test.mjs',
-    'docs/evidence/dabbir-bar12-technical-review.json',
-    'docs/evidence/dabbir-bar12-alert-delivery.json',
     'config/barman-integration-contract.json',
     'config/dabbir-release-policy.json',
   ];
@@ -51,5 +49,20 @@ test('BAR-12 and release evidence contracts always advance the exact Production 
     const result=run(dir,head,base);
     assert.equal(result.status,1,`${relativePath}: ${result.stdout}\n${result.stderr}`);
     assert.match(result.stdout,/Exact-SHA Production verification contract changed|Runtime or unknown path changed/);
+  }
+});
+
+test('static BAR-12 evidence snapshots never manufacture a new Production runtime',()=>{
+  const paths=[
+    'docs/evidence/dabbir-bar12-technical-review.json',
+    'docs/evidence/dabbir-bar12-alert-delivery.json',
+  ];
+  for(const relativePath of paths){
+    const dir=setup();
+    const base=git(dir,'rev-parse','HEAD');
+    const head=change(dir,relativePath);
+    const result=run(dir,head,base);
+    assert.equal(result.status,0,`${relativePath}: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout,/Only explicitly non-runtime DABBIR paths changed/);
   }
 });

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -13,13 +13,14 @@ set -u
 #    build whenever any application, database migration, or unknown path changed
 #    in that range. Database schema is part of the Production artifact contract;
 #    a migration must not leave main SHA ahead of the deployed SHA.
-# 3) Exact-SHA Production verification contracts are deployment-affecting even
-#    when their source files live under .github/, test/, config/ or docs/evidence/.
-#    BAR-12/readiness evidence is truthful only when the canonical Production
-#    release identity advances to the commit that defines that evidence contract.
+# 3) Executable exact-SHA Production verification contracts are deployment-
+#    affecting even when their source files live under .github/, test/ or config/.
+#    Static BAR-12 evidence snapshots under docs/evidence are different: they are
+#    bound to the authoritative runtime SHA inside the evidence and must never
+#    manufacture a new Production runtime merely by recording that proof.
 # 4) Native iOS/App Store-only files and standalone UAE infrastructure-as-code are
 #    explicitly outside the Vercel web runtime. They may reuse the last web-runtime
-#    journey only when no web/database/runtime/release-evidence path changed in the
+#    journey only when no web/database/runtime/release-contract path changed in the
 #    same comparison range.
 # 5) Only explicitly non-runtime paths may skip. Any uncertainty fails safe to a build.
 current="${VERCEL_GIT_COMMIT_SHA:-HEAD}"
@@ -80,7 +81,6 @@ while IFS= read -r path; do
     test/dabbir-capacity-load.mjs|\
     test/dabbir-activity-regression.test.mjs|\
     test/dabbir-bar12-*|\
-    docs/evidence/dabbir-bar12-*|\
     config/barman-integration-contract.json|\
     config/dabbir-release*.json)
       echo "Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence: $path"


### PR DESCRIPTION
Root-cause fix for BAR-12 #84. Static evidence snapshots under docs/evidence no longer manufacture a new Vercel Production runtime. Executable readiness/release contracts remain exact-SHA deployment-affecting. Adds regression coverage proving static BAR-12 evidence commits reuse the authoritative deployed runtime instead of creating an evidence->deploy->journey loop.