### PR TITLE
fix(BAR-39): make DABBIR merge gate fail-closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ permissions:
 
 jobs:
   test:
+    name: ${{ github.event_name == 'pull_request' && 'test' || 'ci-non-pr' }}
     runs-on: ubuntu-latest
     timeout-minutes: 55
     steps:

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -48,6 +48,12 @@ test('persistent worker is event-looped and cannot bypass governance files',()=>
   assert.match(worker,/api\/barman-tool-agent-broker\.js/);
 });
 
+test('required branch-protection test context is emitted only by pull_request CI',()=>{
+  assert.match(ci,/name:\s*\$\{\{\s*github\.event_name == 'pull_request' && 'test' \|\| 'ci-non-pr'\s*\}\}/);
+  assert.match(ci,/Require terminal mobile release gates before merge/);
+  assert.match(ci,/if:\s*github\.event_name == 'pull_request'/);
+});
+
 test('DONE requires CI, exact Production release and full customer journey',()=>{
   assert.match(ci,/workflow_dispatch:/);
   assert.match(worker,/dispatch\('ci\.yml'/);


### PR DESCRIPTION
Closes the merge-gate bypass found in BAR-39.

Root cause: branch protection requires the `test` context, but `DABBIR CI` also exposed that same context for `workflow_dispatch`. The BARMAN tool agent dispatches CI manually before merge, so a non-PR run could satisfy the protected context while the pull-request Mobile/Maestro aggregate gate was still pending.

Fix:
- emit protected context `test` only for `pull_request` runs;
- rename non-PR CI runs to `ci-non-pr`;
- keep the pull-request-only Mobile/Maestro aggregate gate intact;
- add regression coverage locking this invariant.

Result: manual/workflow-dispatch CI can no longer satisfy the branch-protection gate used for merging to `main`.