### PR TITLE
Fix iPhone saved-customer dropdown in car-wash bookings

### DIFF
--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -27,7 +27,7 @@ const script=String.raw`(()=>{
     if(!isCarWash()||window.__dabbirCarWashManualBookingEnhancement)return false;
     if(document.querySelector('script[data-dabbir-car-wash-manual-ui="1"]'))return true;
     const node=document.createElement('script');
-    node.src='/api/car-wash-manual-booking-ui?v=20260903-2-loop-safe';
+    node.src='/api/car-wash-manual-booking-ui?v=20260903-3-native-combobox';
     node.async=true;
     node.dataset.dabbirCarWashManualUi='1';
     node.onerror=()=>console.error('dabbir_car_wash_manual_booking_ui_load_failed');
@@ -66,6 +66,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v5-loop-safe-cache-bust');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v6-native-customer-combobox');
   return res.status(200).send(script);
 }

--- a/api/car-wash-manual-booking-ui.js
+++ b/api/car-wash-manual-booking-ui.js
@@ -47,34 +47,91 @@ const script=String.raw`(()=>{
 
   function ensureCustomerPicker(){
     const input=q('#apptCustomer');if(!input||!isCarWash())return;
-    let list=q('#dabbirCarWashCustomerOptions');
-    if(!list){list=document.createElement('datalist');list.id='dabbirCarWashCustomerOptions';document.body.append(list)}
-    input.setAttribute('list',list.id);input.setAttribute('autocomplete','off');input.setAttribute('placeholder',ar()?'ابحث عن عميل دائم أو اكتب اسمًا جديدًا':'Search a saved customer or enter a new name');
-    const signature=cache.customers.map(row=>[row.id,row.display_name,cleanPhone(row)].join('|')).join('~');
-    if(list.dataset.dabbirSignature!==signature){
-      const fragment=document.createDocumentFragment();
-      for(const customer of cache.customers){
-        const item=document.createElement('option');
-        item.value=String(customer.display_name||'').trim();
-        const phone=cleanPhone(customer);if(phone)item.label=phone;
-        fragment.append(item);
-      }
-      list.replaceChildren(fragment);list.dataset.dabbirSignature=signature;
+    input.removeAttribute('list');
+    q('#dabbirCarWashCustomerOptions')?.remove();
+    input.setAttribute('autocomplete','off');
+    input.setAttribute('role','combobox');
+    input.setAttribute('aria-autocomplete','list');
+    input.setAttribute('aria-controls','dabbirCarWashCustomerMenu');
+    input.setAttribute('placeholder',ar()?'ابحث عن عميل دائم أو اكتب اسمًا جديدًا':'Search a saved customer or enter a new name');
+    const field=input.closest('.field');if(!field)return;
+    field.style.position='relative';
+
+    if(!q('#dabbirCarWashCustomerPickerStyle')){
+      const style=document.createElement('style');style.id='dabbirCarWashCustomerPickerStyle';
+      style.textContent='#dabbirCarWashCustomerMenu{position:absolute;z-index:90;inset-inline:0;top:calc(100% + 6px);max-height:min(38vh,280px);overflow:auto;background:#111a2a;border:1px solid #33445f;border-radius:14px;box-shadow:0 18px 40px #000a;padding:6px;-webkit-overflow-scrolling:touch}#dabbirCarWashCustomerMenu[hidden]{display:none!important}.dabbirCustomerChoice{width:100%;border:0;background:transparent;color:#fff;text-align:start;padding:12px 11px;border-radius:10px;display:flex;align-items:center;justify-content:space-between;gap:10px;font:inherit}.dabbirCustomerChoice:active,.dabbirCustomerChoice:focus{background:#253653;outline:none}.dabbirCustomerChoiceName{font-weight:800}.dabbirCustomerChoicePhone{font-size:12px;color:#9aabc1;direction:ltr;unicode-bidi:embed}.dabbirCustomerNew{color:#79d8ff;border-top:1px solid #2a3950;margin-top:4px;padding-top:12px}';
+      document.head.append(style);
     }
+
     let hidden=q('#dabbirCarWashCustomerId');
     if(!hidden){hidden=document.createElement('input');hidden.type='hidden';hidden.id='dabbirCarWashCustomerId';hidden.dataset.apptKey='customer_id';input.after(hidden)}
-    const sync=()=>{
-      const value=String(input.value||'').trim().toLocaleLowerCase();
-      const matches=cache.customers.filter(row=>String(row.display_name||'').trim().toLocaleLowerCase()===value);
-      const customer=matches.length===1?matches[0]:null;
+    let menu=q('#dabbirCarWashCustomerMenu');
+    if(!menu){menu=document.createElement('div');menu.id='dabbirCarWashCustomerMenu';menu.hidden=true;menu.setAttribute('role','listbox');field.append(menu)}
+
+    const normalize=value=>String(value||'').trim().toLocaleLowerCase();
+    const exactCustomer=()=>{
+      const value=normalize(input.value);
+      const matches=cache.customers.filter(row=>normalize(row.display_name)===value);
+      return matches.length===1?matches[0]:null;
+    };
+    const close=()=>{menu.hidden=true;input.setAttribute('aria-expanded','false')};
+    const syncIdentity=()=>{
+      const customer=exactCustomer();
       hidden.value=customer?.id||'';
       if(customer){const phone=q('[data-appt-key="phone"]');if(phone&&!String(phone.value||'').trim())phone.value=cleanPhone(customer)}
+      return customer;
     };
-    if(input.dataset.dabbirSavedCustomerPicker!=='v2'){
-      input.dataset.dabbirSavedCustomerPicker='v2';
-      input.addEventListener('input',sync);input.addEventListener('change',sync);
+    const choose=customer=>{
+      input.value=String(customer?.display_name||'').trim();
+      hidden.value=customer?.id||'';
+      const phone=q('[data-appt-key="phone"]');if(phone&&!String(phone.value||'').trim())phone.value=cleanPhone(customer);
+      close();input.focus();
+      input.dispatchEvent(new Event('change',{bubbles:true}));
+    };
+    const render=()=>{
+      const term=normalize(input.value);
+      const rows=cache.customers.filter(row=>{
+        if(!term)return true;
+        return normalize(row.display_name).includes(term)||normalize(cleanPhone(row)).includes(term);
+      }).slice(0,12);
+      const fragment=document.createDocumentFragment();
+      for(const customer of rows){
+        const button=document.createElement('button');button.type='button';button.className='dabbirCustomerChoice';button.setAttribute('role','option');button.dataset.customerId=customer.id;
+        const name=document.createElement('span');name.className='dabbirCustomerChoiceName';name.textContent=String(customer.display_name||'').trim();
+        const phoneText=cleanPhone(customer);const phone=document.createElement('span');phone.className='dabbirCustomerChoicePhone';phone.textContent=phoneText;
+        button.append(name,phone);
+        button.addEventListener('pointerdown',event=>event.preventDefault());
+        button.addEventListener('click',()=>choose(customer));
+        fragment.append(button);
+      }
+      if(term&&!exactCustomer()){
+        const button=document.createElement('button');button.type='button';button.className='dabbirCustomerChoice dabbirCustomerNew';button.setAttribute('role','option');
+        button.textContent=(ar()?'استخدام «':'Use “')+String(input.value||'').trim()+(ar()?'» كعميل جديد':'” as a new customer');
+        button.addEventListener('pointerdown',event=>event.preventDefault());
+        button.addEventListener('click',()=>{hidden.value='';close();input.focus()});
+        fragment.append(button);
+      }
+      if(!rows.length&&!term){
+        const empty=document.createElement('div');empty.className='dabbirCustomerChoice';empty.textContent=ar()?'لا يوجد عملاء دائمون بعد — اكتب اسم العميل الجديد':'No saved customers yet — enter a new customer name';fragment.append(empty);
+      }
+      menu.replaceChildren(fragment);
+      menu.hidden=false;input.setAttribute('aria-expanded','true');
+    };
+
+    if(input.dataset.dabbirSavedCustomerPicker!=='v3-combobox'){
+      input.dataset.dabbirSavedCustomerPicker='v3-combobox';
+      input.addEventListener('focus',()=>{syncIdentity();render()});
+      input.addEventListener('input',()=>{syncIdentity();render()});
+      input.addEventListener('change',syncIdentity);
+      input.addEventListener('keydown',event=>{
+        if(event.key==='Escape'){close();return}
+        if(event.key==='ArrowDown'&&!menu.hidden){event.preventDefault();menu.querySelector('button')?.focus()}
+      });
+      input.addEventListener('blur',()=>setTimeout(()=>{if(!menu.contains(document.activeElement))close()},120));
+      document.addEventListener('pointerdown',event=>{if(!field.contains(event.target))close()},true);
     }
-    sync();
+    syncIdentity();
+    if(document.activeElement===input)render();
   }
 
   function option(select,value,text){const item=document.createElement('option');item.value=value;item.textContent=text;select.append(item);return item}
@@ -140,13 +197,13 @@ const script=String.raw`(()=>{
     setTimeout(()=>enhance(false),120);
   }).observe(modal,{attributes:true,attributeFilter:['class']});
   window.addEventListener('focus',()=>{if(q('#appointmentModal.open'))void enhance(false)},{passive:true});
-  window.__dabbirCarWashManualBooking={refresh:()=>enhance(true),version:'car-wash-manual-booking-v2-loop-safe'};
+  window.__dabbirCarWashManualBooking={refresh:()=>enhance(true),version:'car-wash-manual-booking-v3-native-combobox'};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-manual-booking-ui','v2-loop-safe');
+  res.setHeader('x-dabbir-car-wash-manual-booking-ui','v3-native-combobox');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,10 +33,10 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v5-loop-safe-cache-bust/);
+  assert.match(loader,/v6-native-customer-combobox/);
 });
 
-test('car-wash manual booking cache key changes for the loop-safe Safari fix',()=>{
+test('car-wash manual booking cache key changes for the iPhone customer combobox fix',()=>{
   const loader=read('api/car-wash-loader-ui.js');
-  assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-2-loop-safe/);
+  assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-3-native-combobox/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -16,20 +16,24 @@ test('car-wash manual booking loads saved packages and services with an Other ch
   assert.match(manual,/price\.value=String\(Number\(amount\)\)/);
 });
 
-test('car-wash saved customers are searchable and preserve customer identity',()=>{
-  assert.match(manual,/dabbirCarWashCustomerOptions/);
-  assert.match(manual,/setAttribute\('list',list\.id\)/);
+test('car-wash saved customers use an in-app searchable combobox instead of Safari datalist',()=>{
+  assert.match(manual,/dabbirCarWashCustomerMenu/);
+  assert.match(manual,/role','combobox/);
+  assert.match(manual,/aria-autocomplete','list/);
   assert.match(manual,/Search a saved customer or enter a new name|ابحث عن عميل دائم أو اكتب اسمًا جديدًا/);
   assert.match(manual,/dataset\.apptKey='customer_id'/);
   assert.match(manual,/hidden\.value=customer\?\.id\|\|''/);
+  assert.match(manual,/dabbirCustomerChoice/);
+  assert.match(manual,/كعميل جديد|as a new customer/);
+  assert.doesNotMatch(manual,/createElement\('datalist'\)/);
+  assert.doesNotMatch(manual,/setAttribute\('list'/);
 });
 
 test('car-wash selector enhancement cannot self-trigger a document mutation loop',()=>{
   assert.doesNotMatch(manual,/observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.match(manual,/cache\.business_id===id&&cache\.loaded/);
-  assert.match(manual,/list\.dataset\.dabbirSignature!==signature/);
   assert.match(manual,/setTimeout\(\(\)=>enhance\(true\),0\)/);
-  assert.match(manual,/v2-loop-safe/);
+  assert.match(manual,/v3-native-combobox/);
 });
 
 test('adaptive appointment reuses a selected customer only inside the active business',()=>{
@@ -39,8 +43,9 @@ test('adaptive appointment reuses a selected customer only inside the active bus
   assert.match(appointment,/customer_reused:Boolean\(requestedCustomerId\)/);
 });
 
-test('car-wash loader mounts the manual booking enhancement only for car wash',()=>{
+test('car-wash loader mounts the mobile-safe manual booking enhancement only for car wash',()=>{
   assert.match(loader,/function loadManualBooking\(\)/);
   assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
-  assert.match(loader,/v5-loop-safe-cache-bust/);
+  assert.match(loader,/20260903-3-native-combobox/);
+  assert.match(loader,/v6-native-customer-combobox/);
 });


### PR DESCRIPTION
Fixes the iPhone/Safari behavior shown in the booking modal. The saved-customer field no longer relies on HTML datalist, which Safari surfaces as keyboard suggestions rather than a real dropdown.

Changes:
- replace datalist with an in-app searchable combobox;
- show saved customer names + phone numbers in a proper dropdown;
- filter as the owner types;
- allow an explicit new-customer choice without forcing the name into saved customers;
- preserve customer_id reuse and phone autofill;
- keep the loop-safe behavior from the previous Safari fix;
- bump the loader cache key so iPhone receives the fix immediately;
- add regression tests forbidding datalist from returning.