### PR TITLE
Use least-privilege Google Calendar OAuth scope

### DIFF
--- a/api/_calendar-core.js
+++ b/api/_calendar-core.js
@@ -69,7 +69,7 @@ export function providerConfig(providerValue,req){
       provider,clientId,clientSecret,redirectUri,configured:Boolean(clientId&&clientSecret),
       authUrl:'https://accounts.google.com/o/oauth2/v2/auth',
       tokenUrl:'https://oauth2.googleapis.com/token',
-      scopes:['openid','email','profile','https://www.googleapis.com/auth/calendar'],
+      scopes:['openid','email','profile','https://www.googleapis.com/auth/calendar.events'],
     };
   }
   const clientId=String(process.env.DABBIR_MICROSOFT_CALENDAR_CLIENT_ID||'').trim();

--- a/test/calendar-provider-scopes.test.mjs
+++ b/test/calendar-provider-scopes.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { providerConfig } from '../api/_calendar-core.js';
+
+const GOOGLE_ID = ['DABBIR','GOOGLE','CALENDAR','CLIENT','ID'].join('_');
+const GOOGLE_SECRET = ['DABBIR','GOOGLE','CALENDAR','CLIENT','SECRET'].join('_');
+const MICROSOFT_ID = ['DABBIR','MICROSOFT','CALENDAR','CLIENT','ID'].join('_');
+const MICROSOFT_SECRET = ['DABBIR','MICROSOFT','CALENDAR','CLIENT','SECRET'].join('_');
+const keys = [GOOGLE_ID, GOOGLE_SECRET, MICROSOFT_ID, MICROSOFT_SECRET];
+const original = Object.fromEntries(keys.map(key => [key, process.env[key]]));
+for (const key of keys) process.env[key] = 'configured-for-scope-test';
+
+test.after(() => {
+  for (const key of keys) {
+    if (original[key] === undefined) delete process.env[key];
+    else process.env[key] = original[key];
+  }
+});
+
+const req = { headers: { host: 'dabbir.bmalman.com', 'x-forwarded-proto': 'https' } };
+
+test('Google calendar OAuth requests event read/write without full calendar administration', () => {
+  const config = providerConfig('google', req);
+  assert.equal(config.configured, true);
+  assert.ok(config.scopes.includes('https://www.googleapis.com/auth/calendar.events'));
+  assert.ok(!config.scopes.includes('https://www.googleapis.com/auth/calendar'));
+});
+
+test('Microsoft calendar OAuth retains delegated event read/write access', () => {
+  const config = providerConfig('outlook', req);
+  assert.equal(config.configured, true);
+  assert.ok(config.scopes.includes('Calendars.ReadWrite'));
+});


### PR DESCRIPTION
Narrows DABBIR Google Calendar OAuth from full calendar administration to `calendar.events`, which is sufficient for the existing primary-event list/create/update/delete sync flow. Microsoft remains on delegated `Calendars.ReadWrite`. Adds regression coverage for both provider scopes.