### PR TITLE
Improve DABBIR chat readability and iPhone touch targets

### DIFF
--- a/api/chat-human-ui.js
+++ b/api/chat-human-ui.js
@@ -3,59 +3,63 @@ const script=String.raw`(()=>{
   window.__dabbirHumanChatUiLoaded=true;
 
   const style=document.createElement('style');
-  style.dataset.dabbirChatUi='v3';
+  style.dataset.dabbirChatUi='v3-readable';
   style.textContent=[
     '#newChatBtn{display:none!important}',
     '.dabbirChatControl{display:flex;align-items:center;gap:8px;flex-wrap:wrap}',
-    '.dabbirOwnerChip{display:inline-flex;align-items:center;gap:6px;border-radius:999px;padding:6px 9px;font-size:9px;font-weight:900;border:1px solid #31363c;background:#171a1d;color:#c8cdd3}',
-    '.dabbirOwnerChip:before{content:"";width:6px;height:6px;border-radius:50%;background:currentColor;opacity:.9}',
+    '.dabbirOwnerChip{display:inline-flex;align-items:center;gap:7px;border-radius:999px;padding:8px 10px;font-size:12px;line-height:1.4;font-weight:900;border:1px solid #31363c;background:#171a1d;color:#c8cdd3}',
+    '.dabbirOwnerChip:before{content:"";width:7px;height:7px;border-radius:50%;background:currentColor;opacity:.9;flex:0 0 7px}',
     '.dabbirOwnerChip.ai{border-color:#3d4b27;background:#202918;color:#bfe977}',
     '.dabbirOwnerChip.human{border-color:#244a66;background:#132737;color:#9bd2ff}',
     '.dabbirOwnerChip.action{border-color:#665527;background:#332b16;color:#ffd87a}',
-    '.dabbirTakeover{min-height:38px!important;padding:7px 11px!important;border-radius:11px!important;font-size:9px!important;white-space:nowrap}',
+    '.dabbirTakeover{min-height:44px!important;padding:9px 12px!important;border-radius:11px!important;font-size:12px!important;line-height:1.35!important;white-space:nowrap}',
     '.dabbirTakeover.take{border:1px solid #52652c;background:#26331a;color:#d7ff5f;font-weight:900}',
     '.dabbirTakeover.return{border:1px solid #35546b;background:#172b3a;color:#b6dcff;font-weight:900}',
     '#screen-conversations .chatPanel{background:linear-gradient(180deg,#111315,#0d0f11)}',
     '#screen-conversations .chatHead{background:#121416}',
-    '#screen-conversations #translateAll{border:1px solid #30363d!important;background:#181b1f!important;color:#d8dde2!important;border-radius:10px!important;font-size:9px!important;padding:7px 10px!important;min-height:38px!important}',
+    '#screen-conversations #translateAll{border:1px solid #30363d!important;background:#181b1f!important;color:#d8dde2!important;border-radius:10px!important;font-size:12px!important;padding:9px 11px!important;min-height:44px!important}',
     '#screen-conversations .messages{scrollbar-width:thin;scrollbar-color:#31363c transparent}',
     '#screen-conversations .msgrow{margin:12px 0}',
     '#screen-conversations .bubble{max-width:min(78%,560px);box-shadow:none}',
-    '#screen-conversations .bubble .body{font-size:12px;line-height:1.65}',
-    '#screen-conversations .bubble .original{font-size:9px;line-height:1.55;opacity:.72}',
-    '#screen-conversations .meta{margin-top:6px;gap:5px}',
-    '#screen-conversations .meta button{min-height:26px!important;padding:2px 4px!important;font-size:8px!important}',
+    '#screen-conversations .bubble .body{font-size:13px;line-height:1.65}',
+    '#screen-conversations .bubble .original{font-size:11px;line-height:1.55;opacity:.78}',
+    '#screen-conversations .meta{margin-top:7px;gap:6px;font-size:11px;line-height:1.4}',
+    '#screen-conversations .meta button{min-height:44px!important;padding:6px 7px!important;font-size:11px!important}',
     '.compose.dabbirHumanLocked{opacity:1!important;background:#0f1210;border-top-color:#242a22!important}',
-    '.compose.dabbirHumanLocked input{cursor:not-allowed;background:#141814!important;border-color:#252d22!important;color:#8c9584!important;text-align:center;font-size:10px}',
+    '.compose.dabbirHumanLocked input{cursor:not-allowed;background:#141814!important;border-color:#252d22!important;color:#a7b09e!important;text-align:center;font-size:12px}',
     '.compose.dabbirHumanLocked #sendBtn{display:none!important}',
-    '.dabbirSenderLabel{font-size:8px;font-weight:900;margin:0 5px 4px;color:#8f969e;letter-spacing:.01em}',
+    '.dabbirSenderLabel{font-size:11px;line-height:1.4;font-weight:900;margin:0 6px 5px;color:#9ba2aa;letter-spacing:.01em}',
     '.msgrow.customer .bubble{margin-right:auto!important;margin-left:0!important;background:#191c20!important;border-color:#30353b!important}',
-    '.msgrow.customer .dabbirSenderLabel{margin-right:auto!important;margin-left:5px!important}',
+    '.msgrow.customer .dabbirSenderLabel{margin-right:auto!important;margin-left:6px!important}',
     '.msgrow.ai .bubble{margin-left:auto!important;margin-right:0!important;background:#202817!important;border-color:#3a4827!important}',
-    '.msgrow.ai .dabbirSenderLabel{margin-left:auto!important;margin-right:5px!important;color:#b9de7d}',
+    '.msgrow.ai .dabbirSenderLabel{margin-left:auto!important;margin-right:6px!important;color:#b9de7d}',
     '.msgrow.human .bubble{margin-left:auto!important;margin-right:0!important;background:#162735!important;border-color:#2e526c!important}',
-    '.msgrow.human .dabbirSenderLabel{margin-left:auto!important;margin-right:5px!important;color:#9bcaff}',
+    '.msgrow.human .dabbirSenderLabel{margin-left:auto!important;margin-right:6px!important;color:#9bcaff}',
     '@media(max-width:700px){'+
       '#screen-conversations .chatGrid{margin-top:0!important}'+
       '#screen-conversations .chatList{max-height:132px!important;margin-bottom:8px!important;border-radius:14px!important}'+
       '#screen-conversations .chatPanel{height:calc(100dvh - 238px);min-height:500px;border-radius:16px!important;overflow:hidden}'+
       '#screen-conversations .chatHead{display:grid!important;grid-template-columns:minmax(0,1fr) auto!important;gap:8px!important;align-items:center!important;padding:10px!important}'+
       '#screen-conversations .chatHead>.grow{grid-column:1;grid-row:1;min-width:0}'+
-      '#screen-conversations .chatHead>.grow b,#screen-conversations #chatName{font-size:12px!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}'+
-      '#screen-conversations #chatState{font-size:8px!important;color:#858c94!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}'+
-      '#screen-conversations #translateAll{grid-column:2;grid-row:1;min-height:38px!important;padding:6px 9px!important;white-space:nowrap}'+
+      '#screen-conversations .chatHead>.grow b,#screen-conversations #chatName{font-size:14px!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}'+
+      '#screen-conversations #chatState{font-size:11px!important;line-height:1.4!important;color:#9aa2ab!important;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}'+
+      '#screen-conversations #translateAll{grid-column:2;grid-row:1;min-height:44px!important;padding:8px 10px!important;font-size:12px!important;white-space:nowrap}'+
       '#screen-conversations .dabbirChatControl{grid-column:1/-1;grid-row:2;width:100%;display:grid!important;grid-template-columns:minmax(0,1fr) auto;gap:7px;align-items:center}'+
-      '#screen-conversations .dabbirOwnerChip{max-width:none!important;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:6px 8px;font-size:8px}'+
-      '#screen-conversations .dabbirTakeover{min-height:36px!important;padding:6px 9px!important;font-size:8px!important}'+
+      '#screen-conversations .dabbirOwnerChip{max-width:none!important;min-width:0;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;padding:8px 9px;font-size:11px}'+
+      '#screen-conversations .dabbirTakeover{min-height:44px!important;padding:8px 10px!important;font-size:12px!important}'+
       '#screen-conversations .messages{min-height:0!important;padding:11px 9px 14px!important}'+
       '#screen-conversations .msgrow{margin:10px 0!important}'+
-      '#screen-conversations .bubble{max-width:84%!important;border-radius:15px!important;padding:9px 10px!important}'+
-      '#screen-conversations .bubble .body{font-size:13px!important;line-height:1.58!important}'+
+      '#screen-conversations .bubble{max-width:84%!important;border-radius:15px!important;padding:10px 11px!important}'+
+      '#screen-conversations .bubble .body{font-size:14px!important;line-height:1.58!important}'+
+      '#screen-conversations .bubble .original{font-size:12px!important;line-height:1.5!important}'+
+      '#screen-conversations .meta{font-size:11px!important}'+
+      '#screen-conversations .meta button{min-height:44px!important;font-size:11px!important;padding:6px 8px!important}'+
+      '#screen-conversations .dabbirSenderLabel{font-size:11px!important}'+
       '#screen-conversations .compose{padding:8px!important;gap:7px!important;background:#101214}'+
       '#screen-conversations .compose input{min-height:46px!important;border-radius:12px!important;font-size:16px!important}'+
       '#screen-conversations .send{width:46px!important;min-width:46px!important;height:46px!important;border-radius:12px!important}'+
-      '#screen-conversations .compose.dabbirHumanLocked input{font-size:10px!important;min-height:42px!important}'+
-      '#screen-conversations+.truth,#screen-conversations .truth{font-size:8px!important;line-height:1.55!important;padding:9px 10px!important;margin-top:8px!important}'+
+      '#screen-conversations .compose.dabbirHumanLocked input{font-size:13px!important;min-height:46px!important}'+
+      '#screen-conversations+.truth,#screen-conversations .truth{font-size:12px!important;line-height:1.55!important;padding:10px 11px!important;margin-top:8px!important}'+
     '}'
   ].join('');
   document.head.appendChild(style);
@@ -274,6 +278,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-chat-ui','v3-lifecycle');
+  res.setHeader('x-dabbir-chat-ui','v3-lifecycle-readable');
   return res.end(script);
 }

--- a/test/dabbir-chat-render-lifecycle.test.mjs
+++ b/test/dabbir-chat-render-lifecycle.test.mjs
@@ -37,5 +37,17 @@ test('human takeover and manual reply behavior remains present after lifecycle m
   assert.match(human,/await chatControl\('human_message',message\)/);
   assert.match(human,/conversation\.state!=='human_active'/);
   assert.match(human,/window\.__dabbirHumanChatUiVersion='v3-lifecycle'/);
-  assert.match(human,/x-dabbir-chat-ui','v3-lifecycle'/);
+  assert.match(human,/x-dabbir-chat-ui','v3-lifecycle-readable'/);
+});
+
+test('chat status labels and actions remain readable and tappable on iPhone',()=>{
+  assert.match(human,/\.dabbirOwnerChip\{[^}]*font-size:12px/);
+  assert.match(human,/\.dabbirTakeover\{[^}]*min-height:44px!important[^}]*font-size:12px!important/);
+  assert.match(human,/#screen-conversations #translateAll\{[^}]*font-size:12px!important[^}]*min-height:44px!important/);
+  assert.match(human,/#screen-conversations \.meta button\{[^}]*min-height:44px!important[^}]*font-size:11px!important/);
+  assert.match(human,/\.dabbirSenderLabel\{font-size:11px/);
+  assert.match(human,/#screen-conversations #chatState\{font-size:11px!important/);
+  assert.match(human,/#screen-conversations\+\.truth,#screen-conversations \.truth\{font-size:12px!important/);
+  assert.doesNotMatch(human,/\.dabbirTakeover\{[^}]*min-height:(?:36|38)px/);
+  assert.doesNotMatch(human,/#screen-conversations #translateAll\{[^}]*min-height:38px/);
 });


### PR DESCRIPTION
## Why
After the chat lifecycle migration, the conversation UI still contained several micro-text and undersized action controls: 8–10px status/metadata labels and 26–38px translation/takeover targets. Those are difficult to read and tap reliably on iPhone.

## Changes
- raise chat ownership/status chips to readable 11–12px text
- make takeover/return-to-DABBIR controls at least 44px tall
- make conversation translation and per-message translation actions at least 44px tall
- raise sender labels, translated-original text, metadata and mobile chat state text
- raise mobile message body to 14px and truth notice to 12px
- keep composer input at iOS-safe 16px in active mode and improve locked-state readability
- preserve the central chat lifecycle ownership introduced in #374
- add regression tests preventing 36/38px chat controls from returning

## Verification
- base/main remained `87f4bd5077b8c4d0485cb9ebc4cb11ad56ea4380`
- final head `5f98c15f81db654aad4dfcd11e552baee42ae458`
- GitHub DABBIR CI `test` passed
- Vercel fail-closed gate: 922 tests passed, 0 failed
- Vercel Preview `dpl_4Q3LZMrBJaE1VW2iAbncqZz9euux` READY in `bom1`
- Preview `/api/chat-human-ui` returned HTTP 200 with `x-dabbir-chat-ui: v3-lifecycle-readable`
- served CSS confirms 44px takeover/translation targets, 11–12px status/metadata text, 14px mobile message body, and 12px truth notice

## Safety
Presentation-only change. No message persistence, WhatsApp provider flow, takeover API, AI behavior, permissions, or database logic changed.