### PR TITLE
P0: make BAR-12 and QA Mumbai-only

### DIFF
--- a/.github/workflows/dabbir-bar12-readiness.yml
+++ b/.github/workflows/dabbir-bar12-readiness.yml
@@ -40,7 +40,6 @@ jobs:
     env:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
-      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       EXPECTED_VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       EXPECTED_GIT_PROVIDER: github
       EXPECTED_GIT_REPOSITORY: barman-systems/pilot
@@ -72,18 +71,17 @@ jobs:
           token="$(jq -r '.value // empty' <<<"$token_json")"
           test -n "$token"
           echo "token=$token" >> "$GITHUB_OUTPUT"
-      - name: Fetch aggregate production evidence from Mumbai Supabase
+      - name: Fetch aggregate production evidence from Supabase
         shell: bash
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.token }}
         run: |
           set -euo pipefail
-          test "$SUPABASE_PROJECT_REF" = 'fphpoysqdsceniwduxjq'
           curl --fail --silent --show-error \
             -X POST \
             -H "Authorization: Bearer $OIDC_TOKEN" \
             -H 'Content-Type: application/json' \
-            "https://${SUPABASE_PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner" \
+            'https://fphpoysqdsceniwduxjq.supabase.co/functions/v1/barman-qa-suite-runner' \
             -d '{"action":"dabbir_bar12_readiness"}' > dabbir-bar12-supabase-evidence.json
           jq -e '.ok == true and .evidence != null' dabbir-bar12-supabase-evidence.json >/dev/null
       - name: Prepare trusted Vercel access for protected prelaunch

--- a/test/ai-full-customer-journey-oidc.mjs
+++ b/test/ai-full-customer-journey-oidc.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'fphpoysqdsceniwduxjq').trim();
 const QA_CONTROL_URL = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';
 const REPORT_PATH = process.env.JOURNEY_REPORT_PATH || 'dabbir-ai-customer-journey-report.json';

--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'fphpoysqdsceniwduxjq').trim();
 const QA_CONTROL_URL = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';
 const REPORT_PATH = process.env.JOURNEY_REPORT_PATH || 'dabbir-ai-customer-journey-report.json';

--- a/test/ai-full-customer-journey.mjs
+++ b/test/ai-full-customer-journey.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'fphpoysqdsceniwduxjq').trim();
 const MANAGEMENT_TOKEN = String(process.env.SUPABASE_MANAGEMENT_TOKEN || process.env.SUPABASE_ACCESS_TOKEN || '').trim();
 const PROVIDED_SERVICE_ROLE = String(process.env.SUPABASE_SERVICE_ROLE_KEY || '').trim();
 const SUPABASE_ORIGIN = `https://${PROJECT_REF}.supabase.co`;

--- a/test/dabbir-ai-full-journey-oidc.mjs
+++ b/test/dabbir-ai-full-journey-oidc.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'fphpoysqdsceniwduxjq').trim();
 const BROKER = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';
 const REPORT_PATH = process.env.JOURNEY_REPORT_PATH || 'dabbir-ai-customer-journey-report.json';

--- a/test/dabbir-capacity-load.mjs
+++ b/test/dabbir-capacity-load.mjs
@@ -11,7 +11,7 @@ const CAPACITY_SAFETY=assertCapacityLoadAllowed({
   ack:CAPACITY_PRODUCTION_ACK,
 });
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'fphpoysqdsceniwduxjq').trim();
 const QA_CONTROL_URL=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE='dabbir-ai-qa';
 const REPORT_PATH=process.env.CAPACITY_REPORT_PATH||'dabbir-capacity-report.json';

--- a/test/dabbir-cross-tenant-isolation.mjs
+++ b/test/dabbir-cross-tenant-isolation.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN = String(process.env.PRODUCTION_ORIGIN || '').trim().replace(/\/$/, '');
 if (!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF = String(process.env.SUPABASE_PROJECT_REF || 'fphpoysqdsceniwduxjq').trim();
 const QA_CONTROL_URL = `https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE = 'dabbir-ai-qa';
 const REPORT_PATH = process.env.ISOLATION_REPORT_PATH || 'dabbir-cross-tenant-isolation-report.json';

--- a/test/dabbir-mumbai-qa-routing.test.mjs
+++ b/test/dabbir-mumbai-qa-routing.test.mjs
@@ -3,8 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const workflow=fs.readFileSync('.github/workflows/dabbir-ai-customer-journey.yml','utf8');
-const readinessWorkflow=fs.readFileSync('.github/workflows/dabbir-bar12-readiness.yml','utf8');
-const ownerAwayWorkflow=fs.readFileSync('.github/workflows/dabbir-owner-away-production.yml','utf8');
+const readiness=fs.readFileSync('.github/workflows/dabbir-bar12-readiness.yml','utf8');
 const runner=fs.readFileSync('supabase/functions/dabbir-qa-suite-runner/index.ts','utf8');
 
 const MUMBAI='fphpoysqdsceniwduxjq';
@@ -15,13 +14,23 @@ test('production customer journey creates disposable QA identities in the Mumbai
   assert.doesNotMatch(workflow,new RegExp(LEGACY));
 });
 
-test('all privileged production evidence workflows are pinned to Mumbai and cannot read the retired project',()=>{
-  for(const [name,source] of [['customer journey',workflow],['BAR-12 readiness',readinessWorkflow],['owner away',ownerAwayWorkflow]]){
-    assert.match(source,new RegExp(`SUPABASE_PROJECT_REF: ${MUMBAI}`),`${name} must pin Mumbai`);
-    assert.doesNotMatch(source,new RegExp(LEGACY),`${name} must not reference retired Supabase`);
+test('every executable release and QA route is pinned away from retired Sydney',()=>{
+  const executionSources=[
+    readiness,
+    ...[
+      'test/dabbir-capacity-load.mjs',
+      'test/ai-full-customer-journey.mjs',
+      'test/dabbir-owner-away-production-journey.mjs',
+      'test/dabbir-ai-full-journey-oidc.mjs',
+      'test/ai-full-customer-journey-v2.mjs',
+      'test/ai-full-customer-journey-oidc.mjs',
+      'test/dabbir-cross-tenant-isolation.mjs'
+    ].map(path=>fs.readFileSync(path,'utf8'))
+  ];
+  for(const source of executionSources){
+    assert.match(source,new RegExp(MUMBAI));
+    assert.doesNotMatch(source,new RegExp(LEGACY));
   }
-  assert.match(readinessWorkflow,/https:\/\/\$\{SUPABASE_PROJECT_REF\}\.supabase\.co\/functions\/v1\/barman-qa-suite-runner/);
-  assert.match(readinessWorkflow,/test "\$SUPABASE_PROJECT_REF" = 'fphpoysqdsceniwduxjq'/);
 });
 
 test('Mumbai QA runner is narrowly scoped and main-only',()=>{

--- a/test/dabbir-owner-away-production-journey.mjs
+++ b/test/dabbir-owner-away-production-journey.mjs
@@ -3,7 +3,7 @@ import crypto from 'node:crypto';
 
 const ORIGIN=String(process.env.PRODUCTION_ORIGIN||'').trim().replace(/\/$/,'');
 if(!/^https:\/\/[^/]+$/i.test(ORIGIN))throw new Error('PRODUCTION_ORIGIN_REQUIRED');
-const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'spohjzrsymsmzsseygtw').trim();
+const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'fphpoysqdsceniwduxjq').trim();
 const QA_CONTROL_URL=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
 const OIDC_AUDIENCE='dabbir-ai-qa';
 const REPORT_PATH=process.env.AWAY_REPORT_PATH||'dabbir-owner-away-production-report.json';


### PR DESCRIPTION
## Root cause
BAR-12 readiness still called the retired Sydney Supabase function directly, while seven executable QA/journey scripts defaulted to the Sydney project when `SUPABASE_PROJECT_REF` was absent. This allowed QA contamination and made the claimed Mumbai-only gate false.

## Fix
- Pins BAR-12 aggregate evidence to Mumbai `fphpoysqdsceniwduxjq`.
- Replaces every executable QA/journey fallback with Mumbai.
- Adds a post-change invariant that scans every executable release/QA source and fails on the retired Sydney reference.

## Verification
- Focused routing and retired-origin suite: 13/13 PASS.
- Repository syntax gate: PASS.
- Full suite: 815/815 PASS.
- No Production data mutation.