### PR TITLE
Make manage_team permission authoritative

### DIFF
--- a/supabase/migrations/20260903191500_dabbir_team_manage_permission_authority_v2.sql
+++ b/supabase/migrations/20260903191500_dabbir_team_manage_permission_authority_v2.sql
@@ -1,0 +1,206 @@
+-- DABBIR team management authority v2.
+-- The effective manage_team permission is authoritative for team mutations.
+-- Explicit permission sets are required for new team grants, and pending invites
+-- are revalidated at acceptance time so revoked access cannot be resurrected.
+
+create or replace function dabbir_private.user_has_permission(
+  p_business_id uuid,
+  p_user_id uuid,
+  p_permission text
+) returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select exists(
+  select 1
+  from public.dabbir_memberships m
+  where m.business_id=p_business_id
+    and m.user_id=p_user_id
+    and m.status='active'
+    and (
+      (cardinality(m.permissions)>0 and p_permission=any(m.permissions))
+      or
+      (cardinality(m.permissions)=0 and case m.role
+        when 'owner' then p_permission=any(array['view_business','manage_business','manage_store_operations','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','manage_billing','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+        when 'admin' then p_permission=any(array['view_business','manage_business','manage_store_operations','manage_team','view_integrations','manage_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','export_data','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+        when 'manager' then p_permission=any(array['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','manage_automations','view_analytics','view_services','manage_services','view_knowledge','manage_knowledge','view_quality','manage_handoffs'])
+        when 'employee' then p_permission=any(array['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+        when 'staff' then p_permission=any(array['view_business','manage_store_operations','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+        when 'agent' then p_permission=any(array['view_business','view_integrations','view_customers','edit_customers','view_conversations','reply_conversations','view_appointments','manage_appointments','view_services','view_knowledge','manage_handoffs'])
+        when 'viewer' then p_permission=any(array['view_business','view_conversations','view_appointments','view_analytics','view_services','view_knowledge','view_quality'])
+        else false
+      end)
+    )
+);
+$$;
+revoke all on function dabbir_private.user_has_permission(uuid,uuid,text) from public,anon,authenticated;
+grant execute on function dabbir_private.user_has_permission(uuid,uuid,text) to service_role;
+
+create or replace function dabbir_private.has_permission(p_business_id uuid,p_permission text)
+returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select (select auth.uid()) is not null
+  and dabbir_private.user_has_permission(p_business_id,(select auth.uid()),p_permission);
+$$;
+revoke all on function dabbir_private.has_permission(uuid,text) from public,anon;
+grant execute on function dabbir_private.has_permission(uuid,text) to authenticated,service_role;
+
+create or replace function dabbir_private.can_user_manage_role(
+  p_business_id uuid,
+  p_user_id uuid,
+  p_target_role text
+) returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select dabbir_private.user_has_permission(p_business_id,p_user_id,'manage_team')
+  and exists(
+    select 1
+    from public.dabbir_memberships m
+    where m.business_id=p_business_id
+      and m.user_id=p_user_id
+      and m.status='active'
+      and (
+        (m.role='owner' and p_target_role in ('admin','manager','employee','staff','viewer','agent'))
+        or
+        (m.role='admin' and p_target_role in ('manager','employee','staff','viewer','agent'))
+      )
+  );
+$$;
+revoke all on function dabbir_private.can_user_manage_role(uuid,uuid,text) from public,anon,authenticated;
+grant execute on function dabbir_private.can_user_manage_role(uuid,uuid,text) to service_role;
+
+create or replace function dabbir_private.can_manage_role(p_business_id uuid,p_target_role text)
+returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select (select auth.uid()) is not null
+  and dabbir_private.can_user_manage_role(p_business_id,(select auth.uid()),p_target_role);
+$$;
+revoke all on function dabbir_private.can_manage_role(uuid,text) from public,anon;
+grant execute on function dabbir_private.can_manage_role(uuid,text) to authenticated,service_role;
+
+create or replace function dabbir_private.can_user_grant_permissions(
+  p_business_id uuid,
+  p_user_id uuid,
+  p_permissions text[]
+) returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select dabbir_private.valid_permissions(p_permissions)
+  and cardinality(coalesce(p_permissions,'{}'::text[]))>0
+  and not exists(
+    select 1
+    from unnest(coalesce(p_permissions,'{}'::text[])) p
+    where not dabbir_private.user_has_permission(p_business_id,p_user_id,p)
+  );
+$$;
+revoke all on function dabbir_private.can_user_grant_permissions(uuid,uuid,text[]) from public,anon,authenticated;
+grant execute on function dabbir_private.can_user_grant_permissions(uuid,uuid,text[]) to service_role;
+
+create or replace function dabbir_private.can_grant_permissions(p_business_id uuid,p_permissions text[])
+returns boolean
+language sql
+stable
+security definer
+set search_path=public,pg_temp
+as $$
+select (select auth.uid()) is not null
+  and dabbir_private.can_user_grant_permissions(p_business_id,(select auth.uid()),p_permissions);
+$$;
+revoke all on function dabbir_private.can_grant_permissions(uuid,text[]) from public,anon;
+grant execute on function dabbir_private.can_grant_permissions(uuid,text[]) to authenticated,service_role;
+
+create or replace function dabbir_private.dabbir_accept_employee_invitation(p_token text)
+returns table(business_id uuid,role text,status text)
+language plpgsql
+security definer
+set search_path=public,extensions,pg_temp
+as $$
+declare
+  v_user uuid := auth.uid();
+  v_email text := lower(coalesce(auth.jwt()->>'email',''));
+  v_hash text;
+  v_inv public.dabbir_employee_invitations%rowtype;
+  v_existing public.dabbir_memberships%rowtype;
+begin
+  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+  if v_email='' then raise exception 'VERIFIED_EMAIL_REQUIRED'; end if;
+  if p_token is null or length(p_token)<32 or length(p_token)>256 then raise exception 'INVALID_INVITATION'; end if;
+  v_hash := encode(extensions.digest(p_token,'sha256'),'hex');
+
+  select inv.* into v_inv
+  from public.dabbir_employee_invitations inv
+  where inv.token_hash=v_hash
+  for update;
+  if not found then raise exception 'INVITATION_NOT_FOUND'; end if;
+  if v_inv.status<>'pending' then raise exception 'INVITATION_NOT_PENDING'; end if;
+  if v_inv.expires_at<=now() then raise exception 'INVITATION_EXPIRED'; end if;
+  if lower(v_inv.email)<>v_email then raise exception 'INVITATION_EMAIL_MISMATCH'; end if;
+
+  if not dabbir_private.can_user_manage_role(v_inv.business_id,v_inv.invited_by,v_inv.role)
+     or not dabbir_private.can_user_grant_permissions(v_inv.business_id,v_inv.invited_by,v_inv.permissions) then
+    raise exception 'INVITER_NO_LONGER_AUTHORIZED';
+  end if;
+
+  select mem.* into v_existing
+  from public.dabbir_memberships mem
+  where mem.business_id=v_inv.business_id
+    and mem.user_id=v_user
+  for update;
+  if found and v_existing.status in ('active','suspended') then raise exception 'MEMBERSHIP_ALREADY_EXISTS'; end if;
+
+  if found and v_existing.status='removed' then
+    update public.dabbir_memberships mem
+    set role=v_inv.role,
+        permissions=v_inv.permissions,
+        display_name=v_inv.display_name,
+        status='active',
+        invited_by=v_inv.invited_by,
+        accepted_at=now(),
+        suspended_at=null,
+        removed_at=null,
+        updated_at=now()
+    where mem.business_id=v_inv.business_id
+      and mem.user_id=v_user;
+  else
+    insert into public.dabbir_memberships(
+      business_id,user_id,role,status,permissions,display_name,invited_by,accepted_at
+    ) values (
+      v_inv.business_id,v_user,v_inv.role,'active',v_inv.permissions,v_inv.display_name,v_inv.invited_by,now()
+    );
+  end if;
+
+  update public.dabbir_employee_invitations accepted_inv
+  set status='accepted',accepted_by=v_user,accepted_at=now(),updated_at=now()
+  where accepted_inv.id=v_inv.id;
+
+  update public.dabbir_employee_invitations other_inv
+  set status='revoked',revoked_at=now(),updated_at=now()
+  where other_inv.business_id=v_inv.business_id
+    and other_inv.email=v_inv.email
+    and other_inv.status='pending'
+    and other_inv.id<>v_inv.id;
+
+  insert into public.dabbir_access_audit(business_id,actor_user_id,target_user_id,invitation_id,action,metadata)
+  values(v_inv.business_id,v_user,v_user,v_inv.id,'invitation_accepted',jsonb_build_object('role',v_inv.role));
+
+  return query select v_inv.business_id,v_inv.role,'active'::text;
+end;
+$$;
+revoke all on function dabbir_private.dabbir_accept_employee_invitation(text) from public,anon;
+grant execute on function dabbir_private.dabbir_accept_employee_invitation(text) to authenticated,service_role;

--- a/team.html
+++ b/team.html
@@ -125,12 +125,15 @@ async function api(path,options={}){const r=await fetch(path,{credentials:'same-
 function msg(el,text,bad=false){el.textContent=text;el.className=bad?'muted error':'muted'}
 function esc(v){return String(v??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
 function actorPermissions(){if(!currentMembership)return[];const explicit=Array.isArray(currentMembership.permissions)?currentMembership.permissions.filter(Boolean):[];return explicit.length?explicit:(roleDefaults[currentMembership.role]||[])}
+function canManageTeam(){return !!currentMembership&&['owner','admin'].includes(currentMembership.role)&&actorPermissions().includes('manage_team')}
+function permissionApplicableToRole(key,role){return key!=='manage_team'||role==='admin'}
 function allowedPermissionSet(){return new Set(actorPermissions())}
+function allowedPermissionSetForRole(){const role=$('employeeRole').value;return new Set(actorPermissions().filter(p=>permissionApplicableToRole(p,role)))}
 function configureInviteRoles(){const actorRole=currentMembership?.role;const roles=actorRole==='owner'?['employee','staff','manager','admin','agent','viewer']:['employee','staff','manager','agent','viewer'];$('employeeRole').innerHTML=roles.map(r=>`<option value="${r}">${esc(roleLabels[r])}</option>`).join('')}
 function selectedPermissions(){return [...document.querySelectorAll('[data-permission]:checked')].map(x=>x.dataset.permission)}
 function setSelectedPermissions(values){const selected=new Set(values);document.querySelectorAll('[data-permission]').forEach(x=>x.checked=selected.has(x.dataset.permission));updatePermissionSummary()}
-function recommendedPermissions(){const allowed=allowedPermissionSet(),role=$('employeeRole').value;return (roleDefaults[role]||[]).filter(p=>allowed.has(p))}
-function renderPermissionScreen(){const allowed=allowedPermissionSet();$('permissionGroups').innerHTML=permissionCatalog.map(group=>{const items=group.items.filter(([key])=>allowed.has(key));if(!items.length)return'';return `<div class="permissionGroup"><h4>${esc(group.group)}</h4><div class="permissionGrid">${items.map(([key,label,description])=>`<label class="permissionItem"><input type="checkbox" data-permission="${esc(key)}"><span><b>${esc(label)}</b><small>${esc(description)}</small></span></label>`).join('')}</div></div>`}).join('');document.querySelectorAll('[data-permission]').forEach(x=>x.addEventListener('change',updatePermissionSummary));setSelectedPermissions(recommendedPermissions())}
+function recommendedPermissions(){const allowed=allowedPermissionSetForRole(),role=$('employeeRole').value;return (roleDefaults[role]||[]).filter(p=>allowed.has(p))}
+function renderPermissionScreen(){const role=$('employeeRole').value,allowed=allowedPermissionSet();$('permissionGroups').innerHTML=permissionCatalog.map(group=>{const items=group.items.filter(([key])=>allowed.has(key)&&permissionApplicableToRole(key,role));if(!items.length)return'';return `<div class="permissionGroup"><h4>${esc(group.group)}</h4><div class="permissionGrid">${items.map(([key,label,description])=>`<label class="permissionItem"><input type="checkbox" data-permission="${esc(key)}"><span><b>${esc(label)}</b><small>${esc(description)}</small></span></label>`).join('')}</div></div>`}).join('');document.querySelectorAll('[data-permission]').forEach(x=>x.addEventListener('change',updatePermissionSummary));setSelectedPermissions(recommendedPermissions())}
 function updatePermissionSummary(){const count=selectedPermissions().length,name=$('employeeName').value.trim()||'عضو الفريق',role=roleLabels[$('employeeRole').value]||$('employeeRole').value;$('permissionSummary').innerHTML=`<b>${esc(name)}</b><br>${esc(role)} · ${count} صلاحية محددة`}
 function resetInviteFlow(){lastInviteUrl='';$('createdInvite').classList.add('hidden');$('permissionStep').classList.add('hidden');$('inviteBasics').classList.remove('hidden');$('employeeName').value='';$('employeeEmail').value='';configureInviteRoles();msg($('ownerMessage'),'')}
 
@@ -141,8 +144,8 @@ async function loadSession(){
  if(inviteToken)$('inviteCard').classList.remove('hidden');
  const memberships=Array.isArray(p.memberships)?p.memberships:[];
  const preferred=memberships.find(m=>['owner','admin'].includes(m.role))||memberships[0];
- businessId=preferred?.business_id||null;currentMembership=memberships.find(m=>m.business_id===businessId)||null;isTeamManager=!!currentMembership&&['owner','admin'].includes(currentMembership.role);
- if(isTeamManager){$('ownerPanel').classList.remove('hidden');configureInviteRoles()}
+ businessId=preferred?.business_id||null;currentMembership=memberships.find(m=>m.business_id===businessId)||null;isTeamManager=canManageTeam();
+ if(isTeamManager){$('ownerPanel').classList.remove('hidden');configureInviteRoles()}else{$('ownerPanel').classList.add('hidden');$('invitationListCard').classList.add('hidden')}
  if(businessId)await loadTeam();else $('members').innerHTML='<p class="muted">لا توجد عضوية شركة نشطة بعد. إذا كانت لديك دعوة فاقبلها أولاً.</p>';
  return true;
 }
@@ -155,15 +158,15 @@ $('acceptInviteBtn').onclick=async()=>{if(!inviteToken)return;const {r,p}=await 
 $('reviewPermissionsBtn').onclick=()=>{const email=$('employeeEmail').value.trim();if(!email||!email.includes('@'))return msg($('ownerMessage'),'أدخل بريدًا إلكترونيًا صحيحًا قبل تحديد الصلاحيات.',true);$('inviteBasics').classList.add('hidden');$('permissionStep').classList.remove('hidden');renderPermissionScreen();msg($('ownerMessage'),'')};
 $('backInviteBtn').onclick=()=>{$('permissionStep').classList.add('hidden');$('inviteBasics').classList.remove('hidden')};
 $('recommendedPermissionsBtn').onclick=()=>setSelectedPermissions(recommendedPermissions());
-$('selectAllPermissionsBtn').onclick=()=>setSelectedPermissions([...allowedPermissionSet()]);
-$('clearPermissionsBtn').onclick=()=>setSelectedPermissions(allowedPermissionSet().has('view_business')?['view_business']:[]);
+$('selectAllPermissionsBtn').onclick=()=>setSelectedPermissions([...allowedPermissionSetForRole()]);
+$('clearPermissionsBtn').onclick=()=>setSelectedPermissions(allowedPermissionSetForRole().has('view_business')?['view_business']:[]);
 $('createInviteBtn').onclick=async()=>{if(!businessId)return;const permissions=selectedPermissions();if(!permissions.length||!permissions.includes('view_business'))return msg($('ownerMessage'),'يجب إبقاء صلاحية مشاهدة النشاط على الأقل حتى يستطيع العضو استخدام دبّر.',true);const body={business_id:businessId,email:$('employeeEmail').value.trim(),display_name:$('employeeName').value.trim(),role:$('employeeRole').value,permissions};const btn=$('createInviteBtn');btn.disabled=true;const {r,p}=await api('/api/team/invitations',{method:'POST',body:JSON.stringify(body)});btn.disabled=false;if(!r.ok)return msg($('ownerMessage'),p.error||'تعذر إنشاء الدعوة',true);lastInviteUrl=new URL(p.invite_path,location.origin).href;$('inviteUrl').textContent=lastInviteUrl;$('permissionStep').classList.add('hidden');$('createdInvite').classList.remove('hidden');msg($('ownerMessage'),`تم إنشاء الدعوة مع ${permissions.length} صلاحية محددة.`);await loadInvitations()};
 $('copyInviteBtn').onclick=async()=>{if(!lastInviteUrl)return;await navigator.clipboard.writeText(lastInviteUrl);msg($('ownerMessage'),'تم نسخ رابط الدعوة.')};
 $('newInviteBtn').onclick=resetInviteFlow;
 
 async function loadTeam(){
  const {r,p}=await api('/api/team/members?business_id='+encodeURIComponent(businessId));
- if(!r.ok){$('members').innerHTML='<p class="muted">حسابك عضو في الشركة ولا يملك صلاحية إدارة الفريق.</p>';return}
+ if(!r.ok){isTeamManager=false;$('ownerPanel').classList.add('hidden');$('invitationListCard').classList.add('hidden');$('members').innerHTML='<p class="muted">حسابك عضو في الشركة ولا يملك صلاحية إدارة الفريق.</p>';return}
  $('ownerPanel').classList.remove('hidden');isTeamManager=true;
  $('members').innerHTML=(p.members||[]).map(m=>`<div class="row"><div class="grow"><b>${esc(m.display_name||m.email)}</b><small>${esc(m.email)} · ${esc(roleLabels[m.role]||m.role)}${Array.isArray(m.permissions)&&m.permissions.length?` · ${m.permissions.length} صلاحية مخصصة`:''}</small></div><span class="badge ${esc(m.status)}">${esc(m.status)}</span>${m.role==='owner'?'':`<div class="memberActions">${m.status==='active'?`<button class="secondary" onclick="memberAction('${m.user_id}','suspend')">تعليق</button>`:''}${m.status==='suspended'?`<button class="secondary" onclick="memberAction('${m.user_id}','reactivate')">إعادة تفعيل</button>`:''}${m.status!=='removed'?`<button class="danger" onclick="memberAction('${m.user_id}','remove')">إزالة</button>`:''}</div>`}</div>`).join('')||'<p class="muted">لا يوجد أعضاء.</p>';
  await loadInvitations();

--- a/test/team-manage-permission-authority.test.mjs
+++ b/test/team-manage-permission-authority.test.mjs
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const team=fs.readFileSync(path.join(root,'team.html'),'utf8');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260903191500_dabbir_team_manage_permission_authority_v2.sql'),'utf8');
+
+test('team management UI follows effective manage_team permission, not role name alone',()=>{
+  assert.match(team,/function canManageTeam\(\)[\s\S]*actorPermissions\(\)\.includes\('manage_team'\)/);
+  assert.match(team,/isTeamManager=canManageTeam\(\)/);
+  assert.match(team,/if\(!r\.ok\)\{isTeamManager=false;\$\('ownerPanel'\)\.classList\.add\('hidden'\)/);
+});
+
+test('manage_team is only offered to the admin role in the invite permission picker',()=>{
+  assert.match(team,/function permissionApplicableToRole\(key,role\)\{return key!=='manage_team'\|\|role==='admin'\}/);
+  assert.match(team,/allowed\.has\(key\)&&permissionApplicableToRole\(key,role\)/);
+  assert.match(team,/allowedPermissionSetForRole\(\)/);
+});
+
+test('team mutations require effective manage_team permission in addition to role hierarchy',()=>{
+  assert.match(migration,/can_user_manage_role[\s\S]*user_has_permission\(p_business_id,p_user_id,'manage_team'\)/);
+  assert.match(migration,/can_manage_role[\s\S]*can_user_manage_role\(p_business_id,\(select auth\.uid\(\)\),p_target_role\)/);
+});
+
+test('new grants require explicit non-empty permissions and cannot exceed inviter permissions',()=>{
+  assert.match(migration,/can_user_grant_permissions[\s\S]*cardinality\(coalesce\(p_permissions,'\{\}'::text\[\]\)\)>0/);
+  assert.match(migration,/where not dabbir_private\.user_has_permission\(p_business_id,p_user_id,p\)/);
+});
+
+test('pending invitation is revalidated against inviter current team and permission authority',()=>{
+  assert.match(migration,/can_user_manage_role\(v_inv\.business_id,v_inv\.invited_by,v_inv\.role\)/);
+  assert.match(migration,/can_user_grant_permissions\(v_inv\.business_id,v_inv\.invited_by,v_inv\.permissions\)/);
+  assert.match(migration,/INVITER_NO_LONGER_AUTHORIZED/);
+});


### PR DESCRIPTION
Rebased cleanly onto the latest main after branch-protection required a fresh `test` check.

- UI exposes team management only when the membership has effective `manage_team`.
- Team list failure hides all invitation/management controls.
- Backend team mutations require `manage_team` plus the existing role hierarchy.
- New grants require explicit permissions and cannot exceed inviter authority.
- Pending invitations are revalidated when accepted, so revoked authority cannot be resurrected.
- Regression tests cover UI + database authority.