### PR TITLE
Bust Safari cache for car-wash booking fix

### DIFF
--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -27,7 +27,7 @@ const script=String.raw`(()=>{
     if(!isCarWash()||window.__dabbirCarWashManualBookingEnhancement)return false;
     if(document.querySelector('script[data-dabbir-car-wash-manual-ui="1"]'))return true;
     const node=document.createElement('script');
-    node.src='/api/car-wash-manual-booking-ui?v=20260903-1';
+    node.src='/api/car-wash-manual-booking-ui?v=20260903-2-loop-safe';
     node.async=true;
     node.dataset.dabbirCarWashManualUi='1';
     node.onerror=()=>console.error('dabbir_car_wash_manual_booking_ui_load_failed');
@@ -66,6 +66,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v4-manual-booking-selectors');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v5-loop-safe-cache-bust');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,5 +33,10 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v4-manual-booking-selectors/);
+  assert.match(loader,/v5-loop-safe-cache-bust/);
+});
+
+test('car-wash manual booking cache key changes for the loop-safe Safari fix',()=>{
+  const loader=read('api/car-wash-loader-ui.js');
+  assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-2-loop-safe/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -42,5 +42,5 @@ test('adaptive appointment reuses a selected customer only inside the active bus
 test('car-wash loader mounts the manual booking enhancement only for car wash',()=>{
   assert.match(loader,/function loadManualBooking\(\)/);
   assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
-  assert.match(loader,/v4-manual-booking-selectors/);
+  assert.match(loader,/v5-loop-safe-cache-bust/);
 });


### PR DESCRIPTION
Follow-up to PR #352. The loop fix is correct, but the manual booking script was still requested through the old cache key and served with a 5-minute public cache. This changes the script version query and loader version so iPhone Safari receives the loop-safe build immediately instead of retaining the buggy cached copy.