### PR TITLE
Fix car-wash services loading deadlock

### DIFF
--- a/api/service-operations-ui.js
+++ b/api/service-operations-ui.js
@@ -138,6 +138,7 @@ const client=String.raw`
       data=null;
       notify(editingId?t.updated:t.created);
       editingId=null;
+      loading=false;
       await load(true);
     }catch(error){notify(t.failed+' '+String(error?.message||error).slice(0,80))}finally{loading=false;render()}
   }
@@ -162,7 +163,7 @@ const client=String.raw`
   }catch{}
 
   setTimeout(initialize,500);
-  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v4-price'};
+  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v5-save-refresh'};
 })();
 `;
 
@@ -170,6 +171,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
-  res.setHeader('x-dabbir-service-operations-ui','v3');
+  res.setHeader('x-dabbir-service-operations-ui','v4-save-refresh');
   return res.status(200).send(client);
 }

--- a/api/service-operations-ui.js
+++ b/api/service-operations-ui.js
@@ -163,7 +163,7 @@ const client=String.raw`
   }catch{}
 
   setTimeout(initialize,500);
-  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v5-save-refresh'};
+  window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v4-price'};
 })();
 `;
 
@@ -171,6 +171,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300, s-maxage=300');
-  res.setHeader('x-dabbir-service-operations-ui','v4-save-refresh');
+  res.setHeader('x-dabbir-service-operations-ui','v3');
   return res.status(200).send(client);
 }

--- a/test/dabbir-service-operations-save-refresh.test.mjs
+++ b/test/dabbir-service-operations-save-refresh.test.mjs
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source=fs.readFileSync(new URL('../api/service-operations-ui.js',import.meta.url),'utf8');
+
+test('service save releases the loading guard before forced catalog reload',()=>{
+  const match=source.match(/async function saveService\(event\)\{[\s\S]*?\n  function initialize\(\)\{/);
+  assert.ok(match,'saveService source should be present');
+  assert.match(match[0],/editingId=null;\s*loading=false;\s*await load\(true\);/);
+});


### PR DESCRIPTION
Fixes the services screen getting stuck on “Loading services…” after a successful create/update. The save flow now releases the loading guard before forcing a catalog reload. Adds a regression test to keep this from returning.