### PR TITLE
Fix salon booking prerequisites

### DIFF
--- a/api/salon-product-model-ui-patches.js
+++ b/api/salon-product-model-ui-patches.js
@@ -2,12 +2,12 @@ const SALON_PRODUCT_MODEL_PATCHES=[
   {
     name:'salon-copy-ar-employee-owns-services',
     from:`appointmentDetails:'تفاصيل الموعد',serviceRequired:'أضيفي خدمة واربطيها بموظفة أولًا.',endOfDay:'ملخص اليوم'`,
-    to:`appointmentDetails:'تفاصيل الموعد',employeeRequired:'أضيفي موظفة أولًا.',serviceCatalogRequired:'أضيفي خدمة أولًا.',employeeServicesRequired:'أسندي خدمة واحدة على الأقل للموظفة من شاشة الموظفات.',serviceRequired:'اختاري الموظفة أولًا لعرض الخدمات التي تقدمها.',endOfDay:'ملخص اليوم'`,
+    to:`appointmentDetails:'تفاصيل الموعد',employeeRequired:'أضيفي موظفة أولًا.',serviceCatalogRequired:'أضيفي خدمة أولًا.',employeeServicesRequired:'أسندي خدمة واحدة على الأقل للموظفة من شاشة الموظفات.',serviceRequired:'اختاري الموظفة أولًا لعرض الخدمات التي تقدمها.',unassigned:'غير مسند',endOfDay:'ملخص اليوم'`,
   },
   {
     name:'salon-copy-en-employee-owns-services',
     from:`appointmentDetails:'Appointment details',serviceRequired:'Add a service and assign it to an employee first.',endOfDay:'End-of-day summary'`,
-    to:`appointmentDetails:'Appointment details',employeeRequired:'Add an employee first.',serviceCatalogRequired:'Add a service first.',employeeServicesRequired:'Assign at least one service to the employee from the Team screen.',serviceRequired:'Choose the employee first to show the services they provide.',endOfDay:'End-of-day summary'`,
+    to:`appointmentDetails:'Appointment details',employeeRequired:'Add an employee first.',serviceCatalogRequired:'Add a service first.',employeeServicesRequired:'Assign at least one service to the employee from the Team screen.',serviceRequired:'Choose the employee first to show the services they provide.',unassigned:'Unassigned',endOfDay:'End-of-day summary'`,
   },
   {
     name:'salon-month-range-stays-within-api-bound',
@@ -15,19 +15,49 @@ const SALON_PRODUCT_MODEL_PATCHES=[
     to:`    const monthStart=startWeek(new Date(cursor.getFullYear(),cursor.getMonth(),1));\n    const from=view==='month'?monthStart:plus(startDay(cursor),-2),to=view==='month'?plus(monthStart,42):plus(startDay(cursor),view==='week'?12:3);`,
   },
   {
-    name:'salon-quick-book-readiness-is-explicit',
+    name:'salon-quick-book-has-no-setup-gate',
     from:`    if(!services.length||!workers.length){notify(t.serviceRequired);return}`,
-    to:`    if(!workers.length){notify(t.employeeRequired);return}\n    if(!services.length){notify(t.serviceCatalogRequired);return}\n    if(!(data.worker_services||[]).some(x=>x.active&&workers.some(w=>w.id===x.worker_id)&&services.some(s=>s.id===x.service_id))){notify(t.employeeServicesRequired);return}`,
+    to:`    // Booking must remain available even before employees or services are configured.`,
   },
   {
-    name:'salon-quick-book-employee-before-service',
+    name:'salon-quick-book-employee-and-service-independent',
     from:`<div class="salonField"><label>'+esc(t.service)+'</label><select id="sqService" required><option value=""></option>'+services.map(s=>'<option value="'+esc(s.id)+'">'+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+' · '+money(s.price_aed)+'</option>').join('')+'</select></div><div class="salonField"><label>'+esc(t.employee)+'</label><select id="sqWorker" required><option value=""></option></select></div>`,
-    to:`<div class="salonField"><label>'+esc(t.employee)+'</label><select id="sqWorker" required><option value=""></option>'+workers.map(w=>'<option value="'+esc(w.id)+'">'+esc(w.display_name)+'</option>').join('')+'</select></div><div class="salonField"><label>'+esc(t.service)+'</label><select id="sqService" required><option value=""></option></select></div>`,
+    to:`<div class="salonField"><label>'+esc(t.employee)+'</label><select id="sqWorker"><option value=""></option>'+workers.map(w=>'<option value="'+esc(w.id)+'">'+esc(w.display_name)+'</option>').join('')+'</select></div><div class="salonField"><label>'+esc(t.service)+'</label><select id="sqService"><option value=""></option>'+services.map(s=>'<option value="'+esc(s.id)+'">'+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+' · '+money(s.price_aed)+'</option>').join('')+'</select></div>`,
   },
   {
-    name:'salon-quick-book-services-follow-employee',
+    name:'salon-quick-book-removes-worker-service-dependency',
     from:`    const syncWorkers=()=>{const sid=q('#sqService').value,allowed=new Set((data.worker_services||[]).filter(x=>x.service_id===sid&&x.active).map(x=>x.worker_id));q('#sqWorker').innerHTML='<option value=""></option>'+workers.filter(w=>allowed.has(w.id)).map(w=>'<option value="'+esc(w.id)+'">'+esc(w.display_name)+'</option>').join('')};q('#sqService').onchange=syncWorkers;`,
-    to:`    const syncServices=()=>{const wid=q('#sqWorker').value,allowed=new Set((data.worker_services||[]).filter(x=>x.worker_id===wid&&x.active).map(x=>x.service_id));q('#sqService').innerHTML='<option value=""></option>'+services.filter(s=>allowed.has(s.id)).map(s=>'<option value="'+esc(s.id)+'">'+esc(ar()?(s.name_ar||s.name):(s.name_en||s.name))+' · '+money(s.price_aed)+'</option>').join('')};q('#sqWorker').onchange=syncServices;`,
+    to:`    // Employee and service are optional and intentionally independent in quick booking.`,
+  },
+  {
+    name:'salon-quick-book-name-optional',
+    from:`<input id="sqName" maxlength="120" required>`,
+    to:`<input id="sqName" maxlength="120">`,
+  },
+  {
+    name:'salon-quick-book-phone-optional',
+    from:`<input id="sqPhone" maxlength="30" required>`,
+    to:`<input id="sqPhone" maxlength="30">`,
+  },
+  {
+    name:'salon-quick-book-time-optional',
+    from:`<input id="sqTime" type="datetime-local" required>`,
+    to:`<input id="sqTime" type="datetime-local">`,
+  },
+  {
+    name:'salon-quick-book-time-can-default-server-side',
+    from:`starts_at:new Date(q('#sqTime').value).toISOString()`,
+    to:`starts_at:q('#sqTime').value?new Date(q('#sqTime').value).toISOString():null`,
+  },
+  {
+    name:'salon-day-calendar-shows-unassigned-bookings',
+    from:`  function dayCalendar(){\n    const t=text(),workers=(data.workers||[]).filter(w=>w.status==='active'),rows=calendarRows().filter(a=>key(a.starts_at)===key(cursor));\n    if(!workers.length)return '<div class="empty">'+esc(t.addEmployee)+'</div>';\n    let html='<div class="salonCalendarScroll"><div class="salonDayGrid" style="grid-template-columns:72px repeat('+workers.length+',minmax(150px,1fr))"><div class="salonCorner">'+esc(t.time)+'</div>'+workers.map(w=>'<div class="salonWorkerHead">'+esc(w.display_name)+'</div>').join('');\n    for(let h=7;h<=21;h++)for(let m=0;m<60;m+=30){const stamp=new Date(cursor);stamp.setHours(h,m,0,0);const iso=stamp.toISOString();html+='<div class="salonTime">'+esc(fmt(stamp,{hour:'numeric',minute:'2-digit'}))+'</div>';for(const w of workers){const slot=rows.filter(a=>a.worker_id===w.id&&new Date(a.starts_at).getHours()===h&&new Date(a.starts_at).getMinutes()>=m&&new Date(a.starts_at).getMinutes()<m+30);html+='<div class="salonSlot" data-worker="'+esc(w.id)+'" data-time="'+esc(iso)+'">'+slot.map(eventHtml).join('')+'</div>'}}\n    return html+'</div></div>';\n  }`,
+    to:`  function dayCalendar(){\n    const t=text(),activeWorkers=(data.workers||[]).filter(w=>w.status==='active'),rows=calendarRows().filter(a=>key(a.starts_at)===key(cursor)),hasUnassigned=rows.some(a=>!a.worker_id),workers=[...activeWorkers,...((hasUnassigned||!activeWorkers.length)?[{id:'',display_name:t.unassigned,unassigned:true}]:[])];\n    let html='<div class="salonCalendarScroll"><div class="salonDayGrid" style="grid-template-columns:72px repeat('+workers.length+',minmax(150px,1fr))"><div class="salonCorner">'+esc(t.time)+'</div>'+workers.map(w=>'<div class="salonWorkerHead">'+esc(w.display_name)+'</div>').join('');\n    for(let h=7;h<=21;h++)for(let m=0;m<60;m+=30){const stamp=new Date(cursor);stamp.setHours(h,m,0,0);const iso=stamp.toISOString();html+='<div class="salonTime">'+esc(fmt(stamp,{hour:'numeric',minute:'2-digit'}))+'</div>';for(const w of workers){const slot=rows.filter(a=>(w.unassigned?!a.worker_id:a.worker_id===w.id)&&new Date(a.starts_at).getHours()===h&&new Date(a.starts_at).getMinutes()>=m&&new Date(a.starts_at).getMinutes()<m+30),workerAttr=w.unassigned?'':' data-worker="'+esc(w.id)+'"';html+='<div class="salonSlot"'+workerAttr+' data-time="'+esc(iso)+'">'+slot.map(eventHtml).join('')+'</div>'}}\n    return html+'</div></div>';\n  }`,
+  },
+  {
+    name:'salon-week-calendar-shows-unassigned-bookings',
+    from:`  function weekCalendar(){const start=startWeek(cursor),workers=(data.workers||[]).filter(w=>w.status==='active'),rows=calendarRows();let html='<div class="salonCalendarScroll"><div class="salonWeek">';for(let i=0;i<7;i++){const d=plus(start,i),dayRows=rows.filter(a=>key(a.starts_at)===key(d));html+='<div class="salonWeekDay"><div class="salonWeekHead">'+esc(fmt(d,{weekday:'short',day:'numeric',month:'short'}))+'</div>'+workers.map(w=>'<div class="salonWeekWorker"><span>'+esc(w.display_name)+'</span>'+(dayRows.filter(a=>a.worker_id===w.id).map(eventHtml).join('')||'<div class="salonGap">'+esc(text().availableGap)+'</div>')+'</div>').join('')+'</div>'}return html+'</div></div>'}`,
+    to:`  function weekCalendar(){const start=startWeek(cursor),workers=(data.workers||[]).filter(w=>w.status==='active'),rows=calendarRows(),t=text();let html='<div class="salonCalendarScroll"><div class="salonWeek">';for(let i=0;i<7;i++){const d=plus(start,i),dayRows=rows.filter(a=>key(a.starts_at)===key(d)),unassigned=dayRows.filter(a=>!a.worker_id);html+='<div class="salonWeekDay"><div class="salonWeekHead">'+esc(fmt(d,{weekday:'short',day:'numeric',month:'short'}))+'</div>'+workers.map(w=>'<div class="salonWeekWorker"><span>'+esc(w.display_name)+'</span>'+(dayRows.filter(a=>a.worker_id===w.id).map(eventHtml).join('')||'<div class="salonGap">'+esc(t.availableGap)+'</div>')+'</div>').join('')+((unassigned.length||!workers.length)?'<div class="salonWeekWorker"><span>'+esc(t.unassigned)+'</span>'+(unassigned.map(eventHtml).join('')||'<div class="salonGap">'+esc(t.availableGap)+'</div>')+'</div>':'')+'</div>'}return html+'</div></div>'}`,
   },
   {
     name:'salon-new-employee-can-select-services',

--- a/supabase/migrations/20260902220500_dabbir_salon_booking_no_prerequisites_v1.sql
+++ b/supabase/migrations/20260902220500_dabbir_salon_booking_no_prerequisites_v1.sql
@@ -1,0 +1,209 @@
+begin;
+
+-- Quick booking must always be available. Customer, employee and service are
+-- optional; a missing time falls back to 30 minutes from now.
+create or replace function dabbir_private.salon_member_scope(p_business_id uuid,p_worker_id uuid,p_manage boolean default false)
+returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+  select case
+    when not dabbir_private.has_permission(p_business_id,case when p_manage then 'manage_appointments' else 'view_appointments' end) then false
+    when not exists(select 1 from public.dabbir_businesses b where b.id=p_business_id and b.business_type='salon') then true
+    when p_worker_id is null then true
+    when exists(select 1 from public.dabbir_memberships m where m.business_id=p_business_id and m.user_id=(select auth.uid()) and m.status='active' and m.role in ('owner','admin','manager')) then true
+    else exists(select 1 from public.dabbir_workers w where w.business_id=p_business_id and w.id=p_worker_id and w.membership_user_id=(select auth.uid()) and w.status='active')
+  end;
+$$;
+revoke all on function dabbir_private.salon_member_scope(uuid,uuid,boolean) from public,anon,authenticated;
+
+create or replace function dabbir_private.prevent_appointment_calendar_conflict()
+returns trigger
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_end timestamptz;
+  v_timezone text := 'Asia/Dubai';
+  v_local_start timestamp;
+  v_local_end timestamp;
+  v_weekday smallint;
+  v_has_schedule boolean;
+begin
+  if new.starts_at is null or new.status in ('cancelled','completed','no_show') then return new; end if;
+  v_end := coalesce(new.ends_at,new.starts_at+interval '60 minutes');
+  if v_end <= new.starts_at then raise exception 'INVALID_APPOINTMENT_RANGE'; end if;
+
+  select coalesce(s.timezone,'Asia/Dubai') into v_timezone
+  from public.dabbir_salon_settings s where s.business_id=new.business_id;
+  v_local_start := new.starts_at at time zone v_timezone;
+  v_local_end := v_end at time zone v_timezone;
+  v_weekday := extract(dow from v_local_start)::smallint;
+
+  if new.worker_id is not null then
+    select exists(select 1 from public.dabbir_worker_schedules s where s.business_id=new.business_id and s.worker_id=new.worker_id and s.active and s.schedule_type='work') into v_has_schedule;
+    if v_has_schedule and not exists(
+      select 1 from public.dabbir_worker_schedules s
+      where s.business_id=new.business_id and s.worker_id=new.worker_id and s.weekday=v_weekday
+        and s.active and s.schedule_type='work'
+        and s.starts_at <= v_local_start::time and s.ends_at >= v_local_end::time
+    ) then raise exception 'WORKER_OUTSIDE_SCHEDULE'; end if;
+
+    if exists(
+      select 1 from public.dabbir_worker_schedules s
+      where s.business_id=new.business_id and s.worker_id=new.worker_id and s.weekday=v_weekday
+        and s.active and s.schedule_type in ('break','unavailable')
+        and s.starts_at < v_local_end::time and s.ends_at > v_local_start::time
+    ) then raise exception 'WORKER_UNAVAILABLE'; end if;
+
+    if exists(
+      select 1 from public.dabbir_worker_time_off t
+      where t.business_id=new.business_id and t.worker_id=new.worker_id
+        and t.starts_at < v_end and t.ends_at > new.starts_at
+    ) then raise exception 'WORKER_TIME_OFF'; end if;
+  end if;
+
+  if exists(
+    select 1 from public.dabbir_calendar_busy_blocks b
+    where b.business_id=new.business_id and b.starts_at < v_end and b.ends_at > new.starts_at
+  ) then raise exception 'APPOINTMENT_CALENDAR_CONFLICT'; end if;
+
+  if new.worker_id is not null and exists(
+    select 1 from public.dabbir_appointments a
+    where a.business_id=new.business_id
+      and a.id <> coalesce(new.id,gen_random_uuid())
+      and a.starts_at is not null
+      and a.status not in ('cancelled','completed','no_show')
+      and a.worker_id=new.worker_id
+      and a.starts_at < v_end
+      and coalesce(a.ends_at,a.starts_at+interval '60 minutes') > new.starts_at
+  ) then raise exception 'APPOINTMENT_TIME_CONFLICT'; end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.prevent_appointment_calendar_conflict() from public,anon,authenticated;
+
+create or replace function public.dabbir_salon_quick_book(
+  p_business_id uuid,
+  p_customer_name text default '',
+  p_customer_phone text default '',
+  p_service_id uuid default null,
+  p_worker_id uuid default null,
+  p_starts_at timestamptz default null,
+  p_discount_aed numeric default 0,
+  p_notes text default '',
+  p_source text default 'internal'
+) returns jsonb
+language plpgsql
+security invoker
+set search_path=public,pg_temp
+as $$
+declare
+  v_customer_id uuid;
+  v_service_id uuid := p_service_id;
+  v_worker_id uuid := p_worker_id;
+  v_duration integer := 60;
+  v_price numeric := 0;
+  v_discount numeric := 0;
+  v_name_ar text;
+  v_name_en text;
+  v_appointment_id uuid;
+  v_start timestamptz := coalesce(p_starts_at,now()+interval '30 minutes');
+  v_end timestamptz;
+  v_customer_name text := nullif(left(trim(coalesce(p_customer_name,'')),120),'');
+  v_customer_phone text := nullif(trim(coalesce(p_customer_phone,'')),'');
+begin
+  if not dabbir_private.has_permission(p_business_id,'manage_appointments') then raise exception 'APPOINTMENT_MANAGEMENT_REQUIRED'; end if;
+  if not exists(select 1 from public.dabbir_businesses where id=p_business_id and business_type='salon') then raise exception 'SALON_MODE_REQUIRED'; end if;
+  if v_start<=now() then raise exception 'INVALID_START_TIME'; end if;
+  if coalesce(p_source,'internal') not in ('internal','web','whatsapp','phone','walk_in','rebook','waitlist','calendar_sync') then raise exception 'INVALID_BOOKING_SOURCE'; end if;
+
+  if v_worker_id is not null and not exists(
+    select 1 from public.dabbir_workers w
+    where w.business_id=p_business_id and w.id=v_worker_id and w.status='active'
+  ) then
+    v_worker_id := null;
+  end if;
+
+  if v_service_id is not null then
+    select coalesce(ws.duration_minutes,s.duration_minutes,60),
+           coalesce(ws.price_aed,s.price_aed,0),
+           coalesce(s.name_ar,s.name),
+           coalesce(s.name_en,s.name)
+      into v_duration,v_price,v_name_ar,v_name_en
+    from public.dabbir_services s
+    left join public.dabbir_worker_services ws
+      on ws.business_id=s.business_id
+     and ws.service_id=s.id
+     and ws.worker_id=v_worker_id
+     and ws.active
+    where s.business_id=p_business_id and s.id=v_service_id and s.active;
+    if not found then
+      v_service_id := null;
+      v_duration := 60;
+      v_price := 0;
+      v_name_ar := null;
+      v_name_en := null;
+    end if;
+  end if;
+
+  v_discount := least(greatest(coalesce(p_discount_aed,0),0),coalesce(v_price,0));
+  v_end := v_start+make_interval(mins=>greatest(5,coalesce(v_duration,60)));
+
+  if v_customer_phone is not null then
+    select id into v_customer_id
+    from public.dabbir_customers
+    where business_id=p_business_id and phone_e164=v_customer_phone
+    limit 1;
+  end if;
+
+  if v_customer_id is null and (v_customer_name is not null or v_customer_phone is not null)
+     and dabbir_private.has_permission(p_business_id,'edit_customers') then
+    insert into public.dabbir_customers(business_id,display_name,phone_e164,lead_status,metadata)
+    values(p_business_id,coalesce(v_customer_name,'عميل'),v_customer_phone,'converted',jsonb_build_object('source','salon_quick_booking'))
+    returning id into v_customer_id;
+  elsif v_customer_id is not null and v_customer_name is not null
+        and dabbir_private.has_permission(p_business_id,'edit_customers') then
+    update public.dabbir_customers
+    set display_name=v_customer_name,updated_at=now()
+    where business_id=p_business_id and id=v_customer_id;
+  end if;
+
+  insert into public.dabbir_appointments(
+    business_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,
+    quoted_price_aed,discount_aed,notes,booking_source,payment_status
+  ) values(
+    p_business_id,v_customer_id,v_service_id,v_worker_id,v_start,v_end,'new',false,
+    coalesce(v_price,0),v_discount,left(coalesce(p_notes,''),2000),coalesce(p_source,'internal'),'unpaid'
+  ) returning id into v_appointment_id;
+
+  if v_service_id is not null then
+    insert into public.dabbir_appointment_services(
+      business_id,appointment_id,service_id,worker_id,service_name_ar,service_name_en,
+      duration_minutes,unit_price_aed,discount_aed
+    ) values(
+      p_business_id,v_appointment_id,v_service_id,v_worker_id,
+      coalesce(v_name_ar,'خدمة'),coalesce(v_name_en,'Service'),
+      greatest(5,coalesce(v_duration,60)),coalesce(v_price,0),v_discount
+    );
+  end if;
+
+  return jsonb_build_object(
+    'appointment_id',v_appointment_id,
+    'customer_id',v_customer_id,
+    'service_id',v_service_id,
+    'worker_id',v_worker_id,
+    'starts_at',v_start,
+    'ends_at',v_end,
+    'status','new'
+  );
+end;
+$$;
+
+revoke all on function public.dabbir_salon_quick_book(uuid,text,text,uuid,uuid,timestamptz,numeric,text,text) from public,anon;
+grant execute on function public.dabbir_salon_quick_book(uuid,text,text,uuid,uuid,timestamptz,numeric,text,text) to authenticated;
+
+commit;

--- a/supabase/migrations/20260902220500_dabbir_salon_booking_no_prerequisites_v1.sql
+++ b/supabase/migrations/20260902220500_dabbir_salon_booking_no_prerequisites_v1.sql
@@ -1,5 +1,3 @@
-begin;
-
 -- Quick booking must always be available. Customer, employee and service are
 -- optional; a missing time falls back to 30 minutes from now.
 create or replace function dabbir_private.salon_member_scope(p_business_id uuid,p_worker_id uuid,p_manage boolean default false)
@@ -205,5 +203,3 @@ $$;
 
 revoke all on function public.dabbir_salon_quick_book(uuid,text,text,uuid,uuid,timestamptz,numeric,text,text) from public,anon;
 grant execute on function public.dabbir_salon_quick_book(uuid,text,text,uuid,uuid,timestamptz,numeric,text,text) to authenticated;
-
-commit;

--- a/supabase/migrations/20260902220600_fix_salon_member_scope_authenticated_execute.sql
+++ b/supabase/migrations/20260902220600_fix_salon_member_scope_authenticated_execute.sql
@@ -1,0 +1,5 @@
+-- The salon booking migration tightens EXECUTE on the private RLS helper.
+-- RLS policies on dabbir_appointments invoke this helper as authenticated users,
+-- so authenticated must retain EXECUTE while anon/public remain blocked.
+revoke execute on function dabbir_private.salon_member_scope(uuid,uuid,boolean) from public, anon;
+grant execute on function dabbir_private.salon_member_scope(uuid,uuid,boolean) to authenticated, service_role;

--- a/test/dabbir-salon-employee-first-booking.test.mjs
+++ b/test/dabbir-salon-employee-first-booking.test.mjs
@@ -11,24 +11,50 @@ const read=file=>fs.readFileSync(path.join(root,file),'utf8');
 function captureResponse(){return {statusCode:200,headers:{},body:'',status(code){this.statusCode=Number(code);return this},setHeader(key,value){this.headers[String(key).toLowerCase()]=value;return this},send(body=''){this.body=String(body);return this},end(body=''){this.body=String(body);return this}}}
 function emittedSalon(){const res=captureResponse();salonModeUiHandler({method:'GET'},res);assert.equal(res.statusCode,200);return res.body}
 
-test('Salon data model keeps services standalone and assigns them to employees through worker_services',()=>{
+test('Salon data model keeps services standalone and employee-service assignment remains optional metadata',()=>{
   const api=read('api/salon-operations.js');
   const migration=read('supabase/migrations/20260831090000_dabbir_salon_mode_p0.sql');
   assert.match(migration,/create table if not exists public\.dabbir_worker_services/);
-  assert.match(migration,/join public\.dabbir_worker_services ws[\s\S]+ws\.worker_id=p_worker_id[\s\S]+ws\.active/);
   assert.match(api,/action==='assign_worker_service'/);
   const serviceBlock=api.slice(api.indexOf("if(action==='save_service')"),api.indexOf("if(action==='save_waitlist')"));
   assert.doesNotMatch(serviceBlock,/worker_id/,'creating a service must not require an employee');
 });
 
-test('Salon quick booking is employee-first and services are filtered by that employee',()=>{
+test('Salon quick booking opens with no employees, services, customer details, or selected time',()=>{
   const patched=applySalonProductModelPatches(emittedSalon());
   const booking=patched.slice(patched.indexOf('function openQuickBooking()'),patched.indexOf('function transitionButtons'));
-  assert.ok(booking.indexOf('id="sqWorker"')<booking.indexOf('id="sqService"'),'employee selector must appear before service selector');
-  assert.match(booking,/q\('#sqWorker'\)\.onchange=syncServices/);
-  assert.match(booking,/x\.worker_id===wid&&x\.active/);
-  assert.match(booking,/services\.filter\(s=>allowed\.has\(s\.id\)\)/);
-  assert.doesNotMatch(booking,/q\('#sqService'\)\.onchange=syncWorkers/);
+  assert.doesNotMatch(booking,/notify\(t\.employeeRequired\)/);
+  assert.doesNotMatch(booking,/notify\(t\.serviceCatalogRequired\)/);
+  assert.doesNotMatch(booking,/notify\(t\.employeeServicesRequired\)/);
+  assert.doesNotMatch(booking,/id="sqName"[^>]*required/);
+  assert.doesNotMatch(booking,/id="sqPhone"[^>]*required/);
+  assert.doesNotMatch(booking,/id="sqWorker"[^>]*required/);
+  assert.doesNotMatch(booking,/id="sqService"[^>]*required/);
+  assert.doesNotMatch(booking,/id="sqTime"[^>]*required/);
+  assert.match(booking,/starts_at:q\('#sqTime'\)\.value\?new Date\(q\('#sqTime'\)\.value\)\.toISOString\(\):null/);
+  assert.doesNotMatch(booking,/worker_services.*filter/);
+});
+
+test('Salon quick-book RPC accepts customer, service, worker, and time as optional inputs',()=>{
+  const migration=read('supabase/migrations/20260902220500_dabbir_salon_booking_no_prerequisites_v1.sql');
+  assert.match(migration,/p_customer_name text default ''/);
+  assert.match(migration,/p_service_id uuid default null/);
+  assert.match(migration,/p_worker_id uuid default null/);
+  assert.match(migration,/p_starts_at timestamptz default null/);
+  assert.match(migration,/v_start timestamptz := coalesce\(p_starts_at,now\(\)\+interval '30 minutes'\)/);
+  assert.match(migration,/if v_service_id is not null then[\s\S]+insert into public\.dabbir_appointment_services/);
+  assert.doesNotMatch(migration,/WORKER_SERVICE_NOT_AVAILABLE/);
+});
+
+test('Unassigned salon bookings remain visible in day and week calendars',()=>{
+  const patched=applySalonProductModelPatches(emittedSalon());
+  assert.match(patched,/unassigned:'غير مسند'/);
+  const day=patched.slice(patched.indexOf('function dayCalendar()'),patched.indexOf('function weekCalendar()'));
+  const week=patched.slice(patched.indexOf('function weekCalendar()'),patched.indexOf('function monthCalendar()'));
+  assert.match(day,/hasUnassigned=rows\.some\(a=>!a\.worker_id\)/);
+  assert.match(day,/w\.unassigned\?!a\.worker_id:a\.worker_id===w\.id/);
+  assert.match(week,/unassigned=dayRows\.filter\(a=>!a\.worker_id\)/);
+  assert.match(week,/t\.unassigned/);
 });
 
 test('New employee form can assign multiple existing services at creation time',()=>{
@@ -40,7 +66,7 @@ test('New employee form can assign multiple existing services at creation time',
   assert.match(team,/worker_id:workerId/);
 });
 
-test('Salon setup messages describe the real business state instead of reversing ownership',()=>{
+test('Salon setup messages no longer block quick booking',()=>{
   const patched=applySalonProductModelPatches(emittedSalon());
   assert.match(patched,/employeeRequired:'أضيفي موظفة أولًا\.'/);
   assert.match(patched,/serviceCatalogRequired:'أضيفي خدمة أولًا\.'/);

--- a/test/dabbir-salon-member-scope-privileges.test.mjs
+++ b/test/dabbir-salon-member-scope-privileges.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root=path.resolve(path.dirname(fileURLToPath(import.meta.url)),'..');
+const migrationDir=path.join(root,'supabase','migrations');
+const target='dabbir_private.salon_member_scope(uuid,uuid,boolean)';
+
+test('latest salon_member_scope privilege state keeps authenticated execute and blocks anon/public',()=>{
+  const files=fs.readdirSync(migrationDir).filter(name=>name.endsWith('.sql')).sort();
+  let authenticated=null;
+  let anon=null;
+  let publicRole=null;
+  let touched=false;
+  for(const file of files){
+    const sql=fs.readFileSync(path.join(migrationDir,file),'utf8').replace(/\s+/g,' ').toLowerCase();
+    if(!sql.includes(target)) continue;
+    touched=true;
+    if(/revoke (?:all|execute) on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) from [^;]*authenticated/.test(sql)) authenticated=false;
+    if(/grant execute on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) to [^;]*authenticated/.test(sql)) authenticated=true;
+    if(/revoke (?:all|execute) on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) from [^;]*anon/.test(sql)) anon=false;
+    if(/grant execute on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) to [^;]*anon/.test(sql)) anon=true;
+    if(/revoke (?:all|execute) on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) from [^;]*public/.test(sql)) publicRole=false;
+    if(/grant execute on function dabbir_private\.salon_member_scope\(uuid,uuid,boolean\) to [^;]*public/.test(sql)) publicRole=true;
+  }
+  assert.equal(touched,true,'salon_member_scope privileges must be explicitly managed');
+  assert.equal(authenticated,true,'authenticated must retain EXECUTE because appointment RLS invokes salon_member_scope');
+  assert.notEqual(anon,true,'anon must not receive EXECUTE');
+  assert.notEqual(publicRole,true,'PUBLIC must not receive EXECUTE');
+});


### PR DESCRIPTION
Make salon quick booking available without setup prerequisites. Customer details, employee, service, and time are optional; unassigned bookings remain visible in day/week calendars. Add a Mumbai Supabase migration so the quick-book RPC and RLS support unassigned bookings safely.