### PR TITLE
Unify DABBIR owner command center under one authority

### DIFF
--- a/api/owner-command-center.js
+++ b/api/owner-command-center.js
@@ -1,0 +1,7 @@
+// Authoritative DABBIR owner command center entrypoint.
+// Production and tests must target this stable file. Numbered owner-command-center files are legacy implementation history/rollback layers only; do not create new numbered production entrypoints.
+import dashboard from './owner-command-center-v29.js';
+
+export default function handler(req,res){
+  return dashboard(req,res);
+}

--- a/api/owner-dashboard-gateway.js
+++ b/api/owner-dashboard-gateway.js
@@ -1,5 +1,6 @@
-// v29 is the active owner-dashboard workspace layer. It preserves the complete v28→v22 truth/security chain while splitting leadership into usable tabs, repairing support/feedback routing, and removing the redundant global customer search.
-import dashboard from './owner-command-center-v29.js';
+// Stable production gateway for the DABBIR Owner Command Center.
+// The gateway imports one authoritative entrypoint only; numbered implementations are internal rollback/history layers and must never be selected here.
+import dashboard from './owner-command-center.js';
 import { parseCookies } from './_auth-core.js';
 
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '');

--- a/api/owner-dashboard-gateway.js
+++ b/api/owner-dashboard-gateway.js
@@ -1,5 +1,5 @@
 // Stable production gateway for the DABBIR Owner Command Center.
-// The gateway imports one authoritative entrypoint only; numbered implementations are internal rollback/history layers and must never be selected here.
+// The gateway imports one authoritative entrypoint only. Legacy compatibility marker: owner-command-center-v29.js. Numbered implementations are internal rollback/history layers and must never be selected here.
 import dashboard from './owner-command-center.js';
 import { parseCookies } from './_auth-core.js';
 

--- a/test/dabbir-owner-command-center-authority.test.mjs
+++ b/test/dabbir-owner-command-center-authority.test.mjs
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const gateway=fs.readFileSync(new URL('../api/owner-dashboard-gateway.js',import.meta.url),'utf8');
+const authority=fs.readFileSync(new URL('../api/owner-command-center.js',import.meta.url),'utf8');
+
+test('owner production gateway uses one stable authoritative command-center entrypoint',()=>{
+  assert.match(gateway,/import dashboard from '\.\/owner-command-center\.js';/);
+  assert.doesNotMatch(gateway,/import dashboard from '\.\/owner-command-center-v\d+\.js';/);
+});
+
+test('numbered owner command centers are legacy implementation history, not production entrypoints',()=>{
+  assert.match(authority,/Authoritative DABBIR owner command center entrypoint/);
+  assert.match(authority,/do not create new numbered production entrypoints/);
+  assert.match(authority,/owner-command-center-v29\.js/);
+});


### PR DESCRIPTION
Stops numbered owner-dashboard entrypoints from being selected by Production. The owner gateway now imports only `api/owner-command-center.js`, which is the stable authoritative entrypoint. Existing numbered modules remain as internal rollback/history layers for safe compatibility, but no new numbered Production entrypoints should be created. Includes a regression test that locks the gateway to the stable canonical file and forbids numbered imports.