### PR TITLE
Fix editing bookings after their start time

### DIFF
--- a/api/appointment-management.js
+++ b/api/appointment-management.js
@@ -54,10 +54,9 @@ async function appointmentFor(token,businessId,appointmentId){
   return rows?.[0]||null;
 }
 
-function validFutureStart(value){
+function validStart(value){
   const date=new Date(String(value||''));
   if(Number.isNaN(date.getTime()))return null;
-  if(date.getTime()<Date.now())return false;
   return date;
 }
 
@@ -67,9 +66,8 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
 
   const patch={};
   if(body.starts_at!==undefined){
-    const start=validFutureStart(body.starts_at);
+    const start=validStart(body.starts_at);
     if(start===null)return {status:400,body:{ok:false,error:'VALID_START_TIME_REQUIRED'}};
-    if(start===false)return {status:409,body:{ok:false,error:'PAST_APPOINTMENT_NOT_ALLOWED'}};
     patch.starts_at=start.toISOString();
   }
   if(body.status!==undefined){

--- a/api/car-wash-booking-edit-ui.js
+++ b/api/car-wash-booking-edit-ui.js
@@ -1,0 +1,88 @@
+const script=String.raw`(()=>{
+  if(window.__dabbirCarWashBookingEditFix)return;
+  window.__dabbirCarWashBookingEditFix=true;
+  const q=s=>document.querySelector(s);
+  const workspaceNow=()=>{try{return typeof workspace!=='undefined'?workspace:window.workspace}catch{return window.workspace||null}};
+  const isCarWash=()=>String(workspaceNow()?.business?.business_type||'').toLowerCase()==='car_wash';
+  const ar=()=>document.documentElement.lang!=='en';
+  const esc=value=>String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+  const copy=()=>ar()?{title:'تعديل الحجز',customer:'العميل',time:'الموعد',status:'الحالة',save:'حفظ التعديل',cancel:'إلغاء',requested:'مطلوب',confirmed:'مؤكد',rescheduled:'أعيدت جدولته',completed:'مكتمل',cancelled:'ملغي',saved:'تم تعديل الحجز.',failed:'تعذر تعديل الحجز.'}:{title:'Edit booking',customer:'Customer',time:'Booking',status:'Status',save:'Save changes',cancel:'Cancel',requested:'Requested',confirmed:'Confirmed',rescheduled:'Rescheduled',completed:'Completed',cancelled:'Cancelled',saved:'Booking updated.',failed:'Could not update booking.'};
+  let busy=false;
+
+  function dubaiLocalMinute(value){
+    const date=value instanceof Date?value:new Date(value);
+    const f=new Intl.DateTimeFormat('en-CA',{timeZone:'Asia/Dubai',year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',hourCycle:'h23'});
+    const p=Object.fromEntries(f.formatToParts(date).filter(x=>x.type!=='literal').map(x=>[x.type,x.value]));
+    return p.year+'-'+p.month+'-'+p.day+'T'+p.hour+':'+p.minute;
+  }
+  function isoFromDubaiLocal(value){
+    const raw=String(value||'').trim();
+    if(!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(raw))return null;
+    const date=new Date(raw+':00+04:00');
+    return Number.isNaN(date.getTime())?null:date.toISOString();
+  }
+  function customerName(id){
+    const customer=(workspaceNow()?.customers||[]).find(row=>row?.id===id);
+    return customer?.display_name||(ar()?'عميل':'Customer');
+  }
+  function appointment(id){return (workspaceNow()?.appointments||[]).find(row=>row?.id===id)||null}
+
+  function ensureStyle(){
+    if(q('#dabbirCarWashPastEditStyle'))return;
+    const style=document.createElement('style');style.id='dabbirCarWashPastEditStyle';
+    style.textContent='#dabbirCarWashPastEditModal{position:fixed;inset:0;z-index:140;background:#000c;display:none;align-items:center;justify-content:center;padding:18px}#dabbirCarWashPastEditModal.open{display:flex}.dabbirCarWashPastEditBox{width:min(430px,100%);background:#131922;border:1px solid #34445b;border-radius:18px;padding:16px;color:#fff}.dabbirCarWashPastEditBox h3{margin:0 0 12px;font-size:18px}.dabbirCarWashPastEditField{display:grid;gap:6px;margin-top:10px}.dabbirCarWashPastEditField label{font-size:12px;color:#9eacc0}.dabbirCarWashPastEditField input,.dabbirCarWashPastEditField select{width:100%;min-height:46px;border:1px solid #34445b;border-radius:11px;background:#182233;color:#fff;padding:10px;font:inherit}.dabbirCarWashPastEditActions{display:flex;gap:8px;margin-top:14px}.dabbirCarWashPastEditActions button{flex:1;min-height:44px;border-radius:11px;font-weight:800}.dabbirCarWashPastEditCancel{border:1px solid #34445b;background:#182233;color:#fff}.dabbirCarWashPastEditSave{border:0;background:#4f7cff;color:#fff}.dabbirCarWashPastEditSave:disabled{opacity:.5}';
+    document.head.append(style);
+  }
+  function ensureModal(){
+    ensureStyle();let modal=q('#dabbirCarWashPastEditModal');if(modal)return modal;
+    modal=document.createElement('div');modal.id='dabbirCarWashPastEditModal';document.body.append(modal);return modal;
+  }
+  function close(){q('#dabbirCarWashPastEditModal')?.classList.remove('open')}
+  function toast(message){try{if(typeof window.toast==='function')window.toast(message)}catch{}}
+
+  function openEditor(id){
+    if(!isCarWash())return;
+    const row=appointment(id),w=workspaceNow();if(!row||!w?.business?.id)return;
+    const c=copy(),modal=ensureModal(),status=String(row.status||'requested').toLowerCase();
+    modal.innerHTML='<form class="dabbirCarWashPastEditBox" id="dabbirCarWashPastEditForm"><h3>'+esc(c.title)+'</h3><div class="dabbirCarWashPastEditField"><label>'+esc(c.customer)+'</label><input value="'+esc(customerName(row.customer_id))+'" disabled></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.time)+'</label><input id="dabbirCarWashPastEditTime" type="datetime-local" value="'+esc(dubaiLocalMinute(row.starts_at))+'" required></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.status)+'</label><select id="dabbirCarWashPastEditStatus"><option value="requested" '+(status==='requested'?'selected':'')+'>'+esc(c.requested)+'</option><option value="confirmed" '+(status==='confirmed'?'selected':'')+'>'+esc(c.confirmed)+'</option><option value="rescheduled" '+(status==='rescheduled'?'selected':'')+'>'+esc(c.rescheduled)+'</option><option value="completed" '+(status==='completed'?'selected':'')+'>'+esc(c.completed)+'</option><option value="cancelled" '+(status==='cancelled'?'selected':'')+'>'+esc(c.cancelled)+'</option></select></div><div class="dabbirCarWashPastEditActions"><button type="button" class="dabbirCarWashPastEditCancel" id="dabbirCarWashPastEditCancel">'+esc(c.cancel)+'</button><button type="submit" class="dabbirCarWashPastEditSave">'+esc(c.save)+'</button></div></form>';
+    q('#dabbirCarWashPastEditCancel').onclick=close;
+    modal.onclick=event=>{if(event.target===modal)close()};
+    q('#dabbirCarWashPastEditForm').onsubmit=async event=>{
+      event.preventDefault();if(busy)return;
+      const start=isoFromDubaiLocal(q('#dabbirCarWashPastEditTime')?.value),nextStatus=q('#dabbirCarWashPastEditStatus')?.value;
+      if(!start)return;
+      busy=true;const submit=event.submitter;if(submit)submit.disabled=true;
+      try{
+        const response=await fetch('/api/appointment-management',{method:'POST',credentials:'same-origin',cache:'no-store',headers:{'content-type':'application/json',accept:'application/json'},body:JSON.stringify({action:'update',business_id:w.business.id,appointment_id:id,starts_at:start,status:nextStatus})});
+        const data=await response.json().catch(()=>({}));if(!response.ok||!data?.ok)throw new Error(data?.error||'APPOINTMENT_UPDATE_FAILED');
+        close();toast(c.saved);setTimeout(()=>location.reload(),180);
+      }catch(error){toast(c.failed+' '+String(error?.message||''))}
+      finally{busy=false;if(submit)submit.disabled=false}
+    };
+    modal.classList.add('open');setTimeout(()=>q('#dabbirCarWashPastEditTime')?.focus(),0);
+  }
+
+  function repairButtons(){
+    if(!isCarWash())return;
+    document.querySelectorAll('#dabbirApptManage [data-appt-edit][disabled]').forEach(button=>{
+      button.disabled=false;button.removeAttribute('title');button.dataset.dabbirHistoricalEdit='1';
+    });
+  }
+  document.addEventListener('click',event=>{
+    const button=event.target?.closest?.('[data-appt-edit][data-dabbir-historical-edit="1"]');if(!button)return;
+    event.preventDefault();event.stopImmediatePropagation();openEditor(button.dataset.apptEdit);
+  },true);
+  document.addEventListener('keydown',event=>{if(event.key==='Escape')close()});
+  const observer=new MutationObserver(repairButtons);observer.observe(document.body,{subtree:true,childList:true});
+  window.addEventListener('focus',repairButtons,{passive:true});
+  setTimeout(repairButtons,0);setTimeout(repairButtons,700);
+  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v1-historical'};
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=300');
+  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v1-historical');
+  return res.status(200).send(script);
+}

--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -35,8 +35,20 @@ const script=String.raw`(()=>{
     return true;
   }
 
+  function loadBookingEdit(){
+    if(!isCarWash()||window.__dabbirCarWashBookingEditFix)return false;
+    if(document.querySelector('script[data-dabbir-car-wash-booking-edit-ui="1"]'))return true;
+    const node=document.createElement('script');
+    node.src='/api/car-wash-booking-edit-ui?v=20260903-1-historical';
+    node.async=true;
+    node.dataset.dabbirCarWashBookingEditUi='1';
+    node.onerror=()=>console.error('dabbir_car_wash_booking_edit_ui_load_failed');
+    document.head.appendChild(node);
+    return true;
+  }
+
   function load(){
-    enforceSingleCalendar();loadManualBooking();
+    enforceSingleCalendar();loadManualBooking();loadBookingEdit();
     if(loaded||loading||!isCarWash())return false;
     if(window.__dabbirCarWashBookingUi){loaded=true;return true}
     const existing=document.querySelector('script[data-dabbir-car-wash-ui="1"]');
@@ -46,26 +58,26 @@ const script=String.raw`(()=>{
     node.src='/api/car-wash-booking-ui?v=20260831-ops-v1';
     node.async=true;
     node.dataset.dabbirCarWashUi='1';
-    node.onload=()=>{loaded=true;loading=false;enforceSingleCalendar();loadManualBooking()};
+    node.onload=()=>{loaded=true;loading=false;enforceSingleCalendar();loadManualBooking();loadBookingEdit()};
     node.onerror=()=>{loading=false;console.error('dabbir_car_wash_ui_load_failed')};
     document.head.appendChild(node);
     return true;
   }
 
-  const timer=setInterval(()=>{attempts+=1;enforceSingleCalendar();loadManualBooking();if(load()||attempts>=40)clearInterval(timer)},500);
+  const timer=setInterval(()=>{attempts+=1;enforceSingleCalendar();loadManualBooking();loadBookingEdit();if(load()||attempts>=40)clearInterval(timer)},500);
   const loaderObserver=new MutationObserver(()=>{if(load())loaderObserver.disconnect()});
   loaderObserver.observe(document.documentElement,{subtree:true,childList:true,attributes:true,attributeFilter:['class']});
   const calendarObserver=new MutationObserver(enforceSingleCalendar);
   calendarObserver.observe(document.documentElement,{subtree:true,childList:true});
-  setTimeout(()=>{load();enforceSingleCalendar();loadManualBooking();if(attempts>=40)loaderObserver.disconnect()},20000);
-  window.addEventListener('focus',()=>{load();enforceSingleCalendar();loadManualBooking()},{passive:true});
-  window.__dabbirCarWashLoader={load,enforceSingleCalendar,loadManualBooking,get loaded(){return loaded}};
+  setTimeout(()=>{load();enforceSingleCalendar();loadManualBooking();loadBookingEdit();if(attempts>=40)loaderObserver.disconnect()},20000);
+  window.addEventListener('focus',()=>{load();enforceSingleCalendar();loadManualBooking();loadBookingEdit()},{passive:true});
+  window.__dabbirCarWashLoader={load,enforceSingleCalendar,loadManualBooking,loadBookingEdit,get loaded(){return loaded}};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v6-native-customer-combobox');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v7-historical-booking-edit');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-historical-booking-edit.test.mjs
+++ b/test/dabbir-car-wash-historical-booking-edit.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const api=fs.readFileSync('api/appointment-management.js','utf8');
+const ui=fs.readFileSync('api/car-wash-booking-edit-ui.js','utf8');
+
+test('appointment management accepts valid historical timestamps for correction',()=>{
+  assert.match(api,/function validStart\(value\)/);
+  assert.doesNotMatch(api,/PAST_APPOINTMENT_NOT_ALLOWED/);
+  assert.doesNotMatch(api,/date\.getTime\(\)<Date\.now\(\)/);
+  assert.match(api,/patch\.starts_at=start\.toISOString\(\)/);
+});
+
+test('car-wash historical editor repairs disabled edit controls instead of hiding them',()=>{
+  assert.match(ui,/#dabbirApptManage \[data-appt-edit\]\[disabled\]/);
+  assert.match(ui,/button\.disabled=false/);
+  assert.match(ui,/data-dabbir-historical-edit/);
+  assert.match(ui,/event\.stopImmediatePropagation\(\)/);
+});
+
+test('car-wash historical editor persists date and status through the canonical appointment API',()=>{
+  assert.match(ui,/\/api\/appointment-management/);
+  assert.match(ui,/action:'update'/);
+  assert.match(ui,/starts_at:start,status:nextStatus/);
+  assert.match(ui,/location\.reload\(\)/);
+});
+
+test('historical booking editor is event-driven without a continuous interval',()=>{
+  assert.match(ui,/new MutationObserver\(repairButtons\)/);
+  assert.doesNotMatch(ui,/setInterval\(/);
+});

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,10 +33,17 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v6-native-customer-combobox/);
+  assert.match(loader,/v7-historical-booking-edit/);
 });
 
 test('car-wash manual booking cache key changes for the iPhone customer combobox fix',()=>{
   const loader=read('api/car-wash-loader-ui.js');
   assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-3-native-combobox/);
+});
+
+test('car-wash loader mounts the historical booking editor',()=>{
+  const loader=read('api/car-wash-loader-ui.js');
+  assert.match(loader,/function loadBookingEdit\(\)/);
+  assert.match(loader,/car-wash-booking-edit-ui\?v=20260903-1-historical/);
+  assert.match(loader,/data-dabbir-car-wash-booking-edit-ui/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -47,5 +47,5 @@ test('car-wash loader mounts the mobile-safe manual booking enhancement only for
   assert.match(loader,/function loadManualBooking\(\)/);
   assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
   assert.match(loader,/20260903-3-native-combobox/);
-  assert.match(loader,/v6-native-customer-combobox/);
+  assert.match(loader,/v7-historical-booking-edit/);
 });


### PR DESCRIPTION
Fixes the booking-management regression shown on iPhone where an appointment becomes non-editable as soon as its start time passes.

Root cause:
- the booking UI disabled Edit whenever starts_at < Date.now();
- the appointment-management API also rejected any historical starts_at, so status corrections after the appointment time were impossible.

Changes:
- allow valid historical timestamps when correcting an appointment record;
- add a car-wash mobile edit repair that re-enables past booking editing and uses the canonical appointment-management API;
- keep the existing future-booking editor untouched;
- refresh the workspace after a verified save;
- add regression coverage and update the car-wash loader version/cache key.