### PR TITLE
Move DABBIR contextual navigation onto language-aware lifecycle

### DIFF
--- a/api/app-recovery.js
+++ b/api/app-recovery.js
@@ -40,9 +40,9 @@ const UI_MODULE_ORDER = [
 
 // Change this token whenever shell or generated-bundle behavior changes so Safari
 // cannot reuse a previous presentation layer after deployment.
-const UI_BUNDLE_VERSION = '20260903-lifecycle-authority-v1';
+const UI_BUNDLE_VERSION = '20260903-context-language-lifecycle-v2';
 
-// One shell-level lifecycle authority owns the final render/navigation entry points.
+// One shell-level lifecycle authority owns the final render/navigation/language entry points.
 // Legacy modules may still wrap them during migration; reconcile() reasserts the
 // outer authority without creating recursion, while older lifecycle wrappers become inert.
 const UI_LIFECYCLE_BOOTSTRAP = `<script>
@@ -51,17 +51,21 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
     window.__dabbirUiLifecycle.reconcile?.();
     return;
   }
-  const hooks=new Map([['afterRender',new Map()],['afterNavigate',new Map()]]);
+  const hooks=new Map([['afterRender',new Map()],['afterNavigate',new Map()],['afterLanguage',new Map()]]);
   const routes=new Map();
   let renderGeneration=0;
   let navigationGeneration=0;
+  let languageGeneration=0;
   let renderWrapper=null;
   let navigationWrapper=null;
+  let languageWrapper=null;
   let renderReconciliations=0;
   let navigationReconciliations=0;
+  let languageReconciliations=0;
 
   function safeCurrent(){try{return typeof current==='undefined'?null:current}catch{return null}}
   function safeWorkspace(){try{return typeof workspace==='undefined'?null:workspace}catch{return null}}
+  function safeLanguage(){try{return typeof lang==='undefined'?(document.documentElement.lang||null):lang}catch{return document.documentElement.lang||null}}
   function emit(event,payload){
     const group=hooks.get(event);
     if(!group)return;
@@ -116,6 +120,21 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
     navigationReconciliations++;
     return true;
   }
+  function wrapLanguage(){
+    if(typeof applyLang!=='function')return false;
+    if(applyLang===languageWrapper)return true;
+    const base=applyLang;
+    const generation=++languageGeneration;
+    const wrapper=function(){
+      const result=base.apply(this,arguments);
+      if(generation===languageGeneration)emit('afterLanguage',{language:safeLanguage(),current:safeCurrent(),workspace:safeWorkspace()});
+      return result;
+    };
+    languageWrapper=wrapper;
+    applyLang=wrapper;
+    languageReconciliations++;
+    return true;
+  }
   const api={
     version:'ui-lifecycle-v1',
     on(event,id,fn){
@@ -133,10 +152,11 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
     reconcile(){
       const render=wrapRender();
       const navigation=wrapNavigation();
-      return {render,navigation,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations};
+      const language=wrapLanguage();
+      return {render,navigation,language,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations};
     },
     status(){
-      return {version:this.version,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,render_hooks:hooks.get('afterRender').size,navigation_hooks:hooks.get('afterNavigate').size,route_resolvers:routes.size};
+      return {version:this.version,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations,render_hooks:hooks.get('afterRender').size,navigation_hooks:hooks.get('afterNavigate').size,language_hooks:hooks.get('afterLanguage').size,route_resolvers:routes.size};
     }
   };
   window.__dabbirUiLifecycle=api;
@@ -175,8 +195,7 @@ const BOOKING_TIME_GUARD = `<script>
 (()=>{
   if(window.__dabbirBookingTimeGuard)return;
   window.__dabbirBookingTimeGuard=true;
-  const TZ='Asia/Dubai';
-  const OFFSET='+04:00';
+  const GCC_OFFSETS={AE:'+04:00',SA:'+03:00',KW:'+03:00',QA:'+03:00',BH:'+03:00',OM:'+04:00'};
 
   function copy(){
     const ar=String(document.documentElement.lang||'ar').toLowerCase().startsWith('ar');
@@ -185,9 +204,13 @@ const BOOKING_TIME_GUARD = `<script>
       : {past:'Bookings cannot be created in the past. Choose the current time or a later time.'};
   }
 
-  function dubaiMinute(date=new Date()){
+  function businessTimeZone(){
+    return String(document.documentElement.dataset.dabbirTimezone||window.__dabbirTimeZone||'Asia/Dubai');
+  }
+
+  function businessMinute(date=new Date()){
     const fmt=new Intl.DateTimeFormat('en-CA',{
-      timeZone:TZ,year:'numeric',month:'2-digit',day:'2-digit',
+      timeZone:businessTimeZone(),year:'numeric',month:'2-digit',day:'2-digit',
       hour:'2-digit',minute:'2-digit',hourCycle:'h23'
     });
     const parts=Object.fromEntries(fmt.formatToParts(date).filter(p=>p.type!=='literal').map(p=>[p.type,p.value]));
@@ -197,7 +220,16 @@ const BOOKING_TIME_GUARD = `<script>
   function selectedMs(value){
     const raw=String(value||'').trim();
     if(!/^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}/.test(raw))return NaN;
-    return new Date(raw.slice(0,16)+':00'+OFFSET).getTime();
+    try{
+      if(typeof window.dabbirLocalTimeToIso==='function'){
+        const iso=window.dabbirLocalTimeToIso(raw.slice(0,16));
+        const ms=iso?new Date(iso).getTime():NaN;
+        if(Number.isFinite(ms))return ms;
+      }
+    }catch{}
+    const country=String(document.documentElement.dataset.dabbirCountry||'AE').toUpperCase();
+    const offset=GCC_OFFSETS[country]||GCC_OFFSETS.AE;
+    return new Date(raw.slice(0,16)+':00'+offset).getTime();
   }
 
   function currentMinuteMs(){return Math.floor(Date.now()/60000)*60000}
@@ -205,7 +237,7 @@ const BOOKING_TIME_GUARD = `<script>
   function syncMin(){
     const input=document.querySelector('#apptTime');
     if(!input)return;
-    const min=dubaiMinute();
+    const min=businessMinute();
     if(input.min!==min)input.min=min;
     if(input.value&&selectedMs(input.value)<currentMinuteMs())input.value='';
     input.setCustomValidity('');
@@ -232,6 +264,8 @@ const BOOKING_TIME_GUARD = `<script>
   },true);
   document.addEventListener('submit',event=>{if(event.target?.id==='appointmentForm')rejectPast(event)},true);
   document.addEventListener('visibilitychange',()=>{if(!document.hidden)syncMin()});
+  window.__dabbirUiLifecycle?.on?.('afterRender','booking-time-guard',syncMin);
+  window.__dabbirUiLifecycle?.on?.('afterLanguage','booking-time-guard',syncMin);
   setTimeout(syncMin,0);
 })();
 </script>`;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260903-lifecycle-authority-v1';
+const UI_CACHE_BUST = '20260903-context-language-lifecycle-v2';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/dabbir-contextual-navigation-ui.js
+++ b/api/dabbir-contextual-navigation-ui.js
@@ -189,14 +189,17 @@ const script=String.raw`(()=>{
     try{if(typeof setLanguage==='function')setLanguage(ar()?'en':'ar');else if(typeof applyLang==='function')applyLang(ar()?'en':'ar')}catch{}
   }
   function parseClock(value){const match=String(value||'').match(/^(\d{2}):(\d{2})$/);return match?Number(match[1])*60+Number(match[2]):NaN}
-  function currentDubai(){
+  function businessTimeZone(){
+    return String(currentWorkspace()?.business?.timezone||document.documentElement.dataset.dabbirTimezone||window.__dabbirTimeZone||'Asia/Dubai');
+  }
+  function currentBusinessClock(){
     try{
-      const parts=Object.fromEntries(new Intl.DateTimeFormat('en-US',{timeZone:'Asia/Dubai',weekday:'long',hour:'2-digit',minute:'2-digit',hourCycle:'h23'}).formatToParts(new Date()).filter(part=>part.type!=='literal').map(part=>[part.type,part.value]));
+      const parts=Object.fromEntries(new Intl.DateTimeFormat('en-US',{timeZone:businessTimeZone(),weekday:'long',hour:'2-digit',minute:'2-digit',hourCycle:'h23'}).formatToParts(new Date()).filter(part=>part.type!=='literal').map(part=>[part.type,part.value]));
       return {day:parts.weekday,minute:Number(parts.hour)*60+Number(parts.minute)};
     }catch{return null}
   }
   function businessOpenNow(){
-    const now=currentDubai();if(!now)return false;
+    const now=currentBusinessClock();if(!now)return false;
     const raw=String(q('#dk-business_hours')?.value||currentWorkspace()?.business?.business_hours||'');
     const line=raw.split(';').map(value=>value.trim()).find(value=>value.startsWith(now.day+' '));
     const match=line?.match(/^[A-Za-z]+\s+(\d{2}:\d{2})-(\d{2}:\d{2})$/);if(!match)return false;
@@ -241,20 +244,18 @@ const script=String.raw`(()=>{
     syncApprovedSettings();
   }
 
-  try{
-    const baseRenderAll=renderAll;
-    renderAll=function(){const result=baseRenderAll.apply(this,arguments);setTimeout(enforce,0);return result};
-  }catch{}
-
-  try{
-    const baseApplyLang=applyLang;
-    applyLang=function(){const result=baseApplyLang.apply(this,arguments);setTimeout(enforce,0);return result};
-  }catch{}
+  function queueEnforce(){setTimeout(enforce,0)}
+  const lifecycle=window.__dabbirUiLifecycle;
+  if(lifecycle?.on){
+    lifecycle.on('afterRender','contextual-navigation',queueEnforce);
+    lifecycle.on('afterNavigate','contextual-navigation',queueEnforce);
+    lifecycle.on('afterLanguage','contextual-navigation',queueEnforce);
+  }
 
   setTimeout(enforce,0);
   setTimeout(enforce,650);
   setTimeout(enforce,1600);
-  window.__dabbirContextualNavigation={refresh:enforce,version:'v6',authority:'primary-context-router',workspace_source:'global-lexical-first',mobile_menu_resync:true,team_access:'more-and-sidebar',owner_assistant_access:'more',approved_settings_ui:true};
+  window.__dabbirContextualNavigation={refresh:enforce,version:'v7',authority:'primary-context-router',workspace_source:'global-lexical-first',mobile_menu_resync:true,team_access:'more-and-sidebar',owner_assistant_access:'more',approved_settings_ui:true,lifecycle_driven:true,business_timezone_status:true};
 })();`;
 
 export default function handler(req,res){
@@ -262,6 +263,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-contextual-navigation','v6');
+  res.setHeader('x-dabbir-contextual-navigation','v7');
   return res.status(200).send(script);
 }

--- a/test/dabbir-context-language-lifecycle.test.mjs
+++ b/test/dabbir-context-language-lifecycle.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,root),'utf8');
+const recovery=read('api/app-recovery.js');
+const safari=read('api/app-safari-recovery.js');
+const contextual=read('api/dabbir-contextual-navigation-ui.js');
+
+test('contextual navigation is lifecycle driven and no longer wraps global render or language functions',()=>{
+  assert.match(contextual,/lifecycle\.on\('afterRender','contextual-navigation',queueEnforce\)/);
+  assert.match(contextual,/lifecycle\.on\('afterNavigate','contextual-navigation',queueEnforce\)/);
+  assert.match(contextual,/lifecycle\.on\('afterLanguage','contextual-navigation',queueEnforce\)/);
+  assert.doesNotMatch(contextual,/const baseRenderAll=renderAll/);
+  assert.doesNotMatch(contextual,/renderAll\s*=\s*function/);
+  assert.doesNotMatch(contextual,/const baseApplyLang=applyLang/);
+  assert.doesNotMatch(contextual,/applyLang\s*=\s*function/);
+});
+
+test('settings open-now truth follows the selected business timezone rather than Dubai',()=>{
+  assert.match(contextual,/currentWorkspace\(\)\?\.business\?\.timezone/);
+  assert.match(contextual,/dataset\.dabbirTimezone/);
+  assert.match(contextual,/window\.__dabbirTimeZone/);
+  assert.match(contextual,/function currentBusinessClock\(\)/);
+  assert.doesNotMatch(contextual,/function currentDubai\(\)/);
+  assert.doesNotMatch(contextual,/timeZone:'Asia\/Dubai'/);
+});
+
+test('booking time guard derives local time from GCC business authority',()=>{
+  assert.match(recovery,/const GCC_OFFSETS=\{AE:'\+04:00',SA:'\+03:00',KW:'\+03:00',QA:'\+03:00',BH:'\+03:00',OM:'\+04:00'\}/);
+  assert.match(recovery,/dataset\.dabbirTimezone\|\|window\.__dabbirTimeZone/);
+  assert.match(recovery,/window\.dabbirLocalTimeToIso/);
+  assert.match(recovery,/dataset\.dabbirCountry/);
+  assert.match(recovery,/function businessMinute\(/);
+  assert.doesNotMatch(recovery,/const TZ='Asia\/Dubai'/);
+  assert.doesNotMatch(recovery,/const OFFSET='\+04:00'/);
+});
+
+test('Safari and shell use the same deployment cache-bust token',()=>{
+  assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-context-language-lifecycle-v2'/);
+  assert.match(safari,/UI_CACHE_BUST = '20260903-context-language-lifecycle-v2'/);
+});

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-lifecycle-authority-v1'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-context-language-lifecycle-v2'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);

--- a/test/dabbir-ui-lifecycle-authority.test.mjs
+++ b/test/dabbir-ui-lifecycle-authority.test.mjs
@@ -11,15 +11,18 @@ test('authoritative shell installs one lifecycle authority before generated UI b
   assert.match(recovery,/const UI_LIFECYCLE_BOOTSTRAP/);
   assert.match(recovery,/version:'ui-lifecycle-v1'/);
   assert.match(recovery,/UI_LIFECYCLE_BOOTSTRAP \+ `\\n<script src="\/dabbir-ui-critical\.js/);
-  assert.match(recovery,/const hooks=new Map\(\[\['afterRender',new Map\(\)\],\['afterNavigate',new Map\(\)\]\]\)/);
+  assert.match(recovery,/const hooks=new Map\(\[\['afterRender',new Map\(\)\],\['afterNavigate',new Map\(\)\],\['afterLanguage',new Map\(\)\]\]\)/);
   assert.match(recovery,/const routes=new Map\(\)/);
 });
 
-test('lifecycle reconciliation is generation-safe when legacy wrappers still exist',()=>{
+test('lifecycle reconciliation is generation-safe for render navigation and language',()=>{
   assert.match(recovery,/const generation=\+\+renderGeneration/);
   assert.match(recovery,/generation===renderGeneration/);
   assert.match(recovery,/const generation=\+\+navigationGeneration/);
   assert.match(recovery,/generation!==navigationGeneration/);
+  assert.match(recovery,/const generation=\+\+languageGeneration/);
+  assert.match(recovery,/generation===languageGeneration/);
+  assert.match(recovery,/emit\('afterLanguage'/);
   assert.match(recovery,/window\.__dabbirUiLifecycle\?\.reconcile\?\.\(\)/);
   assert.match(recovery,/script\.onload=\(\)=>\{[\s\S]*?__dabbirDeferredUiReady=true;[\s\S]*?__dabbirUiLifecycle\?\.reconcile/);
 });
@@ -32,7 +35,7 @@ test('canonical navigation bridge registers with lifecycle instead of owning the
   assert.match(bridge,/legacy-fallback/);
 });
 
-test('architecture ceiling does not grow while lifecycle authority is introduced',()=>{
+test('architecture ceiling does not grow while lifecycle authority expands',()=>{
   const modules=[...manifest.critical,...manifest.deferred];
   assert.equal(modules.length,26);
   assert.equal(new Set(modules).size,modules.length);


### PR DESCRIPTION
## Why
The contextual navigation layer still wrapped global `renderAll` and `applyLang`, which kept UI behavior dependent on wrapper order. During the same audit, two GCC correctness gaps were confirmed: the Settings “Open now” badge used Dubai time for every tenant, and the shell appointment guard validated local time using a fixed `+04:00` offset.

## Changes
- extend the central UI lifecycle with generation-safe `afterLanguage`
- move contextual navigation render/navigation/language resync onto lifecycle hooks
- remove contextual navigation `renderAll` and `applyLang` monkey-patches
- calculate Settings “Open now” using the business timezone authority
- make the shell booking min/past guard use tenant timezone/country and `dabbirLocalTimeToIso`
- keep Safari cache-bust aligned with the new shell version
- add fail-closed regression tests for lifecycle ownership, GCC time authority, and Safari cache freshness

## Verification
- base/main remained `94e502df60e12d6cf2ac9567ba7d53b664da3127`
- final head `b3177652f703dca3ec478d288ff69f84540db2ad`
- GitHub DABBIR CI `test` passed
- Vercel fail-closed gate: 918 tests passed, 0 failed
- Vercel Preview `dpl_GWk1shUtMhLyGpgfcLcbenpd8vcP` READY in `bom1`
- Preview `/` returned HTTP 200 with `afterLanguage`, aligned cache-bust, GCC offset map, and business-time booking guard
- Preview `/api/dabbir-contextual-navigation-ui` returned HTTP 200 as v7 with lifecycle hooks and business timezone Open-now logic
- no contextual `renderAll` or `applyLang` ownership remains

## Safety
No database schema, booking persistence, payment, inventory, service catalog, permissions, or external-channel behavior changed. This is UI lifecycle ownership plus client-side timezone correctness.