### PR TITLE
Redeploy DABBIR with Google Calendar OAuth production env

### DIFF
--- a/docs/ops/google-calendar-production-redeploy-20260902.md
+++ b/docs/ops/google-calendar-production-redeploy-20260902.md
@@ -1,0 +1,11 @@
+# Google Calendar production redeploy
+
+Purpose: trigger a clean DABBIR production deployment after adding the Google Calendar OAuth client ID and client secret to the Vercel Production environment.
+
+Verification target after deployment:
+
+- `calendar_storage_configured: true`
+- `calendar_security_configured: true`
+- `google_calendar_configured: true`
+
+No credential values are stored in this file.


### PR DESCRIPTION
Triggers a clean production deployment after the Google Calendar OAuth client ID and client secret were added to Vercel Production. Contains no credentials. Post-deploy verification target: `google_calendar_configured=true` on `/api/qa-capability`.