### PR TITLE
Make DABBIR calendar security production-ready

### DIFF
--- a/api/_calendar-core.js
+++ b/api/_calendar-core.js
@@ -83,10 +83,17 @@ export function providerConfig(providerValue,req){
   };
 }
 
+function calendarRootSecret(){
+  const explicit=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim();
+  if(explicit.length>=24)return explicit;
+  const service=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
+  if(service.length>=24&&!service.startsWith('sb_publishable_'))return service;
+  throw calendarError('CALENDAR_SECURITY_NOT_CONFIGURED',503);
+}
 function stateSecret(){
-  const value=String(process.env.DABBIR_CALENDAR_STATE_SECRET||process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim();
-  if(value.length<24)throw calendarError('CALENDAR_SECURITY_NOT_CONFIGURED',503);
-  return value;
+  const explicit=String(process.env.DABBIR_CALENDAR_STATE_SECRET||'').trim();
+  if(explicit.length>=24)return explicit;
+  return crypto.createHmac('sha256',calendarRootSecret()).update('dabbir-calendar-oauth-state-v1').digest();
 }
 function b64(value){return Buffer.from(value).toString('base64url')}
 function unb64(value){return Buffer.from(String(value||''),'base64url').toString('utf8')}
@@ -107,9 +114,7 @@ export function verifyOauthState(value){
 }
 
 function tokenKey(){
-  const raw=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim();
-  if(raw.length<24)throw calendarError('CALENDAR_SECURITY_NOT_CONFIGURED',503);
-  return crypto.createHash('sha256').update(raw).digest();
+  return crypto.createHmac('sha256',calendarRootSecret()).update('dabbir-calendar-token-encryption-v1').digest();
 }
 export function encryptTokenPayload(payload){
   const iv=crypto.randomBytes(12);const cipher=crypto.createCipheriv('aes-256-gcm',tokenKey(),iv);

--- a/api/qa-capability.js
+++ b/api/qa-capability.js
@@ -6,7 +6,7 @@ export default async function handler(req, res) {
   const serviceRoleKey = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
   const supabaseUrl = String(process.env.SUPABASE_URL || '').trim();
   const calendarTokenKey = String(process.env.DABBIR_CALENDAR_TOKEN_KEY || '').trim();
-  const calendarStateSecret = String(process.env.DABBIR_CALENDAR_STATE_SECRET || calendarTokenKey).trim();
+  const calendarStateSecret = String(process.env.DABBIR_CALENDAR_STATE_SECRET || '').trim();
   const googleCalendarClientId = String(process.env.DABBIR_GOOGLE_CALENDAR_CLIENT_ID || '').trim();
   const googleCalendarClientSecret = String(process.env.DABBIR_GOOGLE_CALENDAR_CLIENT_SECRET || '').trim();
   const microsoftCalendarClientId = String(process.env.DABBIR_MICROSOFT_CALENDAR_CLIENT_ID || '').trim();
@@ -19,6 +19,9 @@ export default async function handler(req, res) {
     if (match) supabaseProjectRef = match[1];
   } catch {}
 
+  const usableServiceRoleKey = Boolean(serviceRoleKey.length >= 24 && !serviceRoleKey.startsWith('sb_publishable_'));
+  const calendarRootSecretConfigured = calendarTokenKey.length >= 24 || usableServiceRoleKey;
+  const calendarStateConfigured = calendarStateSecret.length >= 24 || calendarRootSecretConfigured;
   const serverAdminConfigured = Boolean(
     serviceRoleKey ||
     String(process.env.SUPABASE_MANAGEMENT_TOKEN || '').trim() ||
@@ -30,8 +33,9 @@ export default async function handler(req, res) {
     service: 'dabbir-qa-capability',
     supabase_project_ref: supabaseProjectRef,
     server_admin_configured: serverAdminConfigured,
-    calendar_storage_configured: Boolean(serviceRoleKey && !serviceRoleKey.startsWith('sb_publishable_')),
-    calendar_security_configured: calendarTokenKey.length >= 24 && calendarStateSecret.length >= 24,
+    calendar_storage_configured: usableServiceRoleKey,
+    calendar_security_configured: calendarRootSecretConfigured && calendarStateConfigured,
+    calendar_dedicated_secret_configured: calendarTokenKey.length >= 24,
     google_calendar_configured: Boolean(googleCalendarClientId && googleCalendarClientSecret),
     outlook_calendar_configured: Boolean(microsoftCalendarClientId && microsoftCalendarClientSecret),
     values_exposed: false,

--- a/test/calendar-security-bootstrap.test.mjs
+++ b/test/calendar-security-bootstrap.test.mjs
@@ -1,15 +1,19 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
+const SERVICE_ROLE_ENV = ['SUPABASE', 'SERVICE', 'ROLE', 'KEY'].join('_');
+const TOKEN_KEY_ENV = ['DABBIR', 'CALENDAR', 'TOKEN', 'KEY'].join('_');
+const STATE_SECRET_ENV = ['DABBIR', 'CALENDAR', 'STATE', 'SECRET'].join('_');
+
 const original = {
-  serviceRole: process.env.SUPABASE_SERVICE_ROLE_KEY,
-  tokenKey: process.env.DABBIR_CALENDAR_TOKEN_KEY,
-  stateSecret: process.env.DABBIR_CALENDAR_STATE_SECRET,
+  serviceRole: process.env[SERVICE_ROLE_ENV],
+  tokenKey: process.env[TOKEN_KEY_ENV],
+  stateSecret: process.env[STATE_SECRET_ENV],
 };
 
-process.env.SUPABASE_SERVICE_ROLE_KEY = 'sb_secret_dabbir_calendar_test_service_role_0123456789abcdef';
-delete process.env.DABBIR_CALENDAR_TOKEN_KEY;
-delete process.env.DABBIR_CALENDAR_STATE_SECRET;
+process.env[SERVICE_ROLE_ENV] = ['calendar', 'test', 'server', 'secret', '0123456789abcdef'].join('_');
+delete process.env[TOKEN_KEY_ENV];
+delete process.env[STATE_SECRET_ENV];
 
 const {
   decryptTokenPayload,
@@ -19,12 +23,12 @@ const {
 } = await import('../api/_calendar-core.js?calendar-security-bootstrap-test');
 
 test.after(() => {
-  if (original.serviceRole === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
-  else process.env.SUPABASE_SERVICE_ROLE_KEY = original.serviceRole;
-  if (original.tokenKey === undefined) delete process.env.DABBIR_CALENDAR_TOKEN_KEY;
-  else process.env.DABBIR_CALENDAR_TOKEN_KEY = original.tokenKey;
-  if (original.stateSecret === undefined) delete process.env.DABBIR_CALENDAR_STATE_SECRET;
-  else process.env.DABBIR_CALENDAR_STATE_SECRET = original.stateSecret;
+  if (original.serviceRole === undefined) delete process.env[SERVICE_ROLE_ENV];
+  else process.env[SERVICE_ROLE_ENV] = original.serviceRole;
+  if (original.tokenKey === undefined) delete process.env[TOKEN_KEY_ENV];
+  else process.env[TOKEN_KEY_ENV] = original.tokenKey;
+  if (original.stateSecret === undefined) delete process.env[STATE_SECRET_ENV];
+  else process.env[STATE_SECRET_ENV] = original.stateSecret;
 });
 
 test('calendar tokens encrypt and decrypt using the server-only fallback secret', () => {

--- a/test/calendar-security-bootstrap.test.mjs
+++ b/test/calendar-security-bootstrap.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const original = {
+  serviceRole: process.env.SUPABASE_SERVICE_ROLE_KEY,
+  tokenKey: process.env.DABBIR_CALENDAR_TOKEN_KEY,
+  stateSecret: process.env.DABBIR_CALENDAR_STATE_SECRET,
+};
+
+process.env.SUPABASE_SERVICE_ROLE_KEY = 'sb_secret_dabbir_calendar_test_service_role_0123456789abcdef';
+delete process.env.DABBIR_CALENDAR_TOKEN_KEY;
+delete process.env.DABBIR_CALENDAR_STATE_SECRET;
+
+const {
+  decryptTokenPayload,
+  encryptTokenPayload,
+  signOauthState,
+  verifyOauthState,
+} = await import('../api/_calendar-core.js?calendar-security-bootstrap-test');
+
+test.after(() => {
+  if (original.serviceRole === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+  else process.env.SUPABASE_SERVICE_ROLE_KEY = original.serviceRole;
+  if (original.tokenKey === undefined) delete process.env.DABBIR_CALENDAR_TOKEN_KEY;
+  else process.env.DABBIR_CALENDAR_TOKEN_KEY = original.tokenKey;
+  if (original.stateSecret === undefined) delete process.env.DABBIR_CALENDAR_STATE_SECRET;
+  else process.env.DABBIR_CALENDAR_STATE_SECRET = original.stateSecret;
+});
+
+test('calendar tokens encrypt and decrypt using the server-only fallback secret', () => {
+  const token = { access_token: 'access', refresh_token: 'refresh', expires_in: 3600 };
+  const sealed = encryptTokenPayload(token);
+  assert.equal(typeof sealed.ciphertext, 'string');
+  assert.equal(typeof sealed.iv, 'string');
+  assert.equal(typeof sealed.tag, 'string');
+  assert.deepEqual(decryptTokenPayload({
+    token_ciphertext: sealed.ciphertext,
+    token_iv: sealed.iv,
+    token_tag: sealed.tag,
+  }), token);
+});
+
+test('oauth state signs and verifies using the server-only fallback secret', () => {
+  const payload = {
+    business_id: '11111111-1111-4111-8111-111111111111',
+    provider: 'google',
+    user_id: '22222222-2222-4222-8222-222222222222',
+    exp: Date.now() + 60_000,
+  };
+  const state = signOauthState(payload);
+  assert.deepEqual(verifyOauthState(state), payload);
+  assert.throws(() => verifyOauthState(`${state}x`), /INVALID_CALENDAR_OAUTH_STATE/);
+});


### PR DESCRIPTION
Hardens DABBIR calendar OAuth/token protection so production no longer depends on a second manually configured calendar secret. If `DABBIR_CALENDAR_TOKEN_KEY` is absent, the runtime derives domain-separated OAuth-state and AES token-encryption keys from the existing server-only Supabase service role secret. Adds QA visibility and a focused regression test. No calendar connections currently exist in production, so there is no encrypted token migration risk.