### PR TITLE
Make public booking honor GCC business country

### DIFF
--- a/api/car-wash-booking.js
+++ b/api/car-wash-booking.js
@@ -17,9 +17,7 @@ button{touch-action:manipulation}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>`;
 const GCC_PUBLIC_BOOKING_SCRIPT='<script src="/api/gcc-public-booking-ui" defer></script>';
-const BOOKING_PAGE=BOOKING_HTML
-  .replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`)
-  .replace('</body>',`${GCC_PUBLIC_BOOKING_SCRIPT}</body>`);
+const BOOKING_PAGE=BOOKING_HTML.replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`).replace('</body>',`${GCC_PUBLIC_BOOKING_SCRIPT}</body>`);
 const HEADERS={
   'content-type':'text/html; charset=utf-8',
   'cache-control':'no-store',

--- a/api/car-wash-booking.js
+++ b/api/car-wash-booking.js
@@ -16,7 +16,10 @@ button{touch-action:manipulation}
 }
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>`;
-const BOOKING_PAGE=BOOKING_HTML.replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`);
+const GCC_PUBLIC_BOOKING_SCRIPT='<script src="/api/gcc-public-booking-ui" defer></script>';
+const BOOKING_PAGE=BOOKING_HTML
+  .replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`)
+  .replace('</body>',`${GCC_PUBLIC_BOOKING_SCRIPT}</body>`);
 const HEADERS={
   'content-type':'text/html; charset=utf-8',
   'cache-control':'no-store',
@@ -35,7 +38,7 @@ export default function handler(req,res){
     return res.end(JSON.stringify({ok:false,error:'METHOD_NOT_ALLOWED'}));
   }
   for(const [key,value] of Object.entries(HEADERS))res.setHeader(key,value);
-  res.setHeader('x-dabbir-booking-page','public-v1.1-interface-hardening');
+  res.setHeader('x-dabbir-booking-page','public-v1.2-gcc-authority');
   res.statusCode=200;
   return res.end(BOOKING_PAGE);
 }

--- a/api/gcc-public-booking-ui.js
+++ b/api/gcc-public-booking-ui.js
@@ -1,0 +1,164 @@
+const SCRIPT=String.raw`(()=>{
+  if(window.__dabbirPublicBookingGccV1)return;
+  window.__dabbirPublicBookingGccV1=true;
+
+  const baseFetch=window.fetch.bind(window);
+  const params=new URLSearchParams(location.search);
+  const slug=String(params.get('slug')||params.get('booking')||'').trim();
+  let profile=null;
+  let profilePromise=null;
+
+  function arabic(){return String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar')}
+  function locale(){const code=String(profile?.country_code||'AE').toUpperCase();return (arabic()?'ar-':'en-')+code}
+  function timezone(){return String(profile?.timezone||'Asia/Dubai')}
+  function currency(){return String(profile?.currency_code||'AED')}
+  function prefix(){return String(profile?.phone_country_prefix||'+971')}
+  function money(value){
+    const n=Number(value||0);
+    try{return new Intl.NumberFormat(locale(),{style:'currency',currency:currency(),maximumFractionDigits:3}).format(n)}catch{return n.toFixed(2)+' '+currency()}
+  }
+  function day(value){
+    try{return new Intl.DateTimeFormat(locale(),{weekday:'long',day:'numeric',month:'long',timeZone:timezone()}).format(new Date(value))}catch{return String(value)}
+  }
+  function time(value){
+    try{return new Intl.DateTimeFormat(locale(),{hour:'numeric',minute:'2-digit',timeZone:timezone()}).format(new Date(value))}catch{return String(value)}
+  }
+  function dateKey(value){
+    try{return new Intl.DateTimeFormat('en-CA',{timeZone:timezone(),year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date(value))}catch{return ''}
+  }
+
+  async function ensureProfile(){
+    if(profile)return profile;
+    if(profilePromise)return profilePromise;
+    if(!slug)return null;
+    profilePromise=(async()=>{
+      try{
+        const response=await baseFetch('/api/public-car-wash?action=catalog&slug='+encodeURIComponent(slug),{cache:'no-store'});
+        const payload=await response.json().catch(()=>null);
+        const business=payload?.catalog?.business;
+        if(response.ok&&payload?.ok&&business?.timezone&&business?.currency_code){
+          profile=business;
+          document.documentElement.dataset.dabbirCountry=String(business.country_code||'AE');
+          document.documentElement.dataset.dabbirCurrency=String(business.currency_code||'AED');
+          document.documentElement.dataset.dabbirTimezone=String(business.timezone||'Asia/Dubai');
+          apply();
+        }
+      }catch{}
+      return profile;
+    })();
+    return profilePromise;
+  }
+
+  window.fetch=async function(input,init){
+    const url=typeof input==='string'?input:String(input?.url||'');
+    if(url.includes('/api/public-car-wash')&&url.includes('action=slots')){
+      await ensureProfile();
+      if(profile){
+        try{
+          const parsed=new URL(url,location.origin);
+          const now=new Date();
+          parsed.searchParams.set('from_date',dateKey(now));
+          parsed.searchParams.set('to_date',dateKey(new Date(now.getTime()+14*86400000)));
+          const next=parsed.pathname+parsed.search;
+          return baseFetch(next,init);
+        }catch{}
+      }
+    }
+    return baseFetch(input,init);
+  };
+
+  function selectedOffer(){
+    const id=document.querySelector('[data-offer].selected')?.dataset?.offer;
+    return profile?.offers?.find?.(row=>String(row.id)===String(id))||null;
+  }
+  function catalogPayload(){return window.__dabbirPublicBookingCatalog||null}
+  function offerRows(){return catalogPayload()?.offers||[]}
+  function currentOffer(){
+    const id=document.querySelector('[data-offer].selected')?.dataset?.offer;
+    return offerRows().find(row=>String(row.id)===String(id))||null;
+  }
+  function vehicle(){return document.querySelector('[data-vehicle].selected')?.dataset?.vehicle||null}
+
+  function patchPrices(){
+    const rows=offerRows();
+    const type=vehicle();
+    document.querySelectorAll('[data-offer]').forEach(button=>{
+      const row=rows.find(item=>String(item.id)===String(button.dataset.offer));
+      const box=button.querySelector('.price');
+      if(!row||!box)return;
+      const duration=box.querySelector('.duration');
+      const amount=type?(type==='saloon'?row.saloon_price_aed:row.station_price_aed):null;
+      [...box.childNodes].filter(node=>node.nodeType===Node.TEXT_NODE).forEach(node=>node.remove());
+      box.insertBefore(document.createTextNode(amount==null?'—':money(amount)),duration||null);
+    });
+    const summary=document.querySelector('#summaryOffer');
+    const offer=currentOffer();
+    if(summary&&offer){
+      const name=arabic()?offer.name_ar:offer.name_en;
+      const amount=type?(type==='saloon'?offer.saloon_price_aed:offer.station_price_aed):null;
+      summary.textContent=String(name||'')+(amount==null?'':' · '+money(amount));
+    }
+  }
+
+  function patchSlots(){
+    const slots=document.querySelector('#slots');
+    if(!slots)return;
+    slots.querySelectorAll('[data-slot]').forEach(button=>{button.textContent=time(button.dataset.slot)});
+    slots.querySelectorAll('.day').forEach(header=>{
+      let node=header.nextElementSibling;
+      while(node&&!node.matches('[data-slot]'))node=node.nextElementSibling;
+      if(node?.dataset?.slot)header.textContent=day(node.dataset.slot);
+    });
+    const selected=slots.querySelector('[data-slot].selected')?.dataset?.slot;
+    if(selected){
+      const summary=document.querySelector('#summaryTime');
+      if(summary)summary.textContent=day(selected)+' · '+time(selected);
+      const success=document.querySelector('#successDetails .summary div:last-child strong');
+      if(success)success.textContent=day(selected)+' · '+time(selected);
+    }
+  }
+
+  function patchCopy(){
+    const desc=document.querySelector('#slotDesc');
+    if(desc)desc.textContent=arabic()
+      ? 'نعرض لك الأوقات المتاحة فقط حسب المنطقة الزمنية للنشاط ('+timezone()+').'
+      : 'Only available times are shown in the business time zone ('+timezone()+').';
+    const phone=document.querySelector('#customerPhone');
+    if(phone)phone.placeholder=prefix()+' …';
+  }
+
+  function apply(){if(!profile)return;patchCopy();patchPrices();patchSlots()}
+
+  const originalJson=Response.prototype.json;
+  Response.prototype.json=async function(){
+    const payload=await originalJson.call(this);
+    try{
+      if(payload?.catalog?.business?.currency_code){
+        window.__dabbirPublicBookingCatalog=payload.catalog;
+        profile=payload.catalog.business;
+        setTimeout(apply,0);
+      }
+    }catch{}
+    return payload;
+  };
+
+  const observer=new MutationObserver(()=>{if(profile)requestAnimationFrame(apply)});
+  observer.observe(document.body,{subtree:true,childList:true,characterData:true,attributes:true,attributeFilter:['class']});
+  new MutationObserver(()=>{if(profile)apply()}).observe(document.documentElement,{attributes:true,attributeFilter:['lang']});
+  document.addEventListener('click',event=>{if(event.target?.closest?.('[data-offer],[data-vehicle],[data-slot],#arBtn,#enBtn'))setTimeout(apply,0)},true);
+  ensureProfile();
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET'){
+    res.statusCode=405;
+    res.setHeader('allow','GET');
+    return res.end('Method Not Allowed');
+  }
+  res.statusCode=200;
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','no-store');
+  res.setHeader('x-content-type-options','nosniff');
+  res.setHeader('x-dabbir-public-booking-gcc','v1');
+  return res.end(SCRIPT);
+}

--- a/api/public-car-wash.js
+++ b/api/public-car-wash.js
@@ -1,7 +1,6 @@
 import { supabaseKeyHeaders } from './_supabase-key-auth.js';
 
 const SUPABASE_URL=String(process.env.SUPABASE_URL||'').replace(/\/$/,'');
-const SUPABASE_PUBLISHABLE_KEY=String(process.env.SUPABASE_PUBLISHABLE_KEY||'').trim();
 const SLUG_RE=/^[a-z0-9][a-z0-9_-]{2,119}$/i;
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
@@ -20,13 +19,19 @@ function query(req,name){try{return new URL(String(req.url||'/'),'https://dabbir
 function clean(value,max){return String(value??'').trim().slice(0,max)}
 function slug(value){const v=clean(value,120);return SLUG_RE.test(v)?v:null}
 function readBody(req,max=12000){return new Promise((resolve,reject)=>{let n=0;const parts=[];req.on('data',chunk=>{n+=chunk.length;if(n>max){reject(Object.assign(new Error('PAYLOAD_TOO_LARGE'),{status:413}));req.destroy();return}parts.push(chunk)});req.on('end',()=>{try{resolve(JSON.parse(Buffer.concat(parts).toString('utf8')||'{}'))}catch{reject(Object.assign(new Error('INVALID_JSON'),{status:400}))}});req.on('error',reject)})}
+function serviceRoleKey(){
+  const key=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
+  if(!key||key.startsWith('sb_publishable_'))throw Object.assign(new Error('PUBLIC_BOOKING_STORAGE_NOT_CONFIGURED'),{status:503});
+  return key;
+}
 async function rpc(name,params){
-  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',headers:supabaseKeyHeaders(SUPABASE_PUBLISHABLE_KEY,{accept:'application/json','content-type':'application/json'}),body:JSON.stringify(params),cache:'no-store'});
+  const key=serviceRoleKey();
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',headers:supabaseKeyHeaders(key,{accept:'application/json','content-type':'application/json'}),body:JSON.stringify(params),cache:'no-store',signal:AbortSignal.timeout(12000)});
   const text=await response.text();let payload=null;try{payload=text?JSON.parse(text):null}catch{}
   if(!response.ok){const error=new Error(String(payload?.message||payload?.code||'PUBLIC_BOOKING_FAILED').slice(0,120));error.status=response.status;throw error}
   return payload;
 }
-function safeStatus(error){return [400,403,404,405,409,413,422,429].includes(Number(error?.status))?Number(error.status):500}
+function safeStatus(error){return [400,403,404,405,409,413,422,429,503].includes(Number(error?.status))?Number(error.status):500}
 
 export default async function handler(req,res){
   try{

--- a/supabase/migrations/20260903060929_dabbir_public_booking_gcc_timezone.sql
+++ b/supabase/migrations/20260903060929_dabbir_public_booking_gcc_timezone.sql
@@ -1,0 +1,204 @@
+-- Public car-wash booking follows the business GCC profile.
+-- Country remains authoritative through dabbir_businesses.country_code; currency,
+-- timezone and phone prefix are derived by the GCC business-profile trigger.
+
+create or replace function public.dabbir_public_car_wash_catalog(p_slug text)
+returns jsonb
+language sql
+security definer
+stable
+set search_path = public, extensions
+as $$
+  select jsonb_build_object(
+    'business', jsonb_build_object(
+      'id', b.id,
+      'slug', b.slug,
+      'name', b.name,
+      'country_code', b.country_code,
+      'currency_code', b.currency_code,
+      'timezone', b.timezone,
+      'phone_country_prefix', b.phone_country_prefix
+    ),
+    'settings', jsonb_build_object(
+      'slot_interval_minutes', s.slot_interval_minutes,
+      'booking_horizon_days', s.booking_horizon_days,
+      'working_days', s.working_days,
+      'open_time', s.open_time,
+      'close_time', s.close_time
+    ),
+    'offers', coalesce((
+      select jsonb_agg(jsonb_build_object(
+        'id', o.id,
+        'sort_order', o.sort_order,
+        'name_ar', o.name_ar,
+        'name_en', o.name_en,
+        'description_ar', o.description_ar,
+        'description_en', o.description_en,
+        'duration_minutes', o.duration_minutes,
+        'saloon_price_aed', o.saloon_price_aed,
+        'station_price_aed', o.station_price_aed
+      ) order by o.sort_order)
+      from public.dabbir_car_wash_offers o
+      where o.business_id = b.id and o.active = true
+    ), '[]'::jsonb)
+  )
+  from public.dabbir_businesses b
+  join public.dabbir_car_wash_settings s on s.business_id = b.id
+  where lower(b.slug) = lower(trim(p_slug))
+    and b.business_type = 'car_wash'
+    and s.public_booking_enabled = true
+  limit 1;
+$$;
+
+create or replace function public.dabbir_public_car_wash_slots(
+  p_slug text,
+  p_offer_id uuid,
+  p_from_date date default null,
+  p_to_date date default null
+)
+returns table(slot_at timestamptz)
+language plpgsql
+security definer
+stable
+set search_path = public, extensions
+as $$
+declare
+  v_business_id uuid;
+  v_timezone text;
+  v_duration integer;
+  v_interval integer;
+  v_horizon integer;
+  v_open time;
+  v_close time;
+  v_days smallint[];
+  v_today date;
+  v_from date;
+  v_to date;
+begin
+  select b.id, b.timezone, s.slot_interval_minutes, s.booking_horizon_days, s.open_time, s.close_time, s.working_days
+    into v_business_id, v_timezone, v_interval, v_horizon, v_open, v_close, v_days
+  from public.dabbir_businesses b
+  join public.dabbir_car_wash_settings s on s.business_id = b.id and s.public_booking_enabled = true
+  where lower(b.slug) = lower(trim(p_slug)) and b.business_type = 'car_wash'
+  limit 1;
+  if v_business_id is null then return; end if;
+
+  v_today := (now() at time zone v_timezone)::date;
+  v_from := greatest(coalesce(p_from_date, v_today), v_today);
+
+  select o.duration_minutes into v_duration
+  from public.dabbir_car_wash_offers o
+  where o.id = p_offer_id and o.business_id = v_business_id and o.active = true;
+  if v_duration is null then return; end if;
+
+  v_to := least(coalesce(p_to_date, v_from + v_horizon), v_from + v_horizon);
+  return query
+  with days as (
+    select g::date as service_day
+    from generate_series(v_from::timestamp, v_to::timestamp, interval '1 day') g
+    where extract(dow from g)::smallint = any(v_days)
+  ), candidates as (
+    select ((d.service_day + v_open) at time zone v_timezone) + (n * make_interval(mins => v_interval)) as candidate
+    from days d
+    cross join lateral generate_series(
+      0,
+      greatest(0, floor(extract(epoch from (v_close - v_open)) / 60)::integer - v_duration),
+      v_interval
+    ) n
+  )
+  select c.candidate
+  from candidates c
+  where c.candidate > now() + interval '30 minutes'
+    and not exists (
+      select 1
+      from public.dabbir_car_wash_booking_requests r
+      join public.dabbir_car_wash_offers ro on ro.id = r.offer_id
+      where r.business_id = v_business_id
+        and r.status in ('requested','confirmed')
+        and tstzrange(r.starts_at, r.starts_at + make_interval(mins => ro.duration_minutes), '[)')
+            && tstzrange(c.candidate, c.candidate + make_interval(mins => v_duration), '[)')
+    )
+  order by c.candidate
+  limit 200;
+end;
+$$;
+
+create or replace function public.dabbir_public_car_wash_book(
+  p_slug text,
+  p_offer_id uuid,
+  p_vehicle_type text,
+  p_starts_at timestamptz,
+  p_customer_name text,
+  p_customer_phone text,
+  p_location_lat numeric,
+  p_location_lng numeric,
+  p_location_label text default ''
+)
+returns jsonb
+language plpgsql
+security definer
+volatile
+set search_path = public, extensions
+as $$
+declare
+  v_business_id uuid;
+  v_timezone text;
+  v_offer record;
+  v_id uuid;
+  v_name text := left(trim(coalesce(p_customer_name, '')), 120);
+  v_phone text := left(trim(coalesce(p_customer_phone, '')), 30);
+  v_label text := left(trim(coalesce(p_location_label, '')), 240);
+  v_vehicle text := lower(trim(coalesce(p_vehicle_type, '')));
+begin
+  if v_name !~ '^.{2,120}$' or v_phone !~ '^.{7,30}$' then raise exception 'INVALID_CUSTOMER_DETAILS' using errcode = '22023'; end if;
+  if v_vehicle not in ('saloon','station') then raise exception 'INVALID_VEHICLE_TYPE' using errcode = '22023'; end if;
+  if p_location_lat is null or p_location_lat < -90 or p_location_lat > 90 or p_location_lng is null or p_location_lng < -180 or p_location_lng > 180 then raise exception 'VALID_LOCATION_REQUIRED' using errcode = '22023'; end if;
+  if p_starts_at is null or p_starts_at <= now() then raise exception 'INVALID_START_TIME' using errcode = '22023'; end if;
+
+  select b.id, b.timezone into v_business_id, v_timezone
+  from public.dabbir_businesses b
+  join public.dabbir_car_wash_settings s on s.business_id = b.id and s.public_booking_enabled = true
+  where lower(b.slug) = lower(trim(p_slug)) and b.business_type = 'car_wash'
+  limit 1;
+  if v_business_id is null then raise exception 'BOOKING_NOT_AVAILABLE' using errcode = '22023'; end if;
+
+  select o.* into v_offer from public.dabbir_car_wash_offers o where o.id = p_offer_id and o.business_id = v_business_id and o.active = true;
+  if not found then raise exception 'OFFER_NOT_AVAILABLE' using errcode = '22023'; end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(v_business_id::text || date_trunc('minute', p_starts_at)::text, 0));
+  if not exists (
+    select 1 from public.dabbir_public_car_wash_slots(
+      p_slug,
+      p_offer_id,
+      (p_starts_at at time zone v_timezone)::date,
+      (p_starts_at at time zone v_timezone)::date
+    ) x
+    where x.slot_at = date_trunc('minute', p_starts_at)
+  ) then raise exception 'SLOT_NOT_AVAILABLE' using errcode = '23P01'; end if;
+
+  insert into public.dabbir_car_wash_booking_requests (
+    business_id, offer_id, vehicle_type, starts_at, customer_name, customer_phone,
+    location_lat, location_lng, location_label
+  ) values (
+    v_business_id, v_offer.id, v_vehicle, date_trunc('minute', p_starts_at), v_name, v_phone,
+    round(p_location_lat::numeric, 6), round(p_location_lng::numeric, 6), v_label
+  ) returning id into v_id;
+
+  return jsonb_build_object(
+    'id', v_id,
+    'business_id', v_business_id,
+    'offer_id', v_offer.id,
+    'vehicle_type', v_vehicle,
+    'starts_at', date_trunc('minute', p_starts_at),
+    'timezone', v_timezone,
+    'status', 'requested'
+  );
+end;
+$$;
+
+revoke all on function public.dabbir_public_car_wash_catalog(text) from public;
+revoke all on function public.dabbir_public_car_wash_slots(text, uuid, date, date) from public;
+revoke all on function public.dabbir_public_car_wash_book(text, uuid, text, timestamptz, text, text, numeric, numeric, text) from public;
+grant execute on function public.dabbir_public_car_wash_catalog(text) to anon, authenticated;
+grant execute on function public.dabbir_public_car_wash_slots(text, uuid, date, date) to anon, authenticated;
+grant execute on function public.dabbir_public_car_wash_book(text, uuid, text, timestamptz, text, text, numeric, numeric, text) to anon, authenticated;

--- a/test/dabbir-gcc-readiness.test.mjs
+++ b/test/dabbir-gcc-readiness.test.mjs
@@ -7,9 +7,13 @@ import { fileURLToPath } from 'node:url';
 const here=dirname(fileURLToPath(import.meta.url));
 const read=path=>readFileSync(resolve(here,'..',path),'utf8');
 const migration=read('supabase/migrations/20260903092000_dabbir_gcc_business_profile_v1.sql');
+const publicBookingMigration=read('supabase/migrations/20260903060929_dabbir_public_booking_gcc_timezone.sql');
 const createApi=read('api/gcc-create-business.js');
 const profileApi=read('api/gcc-business-profile.js');
 const adaptiveAppointment=read('api/adaptive-appointment.js');
+const publicBookingApi=read('api/public-car-wash.js');
+const publicBookingUi=read('api/gcc-public-booking-ui.js');
+const publicBookingPage=read('api/car-wash-booking.js');
 const ui=read('api/gcc-readiness-ui.js');
 const timezoneUi=read('api/timezone-ui.js');
 const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
@@ -73,6 +77,30 @@ test('appointment phone normalization follows business prefix but remains option
   assert.doesNotMatch(adaptiveAppointment,/PHONE_REQUIRED/);
   assert.match(adaptiveAppointment,/currency_code:business\.currency_code/);
   assert.match(adaptiveAppointment,/timezone:business\.timezone/);
+});
+
+test('public booking database derives slots and validation dates from the business timezone',()=>{
+  assert.match(publicBookingMigration,/b\.timezone/);
+  assert.match(publicBookingMigration,/at time zone v_timezone/);
+  assert.match(publicBookingMigration,/'currency_code', b\.currency_code/);
+  assert.match(publicBookingMigration,/'phone_country_prefix', b\.phone_country_prefix/);
+  assert.doesNotMatch(publicBookingMigration,/at time zone 'Asia\/Dubai'/);
+});
+
+test('public booking privileged RPC authority stays server-side',()=>{
+  assert.match(publicBookingApi,/SUPABASE_SERVICE_ROLE_KEY/);
+  assert.match(publicBookingApi,/serviceRoleKey\(\)/);
+  assert.doesNotMatch(publicBookingApi,/SUPABASE_PUBLISHABLE_KEY/);
+});
+
+test('public booking page renders currency, timezone and phone prefix from catalog profile',()=>{
+  assert.match(publicBookingPage,/gcc-public-booking-ui/);
+  assert.match(publicBookingUi,/profile\?\.timezone/);
+  assert.match(publicBookingUi,/profile\?\.currency_code/);
+  assert.match(publicBookingUi,/profile\?\.phone_country_prefix/);
+  assert.match(publicBookingUi,/style:'currency',currency:currency\(\)/);
+  assert.match(publicBookingUi,/searchParams\.set\('from_date',dateKey\(now\)\)/);
+  assert.match(publicBookingUi,/data-slot/);
 });
 
 test('GCC readiness loads in the critical bundle so country is available during onboarding',()=>{


### PR DESCRIPTION
Completes the next GCC-readiness slice after #366/#368.

- Public car-wash slot generation and booking validation now use each business timezone instead of Asia/Dubai.
- Public catalog exposes country, currency, timezone and phone prefix from the authoritative business profile.
- Public booking page rewrites visible prices, slot times, date queries and phone hints from that profile.
- Public booking RPC calls move behind the server-side service-role bridge so privileged SECURITY DEFINER functions do not need direct browser credentials.
- Tracks the already-applied production migration `20260903060929_dabbir_public_booking_gcc_timezone`.
- Adds GCC regression tests.

Production database verification was performed in a rollback-only SA simulation: country SA derived SAR / Asia-Riyadh / +966, catalog returned SAR / Asia-Riyadh, and a configured 08:00 opening produced an 08:00 Riyadh slot. No test rows were persisted.