### PR TITLE
Fix duplicate car-wash calendar surface

### DIFF
--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -3,7 +3,26 @@ const script=String.raw`(()=>{
   const workspaceNow=()=>{try{return typeof workspace!=='undefined'?workspace:window.workspace}catch{return window.workspace||null}};
   const isCarWash=()=>String(workspaceNow()?.business?.business_type||'').toLowerCase()==='car_wash';
   let loading=false,loaded=false,attempts=0;
+
+  function enforceSingleCalendar(){
+    const duplicate=document.querySelector('#dabbirGenericCalendar');
+    if(!duplicate)return false;
+    if(isCarWash()){
+      duplicate.setAttribute('hidden','');
+      duplicate.style.setProperty('display','none','important');
+      duplicate.dataset.dabbirCarWashDuplicate='hidden';
+      return true;
+    }
+    if(duplicate.dataset.dabbirCarWashDuplicate==='hidden'){
+      duplicate.style.removeProperty('display');
+      duplicate.removeAttribute('hidden');
+      delete duplicate.dataset.dabbirCarWashDuplicate;
+    }
+    return false;
+  }
+
   function load(){
+    enforceSingleCalendar();
     if(loaded||loading||!isCarWash())return false;
     if(window.__dabbirCarWashBookingUi){loaded=true;return true}
     const existing=document.querySelector('script[data-dabbir-car-wash-ui="1"]');
@@ -13,23 +32,26 @@ const script=String.raw`(()=>{
     node.src='/api/car-wash-booking-ui?v=20260831-ops-v1';
     node.async=true;
     node.dataset.dabbirCarWashUi='1';
-    node.onload=()=>{loaded=true;loading=false};
+    node.onload=()=>{loaded=true;loading=false;enforceSingleCalendar()};
     node.onerror=()=>{loading=false;console.error('dabbir_car_wash_ui_load_failed')};
     document.head.appendChild(node);
     return true;
   }
-  const timer=setInterval(()=>{attempts+=1;if(load()||attempts>=40)clearInterval(timer)},500);
-  const observer=new MutationObserver(()=>{if(load())observer.disconnect()});
-  observer.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
-  setTimeout(()=>{load();if(attempts>=40)observer.disconnect()},20000);
-  window.addEventListener('focus',load,{passive:true});
-  window.__dabbirCarWashLoader={load,get loaded(){return loaded}};
+
+  const timer=setInterval(()=>{attempts+=1;enforceSingleCalendar();if(load()||attempts>=40)clearInterval(timer)},500);
+  const loaderObserver=new MutationObserver(()=>{if(load())loaderObserver.disconnect()});
+  loaderObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
+  const calendarObserver=new MutationObserver(enforceSingleCalendar);
+  calendarObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class','hidden']});
+  setTimeout(()=>{load();enforceSingleCalendar();if(attempts>=40)loaderObserver.disconnect()},20000);
+  window.addEventListener('focus',()=>{load();enforceSingleCalendar()},{passive:true});
+  window.__dabbirCarWashLoader={load,enforceSingleCalendar,get loaded(){return loaded}};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v1');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v2-single-calendar');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -19,3 +19,12 @@ test('car-wash loader fetches the operations surface only for car_wash businesse
   assert.match(loader,/\/api\/car-wash-booking-ui/);
   assert.match(loader,/data-dabbir-car-wash-ui/);
 });
+
+test('car-wash workspace suppresses the duplicate generic booking calendar',()=>{
+  const loader=read('api/car-wash-loader-ui.js');
+  assert.match(loader,/function enforceSingleCalendar\(\)/);
+  assert.match(loader,/#dabbirGenericCalendar/);
+  assert.match(loader,/setProperty\('display','none','important'\)/);
+  assert.match(loader,/dabbirCarWashDuplicate/);
+  assert.match(loader,/v2-single-calendar/);
+});


### PR DESCRIPTION
Car-wash appointments currently show the authoritative DABBIR calendar plus a second generic calendar from appointment-management-ui. This adds a car-wash-specific guard in the already-deferred loader so only one calendar remains while keeping the Manage Bookings list/edit/delete controls. Includes a regression test.