### PR TITLE
Require owner approval before any DABBIR Production release

### DIFF
--- a/.github/workflows/barman-tool-agent.yml
+++ b/.github/workflows/barman-tool-agent.yml
@@ -11,6 +11,7 @@ permissions:
   pull-requests: write
   actions: write
   checks: read
+  deployments: read
 
 concurrency:
   group: barman-persistent-tool-agent

--- a/release/DABBIR_TEST_CANDIDATE.json
+++ b/release/DABBIR_TEST_CANDIDATE.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": 1,
+  "product": "DABBIR",
+  "channel": "preview",
+  "status": "AWAITING_OWNER_APPROVAL",
+  "candidate_sha": null,
+  "preview_url": null,
+  "owner_approval": {
+    "required": true,
+    "approved": false,
+    "approved_at": null,
+    "approval_source": "explicit_owner_message_only"
+  },
+  "production": {
+    "automatic_git_deploy": false,
+    "promotion_allowed": false
+  },
+  "rules": [
+    "Every runtime change must be presented as a Preview candidate before Production.",
+    "Production promotion requires explicit owner approval after the Preview is reviewed.",
+    "A merge to main must not automatically publish a Production deployment.",
+    "The candidate SHA and Preview URL must be recorded here before asking for owner approval."
+  ]
+}

--- a/scripts/barman-tool-agent.mjs
+++ b/scripts/barman-tool-agent.mjs
@@ -70,17 +70,24 @@ async function waitWorkflow(workflow,branch,event,headSha,timeoutMs){
   }
   throw new Error(`${workflow}_TIMEOUT_${seen?.html_url||''}`);
 }
-async function waitProduction(commitSha,timeoutMs=900000){
-  const started=Date.now();let last=null;
+async function waitPreviewDeployment(commitSha,timeoutMs=900000){
+  const started=Date.now();let last='none';
   while(Date.now()-started<timeoutMs){
-    try{
-      const response=await fetch(`https://dabbir.bmalman.com/api/release-evidence?t=${Date.now()}`,{headers:{accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)});
-      const payload=await response.json().catch(()=>null);last=payload;
-      if(response.ok&&payload?.ok===true&&String(payload?.environment||'').toLowerCase()==='production'&&String(payload?.commit_sha||'').toLowerCase()===commitSha.toLowerCase())return payload;
-    }catch{}
+    const deployments=await gh(`/deployments?sha=${encodeURIComponent(commitSha)}&per_page=30`).catch(()=>[]);
+    for(const deployment of Array.isArray(deployments)?deployments:[]){
+      const environment=String(deployment?.environment||'').trim();
+      if(environment.toLowerCase()==='production')continue;
+      const statuses=await gh(`/deployments/${deployment.id}/statuses?per_page=30`).catch(()=>[]);
+      const ready=(Array.isArray(statuses)?statuses:[]).find(status=>status?.state==='success'&&String(status?.environment_url||'').startsWith('https://'));
+      if(ready){
+        const url=String(ready.environment_url);
+        if(!url.includes('dabbir.bmalman.com'))return {deploymentId:String(deployment.id),environment:environment||'Preview',url};
+      }
+      last=`deployment:${deployment?.id||'unknown'}:${environment||'unknown'}`;
+    }
     await sleep(10000);
   }
-  throw new Error(`PRODUCTION_EXACT_SHA_TIMEOUT_${clean(last?.commit_sha||'none',80)}`);
+  throw new Error(`PREVIEW_EXACT_SHA_TIMEOUT_${clean(last,160)}`);
 }
 
 function repositoryPaths(){return git(['ls-files','-z']).split('\0').filter(Boolean)}
@@ -116,16 +123,6 @@ function localTests(){
 
 async function createPr(branch,title,body){
   return gh('/pulls',{method:'POST',body:{title,head:branch,base:'main',body,maintainer_can_modify:true}});
-}
-async function mergePr(number,headSha){
-  return gh(`/pulls/${number}/merge`,{method:'PUT',body:{sha:headSha,merge_method:'squash'}});
-}
-async function refreshBranch(branch){
-  git(['fetch','origin','main']);
-  git(['checkout',branch]);
-  sh('git',['merge','--no-edit','origin/main'],{stdio:'inherit'});
-  git(['push','origin',branch]);
-  return git(['rev-parse','HEAD']);
 }
 
 let execution=null;
@@ -191,40 +188,25 @@ try{
   git(['add','--',...changed]);
   git(['commit','-m',`BARMAN: ${clean(proposal.summary||commandText,68)}`]);
   git(['push','-u','origin',branch]);
-  let headSha=git(['rev-parse','HEAD']);
-  const pr=await createPr(branch,`BARMAN: ${clean(proposal.summary||commandText,80)}`,`Automated execution for owner command \`${execution.commandId}\`.\n\nOwner goal: ${clean(commandText,1200)}\n\nSafety: generated patch passed local syntax + npm test before PR creation.`);
+  const headSha=git(['rev-parse','HEAD']);
+  const pr=await createPr(branch,`BARMAN: ${clean(proposal.summary||commandText,80)}`,`Automated execution for owner command \`${execution.commandId}\`.\n\nOwner goal: ${clean(commandText,1200)}\n\nSafety: generated patch passed local syntax + npm test before PR creation.\n\nRelease policy: Preview only. Do not merge or publish Production until the owner explicitly approves this exact candidate.`);
   const prUrl=String(pr.html_url||'');
 
   await dispatch('ci.yml',branch,{});
-  let ciRun=await waitWorkflow('ci.yml',branch,'workflow_dispatch',headSha,900000);
-  let merged;
-  try{merged=await mergePr(pr.number,headSha)}catch(error){
-    if(![405,409,422].includes(Number(error.status)))throw error;
-    headSha=await refreshBranch(branch);
-    localTests();
-    await dispatch('ci.yml',branch,{});
-    ciRun=await waitWorkflow('ci.yml',branch,'workflow_dispatch',headSha,900000);
-    merged=await mergePr(pr.number,headSha);
-  }
-  if(merged?.merged!==true||!merged?.sha)throw new Error(`PR_NOT_MERGED_${clean(merged?.message||'',300)}`);
-  const mergeSha=String(merged.sha);
-  const release=await waitProduction(mergeSha,900000);
-
-  await dispatch('dabbir-ai-customer-journey.yml','main',{run_capacity:false,production_capacity_ack:''});
-  const journey=await waitWorkflow('dabbir-ai-customer-journey.yml','main','workflow_dispatch',mergeSha,1200000);
+  const ciRun=await waitWorkflow('ci.yml',branch,'workflow_dispatch',headSha,900000);
+  const preview=await waitPreviewDeployment(headSha,900000);
   const evidence=[
-    {type:'artifact',reference:prUrl,verified:true,details:{pr_number:pr.number,changed_files:changed}},
+    {type:'artifact',reference:prUrl,verified:true,details:{pr_number:pr.number,changed_files:changed,release_gate:'OWNER_APPROVAL_REQUIRED'}},
     {type:'test',reference:String(ciRun.html_url||'DABBIR CI'),verified:true,details:{workflow:'DABBIR CI',head_sha:headSha}},
-    {type:'commit',reference:mergeSha,verified:true,details:{repository:REPO}},
-    {type:'deployment',reference:String(release?.deployment_id||'production'),verified:true,details:{commit_sha:release?.commit_sha,environment:release?.environment}},
-    {type:'test',reference:String(journey.html_url||'Full Customer Journey'),verified:true,details:{workflow:'DABBIR AI Full Customer Journey',commit_sha:mergeSha}},
+    {type:'commit',reference:headSha,verified:true,details:{repository:REPO,merged:false}},
+    {type:'deployment',reference:preview.url,verified:true,details:{deployment_id:preview.deploymentId,environment:preview.environment,production:false}},
   ];
-  const summary=`BARMAN نفّذ الأمر ودمج التغيير بعد CI ثم تحقق من Production وFull Customer Journey. PR #${pr.number}, commit ${mergeSha.slice(0,12)}.`;
+  const summary=`BARMAN جهّز نسخة تجريبية معتمدة بالاختبارات دون دمج أو نشر Production. PR #${pr.number}, candidate ${headSha.slice(0,12)}. رابط التجربة: ${preview.url}. يلزم اعتماد المالك الصريح قبل أي ترقية للإنتاج.`;
   const result=await finalize('DONE',summary,evidence,'');
-  console.log('DONE',JSON.stringify({command_id:execution.commandId,pr:prUrl,merge_sha:mergeSha,notification:result?.notification||null}));
+  console.log('PREVIEW_READY',JSON.stringify({command_id:execution.commandId,pr:prUrl,candidate_sha:headSha,preview_url:preview.url,owner_approval_required:true,notification:result?.notification||null}));
 }catch(error){
   const message=clean(error?.stack||error?.message||error,1800);
   console.error('BARMAN_TOOL_AGENT_FAILED',message);
-  await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message);
+  await finalize('RETRY','تعذر إكمال دورة إعداد النسخة التجريبية؛ ستعاد المحاولة دون دمج أو نشر Production.',[],message);
   process.exitCode=1;
 }

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -39,7 +39,7 @@ test('tool-agent routes non-code commands fail-closed before patch generation',(
 
 test('persistent worker is event-looped and cannot bypass governance files',()=>{
   assert.match(workflow,/cron:\s*'\*\/5 \* \* \* \*'/);
-  for(const token of ['id-token: write','contents: write','pull-requests: write','actions: write','cancel-in-progress: false'])assert.match(workflow,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+  for(const token of ['id-token: write','contents: write','pull-requests: write','actions: write','deployments: read','cancel-in-progress: false'])assert.match(workflow,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
   assert.match(worker,/phase:'claim'/);
   assert.match(worker,/p_lane:'tool_agent'|phase:'claim'/);
   assert.match(worker,/spawnSync\('git',\['apply','--check'/);
@@ -54,15 +54,24 @@ test('required branch-protection test context is emitted only by pull_request CI
   assert.match(ci,/if:\s*github\.event_name == 'pull_request'/);
 });
 
-test('DONE requires CI, exact Production release and full customer journey',()=>{
-  assert.match(ci,/workflow_dispatch:/);
-  assert.match(worker,/dispatch\('ci\.yml'/);
-  assert.match(worker,/waitWorkflow\('ci\.yml'/);
-  assert.match(worker,/\/api\/release-evidence/);
-  assert.match(worker,/payload\?\.commit_sha/);
-  assert.match(worker,/dispatch\('dabbir-ai-customer-journey\.yml','main'/);
-  assert.match(worker,/waitWorkflow\('dabbir-ai-customer-journey\.yml','main'/);
+test('BARMAN stops at exact Preview and requires explicit owner approval before Production',()=>{
+  assert.match(worker,/waitPreviewDeployment\(headSha/);
+  assert.match(worker,/\/deployments\?sha=/);
+  assert.match(worker,/environment_url/);
+  assert.match(worker,/Release policy: Preview only/);
+  assert.match(worker,/owner_approval_required:true/);
+  assert.match(worker,/دون دمج أو نشر Production/);
+  assert.doesNotMatch(worker,/\/pulls\/\$\{number\}\/merge/);
+  assert.doesNotMatch(worker,/async function mergePr/);
+  assert.doesNotMatch(worker,/waitProduction\(/);
+  assert.doesNotMatch(worker,/dispatch\('dabbir-ai-customer-journey\.yml','main'/);
+});
+
+test('candidate completion records Preview evidence without claiming Production',()=>{
+  assert.match(worker,/type:'deployment'.*production:false/s);
+  assert.match(worker,/type:'commit'.*merged:false/s);
   assert.match(worker,/finalize\('DONE'/);
+  assert.match(worker,/يلزم اعتماد المالك الصريح قبل أي ترقية للإنتاج/);
 });
 
 test('broker finalization sends Telegram outcome and evidence remains fail-closed',()=>{

--- a/test/dabbir-owner-production-approval.test.mjs
+++ b/test/dabbir-owner-production-approval.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const vercel=JSON.parse(fs.readFileSync(new URL('../vercel.json',import.meta.url),'utf8'));
+const candidate=JSON.parse(fs.readFileSync(new URL('../release/DABBIR_TEST_CANDIDATE.json',import.meta.url),'utf8'));
+
+test('main cannot auto-deploy to Production while preview branches remain available',()=>{
+  assert.equal(vercel?.git?.deploymentEnabled?.main,false);
+  assert.notEqual(vercel?.git?.deploymentEnabled,false);
+});
+
+test('DABBIR release candidate is fail-closed until explicit owner approval',()=>{
+  assert.equal(candidate.product,'DABBIR');
+  assert.equal(candidate.channel,'preview');
+  assert.equal(candidate.owner_approval.required,true);
+  assert.equal(candidate.owner_approval.approved,false);
+  assert.equal(candidate.production.automatic_git_deploy,false);
+  assert.equal(candidate.production.promotion_allowed,false);
+  assert.equal(candidate.status,'AWAITING_OWNER_APPROVAL');
+});
+
+test('release candidate must carry exact preview evidence before approval can be requested',()=>{
+  assert.ok(Object.hasOwn(candidate,'candidate_sha'));
+  assert.ok(Object.hasOwn(candidate,'preview_url'));
+  assert.equal(candidate.owner_approval.approval_source,'explicit_owner_message_only');
+});

--- a/vercel.json
+++ b/vercel.json
@@ -4,6 +4,11 @@
   "regions": ["bom1"],
   "buildCommand": "npm run dabbir:build",
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
+  "git": {
+    "deploymentEnabled": {
+      "main": false
+    }
+  },
   "env": {
     "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"
   },


### PR DESCRIPTION
Implements the new release rule requested by the owner.

- disables automatic Vercel Git deployment from `main`;
- keeps non-main branches available for Preview deployments;
- adds `release/DABBIR_TEST_CANDIDATE.json` as the fail-closed test/approval manifest;
- adds regression tests so automatic Production publishing cannot silently return.

Production must remain unchanged. This PR itself is to be verified only through Preview + CI before merge.