### PR TITLE
Stop deferred UI from forcing Dubai time on GCC businesses

### DIFF
--- a/api/adaptive-appointment.js
+++ b/api/adaptive-appointment.js
@@ -3,6 +3,16 @@ const UUID=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]
 const clean=(v,n=500)=>String(v??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,n);
 async function data(r,msg){const t=await r.text();let p;try{p=t?JSON.parse(t):null}catch{}if(!r.ok)throw Object.assign(new Error(p?.message||msg),{status:r.status});return p}
 const rest=(token,path,opt={},msg='REQUEST_FAILED')=>supabaseRest(path,token,opt).then(r=>data(r,msg));
+function e164(value,prefix){
+ const raw=clean(value,40);if(!raw)return null;
+ let compact=raw.replace(/[\s().-]/g,'');
+ if(compact.startsWith('00'))compact='+'+compact.slice(2);
+ if(/^\+[1-9]\d{7,14}$/.test(compact))return compact;
+ const digits=compact.replace(/\D/g,'').replace(/^0+/, '');
+ const country=String(prefix||'').replace(/\D/g,'');
+ const normalized=country&&digits?`+${country}${digits}`:null;
+ return normalized&&/^\+[1-9]\d{7,14}$/.test(normalized)?normalized:null;
+}
 export default async function handler(req,res){
  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'});
  if(!requireSameOrigin(req,res))return;
@@ -10,9 +20,9 @@ export default async function handler(req,res){
   const token=accessTokenFromRequest(req);if(!token)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
   const [user,memberships,body]=await Promise.all([getVerifiedUser(token),getBusinessMemberships(token),readJsonBody(req)]);if(!user)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
   const businessId=clean(body.business_id,60);if(!UUID.test(businessId)||!memberships.some(m=>m.business_id===businessId&&m.status==='active'))return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
-  const b=await rest(token,`dabbir_businesses?select=id,business_type&id=eq.${encodeURIComponent(businessId)}&limit=1`);const business=b?.[0];if(!business)return json(res,404,{ok:false,error:'BUSINESS_NOT_FOUND'});
+  const b=await rest(token,`dabbir_businesses?select=id,business_type,country_code,currency_code,timezone,phone_country_prefix&id=eq.${encodeURIComponent(businessId)}&limit=1`);const business=b?.[0];if(!business)return json(res,404,{ok:false,error:'BUSINESS_NOT_FOUND'});
   const name=clean(body.customer_name,120);const start=new Date(body.starts_at);if(!name||Number.isNaN(start.getTime()))return json(res,400,{ok:false,error:'APPOINTMENT_INPUT_REQUIRED'});
-  const d=body.details&&typeof body.details==='object'?body.details:{};const metadata={source:'dabbir_adaptive_appointment',phone:clean(d.phone,40)||null};
+  const d=body.details&&typeof body.details==='object'?body.details:{};const rawPhone=clean(d.phone,40)||null;const metadata={source:'dabbir_adaptive_appointment',phone:rawPhone,phone_e164:e164(rawPhone,business.phone_country_prefix)};
   const requestedCustomerId=clean(d.customer_id,60);let customer=null;
   if(requestedCustomerId){
    if(!UUID.test(requestedCustomerId))return json(res,400,{ok:false,error:'CUSTOMER_ID_INVALID'});
@@ -25,6 +35,6 @@ export default async function handler(req,res){
   const duration=Math.max(5,Math.min(1440,Number(d.duration)||60));const notes=[d.service&&`service: ${clean(d.service)}`,d.specialist&&`specialist: ${clean(d.specialist)}`,d.vehicle&&`vehicle: ${clean(d.vehicle)}`,d.location&&`location: ${clean(d.location)}`,d.notes&&`notes: ${clean(d.notes,1000)}`].filter(Boolean).join('\n');
   const row={business_id:businessId,customer_id:customer.id,starts_at:start.toISOString(),status:['requested','confirmed','cancelled'].includes(d.status)?d.status:'requested',simulated:false,notes:notes||null,ends_at:new Date(start.getTime()+duration*60000).toISOString()};if(d.price!==''&&Number.isFinite(Number(d.price)))row.quoted_price_aed=Math.max(0,Number(d.price));
   const appointments=await rest(token,'dabbir_appointments?select=id,customer_id,starts_at,ends_at,status,quoted_price_aed,notes',{method:'POST',headers:{prefer:'return=representation'},body:JSON.stringify(row)},'APPOINTMENT_CREATE_FAILED');const appointment=appointments?.[0];if(!appointment)return json(res,502,{ok:false,error:'APPOINTMENT_CREATE_UNVERIFIED'});
-  return json(res,200,{ok:true,appointment,business_type:business.business_type,customer_reused:Boolean(requestedCustomerId)});
+  return json(res,200,{ok:true,appointment,business_type:business.business_type,country_code:business.country_code,currency_code:business.currency_code,timezone:business.timezone,customer_reused:Boolean(requestedCustomerId)});
  }catch(e){return json(res,e.status||500,{ok:false,error:clean(e.message,160)||'APPOINTMENT_CREATE_FAILED'})}
 }

--- a/api/timezone-ui.js
+++ b/api/timezone-ui.js
@@ -28,7 +28,7 @@ const script=String.raw`(()=>{
 
   function locale(){
     const geo=businessGeo();
-    try{return typeof lang!=='undefined'&&lang==='en'?`en-${geo.countryCode}`:`ar-${geo.countryCode}`}catch{return document.documentElement.lang==='en'?`en-${geo.countryCode}`:`ar-${geo.countryCode}`}
+    try{return typeof lang!=='undefined'&&lang==='en'?'en-'+geo.countryCode:'ar-'+geo.countryCode}catch{return document.documentElement.lang==='en'?'en-'+geo.countryCode:'ar-'+geo.countryCode}
   }
 
   function businessFormat(value){
@@ -87,7 +87,7 @@ const script=String.raw`(()=>{
   function fieldLabel(key,arLabel,enLabel){
     if(key!=='price')return isArabic()?arLabel:enLabel;
     const geo=businessGeo();
-    return isArabic()?`${arLabel} (${geo.moneyAr})`:`${enLabel} (${geo.currency})`;
+    return isArabic()?arLabel+' ('+geo.moneyAr+')':enLabel+' ('+geo.currency+')';
   }
   function renderAdaptiveFields(){
     if(!appointmentForm||!appointmentTime)return;
@@ -108,7 +108,7 @@ const script=String.raw`(()=>{
       }else{
         input=document.createElement('input');input.type=type;
         if(type==='text')input.maxLength=500;
-        if(type==='tel'){input.maxLength=40;input.placeholder=`${geo.prefix} …`;input.inputMode='tel';}
+        if(type==='tel'){input.maxLength=40;input.placeholder=geo.prefix+' …';input.inputMode='tel';}
         if(type==='number'){input.min='0';input.step=key==='price'?'0.001':'5';}
       }
       input.dataset.apptKey=key;field.append(label,input);wrap.append(field);

--- a/api/timezone-ui.js
+++ b/api/timezone-ui.js
@@ -1,15 +1,37 @@
 const script=String.raw`(()=>{
   if(window.__dabbirTimezoneLoaded)return;
   window.__dabbirTimezoneLoaded=true;
-  const DABBIR_TIME_ZONE='Asia/Dubai';
-  const DABBIR_UTC_OFFSET='+04:00';
-  window.__dabbirTimeZone=DABBIR_TIME_ZONE;
 
-  function locale(){
-    try{return typeof lang!=='undefined'&&lang==='en'?'en-AE':'ar-AE'}catch{return document.documentElement.lang==='en'?'en-AE':'ar-AE'}
+  const GCC=Object.freeze({
+    AE:{currency:'AED',timezone:'Asia/Dubai',offset:'+04:00',prefix:'+971',moneyAr:'درهم'},
+    SA:{currency:'SAR',timezone:'Asia/Riyadh',offset:'+03:00',prefix:'+966',moneyAr:'ريال سعودي'},
+    KW:{currency:'KWD',timezone:'Asia/Kuwait',offset:'+03:00',prefix:'+965',moneyAr:'دينار كويتي'},
+    QA:{currency:'QAR',timezone:'Asia/Qatar',offset:'+03:00',prefix:'+974',moneyAr:'ريال قطري'},
+    BH:{currency:'BHD',timezone:'Asia/Bahrain',offset:'+03:00',prefix:'+973',moneyAr:'دينار بحريني'},
+    OM:{currency:'OMR',timezone:'Asia/Muscat',offset:'+04:00',prefix:'+968',moneyAr:'ريال عماني'},
+  });
+
+  function businessGeo(){
+    let business=null;
+    try{business=workspace?.business||null}catch{}
+    const code=String(business?.country_code||document.documentElement.dataset.dabbirCountry||'AE').toUpperCase();
+    const base=GCC[code]||GCC.AE;
+    return {
+      countryCode:GCC[code]?code:'AE',
+      currency:String(business?.currency_code||base.currency),
+      timezone:String(business?.timezone||base.timezone),
+      offset:base.offset,
+      prefix:String(business?.phone_country_prefix||base.prefix),
+      moneyAr:base.moneyAr,
+    };
   }
 
-  function dubaiFormat(value){
+  function locale(){
+    const geo=businessGeo();
+    try{return typeof lang!=='undefined'&&lang==='en'?`en-${geo.countryCode}`:`ar-${geo.countryCode}`}catch{return document.documentElement.lang==='en'?`en-${geo.countryCode}`:`ar-${geo.countryCode}`}
+  }
+
+  function businessFormat(value){
     if(!value){
       try{return typeof T==='function'?T().unknown:'—'}catch{return '—'}
     }
@@ -17,12 +39,12 @@ const script=String.raw`(()=>{
       return new Intl.DateTimeFormat(locale(),{
         dateStyle:'medium',
         timeStyle:'short',
-        timeZone:DABBIR_TIME_ZONE,
+        timeZone:businessGeo().timezone,
       }).format(new Date(value));
     }catch{return String(value)}
   }
 
-  function dubaiLocalToIso(value){
+  function businessLocalToIso(value){
     const raw=String(value||'').trim();
     if(!raw)return null;
     if(/[zZ]$|[+-]\d\d:\d\d$/.test(raw)){
@@ -30,23 +52,31 @@ const script=String.raw`(()=>{
       return Number.isNaN(absolute.getTime())?null:absolute.toISOString();
     }
     const normalized=raw.length===16?raw+':00':raw;
-    const date=new Date(normalized+DABBIR_UTC_OFFSET);
+    const date=new Date(normalized+businessGeo().offset);
     return Number.isNaN(date.getTime())?null:date.toISOString();
   }
 
-  try{fmt=dubaiFormat}catch{}
-  window.fmt=dubaiFormat;
-  window.dabbirFormatTime=dubaiFormat;
-  window.dabbirLocalTimeToIso=dubaiLocalToIso;
+  function syncAuthorities(){
+    const geo=businessGeo();
+    window.__dabbirTimeZone=geo.timezone;
+    window.dabbirFormatTime=businessFormat;
+    window.dabbirLocalTimeToIso=businessLocalToIso;
+    try{fmt=businessFormat}catch{}
+    window.fmt=businessFormat;
+    document.documentElement.dataset.dabbirCountry=geo.countryCode;
+    document.documentElement.dataset.dabbirCurrency=geo.currency;
+    document.documentElement.dataset.dabbirTimezone=geo.timezone;
+  }
+  syncAuthorities();
 
   const appointmentForm=document.querySelector('#appointmentForm');
   const appointmentModal=document.querySelector('#appointmentModal');
   const appointmentTime=document.querySelector('#apptTime');
   const appointmentFields={
-    salon:[['phone','tel','رقم الهاتف','Phone'],['service','text','الخدمة','Service'],['specialist','text','الموظفة / المختصة','Specialist'],['duration','number','المدة بالدقائق','Duration (minutes)'],['price','number','السعر (درهم)','Price (AED)'],['status','select','حالة الموعد','Status'],['notes','text','ملاحظات','Notes']],
+    salon:[['phone','tel','رقم الهاتف','Phone'],['service','text','الخدمة','Service'],['specialist','text','الموظفة / المختصة','Specialist'],['duration','number','المدة بالدقائق','Duration (minutes)'],['price','number','السعر','Price'],['status','select','حالة الموعد','Status'],['notes','text','ملاحظات','Notes']],
     clinic:[['phone','tel','رقم الهاتف','Phone'],['service','text','نوع الموعد','Appointment type'],['specialist','text','الطبيب / المختص','Doctor / specialist'],['duration','number','المدة بالدقائق','Duration (minutes)'],['status','select','حالة الموعد','Status'],['notes','text','ملاحظات إدارية','Administrative notes']],
-    car_wash:[['phone','tel','رقم الهاتف','Phone'],['vehicle','text','نوع السيارة','Vehicle type'],['service','text','الخدمة / الباقة','Service / package'],['location','text','الموقع','Location'],['price','number','السعر (درهم)','Price (AED)'],['notes','text','ملاحظات','Notes']],
-    services:[['phone','tel','رقم الهاتف','Phone'],['service','text','الخدمة','Service'],['location','text','الموقع','Location'],['duration','number','المدة بالدقائق','Duration (minutes)'],['price','number','السعر (درهم)','Price (AED)'],['notes','text','ملاحظات','Notes']],
+    car_wash:[['phone','tel','رقم الهاتف','Phone'],['vehicle','text','نوع السيارة','Vehicle type'],['service','text','الخدمة / الباقة','Service / package'],['location','text','الموقع','Location'],['price','number','السعر','Price'],['notes','text','ملاحظات','Notes']],
+    services:[['phone','tel','رقم الهاتف','Phone'],['service','text','الخدمة','Service'],['location','text','الموقع','Location'],['duration','number','المدة بالدقائق','Duration (minutes)'],['price','number','السعر','Price'],['notes','text','ملاحظات','Notes']],
     other:[['phone','tel','رقم الهاتف','Phone'],['service','text','الخدمة / سبب الموعد','Service / purpose'],['notes','text','ملاحظات','Notes']],
   };
 
@@ -54,14 +84,21 @@ const script=String.raw`(()=>{
     try{return workspace?.business?.business_type||'other'}catch{return'other'}
   }
   function isArabic(){return document.documentElement.lang!=='en'}
+  function fieldLabel(key,arLabel,enLabel){
+    if(key!=='price')return isArabic()?arLabel:enLabel;
+    const geo=businessGeo();
+    return isArabic()?`${arLabel} (${geo.moneyAr})`:`${enLabel} (${geo.currency})`;
+  }
   function renderAdaptiveFields(){
     if(!appointmentForm||!appointmentTime)return;
+    syncAuthorities();
     appointmentForm.querySelector('#adaptiveApptFields')?.remove();
     const wrap=document.createElement('div');wrap.id='adaptiveApptFields';
     const fields=appointmentFields[businessType()]||appointmentFields.other;
+    const geo=businessGeo();
     for(const [key,type,arLabel,enLabel] of fields){
       const field=document.createElement('div');field.className='field';
-      const label=document.createElement('label');label.textContent=isArabic()?arLabel:enLabel;
+      const label=document.createElement('label');label.textContent=fieldLabel(key,arLabel,enLabel);
       let input;
       if(type==='select'){
         input=document.createElement('select');
@@ -71,8 +108,8 @@ const script=String.raw`(()=>{
       }else{
         input=document.createElement('input');input.type=type;
         if(type==='text')input.maxLength=500;
-        if(type==='tel')input.maxLength=40;
-        if(type==='number'){input.min='0';input.step=key==='price'?'0.01':'5';}
+        if(type==='tel'){input.maxLength=40;input.placeholder=`${geo.prefix} …`;input.inputMode='tel';}
+        if(type==='number'){input.min='0';input.step=key==='price'?'0.001':'5';}
       }
       input.dataset.apptKey=key;field.append(label,input);wrap.append(field);
     }
@@ -131,19 +168,19 @@ const script=String.raw`(()=>{
     card.dataset.aiAssistant='true';
   }
 
-  function refreshMobileUtilityUi(){fixMobileHeaderSearch();ensureSettingsInMore();markOwnerCopilotAsAi()}
+  function refreshMobileUtilityUi(){syncAuthorities();fixMobileHeaderSearch();ensureSettingsInMore();markOwnerCopilotAsAi()}
   const utilityObserver=new MutationObserver(()=>requestAnimationFrame(refreshMobileUtilityUi));
   if(document.body)utilityObserver.observe(document.body,{subtree:true,childList:true});
   document.addEventListener('click',event=>{if(event.target?.closest?.('#menuBtn,[data-screen="more"],.topActions,#dabbirOwnerCopilot'))setTimeout(refreshMobileUtilityUi,0)},true);
 
-  if(appointmentForm&&!appointmentForm.dataset.dabbirDubaiTime){
-    appointmentForm.dataset.dabbirDubaiTime='v2-adaptive';
+  if(appointmentForm&&!appointmentForm.dataset.dabbirBusinessTime){
+    appointmentForm.dataset.dabbirBusinessTime='v3-gcc';
     appointmentForm.addEventListener('submit',async event=>{
       event.preventDefault();
       event.stopImmediatePropagation();
       const input=document.querySelector('#apptTime');
       const customer=document.querySelector('#apptCustomer');
-      const startsAt=dubaiLocalToIso(input&&input.value);
+      const startsAt=businessLocalToIso(input&&input.value);
       if(!startsAt){
         try{if(typeof toast==='function')toast(typeof T==='function'?T().invalid:'Invalid time')}catch{}
         return;
@@ -178,8 +215,9 @@ const script=String.raw`(()=>{
     },true);
   }
 
-  document.documentElement.dataset.dabbirTimezone=DABBIR_TIME_ZONE;
+  syncAuthorities();
   setTimeout(()=>{
+    syncAuthorities();
     try{if(typeof workspace!=='undefined'&&workspace&&typeof renderAll==='function')renderAll()}catch{}
     refreshMobileUtilityUi();
   },0);
@@ -196,6 +234,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-timezone','Asia/Dubai');
+  res.setHeader('x-dabbir-timezone','business-profile');
   return res.end(script);
 }

--- a/test/dabbir-gcc-readiness.test.mjs
+++ b/test/dabbir-gcc-readiness.test.mjs
@@ -9,6 +9,7 @@ const read=path=>readFileSync(resolve(here,'..',path),'utf8');
 const migration=read('supabase/migrations/20260903092000_dabbir_gcc_business_profile_v1.sql');
 const createApi=read('api/gcc-create-business.js');
 const profileApi=read('api/gcc-business-profile.js');
+const adaptiveAppointment=read('api/adaptive-appointment.js');
 const ui=read('api/gcc-readiness-ui.js');
 const timezoneUi=read('api/timezone-ui.js');
 const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
@@ -63,6 +64,15 @@ test('deferred appointment UI cannot overwrite GCC timezone or price labels with
   assert.doesNotMatch(timezoneUi,/Price \(AED\)/);
   assert.doesNotMatch(timezoneUi,/السعر \(درهم\)/);
   assert.match(timezoneUi,/x-dabbir-timezone','business-profile/);
+});
+
+test('appointment phone normalization follows business prefix but remains optional',()=>{
+  assert.match(adaptiveAppointment,/phone_country_prefix/);
+  assert.match(adaptiveAppointment,/phone_e164:e164\(rawPhone,business\.phone_country_prefix\)/);
+  assert.match(adaptiveAppointment,/if\(!raw\)return null/);
+  assert.doesNotMatch(adaptiveAppointment,/PHONE_REQUIRED/);
+  assert.match(adaptiveAppointment,/currency_code:business\.currency_code/);
+  assert.match(adaptiveAppointment,/timezone:business\.timezone/);
 });
 
 test('GCC readiness loads in the critical bundle so country is available during onboarding',()=>{

--- a/test/dabbir-gcc-readiness.test.mjs
+++ b/test/dabbir-gcc-readiness.test.mjs
@@ -10,6 +10,7 @@ const migration=read('supabase/migrations/20260903092000_dabbir_gcc_business_pro
 const createApi=read('api/gcc-create-business.js');
 const profileApi=read('api/gcc-business-profile.js');
 const ui=read('api/gcc-readiness-ui.js');
+const timezoneUi=read('api/timezone-ui.js');
 const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
 
 const expected={
@@ -50,6 +51,18 @@ test('runtime is enriched with tenant-scoped country profile and dynamic time/mo
   assert.match(ui,/timeZone:g\.timezone/);
   assert.match(profileApi,/getBusinessMemberships/);
   assert.match(profileApi,/BUSINESS_ACCESS_DENIED/);
+});
+
+test('deferred appointment UI cannot overwrite GCC timezone or price labels with UAE-only constants',()=>{
+  assert.match(timezoneUi,/function businessGeo\(\)/);
+  assert.match(timezoneUi,/business\?\.timezone\|\|base\.timezone/);
+  assert.match(timezoneUi,/business\?\.currency_code\|\|base\.currency/);
+  assert.match(timezoneUi,/businessLocalToIso/);
+  assert.match(timezoneUi,/geo\.prefix/);
+  assert.doesNotMatch(timezoneUi,/const DABBIR_TIME_ZONE='Asia\/Dubai'/);
+  assert.doesNotMatch(timezoneUi,/Price \(AED\)/);
+  assert.doesNotMatch(timezoneUi,/السعر \(درهم\)/);
+  assert.match(timezoneUi,/x-dabbir-timezone','business-profile/);
 });
 
 test('GCC readiness loads in the critical bundle so country is available during onboarding',()=>{


### PR DESCRIPTION
Hardens the GCC country authority added in #366.

- Removes the deferred `timezone-ui` hardcoded `Asia/Dubai` and `+04:00` authority.
- Resolves timezone, UTC offset, phone prefix and displayed price currency from `workspace.business` country profile.
- Appointment local-time conversion now follows the selected GCC country.
- Appointment price labels use the tenant currency instead of AED.
- Appointment phone hints use the tenant prefix and stored customer metadata gets a normalized E.164 copy when possible, without making phone mandatory.
- Appointment API returns country/currency/timezone context for verification.
- Adds regression assertions preventing UAE-only constants from returning in this deferred layer.

No database mutation. Existing AE businesses continue to resolve to Asia/Dubai, AED and +971.