### PR TITLE
Add persistent BARMAN tool-agent execution loop

### DIFF
--- a/.github/workflows/barman-tool-agent.yml
+++ b/.github/workflows/barman-tool-agent.yml
@@ -1,0 +1,34 @@
+name: BARMAN Persistent Tool Agent
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/5 * * * *'
+
+permissions:
+  id-token: write
+  contents: write
+  pull-requests: write
+  actions: write
+  checks: read
+
+concurrency:
+  group: barman-persistent-tool-agent
+  cancel-in-progress: false
+
+jobs:
+  execute:
+    runs-on: ubuntu-latest
+    timeout-minutes: 50
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: package.json
+          package-manager-cache: false
+      - name: Execute one BARMAN tool-agent command
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: node scripts/barman-tool-agent.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: DABBIR CI
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches: [main, dabbir/isolated-export]
@@ -29,10 +30,17 @@ jobs:
       - name: Audit production dependencies
         run: npm run audit:prod
       - name: Enforce Production database change discipline
+        shell: bash
         env:
-          DABBIR_DB_GATE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          DABBIR_DB_GATE_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before || '' }}
           DABBIR_DB_GATE_HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
-        run: node scripts/dabbir-production-db-change-gate.mjs
+        run: |
+          set -euo pipefail
+          if [ -z "${DABBIR_DB_GATE_BASE_SHA}" ]; then
+            DABBIR_DB_GATE_BASE_SHA="$(git rev-parse HEAD^)"
+            export DABBIR_DB_GATE_BASE_SHA
+          fi
+          node scripts/dabbir-production-db-change-gate.mjs
       - name: Run DABBIR tests
         run: npm test
       - name: Reject committed secrets

--- a/api/barman-tool-agent-broker.js
+++ b/api/barman-tool-agent-broker.js
@@ -1,0 +1,140 @@
+import { createPublicKey, verify as verifySignature } from 'node:crypto';
+import { getVercelOidcToken } from '@vercel/oidc';
+import { json } from './_auth-core.js';
+import { adminRpc, notifyTelegram, serviceRoleKey, telegramRoute } from './_barman-executive-core.js';
+
+const AUDIENCE='barman-executive-tool-agent';
+const EXPECTED_REPO='barman-systems/pilot';
+const EXPECTED_REF='refs/heads/main';
+const EXPECTED_WORKFLOW=`${EXPECTED_REPO}/.github/workflows/barman-tool-agent.yml@${EXPECTED_REF}`;
+const GITHUB_ISSUER='https://token.actions.githubusercontent.com';
+const GATEWAY_ENDPOINT='https://ai-gateway.vercel.sh/v1/chat/completions';
+const DEFAULT_MODEL='minimax/minimax-m3-free';
+const clean=(value,max=4000)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+
+function decodePart(value){
+  const normalized=value.replace(/-/g,'+').replace(/_/g,'/').padEnd(Math.ceil(value.length/4)*4,'=');
+  return Buffer.from(normalized,'base64');
+}
+function audienceIncludes(aud){return Array.isArray(aud)?aud.includes(AUDIENCE):aud===AUDIENCE}
+function claimAllowed(payload,now=Math.floor(Date.now()/1000)){
+  return payload?.iss===GITHUB_ISSUER
+    &&audienceIncludes(payload?.aud)
+    &&payload?.repository===EXPECTED_REPO
+    &&payload?.ref===EXPECTED_REF
+    &&payload?.workflow_ref===EXPECTED_WORKFLOW
+    &&['schedule','workflow_dispatch'].includes(String(payload?.event_name||''))
+    &&Number(payload?.exp||0)>now-5
+    &&Number(payload?.nbf||0)<=now+30;
+}
+export function validateToolAgentClaims(payload,now=Math.floor(Date.now()/1000)){return claimAllowed(payload,now)}
+
+async function verifyGithubOidc(token){
+  const parts=String(token||'').split('.');
+  if(parts.length!==3)throw Object.assign(new Error('OIDC_TOKEN_INVALID'),{status:401});
+  let header,payload;
+  try{header=JSON.parse(decodePart(parts[0]).toString('utf8'));payload=JSON.parse(decodePart(parts[1]).toString('utf8'))}catch{throw Object.assign(new Error('OIDC_TOKEN_INVALID'),{status:401})}
+  if(header?.alg!=='RS256'||!header?.kid)throw Object.assign(new Error('OIDC_ALG_DENIED'),{status:401});
+  const configResponse=await fetch(`${GITHUB_ISSUER}/.well-known/openid-configuration`,{cache:'force-cache',signal:AbortSignal.timeout(8000)});
+  const config=await configResponse.json();
+  const jwksResponse=await fetch(config.jwks_uri,{cache:'force-cache',signal:AbortSignal.timeout(8000)});
+  const jwks=await jwksResponse.json();
+  const jwk=Array.isArray(jwks?.keys)?jwks.keys.find(key=>key.kid===header.kid):null;
+  if(!jwk)throw Object.assign(new Error('OIDC_KEY_UNKNOWN'),{status:401});
+  const signature=decodePart(parts[2]);
+  const ok=verifySignature('RSA-SHA256',Buffer.from(`${parts[0]}.${parts[1]}`),createPublicKey({key:jwk,format:'jwk'}),signature);
+  if(!ok||!claimAllowed(payload))throw Object.assign(new Error('OIDC_SOURCE_DENIED'),{status:403});
+  return payload;
+}
+
+async function gatewayCredential(){
+  if(process.env.AI_GATEWAY_API_KEY)return String(process.env.AI_GATEWAY_API_KEY);
+  if(process.env.VERCEL_OIDC_TOKEN)return String(process.env.VERCEL_OIDC_TOKEN);
+  try{return String(await getVercelOidcToken()||'')}catch{return ''}
+}
+function parseJsonContent(payload){
+  let value=String(payload?.choices?.[0]?.message?.content||'').trim();
+  value=value.replace(/^```(?:json)?\s*/i,'').replace(/\s*```$/,'');
+  try{return JSON.parse(value)}catch{return null}
+}
+async function brain(system,user,maxTokens){
+  const credential=await gatewayCredential();
+  if(!credential)throw Object.assign(new Error('AI_GATEWAY_CREDENTIAL_MISSING'),{status:503});
+  const model=clean(process.env.BARMAN_TOOL_AGENT_MODEL||process.env.BARMAN_AI_GATEWAY_MODEL||DEFAULT_MODEL,120);
+  const response=await fetch(GATEWAY_ENDPOINT,{
+    method:'POST',headers:{authorization:`Bearer ${credential}`,'content-type':'application/json'},
+    body:JSON.stringify({model,messages:[{role:'system',content:system},{role:'user',content:JSON.stringify(user)}],temperature:0.05,max_tokens:maxTokens,stream:false}),
+    signal:AbortSignal.timeout(45000),
+  });
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok)throw Object.assign(new Error(`AI_GATEWAY_HTTP_${response.status}`),{status:502});
+  const parsed=parseJsonContent(payload);
+  if(!parsed)throw Object.assign(new Error('AI_GATEWAY_INVALID_JSON'),{status:502});
+  return {model,payload:parsed};
+}
+
+async function discover(command,paths){
+  const safePaths=Array.isArray(paths)?paths.map(x=>clean(x,300)).filter(Boolean).slice(0,3000):[];
+  const system=[
+    'You are the repository discovery brain for BARMAN Executive OS.',
+    'Map the Arabic or English owner command to the most likely files in the DABBIR repository.',
+    'Do not execute anything. Do not request secrets. Do not select governance/security files unless the owner command explicitly concerns those systems.',
+    'Return JSON only: {"summary":"...","search_terms":["..."],"file_hints":["exact/path"]}.',
+    'Use 3-8 concise English search terms and at most 8 exact file paths from the supplied path list.'
+  ].join('\n');
+  const result=await brain(system,{command:clean(command,4000),paths:safePaths},1200);
+  const p=result.payload;
+  return {model:result.model,summary:clean(p?.summary,800),search_terms:Array.isArray(p?.search_terms)?p.search_terms.map(x=>clean(x,80)).filter(Boolean).slice(0,8):[],file_hints:Array.isArray(p?.file_hints)?p.file_hints.map(x=>clean(x,300)).filter(x=>safePaths.includes(x)).slice(0,8):[]};
+}
+
+async function proposePatch(command,files,previousPatch='',applyError=''){
+  const context=Array.isArray(files)?files.slice(0,8).map(file=>({path:clean(file?.path,300),content:String(file?.content||'').slice(0,24000)})).filter(file=>file.path):[];
+  const system=[
+    'You are the code-editing brain for BARMAN Executive OS working on DABBIR.',
+    'Produce the smallest correct source change that satisfies the owner command.',
+    'You may edit only files supplied in context, plus create new test files under test/ or new SQL migrations under supabase/migrations/.',
+    'Never edit .github/, .env files, secrets, branch-protection/auth governance, api/barman-tool-agent-broker.js, scripts/barman-tool-agent.mjs, or vercel.json.',
+    'Preserve tenant isolation and Mumbai-only production. Do not weaken tests or authentication to make a test pass.',
+    'Return JSON only: {"summary":"...","patch":"<unified diff>"}. The patch must be a valid git unified diff applicable to the exact supplied content.',
+    'If the request cannot be safely completed from the supplied context, return {"summary":"BLOCKED: ...","patch":""}.'
+  ].join('\n');
+  const result=await brain(system,{command:clean(command,4000),files:context,previous_patch:String(previousPatch||'').slice(0,30000),apply_error:clean(applyError,1200)},7000);
+  return {model:result.model,summary:clean(result.payload?.summary,1200),patch:String(result.payload?.patch||'').trim().slice(0,80000)};
+}
+
+function uuid(value){return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value||''))?String(value):null}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  try{
+    const auth=String(req.headers.authorization||'');
+    if(!auth.startsWith('Bearer '))return json(res,401,{ok:false,error:'OIDC_REQUIRED'});
+    const claims=await verifyGithubOidc(auth.slice(7));
+    let key;try{key=serviceRoleKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
+    const body=req.body&&typeof req.body==='object'?req.body:{};
+    const phase=clean(body.phase,40);
+    if(phase==='claim'){
+      const claim=await adminRpc(key,'barman_executive_claim_v1',{p_worker_id:`github-tool-agent:${clean(claims.run_id,80)||'run'}`,p_lane:'tool_agent',p_lease_seconds:3600});
+      return json(res,200,{ok:true,...claim});
+    }
+    if(phase==='discover')return json(res,200,{ok:true,...await discover(body.command,body.paths)});
+    if(phase==='patch')return json(res,200,{ok:true,...await proposePatch(body.command,body.files,body.previous_patch,body.apply_error)});
+    if(phase==='finalize'){
+      const commandId=uuid(body.command_id),runId=uuid(body.run_id),actionId=uuid(body.action_id);
+      if(!commandId||!runId||!actionId)return json(res,400,{ok:false,error:'EXECUTION_IDS_INVALID'});
+      const outcome=['DONE','BLOCKED','RETRY'].includes(String(body.outcome||'').toUpperCase())?String(body.outcome).toUpperCase():null;
+      if(!outcome)return json(res,400,{ok:false,error:'OUTCOME_INVALID'});
+      const evidence=Array.isArray(body.evidence)?body.evidence.slice(0,12):[];
+      const summary=clean(body.summary,4000),errorText=clean(body.error,2000)||null;
+      const finalized=await adminRpc(key,'barman_executive_finalize_v1',{p_command_id:commandId,p_run_id:runId,p_action_id:actionId,p_outcome:outcome,p_summary:summary,p_evidence:evidence,p_error:errorText});
+      const route=await telegramRoute(key,commandId).catch(()=>null);
+      const notification=await notifyTelegram(route,`${summary}\n\nالحالة: ${outcome} — BARMAN tool-agent.`).catch(error=>({sent:false,reason:clean(error?.message||error,200)}));
+      return json(res,200,{ok:true,finalized,notification});
+    }
+    return json(res,400,{ok:false,error:'PHASE_INVALID'});
+  }catch(error){
+    const status=Number(error?.status)||500;
+    console.error('barman_tool_agent_broker_failed',{status,error:clean(error?.message||error,500)});
+    return json(res,status,{ok:false,error:clean(error?.message||error,200)});
+  }
+}

--- a/scripts/barman-tool-agent.mjs
+++ b/scripts/barman-tool-agent.mjs
@@ -1,0 +1,217 @@
+import fs from 'node:fs';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const REPO=process.env.GITHUB_REPOSITORY||'barman-systems/pilot';
+const GITHUB_API='https://api.github.com';
+const BROKER='https://dabbir.bmalman.com/api/barman-tool-agent-broker';
+const AUDIENCE='barman-executive-tool-agent';
+const TOKEN=String(process.env.GITHUB_TOKEN||'');
+const RUN_ID=String(process.env.GITHUB_RUN_ID||Date.now());
+const sleep=ms=>new Promise(resolve=>setTimeout(resolve,ms));
+const clean=(v,max=4000)=>String(v??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+
+function sh(file,args=[],options={}){
+  return execFileSync(file,args,{encoding:'utf8',stdio:options.stdio||['ignore','pipe','pipe'],...options}).trim();
+}
+function git(args,options={}){return sh('git',args,options)}
+function changedFiles(){return git(['diff','--name-only','HEAD']).split('\n').map(x=>x.trim()).filter(Boolean)}
+function forbiddenPath(path){
+  return path.startsWith('.github/')
+    ||/(^|\/)\.env(?:\.|$)/.test(path)
+    ||path==='api/barman-tool-agent-broker.js'
+    ||path==='scripts/barman-tool-agent.mjs'
+    ||path==='vercel.json';
+}
+function patchTouchesForbidden(patch){
+  const paths=[...String(patch||'').matchAll(/^(?:---|\+\+\+) (?:a\/|b\/)?([^\n]+)$/gm)].map(m=>m[1]).filter(x=>x!=='/dev/null');
+  return paths.some(forbiddenPath);
+}
+
+async function oidc(){
+  const url=String(process.env.ACTIONS_ID_TOKEN_REQUEST_URL||'');
+  const requestToken=String(process.env.ACTIONS_ID_TOKEN_REQUEST_TOKEN||'');
+  if(!url||!requestToken)throw new Error('GITHUB_OIDC_UNAVAILABLE');
+  const sep=url.includes('?')?'&':'?';
+  const response=await fetch(`${url}${sep}audience=${encodeURIComponent(AUDIENCE)}`,{headers:{authorization:`bearer ${requestToken}`},signal:AbortSignal.timeout(15000)});
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok||!payload?.value)throw new Error(`GITHUB_OIDC_HTTP_${response.status}`);
+  return payload.value;
+}
+async function broker(body){
+  const response=await fetch(BROKER,{method:'POST',headers:{authorization:`Bearer ${await oidc()}`,'content-type':'application/json'},body:JSON.stringify(body),signal:AbortSignal.timeout(60000)});
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok||payload?.ok!==true)throw new Error(`BROKER_${response.status}_${clean(payload?.error||'FAILED',200)}`);
+  return payload;
+}
+async function gh(path,{method='GET',body}={}){
+  if(!TOKEN)throw new Error('GITHUB_TOKEN_MISSING');
+  const response=await fetch(`${GITHUB_API}/repos/${REPO}${path}`,{
+    method,headers:{authorization:`Bearer ${TOKEN}`,accept:'application/vnd.github+json','x-github-api-version':'2022-11-28','content-type':'application/json'},
+    body:body===undefined?undefined:JSON.stringify(body),signal:AbortSignal.timeout(30000),
+  });
+  const text=await response.text();let payload=null;try{payload=text?JSON.parse(text):null}catch{payload=text}
+  if(!response.ok)throw Object.assign(new Error(`GITHUB_${response.status}_${clean(payload?.message||text,300)}`),{status:response.status,payload});
+  return payload;
+}
+async function dispatch(workflow,ref,inputs={}){
+  await gh(`/actions/workflows/${encodeURIComponent(workflow)}/dispatches`,{method:'POST',body:{ref,inputs}});
+}
+async function waitWorkflow(workflow,branch,event,headSha,timeoutMs){
+  const started=Date.now();let seen=null;
+  while(Date.now()-started<timeoutMs){
+    const runs=await gh(`/actions/workflows/${encodeURIComponent(workflow)}/runs?branch=${encodeURIComponent(branch)}&event=${encodeURIComponent(event)}&per_page=20`);
+    const candidates=Array.isArray(runs?.workflow_runs)?runs.workflow_runs:[];
+    seen=candidates.find(run=>String(run.head_sha||'')===headSha)||seen;
+    if(seen?.status==='completed'){
+      if(seen.conclusion!=='success')throw new Error(`${workflow}_FAILED_${seen.conclusion||'unknown'}_${seen.html_url||''}`);
+      return seen;
+    }
+    await sleep(10000);
+  }
+  throw new Error(`${workflow}_TIMEOUT_${seen?.html_url||''}`);
+}
+async function waitProduction(commitSha,timeoutMs=900000){
+  const started=Date.now();let last=null;
+  while(Date.now()-started<timeoutMs){
+    try{
+      const response=await fetch(`https://dabbir.bmalman.com/api/release-evidence?t=${Date.now()}`,{headers:{accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)});
+      const payload=await response.json().catch(()=>null);last=payload;
+      if(response.ok&&payload?.ok===true&&String(payload?.environment||'').toLowerCase()==='production'&&String(payload?.commit_sha||'').toLowerCase()===commitSha.toLowerCase())return payload;
+    }catch{}
+    await sleep(10000);
+  }
+  throw new Error(`PRODUCTION_EXACT_SHA_TIMEOUT_${clean(last?.commit_sha||'none',80)}`);
+}
+
+function repositoryPaths(){return git(['ls-files','-z']).split('\0').filter(Boolean)}
+function grepFiles(term){
+  if(!term)return [];
+  const r=spawnSync('git',['grep','-Il','--fixed-strings','-e',term,'--',':(exclude).github'],{encoding:'utf8'});
+  if(![0,1].includes(r.status))return [];
+  return String(r.stdout||'').split('\n').map(x=>x.trim()).filter(Boolean);
+}
+function buildContext(discovery,allPaths){
+  const selected=[];const add=path=>{if(!path||selected.includes(path)||!allPaths.includes(path)||forbiddenPath(path))return;try{const stat=fs.statSync(path);if(!stat.isFile()||stat.size>24000)return;const content=fs.readFileSync(path,'utf8');if(content.includes('\0'))return;selected.push(path)}catch{}};
+  for(const hint of discovery.file_hints||[])add(hint);
+  for(const term of discovery.search_terms||[])for(const path of grepFiles(term))add(path);
+  for(const hint of [...selected]){
+    const base=hint.split('/').pop()?.replace(/\.[^.]+$/,'');
+    if(!base)continue;
+    for(const path of allPaths){if(selected.length>=8)break;if(path.startsWith('test/')&&path.toLowerCase().includes(base.toLowerCase()))add(path)}
+  }
+  return selected.slice(0,8).map(path=>({path,content:fs.readFileSync(path,'utf8')}));
+}
+function applyPatch(patch){
+  const check=spawnSync('git',['apply','--check','--whitespace=error-all','-'],{input:patch,encoding:'utf8'});
+  if(check.status!==0)return {ok:false,error:clean(check.stderr||check.stdout||'git apply --check failed',1200)};
+  const apply=spawnSync('git',['apply','--whitespace=fix','-'],{input:patch,encoding:'utf8'});
+  if(apply.status!==0)return {ok:false,error:clean(apply.stderr||apply.stdout||'git apply failed',1200)};
+  return {ok:true};
+}
+function localTests(){
+  sh('npm',['ci','--no-audit','--no-fund'],{stdio:'inherit'});
+  sh('npm',['run','check:syntax'],{stdio:'inherit'});
+  sh('npm',['test'],{stdio:'inherit'});
+}
+
+async function createPr(branch,title,body){
+  return gh('/pulls',{method:'POST',body:{title,head:branch,base:'main',body,maintainer_can_modify:true}});
+}
+async function mergePr(number,headSha){
+  return gh(`/pulls/${number}/merge`,{method:'PUT',body:{sha:headSha,merge_method:'squash'}});
+}
+async function refreshBranch(branch){
+  git(['fetch','origin','main']);
+  git(['checkout',branch]);
+  sh('git',['merge','--no-edit','origin/main'],{stdio:'inherit'});
+  git(['push','origin',branch]);
+  return git(['rev-parse','HEAD']);
+}
+
+let execution=null;
+async function finalize(outcome,summary,evidence=[],error=''){
+  if(!execution)return null;
+  try{return await broker({phase:'finalize',command_id:execution.commandId,run_id:execution.runId,action_id:execution.actionId,outcome,summary,evidence,error})}
+  catch(finalizeError){console.error('FINALIZE_FAILED',finalizeError);return null}
+}
+
+try{
+  const claim=await broker({phase:'claim'});
+  if(claim.claimed!==true){console.log('No tool_agent command available.');process.exit(0)}
+  const command=claim.command||{};
+  execution={commandId:String(command.id||''),runId:String(claim.run_id||''),actionId:String(claim.action_id||'')};
+  const commandText=String(command.command_text||'').trim();
+  if(!commandText)throw new Error('EMPTY_COMMAND');
+  console.log(`Claimed ${execution.commandId}: ${clean(commandText,300)}`);
+
+  const allPaths=repositoryPaths();
+  const discovery=await broker({phase:'discover',command:commandText,paths:allPaths.slice(0,3000)});
+  let context=buildContext(discovery,allPaths);
+  if(context.length===0){
+    await finalize('BLOCKED','BARMAN لم يجد سياق ملفات آمنًا وكافيًا لتنفيذ الأمر تلقائيًا.',[],`DISCOVERY_EMPTY: ${discovery.summary||''}`);
+    process.exit(0);
+  }
+
+  let proposal=await broker({phase:'patch',command:commandText,files:context});
+  if(!proposal.patch){
+    await finalize('BLOCKED',proposal.summary||'تعذر إنشاء تعديل آمن من السياق المتاح.',[], 'AI_PATCH_EMPTY');
+    process.exit(0);
+  }
+  if(patchTouchesForbidden(proposal.patch))throw new Error('PATCH_TOUCHED_GOVERNANCE_FILE');
+  let applied=applyPatch(proposal.patch);
+  if(!applied.ok){
+    proposal=await broker({phase:'patch',command:commandText,files:context,previous_patch:proposal.patch,apply_error:applied.error});
+    if(!proposal.patch||patchTouchesForbidden(proposal.patch))throw new Error(`PATCH_REPAIR_DENIED_${applied.error}`);
+    applied=applyPatch(proposal.patch);
+    if(!applied.ok)throw new Error(`PATCH_APPLY_FAILED_${applied.error}`);
+  }
+
+  const changed=changedFiles();
+  if(changed.length===0)throw new Error('PATCH_PRODUCED_NO_DIFF');
+  if(changed.length>12||changed.some(forbiddenPath))throw new Error(`PATCH_SCOPE_DENIED_${changed.join(',')}`);
+  localTests();
+
+  const branch=`barman/exec-${execution.commandId.slice(0,8)}-${RUN_ID}`.replace(/[^a-zA-Z0-9_\/-]/g,'-').slice(0,120);
+  git(['config','user.name','BARMAN Executive OS']);
+  git(['config','user.email','barmanai@users.noreply.github.com']);
+  git(['switch','-c',branch]);
+  git(['add','--',...changed]);
+  git(['commit','-m',`BARMAN: ${clean(proposal.summary||commandText,68)}`]);
+  git(['push','-u','origin',branch]);
+  let headSha=git(['rev-parse','HEAD']);
+  const pr=await createPr(branch,`BARMAN: ${clean(proposal.summary||commandText,80)}`,`Automated execution for owner command \`${execution.commandId}\`.\n\nOwner goal: ${clean(commandText,1200)}\n\nSafety: generated patch passed local syntax + npm test before PR creation.`);
+  const prUrl=String(pr.html_url||'');
+
+  await dispatch('ci.yml',branch,{});
+  let ciRun=await waitWorkflow('ci.yml',branch,'workflow_dispatch',headSha,900000);
+  let merged;
+  try{merged=await mergePr(pr.number,headSha)}catch(error){
+    if(![405,409,422].includes(Number(error.status)))throw error;
+    headSha=await refreshBranch(branch);
+    localTests();
+    await dispatch('ci.yml',branch,{});
+    ciRun=await waitWorkflow('ci.yml',branch,'workflow_dispatch',headSha,900000);
+    merged=await mergePr(pr.number,headSha);
+  }
+  if(merged?.merged!==true||!merged?.sha)throw new Error(`PR_NOT_MERGED_${clean(merged?.message||'',300)}`);
+  const mergeSha=String(merged.sha);
+  const release=await waitProduction(mergeSha,900000);
+
+  await dispatch('dabbir-ai-customer-journey.yml','main',{run_capacity:false,production_capacity_ack:''});
+  const journey=await waitWorkflow('dabbir-ai-customer-journey.yml','main','workflow_dispatch',mergeSha,1200000);
+  const evidence=[
+    {type:'artifact',reference:prUrl,verified:true,details:{pr_number:pr.number,changed_files:changed}},
+    {type:'test',reference:String(ciRun.html_url||'DABBIR CI'),verified:true,details:{workflow:'DABBIR CI',head_sha:headSha}},
+    {type:'commit',reference:mergeSha,verified:true,details:{repository:REPO}},
+    {type:'deployment',reference:String(release?.deployment_id||'production'),verified:true,details:{commit_sha:release?.commit_sha,environment:release?.environment}},
+    {type:'test',reference:String(journey.html_url||'Full Customer Journey'),verified:true,details:{workflow:'DABBIR AI Full Customer Journey',commit_sha:mergeSha}},
+  ];
+  const summary=`BARMAN نفّذ الأمر ودمج التغيير بعد CI ثم تحقق من Production وFull Customer Journey. PR #${pr.number}, commit ${mergeSha.slice(0,12)}.`;
+  const result=await finalize('DONE',summary,evidence,'');
+  console.log('DONE',JSON.stringify({command_id:execution.commandId,pr:prUrl,merge_sha:mergeSha,notification:result?.notification||null}));
+}catch(error){
+  const message=clean(error?.stack||error?.message||error,1800);
+  console.error('BARMAN_TOOL_AGENT_FAILED',message);
+  await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message);
+  process.exitCode=1;
+}

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { validateToolAgentClaims } from '../api/barman-tool-agent-broker.js';
+
+const workflow=fs.readFileSync(new URL('../.github/workflows/barman-tool-agent.yml',import.meta.url),'utf8');
+const worker=fs.readFileSync(new URL('../scripts/barman-tool-agent.mjs',import.meta.url),'utf8');
+const broker=fs.readFileSync(new URL('../api/barman-tool-agent-broker.js',import.meta.url),'utf8');
+const ci=fs.readFileSync(new URL('../.github/workflows/ci.yml',import.meta.url),'utf8');
+
+const baseClaims={
+  iss:'https://token.actions.githubusercontent.com',
+  aud:'barman-executive-tool-agent',
+  repository:'barman-systems/pilot',
+  ref:'refs/heads/main',
+  workflow_ref:'barman-systems/pilot/.github/workflows/barman-tool-agent.yml@refs/heads/main',
+  event_name:'schedule',
+  exp:2000,
+  nbf:900,
+};
+
+test('tool-agent OIDC is locked to the canonical main workflow',()=>{
+  assert.equal(validateToolAgentClaims(baseClaims,1000),true);
+  assert.equal(validateToolAgentClaims({...baseClaims,workflow_ref:'barman-systems/pilot/.github/workflows/evil.yml@refs/heads/main'},1000),false);
+  assert.equal(validateToolAgentClaims({...baseClaims,ref:'refs/heads/dev'},1000),false);
+  assert.equal(validateToolAgentClaims({...baseClaims,event_name:'pull_request'},1000),false);
+  assert.equal(validateToolAgentClaims({...baseClaims,aud:'wrong'},1000),false);
+});
+
+test('persistent worker is event-looped and cannot bypass governance files',()=>{
+  assert.match(workflow,/cron:\s*'\*\/5 \* \* \* \*'/);
+  for(const token of ['id-token: write','contents: write','pull-requests: write','actions: write','cancel-in-progress: false'])assert.match(workflow,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+  assert.match(worker,/phase:'claim'/);
+  assert.match(worker,/p_lane:'tool_agent'|phase:'claim'/);
+  assert.match(worker,/git',['"]apply['"],['"]--check/);
+  assert.match(worker,/PATCH_TOUCHED_GOVERNANCE_FILE/);
+  assert.match(worker,/path\.startsWith\('\.github\/'\)/);
+  assert.match(worker,/api\/barman-tool-agent-broker\.js/);
+});
+
+test('DONE requires CI, exact Production release and full customer journey',()=>{
+  assert.match(ci,/workflow_dispatch:/);
+  assert.match(worker,/dispatch\('ci\.yml'/);
+  assert.match(worker,/waitWorkflow\('ci\.yml'/);
+  assert.match(worker,/\/api\/release-evidence/);
+  assert.match(worker,/payload\?\.commit_sha/);
+  assert.match(worker,/dispatch\('dabbir-ai-customer-journey\.yml','main'/);
+  assert.match(worker,/waitWorkflow\('dabbir-ai-customer-journey\.yml','main'/);
+  assert.match(worker,/finalize\('DONE'/);
+});
+
+test('broker finalization sends Telegram outcome and evidence remains fail-closed',()=>{
+  assert.match(broker,/barman_executive_finalize_v1/);
+  assert.match(broker,/notifyTelegram/);
+  assert.match(broker,/barman_executive_claim_v1/);
+  assert.match(broker,/p_lane:'tool_agent'/);
+  assert.match(broker,/Never edit \.github\//);
+});

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -32,7 +32,7 @@ test('persistent worker is event-looped and cannot bypass governance files',()=>
   for(const token of ['id-token: write','contents: write','pull-requests: write','actions: write','cancel-in-progress: false'])assert.match(workflow,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
   assert.match(worker,/phase:'claim'/);
   assert.match(worker,/p_lane:'tool_agent'|phase:'claim'/);
-  assert.match(worker,/git',['"]apply['"],['"]--check/);
+  assert.match(worker,/spawnSync\('git',\['apply','--check'/);
   assert.match(worker,/PATCH_TOUCHED_GOVERNANCE_FILE/);
   assert.match(worker,/path\.startsWith\('\.github\/'\)/);
   assert.match(worker,/api\/barman-tool-agent-broker\.js/);


### PR DESCRIPTION
Turns the existing `tool_agent` queue from a dead-end into a persistent execution lane. The scheduled worker claims one owner command using GitHub OIDC, asks the existing Vercel AI Gateway for discovery/patch proposals, applies only bounded source changes outside governance files, runs local syntax + tests, creates a protected PR, dispatches DABBIR CI on the exact head SHA, merges only after the required `test` check, waits for exact Production release evidence, runs the Full Customer Journey, then finalizes DONE with evidence and Telegram notification. Failures finalize RETRY/BLOCKED rather than pretending execution succeeded.