### PR TITLE
Fix Google Calendar OAuth readiness in booking UI

### DIFF
--- a/api/calendar-connections.js
+++ b/api/calendar-connections.js
@@ -14,9 +14,17 @@ function statusCode(error){
   return [400,401,403,404,409,429,502,503].includes(code)?code:500;
 }
 
-function calendarStorageConfigured(){
-  const key=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
-  return Boolean(key&&!key.startsWith('sb_publishable_'));
+function calendarRuntimeReadiness(){
+  const serviceRoleKey=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
+  const tokenKey=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim();
+  const stateSecret=String(process.env.DABBIR_CALENDAR_STATE_SECRET||'').trim();
+  const storageConfigured=serviceRoleKey.length>=24&&!serviceRoleKey.startsWith('sb_publishable_');
+  const rootSecretConfigured=tokenKey.length>=24||storageConfigured;
+  const stateSecretConfigured=stateSecret.length>=24||rootSecretConfigured;
+  return {
+    storageConfigured,
+    securityReady:rootSecretConfigured&&stateSecretConfigured,
+  };
 }
 
 function logCalendarFailure(error,status){
@@ -34,8 +42,7 @@ export default async function handler(req,res){
       const businessId=safeBusinessId(singleQueryValue(req,'business_id'));
       await requireCalendarMember(req,businessId);
       const google=providerConfig('google',req),outlook=providerConfig('outlook',req);
-      const securityReady=String(process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24&&String(process.env.DABBIR_CALENDAR_STATE_SECRET||process.env.DABBIR_CALENDAR_TOKEN_KEY||'').trim().length>=24;
-      const storageConfigured=calendarStorageConfigured();
+      const {storageConfigured,securityReady}=calendarRuntimeReadiness();
       const connections=storageConfigured?await listConnections(businessId):[];
       return json(res,200,{
         ok:true,

--- a/test/calendar-security-bootstrap.test.mjs
+++ b/test/calendar-security-bootstrap.test.mjs
@@ -1,5 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
 
 const SERVICE_ROLE_ENV = ['SUPABASE', 'SERVICE', 'ROLE', 'KEY'].join('_');
 const TOKEN_KEY_ENV = ['DABBIR', 'CALENDAR', 'TOKEN', 'KEY'].join('_');
@@ -54,4 +55,12 @@ test('oauth state signs and verifies using the server-only fallback secret', () 
   const state = signOauthState(payload);
   assert.deepEqual(verifyOauthState(state), payload);
   assert.throws(() => verifyOauthState(`${state}x`), /INVALID_CALENDAR_OAUTH_STATE/);
+});
+
+test('calendar connection readiness accepts the same server-only security fallback as token handling', async () => {
+  const source = await readFile(new URL('../api/calendar-connections.js', import.meta.url), 'utf8');
+  assert.match(source, /const storageConfigured=serviceRoleKey\.length>=24&&!serviceRoleKey\.startsWith\('sb_publishable_'\)/);
+  assert.match(source, /const rootSecretConfigured=tokenKey\.length>=24\|\|storageConfigured/);
+  assert.match(source, /const stateSecretConfigured=stateSecret\.length>=24\|\|rootSecretConfigured/);
+  assert.match(source, /securityReady:rootSecretConfigured&&stateSecretConfigured/);
 });


### PR DESCRIPTION
Rebased on the latest main. Fixes the production mismatch where /api/qa-capability reports calendar security readiness via the server-only fallback secret, but /api/calendar-connections still required dedicated calendar secrets and disabled the Google/Outlook connect buttons. Adds regression coverage.