### PR TITLE
Add permission selection screen to team invites

### DIFF
--- a/api/team/invitations.js
+++ b/api/team/invitations.js
@@ -15,7 +15,7 @@ import {
 const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const roleSet = new Set(['admin', 'manager', 'employee', 'staff', 'viewer', 'agent']);
 const permissionSet = new Set([
-  'view_business','manage_business','manage_team','view_integrations','manage_integrations',
+  'view_business','manage_business','manage_store_operations','manage_team','view_integrations','manage_integrations',
   'view_customers','edit_customers','view_conversations','reply_conversations',
   'view_appointments','manage_appointments','manage_automations','view_analytics',
   'manage_billing','export_data','view_services','manage_services','view_knowledge',

--- a/api/team/members.js
+++ b/api/team/members.js
@@ -2,7 +2,7 @@ import { singleQueryValue } from '../_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody, readRpcJson, requireSameOrigin, rpcErrorCode, supabaseRpc } from '../_auth-core.js';
 
 const roles = new Set(['admin','manager','employee','staff','viewer','agent']);
-const permissions = new Set(['view_business','manage_business','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs']);
+const permissions = new Set(['view_business','manage_business','manage_store_operations','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs']);
 
 function normalizePermissions(value) {
   if (!Array.isArray(value)) return [];

--- a/supabase/migrations/20260903184000_dabbir_team_invite_permission_gate_v1.sql
+++ b/supabase/migrations/20260903184000_dabbir_team_invite_permission_gate_v1.sql
@@ -1,0 +1,95 @@
+-- DABBIR team invite permission gate.
+-- Explicit member permissions are authoritative for booking approval.
+-- A member may approve/reject a gated booking only when manage_appointments is effective.
+
+create or replace function dabbir_private.guard_owner_booking_decision()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_can_approve boolean := false;
+begin
+  if old.confirmation_gate in ('owner_approval','deposit')
+     and new.confirmation_gate is distinct from old.confirmation_gate then
+    raise exception 'BOOKING_CONFIRMATION_GATE_IMMUTABLE';
+  end if;
+
+  if old.confirmation_gate='owner_approval' and old.owner_approval_status='pending_owner' then
+    v_can_approve := dabbir_private.has_permission(old.business_id,'manage_appointments');
+
+    if new.status='confirmed' or new.owner_approval_status='approved' then
+      if not v_can_approve then raise exception 'OWNER_APPROVAL_REQUIRED'; end if;
+      new.status := 'confirmed';
+      new.owner_approval_status := 'approved';
+      new.owner_decision_at := now();
+      new.owner_decided_by := (select auth.uid());
+    elsif new.owner_approval_status='rejected' then
+      if not v_can_approve then raise exception 'OWNER_APPROVAL_REQUIRED'; end if;
+      new.status := 'cancelled';
+      new.owner_decision_at := now();
+      new.owner_decided_by := (select auth.uid());
+    elsif new.status='cancelled' and old.status is distinct from 'cancelled' and v_can_approve then
+      new.owner_approval_status := 'rejected';
+      new.owner_decision_at := now();
+      new.owner_decided_by := (select auth.uid());
+    elsif new.owner_approval_status is distinct from old.owner_approval_status then
+      raise exception 'OWNER_APPROVAL_REQUIRED';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.guard_owner_booking_decision() from public,anon,authenticated;
+
+create or replace function public.dabbir_salon_owner_decide_booking(
+  p_business_id uuid,
+  p_appointment_id uuid,
+  p_decision text
+) returns jsonb
+language plpgsql
+security invoker
+set search_path=public,pg_temp
+as $$
+declare
+  v_row public.dabbir_appointments%rowtype;
+begin
+  if p_decision not in ('approve','reject') then raise exception 'INVALID_OWNER_DECISION'; end if;
+  if not dabbir_private.has_permission(p_business_id,'manage_appointments') then
+    raise exception 'OWNER_APPROVAL_REQUIRED';
+  end if;
+
+  if p_decision='approve' then
+    update public.dabbir_appointments
+       set status='confirmed',updated_at=now()
+     where business_id=p_business_id
+       and id=p_appointment_id
+       and confirmation_gate='owner_approval'
+       and owner_approval_status='pending_owner'
+       and status='new'
+     returning * into v_row;
+  else
+    update public.dabbir_appointments
+       set owner_approval_status='rejected',updated_at=now()
+     where business_id=p_business_id
+       and id=p_appointment_id
+       and confirmation_gate='owner_approval'
+       and owner_approval_status='pending_owner'
+       and status='new'
+     returning * into v_row;
+  end if;
+
+  if not found then raise exception 'PENDING_OWNER_BOOKING_NOT_FOUND'; end if;
+  return jsonb_build_object(
+    'appointment_id',v_row.id,
+    'status',v_row.status,
+    'confirmation_gate',v_row.confirmation_gate,
+    'owner_approval_status',v_row.owner_approval_status,
+    'owner_decision_at',v_row.owner_decision_at,
+    'decided_by',v_row.owner_decided_by
+  );
+end;
+$$;
+revoke all on function public.dabbir_salon_owner_decide_booking(uuid,uuid,text) from public,anon;
+grant execute on function public.dabbir_salon_owner_decide_booking(uuid,uuid,text) to authenticated;

--- a/team.html
+++ b/team.html
@@ -7,8 +7,8 @@
 <title>DABBIR — Team</title>
 <style>
 :root{color-scheme:dark;--bg:#08090a;--panel:#111315;--panel2:#17191c;--line:#292d32;--text:#f6f7f8;--muted:#979da6;--accent:#d7ff5f;--green:#83e69a;--warn:#ffd87a;--red:#ff9696}
-*{box-sizing:border-box}body{margin:0;min-height:100vh;background:radial-gradient(circle at 50% -10%,#202429,#090a0b 48%,#08090a);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif}.wrap{max-width:980px;margin:auto;padding:22px 16px 80px}.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}.brand{font-weight:950;font-size:18px}.brand span{color:var(--accent)}a,button,input,select{font:inherit;min-height:44px}.back,.secondary,.primary,.danger{border-radius:12px;padding:9px 13px;font-weight:850;font-size:12px}.back,.secondary{border:1px solid var(--line);background:#17191c;color:#fff;text-decoration:none}.primary{border:0;background:var(--accent);color:#10120d}.danger{border:1px solid #5a3030;background:#261616;color:#ffb0b0}.card{background:linear-gradient(180deg,#15171a,#0f1113);border:1px solid var(--line);border-radius:18px;padding:16px;margin-bottom:13px}.hero h1{margin:0 0 6px;font-size:24px}.hero p,.muted{color:var(--muted);font-size:11px;line-height:1.6}.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:10px}.field label{display:block;color:var(--muted);font-size:10px;margin:0 0 5px}.field input,.field select{width:100%;border:1px solid var(--line);background:#17191c;color:#fff;border-radius:11px;padding:10px}.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.row{display:flex;align-items:center;gap:10px;padding:12px;border:1px solid #262a2f;border-radius:14px;margin-top:8px;background:#15171a}.grow{flex:1;min-width:0}.row b{font-size:12px;display:block}.row small{font-size:9px;color:var(--muted)}.badge{display:inline-flex;border-radius:99px;padding:5px 8px;font-size:9px;font-weight:900}.active{background:#14331e;color:#8ce6a1}.suspended{background:#3a3014;color:#ffd87a}.removed{background:#3b1717;color:#ffaaaa}.pending{background:#15283a;color:#97ccff}.hidden{display:none!important}.notice{border:1px solid #475225;background:#19200f;border-radius:14px;padding:12px;font-size:11px;line-height:1.6}.error{border-color:#603333;background:#251515;color:#ffc0c0}.ok{color:var(--green)}.inviteBox{word-break:break-all;background:#0d0f10;border:1px dashed #3a4148;padding:10px;border-radius:10px;font-size:10px;direction:ltr;text-align:left}.login{max-width:500px;margin:8vh auto}.login h2{margin:0 0 5px}.seg{display:flex;gap:6px;margin-bottom:12px}.seg button{flex:1}.memberActions{display:flex;gap:6px;flex-wrap:wrap}.memberActions button{min-height:36px;padding:6px 9px}.lang{font-size:10px;color:var(--muted)}
-@media(max-width:700px){.grid{grid-template-columns:1fr}.row{align-items:flex-start;flex-wrap:wrap}.memberActions{width:100%}.memberActions button{flex:1}.hero h1{font-size:20px}}
+*{box-sizing:border-box}body{margin:0;min-height:100vh;background:radial-gradient(circle at 50% -10%,#202429,#090a0b 48%,#08090a);color:var(--text);font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Tahoma,Arial,sans-serif}.wrap{max-width:980px;margin:auto;padding:22px 16px 80px}.top{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:18px}.brand{font-weight:950;font-size:18px}.brand span{color:var(--accent)}a,button,input,select{font:inherit;min-height:44px}.back,.secondary,.primary,.danger{border-radius:12px;padding:9px 13px;font-weight:850;font-size:12px}.back,.secondary{border:1px solid var(--line);background:#17191c;color:#fff;text-decoration:none}.primary{border:0;background:var(--accent);color:#10120d}.danger{border:1px solid #5a3030;background:#261616;color:#ffb0b0}.card{background:linear-gradient(180deg,#15171a,#0f1113);border:1px solid var(--line);border-radius:18px;padding:16px;margin-bottom:13px}.hero h1{margin:0 0 6px;font-size:24px}.hero p,.muted{color:var(--muted);font-size:11px;line-height:1.6}.grid{display:grid;grid-template-columns:repeat(2,1fr);gap:10px}.field label{display:block;color:var(--muted);font-size:10px;margin:0 0 5px}.field input,.field select{width:100%;border:1px solid var(--line);background:#17191c;color:#fff;border-radius:11px;padding:10px}.actions{display:flex;gap:8px;flex-wrap:wrap;margin-top:12px}.row{display:flex;align-items:center;gap:10px;padding:12px;border:1px solid #262a2f;border-radius:14px;margin-top:8px;background:#15171a}.grow{flex:1;min-width:0}.row b{font-size:12px;display:block}.row small{font-size:9px;color:var(--muted)}.badge{display:inline-flex;border-radius:99px;padding:5px 8px;font-size:9px;font-weight:900}.active{background:#14331e;color:#8ce6a1}.suspended{background:#3a3014;color:#ffd87a}.removed{background:#3b1717;color:#ffaaaa}.pending{background:#15283a;color:#97ccff}.hidden{display:none!important}.notice{border:1px solid #475225;background:#19200f;border-radius:14px;padding:12px;font-size:11px;line-height:1.6}.error{border-color:#603333;background:#251515;color:#ffc0c0}.ok{color:var(--green)}.inviteBox{word-break:break-all;background:#0d0f10;border:1px dashed #3a4148;padding:10px;border-radius:10px;font-size:10px;direction:ltr;text-align:left}.login{max-width:500px;margin:8vh auto}.login h2{margin:0 0 5px}.seg{display:flex;gap:6px;margin-bottom:12px}.seg button{flex:1}.memberActions{display:flex;gap:6px;flex-wrap:wrap}.memberActions button{min-height:36px;padding:6px 9px}.lang{font-size:10px;color:var(--muted)}.stepHead{display:flex;align-items:flex-start;justify-content:space-between;gap:12px;margin-bottom:12px}.stepNo{display:inline-flex;align-items:center;justify-content:center;min-width:28px;height:28px;border:1px solid #465027;border-radius:99px;color:var(--accent);font-weight:950;font-size:11px}.permissionToolbar{display:flex;gap:7px;flex-wrap:wrap;margin:10px 0}.permissionGroup{margin-top:14px}.permissionGroup h4{margin:0 0 7px;font-size:12px}.permissionGrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:8px}.permissionItem{display:flex;gap:10px;align-items:flex-start;border:1px solid #2a2e33;border-radius:13px;background:#131518;padding:11px;cursor:pointer}.permissionItem input{width:20px;height:20px;min-height:20px;margin-top:1px;accent-color:var(--accent)}.permissionItem b{display:block;font-size:11px}.permissionItem small{display:block;color:var(--muted);font-size:9px;line-height:1.5;margin-top:3px}.permissionSummary{border:1px solid #30363c;background:#101214;border-radius:13px;padding:11px;font-size:10px;line-height:1.7}.permissionSummary b{font-size:12px}.warningBox{border:1px solid #51431d;background:#211b0c;border-radius:12px;padding:10px;color:#ffe39d;font-size:10px;line-height:1.6;margin-top:10px}
+@media(max-width:700px){.grid,.permissionGrid{grid-template-columns:1fr}.row{align-items:flex-start;flex-wrap:wrap}.memberActions{width:100%}.memberActions button{flex:1}.hero h1{font-size:20px}.stepHead{flex-direction:column}}
 </style>
 </head>
 <body>
@@ -31,18 +31,29 @@
   </section>
 
   <main id="teamApp" class="hidden">
-    <section class="card hero"><h1>الفريق والموظفون</h1><p>دعوة واحدة لكل موظف، ثم عضوية دائمة ودخول طبيعي. التعليق أو الإزالة يوقف وصول الشركة فورًا عبر RLS.</p><div id="identity" class="muted"></div></section>
+    <section class="card hero"><h1>الفريق والموظفون</h1><p>دعوة واحدة لكل موظف، ثم عضوية دائمة ودخول طبيعي. المالك يحدد صلاحيات كل عضو قبل إرسال الدعوة.</p><div id="identity" class="muted"></div></section>
 
     <section id="ownerPanel" class="card hidden">
-      <h3 style="margin-top:0">إضافة موظف</h3>
-      <div class="grid">
-        <div class="field"><label>الاسم</label><input id="employeeName" maxlength="120"></div>
-        <div class="field"><label>البريد الإلكتروني</label><input id="employeeEmail" type="email"></div>
-        <div class="field"><label>الدور</label><select id="employeeRole"><option value="employee">Employee</option><option value="manager">Manager</option><option value="admin">Admin</option><option value="viewer">Viewer</option></select></div>
-        <div class="field"><label>صلاحيات مخصصة (اختياري)</label><select id="permissionPreset"><option value="">حسب الدور</option><option value="support">المحادثات والعملاء</option><option value="readonly">قراءة فقط</option></select></div>
+      <div id="inviteBasics">
+        <div class="stepHead"><div><h3 style="margin:0">إضافة عضو للفريق</h3><p class="muted">أدخل بيانات العضو أولًا، ثم ستظهر لك شاشة مستقلة لتحديد ما يستطيع فعله داخل دبّر.</p></div><span class="stepNo">1</span></div>
+        <div class="grid">
+          <div class="field"><label>الاسم</label><input id="employeeName" maxlength="120"></div>
+          <div class="field"><label>البريد الإلكتروني</label><input id="employeeEmail" type="email" autocomplete="email"></div>
+          <div class="field"><label>الدور</label><select id="employeeRole"></select></div>
+        </div>
+        <div class="actions"><button class="primary" id="reviewPermissionsBtn">التالي: تحديد الصلاحيات</button></div>
       </div>
-      <div class="actions"><button class="primary" id="createInviteBtn">إنشاء الدعوة الواحدة</button></div>
-      <div id="createdInvite" class="hidden" style="margin-top:12px"><div class="notice">تم إنشاء الدعوة. شارك هذا الرابط مرة واحدة فقط مع الموظف.</div><div id="inviteUrl" class="inviteBox" style="margin-top:8px"></div><div class="actions"><button class="secondary" id="copyInviteBtn">نسخ الرابط</button></div></div>
+
+      <div id="permissionStep" class="hidden">
+        <div class="stepHead"><div><h3 style="margin:0">حدد صلاحيات العضو</h3><p class="muted">الصلاحيات المحددة هنا هي التي ستطبّق فعليًا، حتى لو كان للدور صلاحيات افتراضية أوسع.</p></div><span class="stepNo">2</span></div>
+        <div id="permissionSummary" class="permissionSummary"></div>
+        <div class="permissionToolbar"><button class="secondary" id="recommendedPermissionsBtn" type="button">المقترح لهذا الدور</button><button class="secondary" id="selectAllPermissionsBtn" type="button">تحديد كل المسموح</button><button class="secondary" id="clearPermissionsBtn" type="button">الحد الأدنى</button></div>
+        <div id="permissionGroups"></div>
+        <div class="warningBox">صلاحية <b>إدارة الحجوزات</b> تشمل اعتماد ورفض الحجوزات التي تحتاج موافقة. إذا أزلتها فلن يستطيع هذا العضو اعتمادها.</div>
+        <div class="actions"><button class="secondary" id="backInviteBtn" type="button">رجوع</button><button class="primary" id="createInviteBtn" type="button">إرسال الدعوة بهذه الصلاحيات</button></div>
+      </div>
+
+      <div id="createdInvite" class="hidden" style="margin-top:12px"><div class="notice">تم إنشاء الدعوة بالصلاحيات التي اخترتها. شارك هذا الرابط مرة واحدة فقط مع العضو.</div><div id="inviteUrl" class="inviteBox" style="margin-top:8px"></div><div class="actions"><button class="secondary" id="copyInviteBtn">نسخ الرابط</button><button class="secondary" id="newInviteBtn">دعوة عضو آخر</button></div></div>
       <p id="ownerMessage" class="muted"></p>
     </section>
 
@@ -60,12 +71,68 @@
 <script>
 const $=id=>document.getElementById(id);
 const inviteToken=new URLSearchParams(location.search).get('invite')||'';
-let session=null,businessId=null,isTeamManager=false,lastInviteUrl='';
-const presets={support:['view_business','view_customers','edit_customers','view_conversations','reply_conversations'],readonly:['view_business','view_customers','view_conversations','view_appointments','view_services']};
+let session=null,businessId=null,isTeamManager=false,lastInviteUrl='',currentMembership=null;
+
+const permissionCatalog=[
+ {group:'النشاط والعمليات',items:[
+  ['view_business','مشاهدة النشاط','فتح بيانات النشاط الأساسية.'],
+  ['manage_business','إدارة إعدادات النشاط','تعديل إعدادات النشاط الأساسية.'],
+  ['manage_store_operations','إدارة العمليات والطلبات','تنفيذ وإدارة العمليات اليومية والطلبات.']
+ ]},
+ {group:'العملاء والمحادثات',items:[
+  ['view_customers','مشاهدة العملاء','عرض بيانات العملاء وسجلهم.'],
+  ['edit_customers','تعديل العملاء','إضافة وتحديث بيانات العملاء.'],
+  ['view_conversations','مشاهدة المحادثات','عرض محادثات واتساب والقنوات المرتبطة.'],
+  ['reply_conversations','الرد على المحادثات','الرد والتعامل مع محادثات العملاء.'],
+  ['manage_handoffs','استلام وتحويل المحادثات','إدارة الحالات التي يحولها AI إلى الفريق.']
+ ]},
+ {group:'الحجوزات',items:[
+  ['view_appointments','مشاهدة الحجوزات','عرض التقويم والحجوزات.'],
+  ['manage_appointments','إدارة واعتماد الحجوزات','إنشاء وتعديل وإلغاء واعتماد الحجوزات التي تحتاج موافقة.'],
+  ['manage_automations','إدارة الأتمتة','تعديل قواعد التذكير والأتمتة المرتبطة بالتشغيل.']
+ ]},
+ {group:'الخدمات والمعرفة',items:[
+  ['view_services','مشاهدة الخدمات','عرض الخدمات والأسعار المتاحة.'],
+  ['manage_services','إدارة الخدمات','إضافة وتعديل الخدمات والأسعار.'],
+  ['view_knowledge','مشاهدة معرفة النشاط','عرض المعرفة التي يستخدمها دبّر وAI.'],
+  ['manage_knowledge','إدارة معرفة النشاط','تعديل المعلومات التي يعتمد عليها AI.']
+ ]},
+ {group:'الإدارة والرقابة',items:[
+  ['view_analytics','مشاهدة التقارير','عرض التقارير والتحليلات.'],
+  ['view_quality','مشاهدة الجودة','عرض مؤشرات الجودة والمتابعة.'],
+  ['manage_team','إدارة الفريق','دعوة الأعضاء وتعديل وصولهم.'],
+  ['export_data','تصدير البيانات','تنزيل أو تصدير بيانات النشاط.'],
+  ['manage_billing','إدارة الفوترة','إدارة اشتراك وفوترة دبّر.']
+ ]},
+ {group:'الربط والتكاملات',items:[
+  ['view_integrations','مشاهدة التكاملات','عرض حالة واتساب والتقويم والربط الخارجي.'],
+  ['manage_integrations','إدارة التكاملات','تعديل وربط وفصل التكاملات الخارجية.']
+ ]}
+];
+const allPermissions=permissionCatalog.flatMap(g=>g.items.map(i=>i[0]));
+const roleDefaults={
+ owner:[...allPermissions],
+ admin:['view_business','manage_business','manage_store_operations','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'],
+ manager:['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'],
+ employee:['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'],
+ staff:['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'],
+ agent:['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'],
+ viewer:['view_business','view_conversations','view_appointments','view_analytics','view_services','view_knowledge','view_quality']
+};
+const roleLabels={admin:'مدير',manager:'مشرف',employee:'موظف',staff:'طاقم',agent:'وكيل خدمة',viewer:'مشاهدة فقط'};
 
 async function api(path,options={}){const r=await fetch(path,{credentials:'same-origin',headers:{'content-type':'application/json',...(options.headers||{})},...options});let p={};try{p=await r.json()}catch{}return{r,p}}
 function msg(el,text,bad=false){el.textContent=text;el.className=bad?'muted error':'muted'}
 function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
+function actorPermissions(){if(!currentMembership)return[];const explicit=Array.isArray(currentMembership.permissions)?currentMembership.permissions.filter(Boolean):[];return explicit.length?explicit:(roleDefaults[currentMembership.role]||[])}
+function allowedPermissionSet(){return new Set(actorPermissions())}
+function configureInviteRoles(){const actorRole=currentMembership?.role;const roles=actorRole==='owner'?['employee','staff','manager','admin','agent','viewer']:['employee','staff','manager','agent','viewer'];$('employeeRole').innerHTML=roles.map(r=>`<option value="${r}">${esc(roleLabels[r])}</option>`).join('')}
+function selectedPermissions(){return [...document.querySelectorAll('[data-permission]:checked')].map(x=>x.dataset.permission)}
+function setSelectedPermissions(values){const selected=new Set(values);document.querySelectorAll('[data-permission]').forEach(x=>x.checked=selected.has(x.dataset.permission));updatePermissionSummary()}
+function recommendedPermissions(){const allowed=allowedPermissionSet(),role=$('employeeRole').value;return (roleDefaults[role]||[]).filter(p=>allowed.has(p))}
+function renderPermissionScreen(){const allowed=allowedPermissionSet();$('permissionGroups').innerHTML=permissionCatalog.map(group=>{const items=group.items.filter(([key])=>allowed.has(key));if(!items.length)return'';return `<div class="permissionGroup"><h4>${esc(group.group)}</h4><div class="permissionGrid">${items.map(([key,label,description])=>`<label class="permissionItem"><input type="checkbox" data-permission="${esc(key)}"><span><b>${esc(label)}</b><small>${esc(description)}</small></span></label>`).join('')}</div></div>`}).join('');document.querySelectorAll('[data-permission]').forEach(x=>x.addEventListener('change',updatePermissionSummary));setSelectedPermissions(recommendedPermissions())}
+function updatePermissionSummary(){const count=selectedPermissions().length,name=$('employeeName').value.trim()||'عضو الفريق',role=roleLabels[$('employeeRole').value]||$('employeeRole').value;$('permissionSummary').innerHTML=`<b>${esc(name)}</b><br>${esc(role)} · ${count} صلاحية محددة`}
+function resetInviteFlow(){lastInviteUrl='';$('createdInvite').classList.add('hidden');$('permissionStep').classList.add('hidden');$('inviteBasics').classList.remove('hidden');$('employeeName').value='';$('employeeEmail').value='';configureInviteRoles();msg($('ownerMessage'),'')}
 
 async function loadSession(){
  const {r,p}=await api('/api/auth/session',{method:'GET'});
@@ -74,8 +141,8 @@ async function loadSession(){
  if(inviteToken)$('inviteCard').classList.remove('hidden');
  const memberships=Array.isArray(p.memberships)?p.memberships:[];
  const preferred=memberships.find(m=>['owner','admin'].includes(m.role))||memberships[0];
- businessId=preferred?.business_id||null;isTeamManager=!!memberships.find(m=>m.business_id===businessId&&['owner','admin'].includes(m.role));
- if(isTeamManager)$('ownerPanel').classList.remove('hidden');
+ businessId=preferred?.business_id||null;currentMembership=memberships.find(m=>m.business_id===businessId)||null;isTeamManager=!!currentMembership&&['owner','admin'].includes(currentMembership.role);
+ if(isTeamManager){$('ownerPanel').classList.remove('hidden');configureInviteRoles()}
  if(businessId)await loadTeam();else $('members').innerHTML='<p class="muted">لا توجد عضوية شركة نشطة بعد. إذا كانت لديك دعوة فاقبلها أولاً.</p>';
  return true;
 }
@@ -83,21 +150,27 @@ async function loadSession(){
 $('loginBtn').onclick=async()=>{const email=$('authEmail').value.trim(),password=$('authPassword').value;const {r,p}=await api('/api/auth/login',{method:'POST',body:JSON.stringify({email,password})});if(!r.ok)return msg($('authMessage'),p.error||'فشل تسجيل الدخول',true);msg($('authMessage'),'تم تسجيل الدخول');await loadSession()};
 $('signupBtn').onclick=async()=>{const email=$('authEmail').value.trim(),password=$('authPassword').value;const {r,p}=await api('/api/auth/signup',{method:'POST',body:JSON.stringify({email,password})});if(!r.ok)return msg($('authMessage'),p.error||'تعذر إنشاء الحساب',true);msg($('authMessage'),p.authenticated?'تم إنشاء الحساب وتسجيل الدخول.':'تم إنشاء الحساب. تحقق من بريدك الإلكتروني ثم سجّل الدخول.')};
 
-$('acceptInviteBtn').onclick=async()=>{if(!inviteToken)return;const {r,p}=await api('/api/team/accept-invite',{method:'POST',body:JSON.stringify({token:inviteToken})});if(!r.ok){if(r.status===401){$('authCard').classList.remove('hidden');return msg($('inviteMessage'), 'سجّل الدخول أولاً ثم عد لقبول الدعوة.',true)}return msg($('inviteMessage'),p.error||'تعذر قبول الدعوة',true)}msg($('inviteMessage'),'تم قبول الدعوة. عضويتك الآن دائمة ويمكنك الدخول لاحقًا بدون هذا الرابط.');$('acceptInviteBtn').classList.add('hidden');history.replaceState({},'', '/team.html');await loadSession()};
+$('acceptInviteBtn').onclick=async()=>{if(!inviteToken)return;const {r,p}=await api('/api/team/accept-invite',{method:'POST',body:JSON.stringify({token:inviteToken})});if(!r.ok){if(r.status===401){$('authCard').classList.remove('hidden');return msg($('inviteMessage'),'سجّل الدخول أولاً ثم عد لقبول الدعوة.',true)}return msg($('inviteMessage'),p.error||'تعذر قبول الدعوة',true)}msg($('inviteMessage'),'تم قبول الدعوة. عضويتك الآن دائمة ويمكنك الدخول لاحقًا بدون هذا الرابط.');$('acceptInviteBtn').classList.add('hidden');history.replaceState({},'', '/team.html');await loadSession()};
 
-$('createInviteBtn').onclick=async()=>{if(!businessId)return;const role=$('employeeRole').value,preset=$('permissionPreset').value;const body={business_id:businessId,email:$('employeeEmail').value.trim(),display_name:$('employeeName').value.trim(),role,permissions:presets[preset]||[]};const {r,p}=await api('/api/team/invitations',{method:'POST',body:JSON.stringify(body)});if(!r.ok)return msg($('ownerMessage'),p.error||'تعذر إنشاء الدعوة',true);lastInviteUrl=new URL(p.invite_path,location.origin).href;$('inviteUrl').textContent=lastInviteUrl;$('createdInvite').classList.remove('hidden');msg($('ownerMessage'),'تم. لا تُنشئ دعوة جديدة لهذا الموظف بعد قبولها.');await loadInvitations()};
+$('reviewPermissionsBtn').onclick=()=>{const email=$('employeeEmail').value.trim();if(!email||!email.includes('@'))return msg($('ownerMessage'),'أدخل بريدًا إلكترونيًا صحيحًا قبل تحديد الصلاحيات.',true);$('inviteBasics').classList.add('hidden');$('permissionStep').classList.remove('hidden');renderPermissionScreen();msg($('ownerMessage'),'')};
+$('backInviteBtn').onclick=()=>{$('permissionStep').classList.add('hidden');$('inviteBasics').classList.remove('hidden')};
+$('recommendedPermissionsBtn').onclick=()=>setSelectedPermissions(recommendedPermissions());
+$('selectAllPermissionsBtn').onclick=()=>setSelectedPermissions([...allowedPermissionSet()]);
+$('clearPermissionsBtn').onclick=()=>setSelectedPermissions(allowedPermissionSet().has('view_business')?['view_business']:[]);
+$('createInviteBtn').onclick=async()=>{if(!businessId)return;const permissions=selectedPermissions();if(!permissions.length||!permissions.includes('view_business'))return msg($('ownerMessage'),'يجب إبقاء صلاحية مشاهدة النشاط على الأقل حتى يستطيع العضو استخدام دبّر.',true);const body={business_id:businessId,email:$('employeeEmail').value.trim(),display_name:$('employeeName').value.trim(),role:$('employeeRole').value,permissions};const btn=$('createInviteBtn');btn.disabled=true;const {r,p}=await api('/api/team/invitations',{method:'POST',body:JSON.stringify(body)});btn.disabled=false;if(!r.ok)return msg($('ownerMessage'),p.error||'تعذر إنشاء الدعوة',true);lastInviteUrl=new URL(p.invite_path,location.origin).href;$('inviteUrl').textContent=lastInviteUrl;$('permissionStep').classList.add('hidden');$('createdInvite').classList.remove('hidden');msg($('ownerMessage'),`تم إنشاء الدعوة مع ${permissions.length} صلاحية محددة.`);await loadInvitations()};
 $('copyInviteBtn').onclick=async()=>{if(!lastInviteUrl)return;await navigator.clipboard.writeText(lastInviteUrl);msg($('ownerMessage'),'تم نسخ رابط الدعوة.')};
+$('newInviteBtn').onclick=resetInviteFlow;
 
 async function loadTeam(){
  const {r,p}=await api('/api/team/members?business_id='+encodeURIComponent(businessId));
  if(!r.ok){$('members').innerHTML='<p class="muted">حسابك عضو في الشركة ولا يملك صلاحية إدارة الفريق.</p>';return}
  $('ownerPanel').classList.remove('hidden');isTeamManager=true;
- $('members').innerHTML=(p.members||[]).map(m=>`<div class="row"><div class="grow"><b>${esc(m.display_name||m.email)}</b><small>${esc(m.email)} · ${esc(m.role)}</small></div><span class="badge ${esc(m.status)}">${esc(m.status)}</span>${m.role==='owner'?'':`<div class="memberActions">${m.status==='active'?`<button class="secondary" onclick="memberAction('${m.user_id}','suspend')">تعليق</button>`:''}${m.status==='suspended'?`<button class="secondary" onclick="memberAction('${m.user_id}','reactivate')">إعادة تفعيل</button>`:''}${m.status!=='removed'?`<button class="danger" onclick="memberAction('${m.user_id}','remove')">إزالة</button>`:''}</div>`}</div>`).join('')||'<p class="muted">لا يوجد أعضاء.</p>';
+ $('members').innerHTML=(p.members||[]).map(m=>`<div class="row"><div class="grow"><b>${esc(m.display_name||m.email)}</b><small>${esc(m.email)} · ${esc(roleLabels[m.role]||m.role)}${Array.isArray(m.permissions)&&m.permissions.length?` · ${m.permissions.length} صلاحية مخصصة`:''}</small></div><span class="badge ${esc(m.status)}">${esc(m.status)}</span>${m.role==='owner'?'':`<div class="memberActions">${m.status==='active'?`<button class="secondary" onclick="memberAction('${m.user_id}','suspend')">تعليق</button>`:''}${m.status==='suspended'?`<button class="secondary" onclick="memberAction('${m.user_id}','reactivate')">إعادة تفعيل</button>`:''}${m.status!=='removed'?`<button class="danger" onclick="memberAction('${m.user_id}','remove')">إزالة</button>`:''}</div>`}</div>`).join('')||'<p class="muted">لا يوجد أعضاء.</p>';
  await loadInvitations();
 }
 
 window.memberAction=async(userId,action)=>{const {r,p}=await api('/api/team/members',{method:'PATCH',body:JSON.stringify({business_id:businessId,user_id:userId,action})});if(!r.ok)return alert(p.error||'تعذر تحديث العضو');await loadTeam()};
-async function loadInvitations(){if(!isTeamManager||!businessId)return;const {r,p}=await api('/api/team/invitations?business_id='+encodeURIComponent(businessId));if(!r.ok)return;$('invitationListCard').classList.remove('hidden');$('invitations').innerHTML=(p.invitations||[]).map(i=>`<div class="row"><div class="grow"><b>${esc(i.display_name||i.email)}</b><small>${esc(i.email)} · ${esc(i.role)} · ${new Date(i.expires_at).toLocaleString()}</small></div><span class="badge ${esc(i.status)}">${esc(i.status)}</span></div>`).join('')||'<p class="muted">لا توجد دعوات.</p>'}
+async function loadInvitations(){if(!isTeamManager||!businessId)return;const {r,p}=await api('/api/team/invitations?business_id='+encodeURIComponent(businessId));if(!r.ok)return;$('invitationListCard').classList.remove('hidden');$('invitations').innerHTML=(p.invitations||[]).map(i=>`<div class="row"><div class="grow"><b>${esc(i.display_name||i.email)}</b><small>${esc(i.email)} · ${esc(roleLabels[i.role]||i.role)} · ${Array.isArray(i.permissions)?i.permissions.length:0} صلاحية · ${new Date(i.expires_at).toLocaleString()}</small></div><span class="badge ${esc(i.status)}">${esc(i.status)}</span></div>`).join('')||'<p class="muted">لا توجد دعوات.</p>'}
 
 loadSession();
 </script>

--- a/test/team-invite-permission-screen.test.mjs
+++ b/test/team-invite-permission-screen.test.mjs
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const team=fs.readFileSync(path.join(root,'team.html'),'utf8');
+const invites=fs.readFileSync(path.join(root,'api/team/invitations.js'),'utf8');
+const members=fs.readFileSync(path.join(root,'api/team/members.js'),'utf8');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260903184000_dabbir_team_invite_permission_gate_v1.sql'),'utf8');
+
+test('owner invite flow has a dedicated permission step before sending',()=>{
+  assert.match(team,/id="reviewPermissionsBtn"/);
+  assert.match(team,/id="permissionStep"/);
+  assert.match(team,/id="permissionGroups"/);
+  assert.match(team,/data-permission/);
+  assert.match(team,/التالي: تحديد الصلاحيات/);
+  assert.match(team,/إرسال الدعوة بهذه الصلاحيات/);
+});
+
+test('invite always sends an explicit non-empty permission selection',()=>{
+  assert.match(team,/const permissions=selectedPermissions\(\)/);
+  assert.match(team,/!permissions\.includes\('view_business'\)/);
+  assert.match(team,/permissions\}/);
+  assert.doesNotMatch(team,/presets\[preset\]/);
+});
+
+test('permission catalog includes operational and booking controls',()=>{
+  for(const marker of ['manage_store_operations','manage_appointments','reply_conversations','manage_team','manage_integrations']){
+    assert.match(team,new RegExp(marker));
+    assert.match(invites,new RegExp(marker));
+    assert.match(members,new RegExp(marker));
+  }
+});
+
+test('booking approval follows effective manage_appointments permission',()=>{
+  assert.match(migration,/has_permission\(old\.business_id,'manage_appointments'\)/);
+  assert.match(migration,/has_permission\(p_business_id,'manage_appointments'\)/);
+  assert.doesNotMatch(migration,/m\.role in \('owner','admin','manager','employee','staff'\)/);
+});


### PR DESCRIPTION
Implements the DABBIR team invitation permission flow requested by the owner:

- Step 1: enter member name, email and role.
- Step 2: dedicated Arabic permission screen before the invite is created.
- Permissions are grouped by business operations, customers/conversations, bookings, services/knowledge, administration and integrations.
- Role-based recommendations are preselected, but the inviter can change them.
- Invite always persists an explicit permission set (at least view_business), avoiding the old empty-array fallback to broad role defaults.
- Adds manage_store_operations to the invite/member API permission catalog to match production DB support.
- Booking approval now follows the effective manage_appointments permission, so removing booking management from a member also removes approval/rejection ability.
- Adds regression tests.