### PR TITLE
Move DABBIR operations screens onto central UI lifecycle

### DIFF
--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -188,23 +188,25 @@ const script=String.raw`(()=>{
     try{await mutate({action:'update_order_status',order_id:orderId,status});notify(t.orderUpdated);data=null;await load(true)}catch(error){notify(t.failed+' — '+error.message);data=null;await load(true)}
   }
 
+  function syncOperationsUi(){
+    ensureScreen();
+    applyCopy();
+    if(current==='operations')load();
+  }
+
+  function activateOperations({target}={}){
+    if(target!=='operations')return;
+    ensureScreen();
+    if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;
+    load();
+  }
+
   ensureScreen();
-
-  try{
-    const baseShowScreen=showScreen;
-    showScreen=function(name){
-      const result=baseShowScreen(name);
-      if(name==='operations'){
-        ensureScreen();if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;load();
-      }
-      return result;
-    };
-  }catch{}
-
-  try{
-    const baseRenderAll=renderAll;
-    renderAll=function(){const result=baseRenderAll.apply(this,arguments);ensureScreen();applyCopy();if(current==='operations')load();return result};
-  }catch{}
+  const lifecycle=window.__dabbirUiLifecycle;
+  if(lifecycle?.on){
+    lifecycle.on('afterRender','owner-operations',syncOperationsUi);
+    lifecycle.on('afterNavigate','owner-operations',activateOperations);
+  }
 
   new MutationObserver(applyCopy).observe(document.documentElement,{attributes:true,attributeFilter:['lang','dir']});
   setTimeout(()=>{ensureScreen();if(isStore())load()},600);

--- a/api/service-operations-ui.js
+++ b/api/service-operations-ui.js
@@ -17,7 +17,6 @@ const client=String.raw`
   let data=null;
   let loading=false;
   let editingId=null;
-  let observedScreen=null;
 
   const copy=()=>ar()?{
     nav:'الخدمات',title:'الخدمات',desc:'الخدمات الفعلية التي يقدمها نشاطك. دَبِّر يستخدم الخدمات النشطة عند الرد على العملاء.',truth:'الخدمات النشطة هنا تُعامل كمعلومة تشغيلية حية لدى AI.',add:'إضافة خدمة',name:'اسم الخدمة',price:'قيمة الخدمة',aed:'درهم',duration:'المدة',minutes:'دقيقة',status:'الحالة',active:'نشطة',inactive:'متوقفة',edit:'تعديل',save:'حفظ',cancel:'إلغاء',empty:'لا توجد خدمات بعد.',loading:'جارٍ تحميل الخدمات…',failed:'تعذر تحميل الخدمات.',created:'تمت إضافة الخدمة.',updated:'تم تحديث الخدمة.',activeMetric:'الخدمات النشطة',totalMetric:'إجمالي الخدمات'
@@ -146,21 +145,22 @@ const client=String.raw`
   function initialize(){
     if(!isServiceBusiness())return;
     applyCopy();
-    const screen=ensureScreen();
-    if(screen&&screen!==observedScreen){
-      observedScreen=screen;
-      new MutationObserver(()=>{if(screen.classList.contains('active')){applyCopy();load(false)}}).observe(screen,{attributes:true,attributeFilter:['class']});
-    }
+    ensureScreen();
     if(current==='operations')load(false);
   }
 
-  const baseSetLanguage=typeof setLanguage==='function'?setLanguage:null;
-  if(baseSetLanguage)setLanguage=function(next){const result=baseSetLanguage(next);applyCopy();return result};
+  function activateServices({target}={}){
+    if(target!=='operations'||!isServiceBusiness())return;
+    applyCopy();
+    ensureScreen();
+    load(false);
+  }
 
-  try{
-    const baseRenderAll=renderAll;
-    renderAll=function(){const result=baseRenderAll.apply(this,arguments);initialize();return result};
-  }catch{}
+  const lifecycle=window.__dabbirUiLifecycle;
+  if(lifecycle?.on){
+    lifecycle.on('afterRender','service-operations',initialize);
+    lifecycle.on('afterNavigate','service-operations',activateServices);
+  }
 
   setTimeout(initialize,500);
   window.__dabbirServiceOperations={refresh:()=>load(true),version:'service-catalog-v4-price'};

--- a/test/dabbir-operations-lifecycle-hooks.test.mjs
+++ b/test/dabbir-operations-lifecycle-hooks.test.mjs
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,root),'utf8');
+const owner=read('api/owner-operations-ui.js');
+const service=read('api/service-operations-ui.js');
+
+test('owner operations uses central lifecycle instead of global render/navigation monkey-patches',()=>{
+  assert.match(owner,/window\.__dabbirUiLifecycle/);
+  assert.match(owner,/lifecycle\.on\('afterRender','owner-operations',syncOperationsUi\)/);
+  assert.match(owner,/lifecycle\.on\('afterNavigate','owner-operations',activateOperations\)/);
+  assert.doesNotMatch(owner,/showScreen\s*=\s*function/);
+  assert.doesNotMatch(owner,/renderAll\s*=\s*function/);
+  assert.doesNotMatch(owner,/setInterval\s*\(/);
+});
+
+test('service operations uses lifecycle activation without screen-class observers or render monkey-patches',()=>{
+  assert.match(service,/window\.__dabbirUiLifecycle/);
+  assert.match(service,/lifecycle\.on\('afterRender','service-operations',initialize\)/);
+  assert.match(service,/lifecycle\.on\('afterNavigate','service-operations',activateServices\)/);
+  assert.doesNotMatch(service,/renderAll\s*=\s*function/);
+  assert.doesNotMatch(service,/setLanguage\s*=\s*function/);
+  assert.doesNotMatch(service,/new MutationObserver/);
+  assert.doesNotMatch(service,/setInterval\s*\(/);
+});

--- a/test/dabbir-operations-screen-ownership.test.mjs
+++ b/test/dabbir-operations-screen-ownership.test.mjs
@@ -13,9 +13,13 @@ test('unknown business type is not classified as a service business',()=>{
   assert.doesNotMatch(source,/business_type\|\|''\)\.toLowerCase\(\)!=='store'/,'unknown workspace must not own the service operations screen');
 });
 
-test('service operations initializes after workspace render',()=>{
-  assert.match(source,/const baseRenderAll=renderAll;/);
-  assert.match(source,/renderAll=function\(\)\{const result=baseRenderAll\.apply\(this,arguments\);initialize\(\);return result\};/);
+test('service operations initializes through the central UI lifecycle',()=>{
+  assert.match(source,/const lifecycle=window\.__dabbirUiLifecycle;/);
+  assert.match(source,/lifecycle\.on\('afterRender','service-operations',initialize\);/);
+  assert.match(source,/lifecycle\.on\('afterNavigate','service-operations',activateServices\);/);
+  assert.doesNotMatch(source,/const baseRenderAll=renderAll;/);
+  assert.doesNotMatch(source,/renderAll\s*=\s*function/);
+  assert.doesNotMatch(source,/new MutationObserver/);
 });
 
 test('service screen ownership remains activity-gated without owning primary navigation',()=>{


### PR DESCRIPTION
## Why
After introducing the central UI lifecycle, the owner/store operations screen still wrapped `showScreen` and `renderAll`, while the service operations screen wrapped `renderAll` and watched screen class mutations. Those legacy hooks made feature behavior depend on wrapper order.

## Changes
- owner operations now uses lifecycle `afterRender` and `afterNavigate` hooks
- remove owner operations `showScreen` and `renderAll` monkey-patches
- service operations now uses lifecycle `afterRender` and `afterNavigate` hooks
- remove service operations `renderAll`/language monkey-patches and screen-class MutationObserver
- keep business data loading, forms, mutations, and screen content unchanged
- update the old ownership regression test so it enforces lifecycle ownership instead of requiring the retired `renderAll` wrapper
- add focused regression tests forbidding these global overrides from returning

## Verification
- synchronized with current `main` `11a0da32806d5569d3cb2c134e9fb9ce9c6cf915`
- final head `cb5be76201ee50934b10a440cbb4d0d1d23c8de3`
- GitHub DABBIR CI `test` job passed
- Vercel fail-closed gate: 888 tests passed, 0 failed
- Vercel Preview READY in `bom1`
- preview `/` returned HTTP 200 with `ui-lifecycle-v1`
- preview `/api/owner-operations-ui` returned HTTP 200 with owner lifecycle hooks and no render/navigation overrides
- preview `/api/service-operations-ui` returned HTTP 200 with service lifecycle hooks and no screen MutationObserver/render override
- deferred UI bundle decreased from 544897 bytes before lifecycle cleanup to 544665 bytes with this migration

## Safety
No database, booking, payment, inventory, service-catalog, or API contracts changed.