### PR TITLE
Stop car-wash observer feedback loop

### DIFF
--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -8,9 +8,11 @@ const script=String.raw`(()=>{
     const duplicate=document.querySelector('#dabbirGenericCalendar');
     if(!duplicate)return false;
     if(isCarWash()){
-      duplicate.setAttribute('hidden','');
-      duplicate.style.setProperty('display','none','important');
-      duplicate.dataset.dabbirCarWashDuplicate='hidden';
+      if(duplicate.dataset.dabbirCarWashDuplicate!=='hidden'){
+        duplicate.dataset.dabbirCarWashDuplicate='hidden';
+        duplicate.setAttribute('hidden','');
+        duplicate.style.setProperty('display','none','important');
+      }
       return true;
     }
     if(duplicate.dataset.dabbirCarWashDuplicate==='hidden'){
@@ -42,7 +44,7 @@ const script=String.raw`(()=>{
   const loaderObserver=new MutationObserver(()=>{if(load())loaderObserver.disconnect()});
   loaderObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
   const calendarObserver=new MutationObserver(enforceSingleCalendar);
-  calendarObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class','hidden']});
+  calendarObserver.observe(document.documentElement,{subtree:true,childList:true});
   setTimeout(()=>{load();enforceSingleCalendar();if(attempts>=40)loaderObserver.disconnect()},20000);
   window.addEventListener('focus',()=>{load();enforceSingleCalendar()},{passive:true});
   window.__dabbirCarWashLoader={load,enforceSingleCalendar,get loaded(){return loaded}};
@@ -52,6 +54,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v2-single-calendar');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v3-observer-safe');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -26,5 +26,12 @@ test('car-wash workspace suppresses the duplicate generic booking calendar',()=>
   assert.match(loader,/#dabbirGenericCalendar/);
   assert.match(loader,/setProperty\('display','none','important'\)/);
   assert.match(loader,/dabbirCarWashDuplicate/);
-  assert.match(loader,/v2-single-calendar/);
+});
+
+test('car-wash calendar observer is idempotent and never observes hidden mutations',()=>{
+  const loader=read('api/car-wash-loader-ui.js');
+  assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
+  assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
+  assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
+  assert.match(loader,/v3-observer-safe/);
 });


### PR DESCRIPTION
Hotfix for the regression introduced by #344. The car-wash calendar MutationObserver watched the same `hidden` attribute that its callback rewrote, causing an endless DOM mutation loop on Safari. This makes the hide operation idempotent and observes child insertion only, preserving the single-calendar behavior without freezing the page. Includes a regression test.