### PR TITLE
Add searchable car-wash booking selectors

### DIFF
--- a/api/adaptive-appointment.js
+++ b/api/adaptive-appointment.js
@@ -13,10 +13,18 @@ export default async function handler(req,res){
   const b=await rest(token,`dabbir_businesses?select=id,business_type&id=eq.${encodeURIComponent(businessId)}&limit=1`);const business=b?.[0];if(!business)return json(res,404,{ok:false,error:'BUSINESS_NOT_FOUND'});
   const name=clean(body.customer_name,120);const start=new Date(body.starts_at);if(!name||Number.isNaN(start.getTime()))return json(res,400,{ok:false,error:'APPOINTMENT_INPUT_REQUIRED'});
   const d=body.details&&typeof body.details==='object'?body.details:{};const metadata={source:'dabbir_adaptive_appointment',phone:clean(d.phone,40)||null};
-  const customers=await rest(token,'dabbir_customers?select=id,display_name,metadata',{method:'POST',headers:{prefer:'return=representation'},body:JSON.stringify({business_id:businessId,display_name:name,lead_status:'new',metadata})},'CUSTOMER_CREATE_FAILED');const customer=customers?.[0];if(!customer)return json(res,502,{ok:false,error:'CUSTOMER_CREATE_UNVERIFIED'});
+  const requestedCustomerId=clean(d.customer_id,60);let customer=null;
+  if(requestedCustomerId){
+   if(!UUID.test(requestedCustomerId))return json(res,400,{ok:false,error:'CUSTOMER_ID_INVALID'});
+   const existing=await rest(token,`dabbir_customers?select=id,display_name,metadata&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(requestedCustomerId)}&limit=1`,{},'CUSTOMER_LOOKUP_FAILED');
+   customer=existing?.[0]||null;if(!customer)return json(res,404,{ok:false,error:'CUSTOMER_NOT_FOUND'});
+  }else{
+   const customers=await rest(token,'dabbir_customers?select=id,display_name,metadata',{method:'POST',headers:{prefer:'return=representation'},body:JSON.stringify({business_id:businessId,display_name:name,lead_status:'new',metadata})},'CUSTOMER_CREATE_FAILED');customer=customers?.[0]||null;
+   if(!customer)return json(res,502,{ok:false,error:'CUSTOMER_CREATE_UNVERIFIED'});
+  }
   const duration=Math.max(5,Math.min(1440,Number(d.duration)||60));const notes=[d.service&&`service: ${clean(d.service)}`,d.specialist&&`specialist: ${clean(d.specialist)}`,d.vehicle&&`vehicle: ${clean(d.vehicle)}`,d.location&&`location: ${clean(d.location)}`,d.notes&&`notes: ${clean(d.notes,1000)}`].filter(Boolean).join('\n');
   const row={business_id:businessId,customer_id:customer.id,starts_at:start.toISOString(),status:['requested','confirmed','cancelled'].includes(d.status)?d.status:'requested',simulated:false,notes:notes||null,ends_at:new Date(start.getTime()+duration*60000).toISOString()};if(d.price!==''&&Number.isFinite(Number(d.price)))row.quoted_price_aed=Math.max(0,Number(d.price));
   const appointments=await rest(token,'dabbir_appointments?select=id,customer_id,starts_at,ends_at,status,quoted_price_aed,notes',{method:'POST',headers:{prefer:'return=representation'},body:JSON.stringify(row)},'APPOINTMENT_CREATE_FAILED');const appointment=appointments?.[0];if(!appointment)return json(res,502,{ok:false,error:'APPOINTMENT_CREATE_UNVERIFIED'});
-  return json(res,200,{ok:true,appointment,business_type:business.business_type});
+  return json(res,200,{ok:true,appointment,business_type:business.business_type,customer_reused:Boolean(requestedCustomerId)});
  }catch(e){return json(res,e.status||500,{ok:false,error:clean(e.message,160)||'APPOINTMENT_CREATE_FAILED'})}
 }

--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -23,8 +23,20 @@ const script=String.raw`(()=>{
     return false;
   }
 
+  function loadManualBooking(){
+    if(!isCarWash()||window.__dabbirCarWashManualBookingEnhancement)return false;
+    if(document.querySelector('script[data-dabbir-car-wash-manual-ui="1"]'))return true;
+    const node=document.createElement('script');
+    node.src='/api/car-wash-manual-booking-ui?v=20260903-1';
+    node.async=true;
+    node.dataset.dabbirCarWashManualUi='1';
+    node.onerror=()=>console.error('dabbir_car_wash_manual_booking_ui_load_failed');
+    document.head.appendChild(node);
+    return true;
+  }
+
   function load(){
-    enforceSingleCalendar();
+    enforceSingleCalendar();loadManualBooking();
     if(loaded||loading||!isCarWash())return false;
     if(window.__dabbirCarWashBookingUi){loaded=true;return true}
     const existing=document.querySelector('script[data-dabbir-car-wash-ui="1"]');
@@ -34,26 +46,26 @@ const script=String.raw`(()=>{
     node.src='/api/car-wash-booking-ui?v=20260831-ops-v1';
     node.async=true;
     node.dataset.dabbirCarWashUi='1';
-    node.onload=()=>{loaded=true;loading=false;enforceSingleCalendar()};
+    node.onload=()=>{loaded=true;loading=false;enforceSingleCalendar();loadManualBooking()};
     node.onerror=()=>{loading=false;console.error('dabbir_car_wash_ui_load_failed')};
     document.head.appendChild(node);
     return true;
   }
 
-  const timer=setInterval(()=>{attempts+=1;enforceSingleCalendar();if(load()||attempts>=40)clearInterval(timer)},500);
+  const timer=setInterval(()=>{attempts+=1;enforceSingleCalendar();loadManualBooking();if(load()||attempts>=40)clearInterval(timer)},500);
   const loaderObserver=new MutationObserver(()=>{if(load())loaderObserver.disconnect()});
   loaderObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
   const calendarObserver=new MutationObserver(enforceSingleCalendar);
   calendarObserver.observe(document.documentElement,{subtree:true,childList:true});
-  setTimeout(()=>{load();enforceSingleCalendar();if(attempts>=40)loaderObserver.disconnect()},20000);
-  window.addEventListener('focus',()=>{load();enforceSingleCalendar()},{passive:true});
-  window.__dabbirCarWashLoader={load,enforceSingleCalendar,get loaded(){return loaded}};
+  setTimeout(()=>{load();enforceSingleCalendar();loadManualBooking();if(attempts>=40)loaderObserver.disconnect()},20000);
+  window.addEventListener('focus',()=>{load();enforceSingleCalendar();loadManualBooking()},{passive:true});
+  window.__dabbirCarWashLoader={load,enforceSingleCalendar,loadManualBooking,get loaded(){return loaded}};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v3-observer-safe');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v4-manual-booking-selectors');
   return res.status(200).send(script);
 }

--- a/api/car-wash-manual-booking-ui.js
+++ b/api/car-wash-manual-booking-ui.js
@@ -1,0 +1,133 @@
+const script=String.raw`(()=>{
+  if(window.__dabbirCarWashManualBookingEnhancement)return;
+  window.__dabbirCarWashManualBookingEnhancement=true;
+  const q=s=>document.querySelector(s);
+  const workspaceNow=()=>{try{return typeof workspace!=='undefined'?workspace:window.workspace}catch{return window.workspace||null}};
+  const businessId=()=>workspaceNow()?.business?.id||null;
+  const isCarWash=()=>String(workspaceNow()?.business?.business_type||'').toLowerCase()==='car_wash';
+  const ar=()=>document.documentElement.lang!=='en';
+  let cache={business_id:null,customers:[],offers:[],services:[]};
+  let pending=null;
+
+  function cleanPhone(customer){return String(customer?.phone_e164||customer?.phone||customer?.metadata?.phone||'').trim()}
+  function customerRows(admin){
+    const rows=[...(Array.isArray(workspaceNow()?.customers)?workspaceNow().customers:[]),...(Array.isArray(admin?.operations?.customers)?admin.operations.customers:[])];
+    const byId=new Map();
+    for(const row of rows){if(row?.id&&!byId.has(row.id))byId.set(row.id,row)}
+    return [...byId.values()].filter(row=>String(row?.display_name||'').trim()).sort((a,b)=>String(a.display_name).localeCompare(String(b.display_name),ar()?'ar':'en'));
+  }
+  async function jsonFetch(url){
+    const response=await fetch(url,{cache:'no-store',credentials:'same-origin',headers:{accept:'application/json'}});
+    const payload=await response.json().catch(()=>null);
+    if(!response.ok||!payload?.ok)throw new Error(payload?.error||'LOOKUP_FAILED');
+    return payload;
+  }
+  async function loadData(force=false){
+    const id=businessId();if(!id||!isCarWash())return cache;
+    if(!force&&cache.business_id===id&&(cache.customers.length||cache.offers.length||cache.services.length))return cache;
+    if(pending)return pending;
+    pending=(async()=>{
+      const [adminResult,serviceResult]=await Promise.allSettled([
+        jsonFetch('/api/car-wash-admin?business_id='+encodeURIComponent(id)),
+        jsonFetch('/api/service-catalog?business_id='+encodeURIComponent(id)),
+      ]);
+      const admin=adminResult.status==='fulfilled'?adminResult.value:null;
+      const catalog=serviceResult.status==='fulfilled'?serviceResult.value:null;
+      cache={
+        business_id:id,
+        customers:customerRows(admin),
+        offers:(Array.isArray(admin?.offers)?admin.offers:[]).filter(row=>row.active!==false),
+        services:(Array.isArray(catalog?.services)?catalog.services:[]).filter(row=>row.active!==false),
+      };
+      return cache;
+    })().finally(()=>{pending=null});
+    return pending;
+  }
+
+  function ensureCustomerPicker(){
+    const input=q('#apptCustomer');if(!input||!isCarWash())return;
+    let list=q('#dabbirCarWashCustomerOptions');
+    if(!list){list=document.createElement('datalist');list.id='dabbirCarWashCustomerOptions';document.body.append(list)}
+    input.setAttribute('list',list.id);input.setAttribute('autocomplete','off');input.setAttribute('placeholder',ar()?'ابحث عن عميل دائم أو اكتب اسمًا جديدًا':'Search a saved customer or enter a new name');
+    list.replaceChildren();
+    for(const customer of cache.customers){
+      const option=document.createElement('option');
+      option.value=String(customer.display_name||'').trim();
+      const phone=cleanPhone(customer);if(phone)option.label=phone;
+      list.append(option);
+    }
+    let hidden=q('#dabbirCarWashCustomerId');
+    if(!hidden){hidden=document.createElement('input');hidden.type='hidden';hidden.id='dabbirCarWashCustomerId';hidden.dataset.apptKey='customer_id';input.after(hidden)}
+    const sync=()=>{
+      const value=String(input.value||'').trim().toLocaleLowerCase();
+      const matches=cache.customers.filter(row=>String(row.display_name||'').trim().toLocaleLowerCase()===value);
+      const customer=matches.length===1?matches[0]:null;
+      hidden.value=customer?.id||'';
+      if(customer){const phone=q('[data-appt-key="phone"]');if(phone&&!String(phone.value||'').trim())phone.value=cleanPhone(customer)}
+    };
+    if(input.dataset.dabbirSavedCustomerPicker!=='v1'){
+      input.dataset.dabbirSavedCustomerPicker='v1';
+      input.addEventListener('input',sync);input.addEventListener('change',sync);
+    }
+    sync();
+  }
+
+  function option(select,value,text){const item=document.createElement('option');item.value=value;item.textContent=text;select.append(item);return item}
+  function findSelection(value){
+    const [kind,id]=String(value||'').split(':');
+    if(kind==='offer')return {kind,row:cache.offers.find(row=>String(row.id)===id)||null};
+    if(kind==='service')return {kind,row:cache.services.find(row=>String(row.id)===id)||null};
+    return {kind:'other',row:null};
+  }
+  function vehicleLooksStation(value){return /(station|suv|4x4|ستيشن|دفع رباعي)/i.test(String(value||''))}
+
+  function enhanceServicePicker(){
+    if(!isCarWash())return;
+    const original=q('#adaptiveApptFields [data-appt-key="service"]');
+    if(!original||original.dataset.dabbirCatalogBacking==='v1')return;
+    original.dataset.dabbirCatalogBacking='v1';original.type='hidden';
+    const field=original.closest('.field');if(!field)return;
+    const select=document.createElement('select');select.id='dabbirCarWashServicePicker';select.dataset.dabbirServicePicker='v1';
+    option(select,'',ar()?'اختر الباقة / الخدمة':'Choose package / service').disabled=true;
+    if(cache.offers.length){const group=document.createElement('optgroup');group.label=ar()?'الباقات المحفوظة':'Saved packages';for(const row of cache.offers){const item=document.createElement('option');item.value='offer:'+row.id;item.textContent=ar()?(row.name_ar||row.name_en):(row.name_en||row.name_ar);group.append(item)}select.append(group)}
+    if(cache.services.length){const group=document.createElement('optgroup');group.label=ar()?'الخدمات المحفوظة':'Saved services';for(const row of cache.services){const item=document.createElement('option');item.value='service:'+row.id;item.textContent=row.name;group.append(item)}select.append(group)}
+    option(select,'other',ar()?'أخرى — ليست ضمن الباقات / الخدمات':'Other — not in saved packages / services');
+    const other=document.createElement('input');other.type='text';other.maxLength=500;other.placeholder=ar()?'اكتب الخدمة أو الباقة':'Enter service or package';other.hidden=true;other.id='dabbirCarWashOtherService';
+    field.insertBefore(select,original);field.insertBefore(other,original);
+    let duration=q('#dabbirCarWashDuration');if(!duration){duration=document.createElement('input');duration.type='hidden';duration.id='dabbirCarWashDuration';duration.dataset.apptKey='duration';field.append(duration)}
+
+    const apply=()=>{
+      const picked=findSelection(select.value);const price=q('[data-appt-key="price"]');const vehicle=q('[data-appt-key="vehicle"]');
+      if(picked.kind==='other'){other.hidden=false;original.value=String(other.value||'').trim();duration.value='';return}
+      other.hidden=true;
+      if(!picked.row){original.value='';duration.value='';return}
+      original.value=picked.kind==='offer'?(ar()?(picked.row.name_ar||picked.row.name_en):(picked.row.name_en||picked.row.name_ar)):String(picked.row.name||'');
+      duration.value=String(picked.row.duration_minutes||'');
+      if(price){
+        const amount=picked.kind==='offer'?(vehicleLooksStation(vehicle?.value)?picked.row.station_price_aed:picked.row.saloon_price_aed):picked.row.price_aed;
+        if(amount!==null&&amount!==undefined&&Number.isFinite(Number(amount)))price.value=String(Number(amount));
+      }
+    };
+    select.addEventListener('change',apply);other.addEventListener('input',apply);
+    q('[data-appt-key="vehicle"]')?.addEventListener('input',()=>{if(select.value.startsWith('offer:'))apply()});
+  }
+
+  async function enhance(force=false){
+    if(!isCarWash())return;
+    await loadData(force).catch(()=>cache);
+    ensureCustomerPicker();enhanceServicePicker();
+  }
+  const modal=q('#appointmentModal');
+  if(modal)new MutationObserver(()=>{if(modal.classList.contains('open')){setTimeout(()=>enhance(false),0);setTimeout(()=>enhance(false),120)}}).observe(modal,{attributes:true,attributeFilter:['class']});
+  new MutationObserver(()=>{if(q('#appointmentModal.open'))setTimeout(()=>enhance(false),0)}).observe(document.documentElement,{subtree:true,childList:true});
+  window.addEventListener('focus',()=>{if(q('#appointmentModal.open'))void enhance(false)},{passive:true});
+  window.__dabbirCarWashManualBooking={refresh:()=>enhance(true),version:'car-wash-manual-booking-v1'};
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=300');
+  res.setHeader('x-dabbir-car-wash-manual-booking-ui','v1');
+  return res.status(200).send(script);
+}

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,5 +33,5 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v3-observer-safe/);
+  assert.match(loader,/v4-manual-booking-selectors/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const manual=fs.readFileSync(new URL('../api/car-wash-manual-booking-ui.js',import.meta.url),'utf8');
+const loader=fs.readFileSync(new URL('../api/car-wash-loader-ui.js',import.meta.url),'utf8');
+const appointment=fs.readFileSync(new URL('../api/adaptive-appointment.js',import.meta.url),'utf8');
+
+test('car-wash manual booking loads saved packages and services with an Other choice',()=>{
+  assert.match(manual,/\/api\/car-wash-admin\?business_id=/);
+  assert.match(manual,/\/api\/service-catalog\?business_id=/);
+  assert.match(manual,/Saved packages|الباقات المحفوظة/);
+  assert.match(manual,/Saved services|الخدمات المحفوظة/);
+  assert.match(manual,/Other — not in saved packages \/ services|أخرى — ليست ضمن الباقات \/ الخدمات/);
+  assert.match(manual,/data\.apptKey='duration'|dataset\.apptKey='duration'/);
+  assert.match(manual,/price\.value=String\(Number\(amount\)\)/);
+});
+
+test('car-wash saved customers are searchable and preserve customer identity',()=>{
+  assert.match(manual,/dabbirCarWashCustomerOptions/);
+  assert.match(manual,/setAttribute\('list',list\.id\)/);
+  assert.match(manual,/Search a saved customer or enter a new name|ابحث عن عميل دائم أو اكتب اسمًا جديدًا/);
+  assert.match(manual,/dataset\.apptKey='customer_id'/);
+  assert.match(manual,/hidden\.value=customer\?\.id\|\|''/);
+});
+
+test('adaptive appointment reuses a selected customer only inside the active business',()=>{
+  assert.match(appointment,/requestedCustomerId=clean\(d\.customer_id,60\)/);
+  assert.match(appointment,/business_id=eq\.\$\{encodeURIComponent\(businessId\)\}.*id=eq\.\$\{encodeURIComponent\(requestedCustomerId\)\}/s);
+  assert.match(appointment,/CUSTOMER_NOT_FOUND/);
+  assert.match(appointment,/customer_reused:Boolean\(requestedCustomerId\)/);
+});
+
+test('car-wash loader mounts the manual booking enhancement only for car wash',()=>{
+  assert.match(loader,/function loadManualBooking\(\)/);
+  assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
+  assert.match(loader,/v4-manual-booking-selectors/);
+});


### PR DESCRIPTION
Clean rebase of the owner-requested car-wash booking UX on the latest main.

- Package/service is a dropdown sourced from active car-wash offers and saved services.
- Includes an explicit “Other / أخرى” option for one-off services.
- Existing saved customers are searchable from the customer field.
- Selecting one preserves customer_id and reuses the customer instead of creating a duplicate.
- Saved selections carry duration and price into the booking when available.
- Keeps the Safari-safe single-calendar observer behavior.

Includes regression coverage for selectors, customer reuse, and loader safety.