### PR TITLE
Move DABBIR human chat onto central render lifecycle

### DIFF
--- a/api/app-recovery.js
+++ b/api/app-recovery.js
@@ -40,9 +40,9 @@ const UI_MODULE_ORDER = [
 
 // Change this token whenever shell or generated-bundle behavior changes so Safari
 // cannot reuse a previous presentation layer after deployment.
-const UI_BUNDLE_VERSION = '20260903-context-language-lifecycle-v2';
+const UI_BUNDLE_VERSION = '20260903-chat-render-lifecycle-v3';
 
-// One shell-level lifecycle authority owns the final render/navigation/language entry points.
+// One shell-level lifecycle authority owns final render/navigation/language/chat render entry points.
 // Legacy modules may still wrap them during migration; reconcile() reasserts the
 // outer authority without creating recursion, while older lifecycle wrappers become inert.
 const UI_LIFECYCLE_BOOTSTRAP = `<script>
@@ -51,21 +51,34 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
     window.__dabbirUiLifecycle.reconcile?.();
     return;
   }
-  const hooks=new Map([['afterRender',new Map()],['afterNavigate',new Map()],['afterLanguage',new Map()]]);
+  const hooks=new Map([
+    ['afterRender',new Map()],
+    ['afterNavigate',new Map()],
+    ['afterLanguage',new Map()],
+    ['afterChats',new Map()],
+    ['afterMessages',new Map()]
+  ]);
   const routes=new Map();
   let renderGeneration=0;
   let navigationGeneration=0;
   let languageGeneration=0;
+  let chatsGeneration=0;
+  let messagesGeneration=0;
   let renderWrapper=null;
   let navigationWrapper=null;
   let languageWrapper=null;
+  let chatsWrapper=null;
+  let messagesWrapper=null;
   let renderReconciliations=0;
   let navigationReconciliations=0;
   let languageReconciliations=0;
+  let chatsReconciliations=0;
+  let messagesReconciliations=0;
 
   function safeCurrent(){try{return typeof current==='undefined'?null:current}catch{return null}}
   function safeWorkspace(){try{return typeof workspace==='undefined'?null:workspace}catch{return null}}
   function safeLanguage(){try{return typeof lang==='undefined'?(document.documentElement.lang||null):lang}catch{return document.documentElement.lang||null}}
+  function safeConversationId(){try{return typeof selectedConversationId==='undefined'?null:selectedConversationId}catch{return null}}
   function emit(event,payload){
     const group=hooks.get(event);
     if(!group)return;
@@ -135,6 +148,36 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
     languageReconciliations++;
     return true;
   }
+  function wrapChats(){
+    if(typeof renderChats!=='function')return false;
+    if(renderChats===chatsWrapper)return true;
+    const base=renderChats;
+    const generation=++chatsGeneration;
+    const wrapper=function(){
+      const result=base.apply(this,arguments);
+      if(generation===chatsGeneration)emit('afterChats',{current:safeCurrent(),workspace:safeWorkspace(),conversation_id:safeConversationId()});
+      return result;
+    };
+    chatsWrapper=wrapper;
+    renderChats=wrapper;
+    chatsReconciliations++;
+    return true;
+  }
+  function wrapMessages(){
+    if(typeof renderMessages!=='function')return false;
+    if(renderMessages===messagesWrapper)return true;
+    const base=renderMessages;
+    const generation=++messagesGeneration;
+    const wrapper=function(){
+      const result=base.apply(this,arguments);
+      if(generation===messagesGeneration)emit('afterMessages',{current:safeCurrent(),workspace:safeWorkspace(),conversation_id:safeConversationId()});
+      return result;
+    };
+    messagesWrapper=wrapper;
+    renderMessages=wrapper;
+    messagesReconciliations++;
+    return true;
+  }
   const api={
     version:'ui-lifecycle-v1',
     on(event,id,fn){
@@ -153,10 +196,12 @@ const UI_LIFECYCLE_BOOTSTRAP = `<script>
       const render=wrapRender();
       const navigation=wrapNavigation();
       const language=wrapLanguage();
-      return {render,navigation,language,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations};
+      const chats=wrapChats();
+      const messages=wrapMessages();
+      return {render,navigation,language,chats,messages,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations,chats_reconciliations:chatsReconciliations,messages_reconciliations:messagesReconciliations};
     },
     status(){
-      return {version:this.version,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations,render_hooks:hooks.get('afterRender').size,navigation_hooks:hooks.get('afterNavigate').size,language_hooks:hooks.get('afterLanguage').size,route_resolvers:routes.size};
+      return {version:this.version,render_reconciliations:renderReconciliations,navigation_reconciliations:navigationReconciliations,language_reconciliations:languageReconciliations,chats_reconciliations:chatsReconciliations,messages_reconciliations:messagesReconciliations,render_hooks:hooks.get('afterRender').size,navigation_hooks:hooks.get('afterNavigate').size,language_hooks:hooks.get('afterLanguage').size,chats_hooks:hooks.get('afterChats').size,messages_hooks:hooks.get('afterMessages').size,route_resolvers:routes.size};
     }
   };
   window.__dabbirUiLifecycle=api;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260903-context-language-lifecycle-v2';
+const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/chat-human-ui.js
+++ b/api/chat-human-ui.js
@@ -3,7 +3,7 @@ const script=String.raw`(()=>{
   window.__dabbirHumanChatUiLoaded=true;
 
   const style=document.createElement('style');
-  style.dataset.dabbirChatUi='v2';
+  style.dataset.dabbirChatUi='v3';
   style.textContent=[
     '#newChatBtn{display:none!important}',
     '.dabbirChatControl{display:flex;align-items:center;gap:8px;flex-wrap:wrap}',
@@ -100,14 +100,14 @@ const script=String.raw`(()=>{
     const input=q('#composer');
     if(input&&!input.dataset.dabbirHumanComposer){
       const clone=input.cloneNode(true);
-      clone.dataset.dabbirHumanComposer='v2';
+      clone.dataset.dabbirHumanComposer='v3';
       input.replaceWith(clone);
       clone.addEventListener('keydown',event=>{if(event.key==='Enter'&&!event.shiftKey){event.preventDefault();sendHumanReply()}});
     }
     const button=q('#sendBtn');
     if(button&&!button.dataset.dabbirHumanComposer){
       const clone=button.cloneNode(true);
-      clone.dataset.dabbirHumanComposer='v2';
+      clone.dataset.dabbirHumanComposer='v3';
       button.replaceWith(clone);
       clone.addEventListener('click',sendHumanReply);
     }
@@ -185,6 +185,14 @@ const script=String.raw`(()=>{
     }
   }
 
+  let refreshQueued=false;
+  function queueHumanUi(){
+    if(refreshQueued)return;
+    refreshQueued=true;
+    const run=()=>{refreshQueued=false;updateHumanUi()};
+    if(typeof queueMicrotask==='function')queueMicrotask(run);else Promise.resolve().then(run);
+  }
+
   async function chatControl(action,message){
     const businessId=currentBusinessId();
     const conversationId=currentConversationId();
@@ -216,7 +224,7 @@ const script=String.raw`(()=>{
       }
       if(typeof loadRuntime==='function')await loadRuntime(currentBusinessId(),currentConversationId());
     }catch(error){notify((conversation.state==='human_active'?t.returnFail:t.takeoverFail)+(error&&error.message?' — '+error.message:''))}
-    finally{if(button)button.disabled=false;updateHumanUi()}
+    finally{if(button)button.disabled=false;queueHumanUi()}
   }
 
   let sending=false;
@@ -238,34 +246,24 @@ const script=String.raw`(()=>{
         workspace.messages.push(saved);
         workspace.messages_loaded=true;
         if(typeof renderMessages==='function')renderMessages();
-        labelMessages();
       }else if(typeof loadRuntime==='function'){
         await loadRuntime(currentBusinessId(),currentConversationId());
       }
     }catch(error){notify(t.sendFail+(error&&error.message?' — '+error.message:''))}
-    finally{sending=false;if(button)button.disabled=false;updateHumanUi();const live=q('#composer');if(live&&!live.disabled)live.focus()}
+    finally{sending=false;if(button)button.disabled=false;queueHumanUi();const live=q('#composer');if(live&&!live.disabled)live.focus()}
   }
 
   ensureControl();
   replaceLegacyComposer();
-  try{
-    if(typeof renderMessages==='function'){
-      const baseRenderMessages=renderMessages;
-      renderMessages=function(){const value=baseRenderMessages.apply(this,arguments);labelMessages();updateHumanUi();return value};
-    }
-    if(typeof renderChats==='function'){
-      const baseRenderChats=renderChats;
-      renderChats=function(){const value=baseRenderChats.apply(this,arguments);updateHumanUi();return value};
-    }
-    if(typeof renderAll==='function'){
-      const baseRenderAll=renderAll;
-      renderAll=function(){const value=baseRenderAll.apply(this,arguments);updateHumanUi();return value};
-    }
-  }catch{}
-  new MutationObserver(updateHumanUi).observe(document.documentElement,{attributes:true,attributeFilter:['lang','dir']});
+  const lifecycle=window.__dabbirUiLifecycle;
+  if(lifecycle?.on){
+    lifecycle.on('afterMessages','human-chat-ui',queueHumanUi);
+    lifecycle.on('afterChats','human-chat-ui',queueHumanUi);
+    lifecycle.on('afterRender','human-chat-ui',queueHumanUi);
+    lifecycle.on('afterLanguage','human-chat-ui',queueHumanUi);
+  }
   setTimeout(updateHumanUi,0);
-  setTimeout(updateHumanUi,500);
-  window.__dabbirHumanChatUiVersion='v2';
+  window.__dabbirHumanChatUiVersion='v3-lifecycle';
 })();`;
 
 export default function handler(req,res){
@@ -276,6 +274,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-chat-ui','v2');
+  res.setHeader('x-dabbir-chat-ui','v3-lifecycle');
   return res.end(script);
 }

--- a/test/dabbir-chat-render-lifecycle.test.mjs
+++ b/test/dabbir-chat-render-lifecycle.test.mjs
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,root),'utf8');
+const recovery=read('api/app-recovery.js');
+const human=read('api/chat-human-ui.js');
+
+test('central lifecycle owns independent chat and message render events',()=>{
+  assert.match(recovery,/function wrapChats\(\)/);
+  assert.match(recovery,/function wrapMessages\(\)/);
+  assert.match(recovery,/emit\('afterChats'/);
+  assert.match(recovery,/emit\('afterMessages'/);
+  assert.match(recovery,/renderChats=wrapper/);
+  assert.match(recovery,/renderMessages=wrapper/);
+});
+
+test('human chat UI subscribes to lifecycle and no longer monkey-patches render globals',()=>{
+  assert.match(human,/lifecycle\.on\('afterMessages','human-chat-ui',queueHumanUi\)/);
+  assert.match(human,/lifecycle\.on\('afterChats','human-chat-ui',queueHumanUi\)/);
+  assert.match(human,/lifecycle\.on\('afterRender','human-chat-ui',queueHumanUi\)/);
+  assert.match(human,/lifecycle\.on\('afterLanguage','human-chat-ui',queueHumanUi\)/);
+  assert.doesNotMatch(human,/const baseRenderMessages=renderMessages/);
+  assert.doesNotMatch(human,/const baseRenderChats=renderChats/);
+  assert.doesNotMatch(human,/const baseRenderAll=renderAll/);
+  assert.doesNotMatch(human,/renderMessages\s*=\s*function/);
+  assert.doesNotMatch(human,/renderChats\s*=\s*function/);
+  assert.doesNotMatch(human,/renderAll\s*=\s*function/);
+  assert.doesNotMatch(human,/new MutationObserver/);
+  assert.doesNotMatch(human,/setInterval\s*\(/);
+});
+
+test('human takeover and manual reply behavior remains present after lifecycle migration',()=>{
+  assert.match(human,/await chatControl\('takeover'\)/);
+  assert.match(human,/await chatControl\('return_to_ai'\)/);
+  assert.match(human,/await chatControl\('human_message',message\)/);
+  assert.match(human,/conversation\.state!=='human_active'/);
+  assert.match(human,/window\.__dabbirHumanChatUiVersion='v3-lifecycle'/);
+  assert.match(human,/x-dabbir-chat-ui','v3-lifecycle'/);
+});

--- a/test/dabbir-context-language-lifecycle.test.mjs
+++ b/test/dabbir-context-language-lifecycle.test.mjs
@@ -38,6 +38,6 @@ test('booking time guard derives local time from GCC business authority',()=>{
 });
 
 test('Safari and shell use the same deployment cache-bust token',()=>{
-  assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-context-language-lifecycle-v2'/);
-  assert.match(safari,/UI_CACHE_BUST = '20260903-context-language-lifecycle-v2'/);
+  assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(safari,/UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
 });

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-context-language-lifecycle-v2'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);

--- a/test/dabbir-ui-lifecycle-authority.test.mjs
+++ b/test/dabbir-ui-lifecycle-authority.test.mjs
@@ -11,18 +11,26 @@ test('authoritative shell installs one lifecycle authority before generated UI b
   assert.match(recovery,/const UI_LIFECYCLE_BOOTSTRAP/);
   assert.match(recovery,/version:'ui-lifecycle-v1'/);
   assert.match(recovery,/UI_LIFECYCLE_BOOTSTRAP \+ `\\n<script src="\/dabbir-ui-critical\.js/);
-  assert.match(recovery,/const hooks=new Map\(\[\['afterRender',new Map\(\)\],\['afterNavigate',new Map\(\)\],\['afterLanguage',new Map\(\)\]\]\)/);
+  for(const event of ['afterRender','afterNavigate','afterLanguage','afterChats','afterMessages']){
+    assert.match(recovery,new RegExp(`\\['${event}',new Map\\(\\)\\]`));
+  }
   assert.match(recovery,/const routes=new Map\(\)/);
 });
 
-test('lifecycle reconciliation is generation-safe for render navigation and language',()=>{
+test('lifecycle reconciliation is generation-safe for render navigation language and chat renders',()=>{
   assert.match(recovery,/const generation=\+\+renderGeneration/);
   assert.match(recovery,/generation===renderGeneration/);
   assert.match(recovery,/const generation=\+\+navigationGeneration/);
   assert.match(recovery,/generation!==navigationGeneration/);
   assert.match(recovery,/const generation=\+\+languageGeneration/);
   assert.match(recovery,/generation===languageGeneration/);
+  assert.match(recovery,/const generation=\+\+chatsGeneration/);
+  assert.match(recovery,/generation===chatsGeneration/);
+  assert.match(recovery,/const generation=\+\+messagesGeneration/);
+  assert.match(recovery,/generation===messagesGeneration/);
   assert.match(recovery,/emit\('afterLanguage'/);
+  assert.match(recovery,/emit\('afterChats'/);
+  assert.match(recovery,/emit\('afterMessages'/);
   assert.match(recovery,/window\.__dabbirUiLifecycle\?\.reconcile\?\.\(\)/);
   assert.match(recovery,/script\.onload=\(\)=>\{[\s\S]*?__dabbirDeferredUiReady=true;[\s\S]*?__dabbirUiLifecycle\?\.reconcile/);
 });


### PR DESCRIPTION
## Why
`chat-human-ui` was the remaining high-risk UI feature layer that directly wrapped `renderMessages`, `renderChats`, and `renderAll`, plus a language MutationObserver. Unlike simple screen features, chat also rerenders messages independently during translation, optimistic send, WhatsApp replies, and human takeover, so removing those wrappers required explicit message/chat lifecycle events rather than relying on `afterRender` alone.

## Changes
- extend the central UI lifecycle with generation-safe `afterChats` and `afterMessages` events
- centralize wrapping of canonical `renderChats` and `renderMessages`
- migrate human chat UI to `afterMessages`, `afterChats`, `afterRender`, and `afterLanguage` subscriptions
- remove human chat `renderMessages` / `renderChats` / `renderAll` monkey-patches
- remove its language MutationObserver and redundant delayed refresh
- preserve takeover, return-to-AI, manual human reply, message labeling, translation cleanup, and composer ownership behavior
- align Safari cache-bust with the new lifecycle shell
- add fail-closed regression tests for chat lifecycle ownership and behavior

## Verification
- base/main remained `07273928ebc7c909313e592976617d3e831cd4e7`
- final head `b862e3575c3cdbba1c51a1b586ba2351a91187ac`
- GitHub DABBIR CI `test` passed
- Vercel fail-closed gate: 921 tests passed, 0 failed
- Vercel Preview `dpl_eGQnUpdkCfnbhwAqrPJbrDC4MXEn` READY in `bom1`
- Preview `/` returned HTTP 200 with `afterChats`, `afterMessages`, and cache-bust `20260903-chat-render-lifecycle-v3`
- Preview `/api/chat-human-ui` returned HTTP 200 with `x-dabbir-chat-ui: v3-lifecycle`
- human chat endpoint contains lifecycle subscriptions for message/chat/render/language updates and no feature-owned global render wrappers or MutationObserver

## Safety
No chat-control API, WhatsApp provider flow, message persistence, database schema, AI behavior, or permissions changed. This is UI render ownership only.