### PR TITLE
Fix Outlook calendar account identity permission

### DIFF
--- a/api/_calendar-core.js
+++ b/api/_calendar-core.js
@@ -79,7 +79,7 @@ export function providerConfig(providerValue,req){
     provider,clientId,clientSecret,redirectUri,configured:Boolean(clientId&&clientSecret),tenant,
     authUrl:`https://login.microsoftonline.com/${encodeURIComponent(tenant)}/oauth2/v2.0/authorize`,
     tokenUrl:`https://login.microsoftonline.com/${encodeURIComponent(tenant)}/oauth2/v2.0/token`,
-    scopes:['openid','profile','email','offline_access','Calendars.ReadWrite'],
+    scopes:['openid','profile','email','offline_access','User.Read','Calendars.ReadWrite'],
   };
 }
 

--- a/test/calendar-provider-scopes.test.mjs
+++ b/test/calendar-provider-scopes.test.mjs
@@ -26,8 +26,9 @@ test('Google calendar OAuth requests event read/write without full calendar admi
   assert.ok(!config.scopes.includes('https://www.googleapis.com/auth/calendar'));
 });
 
-test('Microsoft calendar OAuth retains delegated event read/write access', () => {
+test('Microsoft calendar OAuth requests event read/write and signed-in account identity', () => {
   const config = providerConfig('outlook', req);
   assert.equal(config.configured, true);
+  assert.ok(config.scopes.includes('User.Read'));
   assert.ok(config.scopes.includes('Calendars.ReadWrite'));
 });


### PR DESCRIPTION
Adds delegated `User.Read`, the least-privileged Microsoft Graph permission required by DABBIR's existing `/me` account identity lookup after Outlook OAuth. Keeps `Calendars.ReadWrite` for the actual two-way calendar sync and extends provider-scope regression coverage.