### PR TITLE
P0: route multi-action BARMAN commands to the tool agent

### DIFF
--- a/supabase/migrations/20260902162000_barman_executive_runtime_v1.sql
+++ b/supabase/migrations/20260902162000_barman_executive_runtime_v1.sql
@@ -56,7 +56,9 @@ begin
     and (c.lease_until is null or c.lease_until < now())
     and coalesce(c.execution_lane,
       case
-        when c.command_text ~* '(تقرير|الحالة|حاله|افحص|فحص|راجع|صحة|صحه|status|report|health)' then 'runtime'
+        when char_length(c.command_text) <= 160
+          and btrim(c.command_text) ~* '^(اعطني|أعطني|اريد|أريد|give me|show)?[[:space:]]*(تقرير|الحالة|حاله|افحص|فحص|صحة|صحه|status|report|health)([[:space:]]+(دبر|dabbir))?[[:space:]؟?!.]*$'
+          then 'runtime'
         else 'tool_agent'
       end
     ) = v_lane

--- a/test/barman-executive-runtime.test.mjs
+++ b/test/barman-executive-runtime.test.mjs
@@ -10,6 +10,8 @@ const vercel=JSON.parse(fs.readFileSync(new URL('../vercel.json',import.meta.url
 
 test('BARMAN runtime has atomic lease, evidence gate and private queue',()=>{
   for(const token of ['for update skip locked','lease_until','attempt_count','barman_executive_claim_v1','barman_executive_finalize_v1','DONE_REQUIRES_SUMMARY_AND_EVIDENCE','dabbir_private.dabbir_ceo_commands'])assert.match(migration,new RegExp(token,'i'));
+  assert.match(migration,/char_length\(c\.command_text\) <= 160/i);
+  assert.match(migration,/else 'tool_agent'/i);
   assert.match(migration,/revoke all on function public\.barman_executive_claim_v1/i);
   assert.match(migration,/grant execute on function public\.barman_executive_claim_v1[\s\S]*service_role/i);
 });


### PR DESCRIPTION
## Root cause
The runtime-lane classifier matched any command containing a report/health word. A 729-character multi-action owner directive containing `التقرير` was incorrectly treated as a health report and marked DONE by the lightweight worker.

## Fix
- Runtime lane now accepts only short, whole-message report/health/status requests.
- Every composite or long directive routes to `tool_agent`.
- Adds regression assertions for the bounded classification.

## Live containment
The false completion was reopened in Mumbai, pinned to `tool_agent`, and reclaimed by the tool agent. Its prior health proof remains audit history but no longer satisfies the command.

## Verification
- Targeted runtime suite: 5/5 PASS.
- Live claim now routes the complex command to `tool_agent`.