### PR TITLE
P0: turn BARMAN into a durable executive runtime

### DIFF
--- a/api/_barman-executive-core.js
+++ b/api/_barman-executive-core.js
@@ -1,0 +1,152 @@
+import { createHmac, timingSafeEqual } from 'node:crypto';
+import { getVercelOidcToken } from '@vercel/oidc';
+import { SUPABASE_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+
+const GATEWAY_ENDPOINT='https://ai-gateway.vercel.sh/v1/chat/completions';
+const DEFAULT_MODEL='minimax/minimax-m3-free';
+const DABBIR_ORIGIN='https://dabbir.bmalman.com';
+const clean=(value,max=4000)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+
+export function serviceRoleKey(env=process.env){
+  const key=clean(env.SUPABASE_SERVICE_ROLE_KEY,8192);
+  if(!key||key.startsWith('sb_publishable_'))throw Object.assign(new Error('BARMAN_SERVICE_ROLE_NOT_CONFIGURED'),{status:503});
+  return key;
+}
+
+export function signedBody(body,key,timestamp=Math.floor(Date.now()/1000)){
+  const raw=typeof body==='string'?body:JSON.stringify(body);
+  return {timestamp:String(timestamp),signature:createHmac('sha256',key).update(`${timestamp}.${raw}`).digest('hex'),raw};
+}
+
+export function verifySignedBody(raw,timestamp,signature,key,now=Math.floor(Date.now()/1000)){
+  const ts=Number(timestamp);
+  if(!Number.isFinite(ts)||Math.abs(now-ts)>300)return false;
+  const expected=createHmac('sha256',key).update(`${timestamp}.${raw}`).digest('hex');
+  const a=Buffer.from(expected),b=Buffer.from(clean(signature,256));
+  return a.length===b.length&&a.length>0&&timingSafeEqual(a,b);
+}
+
+export async function adminRpc(key,name,params={}){
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{
+    method:'POST',cache:'no-store',redirect:'manual',
+    headers:supabaseKeyHeaders(key,{accept:'application/json','content-type':'application/json','prefer':'return=representation'}),
+    body:JSON.stringify(params),signal:AbortSignal.timeout(15000),
+  });
+  const text=await response.text();let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok)throw Object.assign(new Error(payload?.message||payload?.code||`${name.toUpperCase()}_FAILED`),{status:response.status});
+  return payload;
+}
+
+export function deterministicDecision(text){
+  const value=clean(text,4000);
+  const normalized=value.toLowerCase();
+  if(/^(\/status|هل نفذت|هل تم|وين وصلت|ما الحالة|الحالة|حاله|status)[؟?]?$/i.test(value))
+    return {kind:'status',reply:'سأعرض لك الحالة الحقيقية لآخر الأوامر، دون إنشاء أمر جديد.',command_text:'',priority:'P1'};
+  if(/^(وينك|مرحبا|هلا|السلام|شكرا|شكراً|من انت|من أنت)[؟?]?$/i.test(value))
+    return {kind:'chat',reply:'أنا BARMAN Executive OS. أتابع التنفيذ والأدلة، وأفصل الحديث العادي عن الأوامر.',command_text:'',priority:'P2'};
+  const explicit=/(نفذ|نفّذ|أصلح|اصلح|ابن|ابدأ|ابدا|غيّر|غير|انشر|اربط|راجع|افحص|أنشئ|انشئ|جهز|طوّر|طور)/i.test(value);
+  if(explicit)return {kind:'command',reply:'استلمت الهدف التنفيذي وسأدخله دورة التنفيذ.',command_text:value,priority:/عاجل|حرج|p0/i.test(normalized)?'P0':'P1'};
+  return {kind:'chat',reply:'فهمت رسالتك. إذا أردتها مهمة تنفيذية اذكر النتيجة المطلوبة بوضوح، وسأتابعها حتى دليل أو عائق حقيقي.',command_text:'',priority:'P2'};
+}
+
+async function gatewayCredential(env=process.env){
+  if(env.AI_GATEWAY_API_KEY)return String(env.AI_GATEWAY_API_KEY);
+  if(env.VERCEL_OIDC_TOKEN)return String(env.VERCEL_OIDC_TOKEN);
+  try{return String(await getVercelOidcToken()||'')}catch{return ''}
+}
+
+function outputJson(payload){
+  let value=String(payload?.choices?.[0]?.message?.content||'').trim();
+  value=value.replace(/^```(?:json)?\s*/i,'').replace(/\s*```$/,'');
+  try{return JSON.parse(value)}catch{return null}
+}
+
+export async function decideExecutiveMessage({text,memory=[],commands=[],env=process.env}){
+  const fallback=deterministicDecision(text);
+  const credential=await gatewayCredential(env);
+  if(!credential)return {...fallback,brain_state:'DETERMINISTIC_FALLBACK',brain_error:'GATEWAY_CREDENTIAL_MISSING'};
+  const model=clean(env.BARMAN_AI_GATEWAY_MODEL||env.DABBIR_AI_GATEWAY_MODEL||DEFAULT_MODEL,120);
+  const system=[
+    'You are BARMAN Executive OS, the sole executive AI for DABBIR.',
+    'Reply in concise natural Arabic. Separate normal conversation from status checks and executable commands.',
+    'Never claim execution from QUEUED or IN_PROGRESS. DONE requires verified evidence.',
+    'A status question such as هل نفذت or وين وصلت is status, never a new command.',
+    'Only classify command when the owner clearly asks for an action or outcome.',
+    'Return JSON only: {"kind":"chat|status|command","reply":"...","command_text":"...","priority":"P0|P1|P2|P3"}.',
+    'P0 is only an active critical incident. Financial/legal/KYC/OTP remain owner-only.',
+  ].join('\n');
+  try{
+    const response=await fetch(GATEWAY_ENDPOINT,{
+      method:'POST',headers:{authorization:`Bearer ${credential}`,'content-type':'application/json'},
+      body:JSON.stringify({model,messages:[{role:'system',content:system},{role:'user',content:JSON.stringify({message:clean(text),memory:Array.isArray(memory)?memory.slice(-16):[],commands:Array.isArray(commands)?commands.slice(0,8):[]})}],temperature:0.1,max_tokens:600,stream:false}),
+      signal:AbortSignal.timeout(12000),
+    });
+    const payload=await response.json().catch(()=>({}));
+    if(!response.ok)throw new Error(`GATEWAY_HTTP_${response.status}`);
+    const decision=outputJson(payload);
+    if(!decision||!['chat','status','command'].includes(decision.kind))throw new Error('GATEWAY_INVALID_DECISION');
+    return {
+      kind:decision.kind,
+      reply:clean(decision.reply,1800)||fallback.reply,
+      command_text:decision.kind==='command'?clean(decision.command_text||text,4000):'',
+      priority:/^P[0-3]$/.test(String(decision.priority||'').toUpperCase())?String(decision.priority).toUpperCase():fallback.priority,
+      brain_state:'AI_GATEWAY',model,
+    };
+  }catch(error){return {...fallback,brain_state:'DETERMINISTIC_FALLBACK',brain_error:clean(error?.message||error,160),model}}
+}
+
+async function probe(url){
+  const started=Date.now();
+  try{
+    const response=await fetch(url,{cache:'no-store',redirect:'follow',signal:AbortSignal.timeout(12000)});
+    const body=await response.text();
+    return {url,status:response.status,ok:response.ok,latency_ms:Date.now()-started,final_url:response.url,vercel_id:response.headers.get('x-vercel-id'),body:body.slice(0,1800)};
+  }catch(error){return {url,status:0,ok:false,latency_ms:Date.now()-started,error:clean(error?.message||error,200)}}
+}
+
+export async function observeDabbirLive(){
+  const [site,capability,commit]=await Promise.all([
+    probe(DABBIR_ORIGIN),
+    probe(`${DABBIR_ORIGIN}/api/qa-capability`),
+    probe('https://api.github.com/repos/barman-systems/pilot/commits/main'),
+  ]);
+  let capabilityJson=null,commitJson=null;
+  try{capabilityJson=JSON.parse(capability.body||'')}catch{}
+  try{commitJson=JSON.parse(commit.body||'')}catch{}
+  const sha=clean(process.env.VERCEL_GIT_COMMIT_SHA||commitJson?.sha||'',64);
+  const healthy=site.ok&&capability.ok&&capabilityJson?.ok===true&&capabilityJson?.supabase_project_ref==='fphpoysqdsceniwduxjq';
+  return {
+    healthy,observed_at:new Date().toISOString(),region:clean(process.env.VERCEL_REGION||site.vercel_id||'UNAVAILABLE',160),
+    deployment_id:clean(process.env.VERCEL_DEPLOYMENT_ID||'UNAVAILABLE',160),commit_sha:sha||'UNAVAILABLE',
+    site:{status:site.status,latency_ms:site.latency_ms,final_url:site.final_url},
+    database:{project_ref:capabilityJson?.supabase_project_ref||'UNAVAILABLE',server_admin_configured:capabilityJson?.server_admin_configured===true},
+    probes:{site_ok:site.ok,capability_ok:capability.ok},
+  };
+}
+
+export function runtimeEvidence(snapshot){
+  return [
+    {type:'url',reference:DABBIR_ORIGIN,verified:snapshot.site.status>=200&&snapshot.site.status<400,details:snapshot.site},
+    {type:'query',reference:'dabbir-qa-capability',verified:snapshot.database.project_ref==='fphpoysqdsceniwduxjq',details:snapshot.database},
+    {type:'commit',reference:snapshot.commit_sha,verified:snapshot.commit_sha!=='UNAVAILABLE',details:{deployment_id:snapshot.deployment_id,region:snapshot.region}},
+  ];
+}
+
+export async function telegramRoute(key,commandId){
+  const cfg=await adminRpc(key,'barman_telegram_config_v1',{});
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/barman_telegram_updates?command_id=eq.${encodeURIComponent(commandId)}&select=chat_id&order=created_at.desc&limit=1`,{
+    headers:supabaseKeyHeaders(key,{accept:'application/json'}),cache:'no-store',signal:AbortSignal.timeout(10000),
+  });
+  const rows=response.ok?await response.json().catch(()=>[]):[];
+  return {token:clean(cfg?.bot_token,4096),chat_id:Array.isArray(rows)&&rows[0]?.chat_id?Number(rows[0].chat_id):null};
+}
+
+export async function notifyTelegram(route,text){
+  if(!route?.token||!route?.chat_id)return {sent:false,reason:'NO_TELEGRAM_ROUTE'};
+  const response=await fetch(`https://api.telegram.org/bot${route.token}/sendMessage`,{
+    method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify({chat_id:route.chat_id,text:clean(text,3900)}),signal:AbortSignal.timeout(10000),
+  });
+  return {sent:response.ok,status:response.status};
+}

--- a/api/barman-executive-chat.js
+++ b/api/barman-executive-chat.js
@@ -1,0 +1,16 @@
+import { json } from './_auth-core.js';
+import { decideExecutiveMessage, serviceRoleKey, verifySignedBody } from './_barman-executive-core.js';
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  let key;
+  try{key=serviceRoleKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
+  const body=req.body&&typeof req.body==='object'?req.body:{};
+  const raw=JSON.stringify(body);
+  if(!verifySignedBody(raw,req.headers['x-barman-timestamp'],req.headers['x-barman-signature'],key))
+    return json(res,401,{ok:false,error:'BARMAN_SIGNATURE_REQUIRED'});
+  const text=String(body.text||'').trim();
+  if(!text||text.length>4000)return json(res,400,{ok:false,error:'MESSAGE_INVALID'});
+  const decision=await decideExecutiveMessage({text,memory:body.memory,commands:body.commands});
+  return json(res,200,{ok:true,decision});
+}

--- a/api/barman-executive-cron.js
+++ b/api/barman-executive-cron.js
@@ -1,0 +1,54 @@
+import { timingSafeEqual } from 'node:crypto';
+import { json } from './_auth-core.js';
+import { adminRpc, notifyTelegram, observeDabbirLive, runtimeEvidence, serviceRoleKey, telegramRoute } from './_barman-executive-core.js';
+
+const EXPECTED_SCHEDULE='*/5 * * * *';
+const clean=(value,max=4000)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+function sameSecret(left,right){const a=Buffer.from(String(left||'')),b=Buffer.from(String(right||''));return a.length===b.length&&a.length>0&&timingSafeEqual(a,b)}
+export function cronAuthMode(req,env=process.env){
+  const secret=clean(env.CRON_SECRET,4096),authorization=clean(req.headers?.authorization,8192);
+  if(secret)return sameSecret(authorization,`Bearer ${secret}`)?'secret':null;
+  return clean(env.VERCEL_ENV,32)==='production'&&clean(req.headers?.['user-agent'],120).toLowerCase()==='vercel-cron/1.0'&&clean(req.headers?.['x-vercel-cron-schedule'],120)===EXPECTED_SCHEDULE?'vercel_schedule':null;
+}
+
+function report(snapshot){
+  const state=snapshot.healthy?'سليم':'يحتاج تدخل';
+  return `نفّذ BARMAN فحصاً حياً لـ DABBIR. الحالة: ${state}. الموقع HTTP ${snapshot.site.status}، قاعدة البيانات ${snapshot.database.project_ref}، commit ${snapshot.commit_sha.slice(0,12)}، المنطقة ${snapshot.region}.`;
+}
+
+async function executeOne(key){
+  const claim=await adminRpc(key,'barman_executive_claim_v1',{p_worker_id:'vercel-runtime-worker',p_lane:'runtime',p_lease_seconds:300});
+  if(claim?.claimed!==true)return {claimed:false};
+  const command=claim.command||{},commandId=String(command.id||'');
+  try{
+    const snapshot=await observeDabbirLive();
+    const evidence=runtimeEvidence(snapshot),summary=report(snapshot),outcome=snapshot.healthy?'DONE':'BLOCKED';
+    await adminRpc(key,'barman_executive_finalize_v1',{
+      p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:outcome,
+      p_summary:summary,p_evidence:evidence,p_error:snapshot.healthy?null:'DABBIR_LIVE_HEALTH_CHECK_FAILED',
+    });
+    const route=await telegramRoute(key,commandId).catch(()=>null);
+    await notifyTelegram(route,`${summary}\n\nالحالة: ${outcome} — تم تسجيل ACTION → ARTIFACT → TEST → EVIDENCE.`).catch(()=>null);
+    return {claimed:true,command_id:commandId,outcome,evidence_count:evidence.length};
+  }catch(error){
+    const message=clean(error?.message||error,1000);
+    await adminRpc(key,'barman_executive_finalize_v1',{
+      p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:'RETRY',
+      p_summary:'فشل تنفيذ الفحص الحي وسيعاد بعد معالجة السبب.',p_evidence:[],p_error:message,
+    }).catch(()=>null);
+    return {claimed:true,command_id:commandId,outcome:'RETRY',error:message};
+  }
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const authMode=cronAuthMode(req);if(!authMode)return json(res,401,{ok:false,error:'CRON_AUTH_REQUIRED'});
+  let key;try{key=serviceRoleKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
+  const results=[];
+  try{
+    for(let i=0;i<3;i+=1){const result=await executeOne(key);if(!result.claimed)break;results.push(result)}
+    const summary={ok:true,claimed:results.length,done:results.filter(x=>x.outcome==='DONE').length,blocked:results.filter(x=>x.outcome==='BLOCKED').length,retry:results.filter(x=>x.outcome==='RETRY').length,results};
+    console.info('barman_executive_cron',{auth_mode:authMode,...summary});
+    return json(res,200,summary);
+  }catch(error){const message=clean(error?.message||error,500);console.error('barman_executive_cron_failed',{error:message});return json(res,500,{ok:false,error:message})}
+}

--- a/supabase/functions/barman-telegram-webhook/index.ts
+++ b/supabase/functions/barman-telegram-webhook/index.ts
@@ -1,0 +1,64 @@
+const SUPABASE_URL=Deno.env.get('SUPABASE_URL')||'';
+const SERVICE_KEY=Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')||'';
+const EXECUTIVE_CHAT_URL='https://dabbir.bmalman.com/api/barman-executive-chat';
+const JSON_HEADERS={'content-type':'application/json','cache-control':'no-store'};
+const sbHeaders=()=>({'apikey':SERVICE_KEY,'authorization':`Bearer ${SERVICE_KEY}`,'content-type':'application/json'});
+const json=(status:number,body:unknown)=>new Response(JSON.stringify(body),{status,headers:JSON_HEADERS});
+async function rpc(name:string,body:any={}){const r=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${name}`,{method:'POST',headers:sbHeaders(),body:JSON.stringify(body)});const p=await r.json().catch(()=>null);if(!r.ok)throw new Error(`${name}:${r.status}`);return p}
+async function tgCfg(){const c=await rpc('barman_telegram_config_v1',{});return {bot_token:String(c?.bot_token||''),webhook_secret:String(c?.webhook_secret||'')}}
+async function sha256(s:string){const bytes=new Uint8Array(await crypto.subtle.digest('SHA-256',new TextEncoder().encode(s)));return Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('')}
+async function hmac(key:string,value:string){const cryptoKey=await crypto.subtle.importKey('raw',new TextEncoder().encode(key),{name:'HMAC',hash:'SHA-256'},false,['sign']);const bytes=new Uint8Array(await crypto.subtle.sign('HMAC',cryptoKey,new TextEncoder().encode(value)));return Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('')}
+async function tg(token:string,method:string,payload:any){const r=await fetch(`https://api.telegram.org/bot${token}/${method}`,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(payload)});const p=await r.json().catch(()=>null);if(!r.ok||p?.ok===false)throw new Error(`telegram:${method}:${r.status}`);return p}
+async function send(token:string,chatId:number,text:string){return tg(token,'sendMessage',{chat_id:chatId,text:text.length>3900?text.slice(0,3890)+'…':text})}
+function commands(data:any){return Array.isArray(data)?data:(Array.isArray(data?.commands)?data.commands:[])}
+function compactCommands(arr:any[]){return arr.slice(0,8).map((c:any)=>({id:String(c?.id||''),status:String(c?.status||''),priority:String(c?.priority||''),command_text:String(c?.command_text||'').slice(0,1200),result_summary:c?.result_summary||null,blocked_reason:c?.blocked_reason||null,actions:Array.isArray(c?.actions)?c.actions.slice(0,10):[]}))}
+function localDecision(text:string){
+ if(/^(هل نفذت|هل تم|وين وصلت|ما الحالة|الحالة|حاله|status)[؟?]?$/i.test(text))return {kind:'status',reply:'',command_text:'',priority:'P1',brain_state:'LOCAL_STATUS'};
+ if(/^(وينك|مرحبا|هلا|السلام|شكرا|شكراً|من انت|من أنت)[؟?]?$/i.test(text))return {kind:'chat',reply:'أنا BARMAN Executive OS. أتابع التنفيذ الفعلي والأدلة، لا مجرد تسجيل الرسائل.',command_text:'',priority:'P2',brain_state:'LOCAL_CHAT'};
+ if(/(نفذ|نفّذ|أصلح|اصلح|ابن|ابدأ|ابدا|غيّر|غير|انشر|اربط|راجع|افحص|أنشئ|انشئ|جهز|طوّر|طور)/i.test(text))return {kind:'command',reply:'استلمت الهدف التنفيذي.',command_text:text,priority:/عاجل|حرج|p0/i.test(text)?'P0':'P1',brain_state:'LOCAL_COMMAND'};
+ return {kind:'chat',reply:'فهمت رسالتك. سأتحدث معك طبيعيًا، ولن أحولها إلى مهمة إلا إذا طلبت إجراءً واضحًا.',command_text:'',priority:'P2',brain_state:'LOCAL_CHAT'};
+}
+async function decide(text:string,memory:any[],recent:any[]){
+ const body=JSON.stringify({text,memory:Array.isArray(memory)?memory.slice(-16):[],commands:compactCommands(recent)});
+ const ts=String(Math.floor(Date.now()/1000)),signature=await hmac(SERVICE_KEY,`${ts}.${body}`);
+ try{
+  const r=await fetch(EXECUTIVE_CHAT_URL,{method:'POST',headers:{'content-type':'application/json','x-barman-timestamp':ts,'x-barman-signature':signature},body,signal:AbortSignal.timeout(15000)});
+  const p=await r.json().catch(()=>null);
+  if(!r.ok||p?.ok!==true||!p?.decision)throw new Error(`executive-chat:${r.status}`);
+  return p.decision;
+ }catch(error){console.error('executive_chat_fallback',String(error));return localDecision(text)}
+}
+async function remember(userId:number,chatId:number,role:'user'|'assistant',content:string,metadata:any={}){try{await rpc('barman_telegram_memory_append_v1',{p_user_id:userId,p_chat_id:chatId,p_role:role,p_content:content,p_metadata:metadata})}catch(error){console.error('memory',String(error))}}
+function statusReply(data:any){const arr=commands(data);return arr.length?arr.map((c:any,i:number)=>{const result=String(c.result_summary||c.blocked_reason||'').replace(/\s+/g,' ').slice(0,240);return `${i+1}) ${String(c.status||'UNKNOWN')} — ${String(c.command_text||'').replace(/\s+/g,' ').slice(0,180)}${result?`\n${result}`:''}`}).join('\n\n'):'لا توجد مهام مسجلة.'}
+
+Deno.serve(async(req:Request)=>{try{
+ if(req.method!=='POST')return json(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
+ const {bot_token,webhook_secret}=await tgCfg();if(!bot_token||!webhook_secret)return json(503,{ok:false,error:'TELEGRAM_NOT_CONFIGURED'});
+ if(req.headers.get('x-telegram-bot-api-secret-token')!==webhook_secret)return json(403,{ok:false,error:'INVALID_WEBHOOK_SECRET'});
+ const update=await req.json().catch(()=>null),m=update?.message;if(!m?.chat?.id||!m?.from?.id)return json(200,{ok:true,ignored:true});
+ if(m.chat.type&&m.chat.type!=='private')return json(200,{ok:true,ignored:true,reason:'PRIVATE_ONLY'});
+ const chatId=Number(m.chat.id),userId=Number(m.from.id),updateId=Number(update?.update_id||0),username=String(m.from.username||''),text=String(m.text||'').trim();
+ if(!text){await send(bot_token,chatId,'حالياً المحادثة النصية مفعلة.');return json(200,{ok:true})}
+ const auth=await rpc('barman_telegram_authorize_v1',{p_user_id:userId,p_chat_id:chatId});
+ if(text==='/start'){await send(bot_token,chatId,auth===true?'BARMAN Executive OS متصل: محادثة AI، ذاكرة، وطابور تنفيذ موثق.':'أرسل /claim متبوعاً برمز الربط لإثبات المالك.');return json(200,{ok:true})}
+ if(text.startsWith('/claim ')){const result=await rpc('barman_telegram_claim_v1',{p_user_id:userId,p_chat_id:chatId,p_username:username,p_claim_hash:await sha256(text.slice(7).trim())});await send(bot_token,chatId,result?.ok===true?'تم توثيقك كمالك BARMAN Executive OS.':'رمز الربط غير صحيح أو الهوية مثبتة مسبقًا.');return json(200,{ok:true})}
+ if(auth!==true){await send(bot_token,chatId,'غير مصرح لهذا الحساب.');return json(200,{ok:true})}
+ if(text==='/help'){await send(bot_token,chatId,'تحدث معي طبيعيًا. /status يعرض الحقيقة. استخدم /p0 إلى /p3 فقط لفرض أولوية أمر واضح.');return json(200,{ok:true})}
+ if(text==='/status'){const s=await rpc('barman_telegram_status_v1',{p_user_id:userId,p_chat_id:chatId,p_limit:5});await send(bot_token,chatId,statusReply(s));return json(200,{ok:true,status:true})}
+ await remember(userId,chatId,'user',text,{update_id:updateId});
+ const memory=await rpc('barman_telegram_memory_recent_v1',{p_user_id:userId,p_chat_id:chatId,p_limit:18});
+ const status=await rpc('barman_telegram_status_v1',{p_user_id:userId,p_chat_id:chatId,p_limit:8});
+ let userText=text,forcedPriority:string|null=null;const match=text.match(/^\/(p[0-3])\s+([\s\S]+)/i);if(match){forcedPriority=match[1].toUpperCase();userText=match[2].trim()}
+ const decision=forcedPriority?{kind:'command',reply:'استلمت الأمر الصريح.',command_text:userText,priority:forcedPriority,brain_state:'FORCED_COMMAND'}:await decide(userText,Array.isArray(memory)?memory:[],commands(status));
+ const kind=['chat','status','command'].includes(String(decision?.kind))?String(decision.kind):'chat';
+ let reply=String(decision?.reply||'').trim()||'وصلت.';
+ if(kind==='status')reply=statusReply(status);
+ if(kind==='command'){
+  const commandText=String(decision?.command_text||userText).trim(),priority=/^P[0-3]$/.test(String(decision?.priority||'').toUpperCase())?String(decision.priority).toUpperCase():'P1';
+  const queued=await rpc('barman_telegram_enqueue_v1',{p_update_id:updateId,p_user_id:userId,p_chat_id:chatId,p_text:commandText,p_priority:priority});
+  if(queued?.ok===true){const command=queued.command||{},id=String(command.id||command.command_id||queued.command_id||'').slice(0,12);reply=`${reply}\n\nالمهمة ${priority} مسجلة${id?` (${id})`:''}. سيطالب بها عامل التنفيذ؛ QUEUED لا تعني أنها نُفذت.`}
+  else reply=`لم أستطع تسجيل المهمة: ${String(queued?.reason||'UNKNOWN')}`;
+ }
+ await remember(userId,chatId,'assistant',reply,{kind,brain_state:decision?.brain_state||'UNKNOWN',model:decision?.model||null});
+ await send(bot_token,chatId,reply);return json(200,{ok:true,kind,brain_state:decision?.brain_state||'UNKNOWN'});
+}catch(error){console.error(String((error as any)?.stack||error));return json(500,{ok:false,error:'INTERNAL_ERROR'})}});

--- a/supabase/migrations/20260902162000_barman_executive_runtime_v1.sql
+++ b/supabase/migrations/20260902162000_barman_executive_runtime_v1.sql
@@ -1,0 +1,195 @@
+-- Durable runtime for BARMAN Executive OS.
+-- The command ledger lives in the private schema in Mumbai; only server-side
+-- service-role workers may claim or finalize work through these RPCs.
+
+alter table dabbir_private.dabbir_ceo_commands
+  add column if not exists attempt_count integer not null default 0,
+  add column if not exists lease_until timestamptz,
+  add column if not exists worker_id text,
+  add column if not exists execution_lane text,
+  add column if not exists execution_plan jsonb not null default '{}'::jsonb,
+  add column if not exists last_error text,
+  add column if not exists completed_at timestamptz;
+
+alter table dabbir_private.dabbir_ceo_commands
+  drop constraint if exists dabbir_ceo_commands_attempt_count_check;
+alter table dabbir_private.dabbir_ceo_commands
+  add constraint dabbir_ceo_commands_attempt_count_check
+  check (attempt_count between 0 and 12);
+
+alter table dabbir_private.dabbir_ceo_commands
+  drop constraint if exists dabbir_ceo_commands_execution_plan_check;
+alter table dabbir_private.dabbir_ceo_commands
+  add constraint dabbir_ceo_commands_execution_plan_check
+  check (jsonb_typeof(execution_plan) = 'object');
+
+create index if not exists dabbir_ceo_commands_runtime_claim_idx
+  on dabbir_private.dabbir_ceo_commands(status, execution_lane, priority, created_at)
+  where status in ('QUEUED','ACCEPTED','IN_PROGRESS');
+
+create or replace function public.barman_executive_claim_v1(
+  p_worker_id text,
+  p_lane text,
+  p_lease_seconds integer default 300
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, pg_temp
+as $$
+declare
+  v_command dabbir_private.dabbir_ceo_commands%rowtype;
+  v_event dabbir_private.executive_events%rowtype;
+  v_run_id uuid := gen_random_uuid();
+  v_action_id uuid := gen_random_uuid();
+  v_worker text := left(btrim(coalesce(p_worker_id,'')),120);
+  v_lane text := lower(left(btrim(coalesce(p_lane,'')),40));
+  v_lease integer := greatest(60,least(coalesce(p_lease_seconds,300),3600));
+begin
+  if v_worker = '' then raise exception 'WORKER_ID_REQUIRED'; end if;
+  if v_lane not in ('runtime','tool_agent') then raise exception 'EXECUTION_LANE_INVALID'; end if;
+
+  select c.* into v_command
+  from dabbir_private.dabbir_ceo_commands c
+  where c.status in ('QUEUED','ACCEPTED','IN_PROGRESS')
+    and c.attempt_count < 12
+    and (c.lease_until is null or c.lease_until < now())
+    and coalesce(c.execution_lane,
+      case
+        when c.command_text ~* '(تقرير|الحالة|حاله|افحص|فحص|راجع|صحة|صحه|status|report|health)' then 'runtime'
+        else 'tool_agent'
+      end
+    ) = v_lane
+  order by case c.priority when 'P0' then 0 when 'P1' then 1 when 'P2' then 2 else 3 end,
+           c.created_at
+  for update skip locked
+  limit 1;
+
+  if not found then return jsonb_build_object('ok',true,'claimed',false); end if;
+
+  select * into v_event
+  from dabbir_private.executive_events e
+  where e.source='owner-directive' and e.kind='ceo_command' and e.external_ref=v_command.id::text
+  order by e.detected_at desc
+  for update
+  limit 1;
+
+  update dabbir_private.dabbir_ceo_commands
+  set status='IN_PROGRESS', claimed_at=coalesce(claimed_at,now()), updated_at=now(),
+      attempt_count=attempt_count+1, lease_until=now()+make_interval(secs=>v_lease),
+      worker_id=v_worker, execution_lane=v_lane, last_error=null
+  where id=v_command.id
+  returning * into v_command;
+
+  if v_event.id is not null then
+    update dabbir_private.executive_events
+    set status='claimed', payload=payload || jsonb_build_object(
+      'worker_id',v_worker,'execution_lane',v_lane,'claimed_at',now(),'attempt_count',v_command.attempt_count
+    )
+    where id=v_event.id
+    returning * into v_event;
+  end if;
+
+  insert into dabbir_private.executive_runs(id,trigger_type,trigger_ref,status,started_at,metrics)
+  values(v_run_id,'owner',v_command.id::text,'running',now(),jsonb_build_object('worker_id',v_worker,'lane',v_lane,'attempt',v_command.attempt_count));
+
+  insert into dabbir_private.executive_actions(
+    id,run_id,event_id,action_type,authority_level,status,description,owner_interruption,started_at
+  ) values(
+    v_action_id,v_run_id,v_event.id,'execute_owner_command','auto','running',v_command.command_text,false,now()
+  );
+
+  return jsonb_build_object(
+    'ok',true,'claimed',true,'command',to_jsonb(v_command),
+    'event_id',v_event.id,'run_id',v_run_id,'action_id',v_action_id
+  );
+end;
+$$;
+
+create or replace function public.barman_executive_finalize_v1(
+  p_command_id uuid,
+  p_run_id uuid,
+  p_action_id uuid,
+  p_outcome text,
+  p_summary text,
+  p_evidence jsonb default '[]'::jsonb,
+  p_error text default null
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, pg_temp
+as $$
+declare
+  v_outcome text := upper(btrim(coalesce(p_outcome,'')));
+  v_summary text := left(btrim(coalesce(p_summary,'')),4000);
+  v_evidence jsonb := coalesce(p_evidence,'[]'::jsonb);
+  v_event_id uuid;
+  v_item jsonb;
+  v_final_status text;
+begin
+  if v_outcome not in ('DONE','BLOCKED','RETRY') then raise exception 'OUTCOME_INVALID'; end if;
+  if jsonb_typeof(v_evidence) <> 'array' then raise exception 'EVIDENCE_ARRAY_REQUIRED'; end if;
+  if v_outcome='DONE' and (v_summary='' or jsonb_array_length(v_evidence)=0) then
+    raise exception 'DONE_REQUIRES_SUMMARY_AND_EVIDENCE';
+  end if;
+
+  select e.id into v_event_id
+  from dabbir_private.executive_events e
+  where e.source='owner-directive' and e.kind='ceo_command' and e.external_ref=p_command_id::text
+  order by e.detected_at desc limit 1;
+
+  v_final_status := case v_outcome when 'DONE' then 'DONE' when 'BLOCKED' then 'BLOCKED' else 'QUEUED' end;
+  update dabbir_private.dabbir_ceo_commands
+  set status=v_final_status, result_summary=nullif(v_summary,''), evidence=v_evidence,
+      blocked_reason=case when v_outcome='BLOCKED' then left(coalesce(p_error,v_summary),2000) else null end,
+      last_error=left(p_error,2000), completed_at=case when v_outcome in ('DONE','BLOCKED') then now() else null end,
+      lease_until=null, worker_id=case when v_outcome='RETRY' then null else worker_id end, updated_at=now()
+  where id=p_command_id;
+
+  -- Evidence must exist before the action becomes verified. The database
+  -- verification trigger intentionally rejects the opposite order.
+  for v_item in select value from jsonb_array_elements(v_evidence)
+  loop
+    insert into dabbir_private.executive_evidence(action_id,evidence_type,reference,details,verified)
+    values(
+      p_action_id,
+      case when coalesce(v_item->>'type','') in ('commit','deployment','test','query','log','url','artifact','decision') then v_item->>'type' else 'artifact' end,
+      left(coalesce(nullif(v_item->>'reference',''),'barman-runtime:'||p_command_id::text),1000),
+      coalesce(v_item->'details','{}'::jsonb),
+      coalesce((v_item->>'verified')::boolean,false)
+    );
+  end loop;
+
+  update dabbir_private.executive_actions
+  set status=case when v_outcome='DONE' then 'verified' when v_outcome='BLOCKED' then 'failed' else 'failed' end,
+      completed_at=now(), error_message=left(p_error,2000)
+  where id=p_action_id and run_id=p_run_id;
+
+  if v_event_id is not null then
+    update dabbir_private.executive_events
+    set status=case when v_outcome='DONE' then 'resolved' when v_outcome='BLOCKED' then 'escalated' else 'open' end,
+        resolved_at=case when v_outcome in ('DONE','BLOCKED') then now() else null end,
+        payload=payload || jsonb_build_object('outcome',v_outcome,'summary',v_summary,'finished_at',now())
+    where id=v_event_id;
+  end if;
+
+  update dabbir_private.executive_runs
+  set status=case when v_outcome='DONE' then 'completed' when v_outcome='BLOCKED' then 'partial' else 'failed' end,
+      finished_at=now(), summary=nullif(v_summary,''),
+      metrics=metrics || jsonb_build_object('outcome',v_outcome,'evidence_count',jsonb_array_length(v_evidence))
+  where id=p_run_id;
+
+  return jsonb_build_object('ok',true,'command_id',p_command_id,'status',v_final_status,'outcome',v_outcome);
+end;
+$$;
+
+revoke all on function public.barman_executive_claim_v1(text,text,integer) from public, anon, authenticated;
+revoke all on function public.barman_executive_finalize_v1(uuid,uuid,uuid,text,text,jsonb,text) from public, anon, authenticated;
+grant execute on function public.barman_executive_claim_v1(text,text,integer) to service_role;
+grant execute on function public.barman_executive_finalize_v1(uuid,uuid,uuid,text,text,jsonb,text) to service_role;
+
+comment on function public.barman_executive_claim_v1(text,text,integer) is
+  'Atomically claims one DABBIR owner command with a bounded lease and creates its run/action evidence chain.';
+comment on function public.barman_executive_finalize_v1(uuid,uuid,uuid,text,text,jsonb,text) is
+  'Finalizes a BARMAN command; DONE fails closed unless a summary and at least one evidence item are supplied.';

--- a/test/barman-executive-runtime.test.mjs
+++ b/test/barman-executive-runtime.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { deterministicDecision, signedBody, verifySignedBody } from '../api/_barman-executive-core.js';
+import { cronAuthMode } from '../api/barman-executive-cron.js';
+
+const migration=fs.readFileSync(new URL('../supabase/migrations/20260902162000_barman_executive_runtime_v1.sql',import.meta.url),'utf8');
+const telegram=fs.readFileSync(new URL('../supabase/functions/barman-telegram-webhook/index.ts',import.meta.url),'utf8');
+const vercel=JSON.parse(fs.readFileSync(new URL('../vercel.json',import.meta.url),'utf8'));
+
+test('BARMAN runtime has atomic lease, evidence gate and private queue',()=>{
+  for(const token of ['for update skip locked','lease_until','attempt_count','barman_executive_claim_v1','barman_executive_finalize_v1','DONE_REQUIRES_SUMMARY_AND_EVIDENCE','dabbir_private.dabbir_ceo_commands'])assert.match(migration,new RegExp(token,'i'));
+  assert.match(migration,/revoke all on function public\.barman_executive_claim_v1/i);
+  assert.match(migration,/grant execute on function public\.barman_executive_claim_v1[\s\S]*service_role/i);
+});
+
+test('Telegram conversation uses signed Vercel AI bridge and truth-preserving status',()=>{
+  for(const token of ['barman-executive-chat','x-barman-timestamp','x-barman-signature','barman_telegram_memory_recent_v1','barman_telegram_status_v1','QUEUED لا تعني'])assert.match(telegram,new RegExp(token));
+  assert.doesNotMatch(telegram,/barman_openai_api_key|api\.openai\.com/);
+});
+
+test('signed bridge rejects tampering and old requests',()=>{
+  const body={text:'مرحبا'},key='test-service-role-key',signed=signedBody(body,key,1000);
+  assert.equal(verifySignedBody(signed.raw,signed.timestamp,signed.signature,key,1001),true);
+  assert.equal(verifySignedBody(JSON.stringify({text:'نفذ'}),signed.timestamp,signed.signature,key,1001),false);
+  assert.equal(verifySignedBody(signed.raw,signed.timestamp,signed.signature,key,1401),false);
+});
+
+test('deterministic fallback never turns status chatter into commands',()=>{
+  assert.equal(deterministicDecision('هل نفذت؟').kind,'status');
+  assert.equal(deterministicDecision('وينك').kind,'chat');
+  assert.equal(deterministicDecision('نفذ فحص دبر').kind,'command');
+});
+
+test('Vercel runs the executive worker every five minutes with fail-closed cron auth',()=>{
+  assert.ok(vercel.crons.some(item=>item.path==='/api/barman-executive-cron'&&item.schedule==='*/5 * * * *'));
+  const official={headers:{'user-agent':'vercel-cron/1.0','x-vercel-cron-schedule':'*/5 * * * *'}};
+  assert.equal(cronAuthMode(official,{VERCEL_ENV:'production'}),'vercel_schedule');
+  assert.equal(cronAuthMode(official,{VERCEL_ENV:'preview'}),null);
+  assert.equal(cronAuthMode(official,{VERCEL_ENV:'production',CRON_SECRET:'set'}),null);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -11,10 +11,17 @@
     {
       "path": "/api/salon-reminders-cron",
       "schedule": "*/5 * * * *"
+    },
+    {
+      "path": "/api/barman-executive-cron",
+      "schedule": "*/5 * * * *"
     }
   ],
   "functions": {
     "api/salon-reminders-cron.js": {
+      "maxDuration": 60
+    },
+    "api/barman-executive-cron.js": {
       "maxDuration": 60
     },
     "api/app.js": {


### PR DESCRIPTION
## Outcome
Replaces the Telegram message-recorder behavior with an evidence-gated executive runtime for DABBIR.

## What changes
- Adds an atomic command claim lease with retries and worker identity.
- Adds a fail-closed finalizer: DONE requires summary + evidence.
- Adds a Mumbai Vercel worker every 5 minutes for live reports and health checks.
- Adds a signed Supabase → Vercel AI Gateway bridge for real Telegram conversation without a separate OpenAI key.
- Keeps deterministic fallback for status/chat/commands if the AI provider is unavailable.
- Preserves owner-only financial/legal/KYC/OTP boundaries.
- Adds Telegram delivery of completed runtime work.
- Commits the Telegram webhook source that had previously existed only as a live direct deployment.

## Verification
- `npm run check:syntax` PASS.
- `npm test` PASS: 814/814.
- Signed request tamper/expiry tests PASS.
- Arabic status intent regression PASS.
- Supabase migration applied additively to Mumbai and verified separately.

## Production safety
- No DABBIR customer/runtime table data changed.
- Queue and evidence changes are additive.
- Client roles receive no access to the private executive ledger.
- Source/deployment changes still require tool-agent execution and proof; the worker cannot manufacture DONE.