### PR TITLE
Make native DABBIR GCC-aware end to end

### DIFF
--- a/api/mobile/runtime.js
+++ b/api/mobile/runtime.js
@@ -1,14 +1,152 @@
-import { accessTokenFromRequest, getVerifiedUser, json } from '../_auth-core.js';
+import { accessTokenFromRequest, getVerifiedUser, json, readJsonBody, supabaseRest, supabaseRpc } from '../_auth-core.js';
 import runtimeHandler from '../dabbir-runtime-fast.js';
 import { requireNativeBearer } from './_native-core.js';
 
-export default async function handler(req, res) {
-  if (!['GET', 'POST'].includes(req.method)) return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET, POST' });
-  if (!requireNativeBearer(req, res)) return;
+const BUSINESS_TYPES=new Set(['store','laundry','car_wash','clinic','creator','salon','real_estate','services','other']);
+const GCC=Object.freeze({
+  AE:{currency:'AED',timezone:'Asia/Dubai',prefix:'+971',offset:'+04:00'},
+  SA:{currency:'SAR',timezone:'Asia/Riyadh',prefix:'+966',offset:'+03:00'},
+  KW:{currency:'KWD',timezone:'Asia/Kuwait',prefix:'+965',offset:'+03:00'},
+  QA:{currency:'QAR',timezone:'Asia/Qatar',prefix:'+974',offset:'+03:00'},
+  BH:{currency:'BHD',timezone:'Asia/Bahrain',prefix:'+973',offset:'+03:00'},
+  OM:{currency:'OMR',timezone:'Asia/Muscat',prefix:'+968',offset:'+04:00'},
+});
+const clean=(value,max=120)=>String(value??'').trim().slice(0,max);
+const enc=value=>encodeURIComponent(String(value));
 
-  const token = accessTokenFromRequest(req);
-  const user = token ? await getVerifiedUser(token).catch(() => null) : null;
-  if (!user) return json(res, 401, { ok: false, authenticated: false, error: 'AUTH_REQUIRED' });
+async function parse(response,fallback){
+  const text=await response.text();let data=null;
+  try{data=text?JSON.parse(text):null}catch{}
+  if(!response.ok){const error=new Error(fallback);error.status=response.status;error.detail=data?.code||data?.message||null;throw error}
+  return data;
+}
 
-  return runtimeHandler(req, res);
+async function exactCount(response,fallback){
+  if(!response.ok)return parse(response,fallback);
+  const range=String(response.headers.get('content-range')||'');
+  const raw=range.includes('/')?range.slice(range.lastIndexOf('/')+1):'';
+  const total=Number(raw);
+  await response.text().catch(()=>{});
+  if(!Number.isSafeInteger(total)||total<0)throw Object.assign(new Error(`${fallback}_UNVERIFIED`),{status:502});
+  return total;
+}
+
+function localDay(profile,now=new Date()){
+  const config=GCC[profile?.country_code];
+  if(!config||profile?.timezone!==config.timezone)throw Object.assign(new Error('BUSINESS_GCC_TIMEZONE_UNVERIFIED'),{status:502});
+  const parts=Object.fromEntries(new Intl.DateTimeFormat('en-CA',{timeZone:config.timezone,year:'numeric',month:'2-digit',day:'2-digit'}).formatToParts(now).filter(part=>part.type!=='literal').map(part=>[part.type,part.value]));
+  const dateKey=`${parts.year}-${parts.month}-${parts.day}`;
+  const start=new Date(`${dateKey}T00:00:00${config.offset}`);
+  if(Number.isNaN(start.getTime()))throw Object.assign(new Error('BUSINESS_LOCAL_DAY_FAILED'),{status:502});
+  return {dateKey,start:start.toISOString(),end:new Date(start.getTime()+86400000).toISOString()};
+}
+
+function captureFastRuntime(req){
+  return new Promise((resolve,reject)=>{
+    const headers=new Map();let settled=false;
+    const proxy={
+      statusCode:200,
+      setHeader(name,value){headers.set(String(name).toLowerCase(),value);return proxy},
+      getHeader(name){return headers.get(String(name).toLowerCase())},
+      removeHeader(name){headers.delete(String(name).toLowerCase())},
+      end(body=''){
+        if(!settled){settled=true;resolve({statusCode:proxy.statusCode,headers,body:String(body??'')})}
+        return proxy;
+      },
+    };
+    Promise.resolve(runtimeHandler(req,proxy)).then(()=>{if(!settled)reject(new Error('FAST_RUNTIME_NO_RESPONSE'))}).catch(reject);
+  });
+}
+
+function forwardCaptured(res,captured,payload=null){
+  res.statusCode=Number(captured.statusCode||200);
+  for(const [name,value] of captured.headers.entries()){
+    if(name==='content-length'||name==='transfer-encoding')continue;
+    res.setHeader(name,value);
+  }
+  res.setHeader('x-dabbir-mobile-gcc-authority','v1');
+  return res.end(payload==null?captured.body:JSON.stringify(payload));
+}
+
+async function enrichNativeGet(req,res,token){
+  try{
+    const captured=await captureFastRuntime(req);
+    if(Number(captured.statusCode)!==200)return forwardCaptured(res,captured);
+    let payload=null;
+    try{payload=captured.body?JSON.parse(captured.body):null}catch{return forwardCaptured(res,captured)}
+    const businessId=clean(payload?.business?.id,64);
+    if(!businessId)return forwardCaptured(res,captured,payload);
+
+    const rows=await parse(await supabaseRest(
+      `dabbir_businesses?select=id,slug,name,business_type,locale,demo_mode,country_code,currency_code,timezone,phone_country_prefix,vat_status,default_vat_rate,created_at,updated_at&id=eq.${enc(businessId)}&limit=1`,
+      token,
+    ),'BUSINESS_PROFILE_LOOKUP_FAILED');
+    const business=Array.isArray(rows)?rows[0]:null;
+    const config=GCC[business?.country_code];
+    if(!business?.id||!config||business.currency_code!==config.currency||business.timezone!==config.timezone||business.phone_country_prefix!==config.prefix){
+      return json(res,502,{ok:false,error:'BUSINESS_GCC_PROFILE_UNVERIFIED'});
+    }
+
+    const day=localDay(business);
+    const todayAppointments=await exactCount(await supabaseRest(
+      `dabbir_appointments?select=id&business_id=eq.${enc(businessId)}&starts_at=gte.${enc(day.start)}&starts_at=lt.${enc(day.end)}&simulated=eq.false&limit=1`,
+      token,
+      {headers:{prefer:'count=exact'}},
+    ),'TODAY_APPOINTMENTS_COUNT_FAILED');
+
+    payload.business={...(payload.business||{}),...business};
+    payload.business_profile={country_code:business.country_code,currency_code:business.currency_code,timezone:business.timezone,phone_country_prefix:business.phone_country_prefix,vat_status:business.vat_status,default_vat_rate:business.default_vat_rate};
+    if(payload.verified_metrics&&typeof payload.verified_metrics==='object')payload.verified_metrics={...payload.verified_metrics,time_zone:business.timezone,date_key:day.dateKey,today_appointments:todayAppointments,country_code:business.country_code,currency_code:business.currency_code};
+    payload.data_truth={...(payload.data_truth||{}),mobile_gcc_profile_verified:true,mobile_local_day_verified:true};
+    payload.performance={...(payload.performance||{}),mobile_gcc_authority:true};
+    return forwardCaptured(res,captured,payload);
+  }catch(error){
+    const status=[400,401,403,404,409,413,422,429,502,503,504].includes(Number(error?.status))?Number(error.status):500;
+    return json(res,status,{ok:false,error:String(error?.message||'NATIVE_RUNTIME_GCC_ENRICH_FAILED').slice(0,120),detail:error?.detail||null});
+  }
+}
+
+async function createNativeBusiness(req,res,token){
+  try{
+    const body=await readJsonBody(req,8192);
+    if(clean(body?.action,60)!=='create_business')return json(res,400,{ok:false,error:'UNSUPPORTED_NATIVE_RUNTIME_ACTION'});
+    const name=clean(body?.name,120);
+    const businessType=clean(body?.business_type,40).toLowerCase();
+    const countryCode=clean(body?.country_code||'AE',2).toUpperCase();
+    const language=String(body?.locale||'ar').toLowerCase().startsWith('en')?'en':'ar';
+    if(!name)return json(res,400,{ok:false,error:'BUSINESS_NAME_REQUIRED'});
+    if(!BUSINESS_TYPES.has(businessType))return json(res,400,{ok:false,error:'UNSUPPORTED_BUSINESS_TYPE'});
+    if(!GCC[countryCode])return json(res,400,{ok:false,error:'UNSUPPORTED_GCC_COUNTRY'});
+    const locale=`${language}-${countryCode}`;
+    const created=await parse(await supabaseRpc('dabbir_create_business',token,{
+      p_name:name,p_business_type:businessType,p_locale:locale,p_country_code:countryCode,
+    }),'BUSINESS_CREATE_FAILED');
+    const businessId=Array.isArray(created)?created[0]?.business_id:created?.business_id;
+    if(!businessId)return json(res,502,{ok:false,error:'BUSINESS_CREATE_UNVERIFIED'});
+    const rows=await parse(await supabaseRest(
+      `dabbir_businesses?select=id,slug,name,business_type,locale,demo_mode,country_code,currency_code,timezone,phone_country_prefix,vat_status,default_vat_rate,created_at,updated_at&id=eq.${enc(businessId)}&limit=1`,
+      token,
+    ),'BUSINESS_PROFILE_VERIFY_FAILED');
+    const business=Array.isArray(rows)?rows[0]:null;
+    const expected=GCC[countryCode];
+    if(!business?.id||business.country_code!==countryCode||business.currency_code!==expected.currency||business.timezone!==expected.timezone||business.phone_country_prefix!==expected.prefix){
+      return json(res,502,{ok:false,error:'BUSINESS_COUNTRY_PROFILE_UNVERIFIED',business_id:businessId});
+    }
+    return json(res,200,{ok:true,action:'create_business',state:'VERIFIED_PERSISTED',business_id:businessId,verified_persisted:true,business,country_profile:{country_code:business.country_code,currency_code:business.currency_code,timezone:business.timezone,phone_country_prefix:business.phone_country_prefix,vat_status:business.vat_status,default_vat_rate:business.default_vat_rate},truth:{state:'VERIFIED',source:'SUPABASE_RETURN_AND_READBACK',entity:'business',entity_id:businessId,verified_at:new Date().toISOString()}});
+  }catch(error){
+    const status=[400,401,403,404,409,413,422,429,502,503].includes(Number(error?.status))?Number(error.status):500;
+    return json(res,status,{ok:false,error:String(error?.message||'NATIVE_BUSINESS_CREATE_FAILED').slice(0,120),detail:error?.detail||null});
+  }
+}
+
+export default async function handler(req,res){
+  if (!['GET', 'POST'].includes(req.method)) return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET, POST'});
+  if(!requireNativeBearer(req,res))return;
+
+  const token=accessTokenFromRequest(req);
+  const user=token?await getVerifiedUser(token).catch(()=>null):null;
+  if(!user)return json(res,401,{ok:false,authenticated:false,error:'AUTH_REQUIRED'});
+
+  if(req.method==='POST')return createNativeBusiness(req,res,token);
+  return enrichNativeGet(req,res,token);
 }

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -1,4 +1,5 @@
 import type { DabbirSession } from './session';
+import { isGccCountryCode, resolveSelectedCountry, saveSelectedCountry, type GccCountryCode } from './country';
 
 const configuredBase = String(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL || '').trim().replace(/\/$/, '');
 
@@ -72,17 +73,35 @@ export async function loadRuntime(accessToken: string): Promise<any> {
   const response = await fetch(`${apiBase()}/api/mobile/runtime?summary=1`, {
     headers: { accept: 'application/json', authorization: `Bearer ${accessToken}` },
   });
-  return parseJson(response);
+  const payload = await parseJson(response);
+  const countryCode = String(payload?.business?.country_code || '').toUpperCase();
+  if (isGccCountryCode(countryCode)) await saveSelectedCountry(countryCode).catch(() => undefined);
+  return payload;
 }
 
 export type DabbirBusinessType = 'store' | 'laundry' | 'car_wash';
+export type DabbirLocale = `${'ar' | 'en'}-${GccCountryCode}`;
+export type { GccCountryCode } from './country';
 
-export async function createBusiness(accessToken: string, name: string, businessType: DabbirBusinessType, locale: 'ar-AE' | 'en-AE'): Promise<any> {
-  return post('/api/mobile/runtime', { action: 'create_business', name, business_type: businessType, locale }, accessToken);
+async function resolvedCountry(explicit?: GccCountryCode): Promise<GccCountryCode> {
+  if (explicit && isGccCountryCode(explicit)) return explicit;
+  return resolveSelectedCountry();
 }
 
-export async function createStore(accessToken: string, name: string, locale: 'ar-AE' | 'en-AE'): Promise<any> {
-  return post('/api/mobile/runtime', { action: 'create_business', name, business_type: 'store', locale }, accessToken);
+export async function createBusiness(accessToken: string, name: string, businessType: DabbirBusinessType, locale: DabbirLocale | 'ar-AE' | 'en-AE', countryCode?: GccCountryCode): Promise<any> {
+  const resolved = await resolvedCountry(countryCode);
+  const language = String(locale || '').toLowerCase().startsWith('en') ? 'en' : 'ar';
+  const payload = await post('/api/mobile/runtime', { action: 'create_business', name, business_type: businessType, locale: `${language}-${resolved}`, country_code: resolved }, accessToken);
+  await saveSelectedCountry(resolved).catch(() => undefined);
+  return payload;
+}
+
+export async function createStore(accessToken: string, name: string, locale: DabbirLocale | 'ar-AE' | 'en-AE', countryCode?: GccCountryCode): Promise<any> {
+  const resolved = await resolvedCountry(countryCode);
+  const language = String(locale || '').toLowerCase().startsWith('en') ? 'en' : 'ar';
+  const payload = await post('/api/mobile/runtime', { action: 'create_business', name, business_type: 'store', locale: `${language}-${resolved}`, country_code: resolved }, accessToken);
+  await saveSelectedCountry(resolved).catch(() => undefined);
+  return payload;
 }
 
 export async function deleteDabbirAccount(accessToken: string): Promise<any> {

--- a/mobile/src/country.ts
+++ b/mobile/src/country.ts
@@ -1,0 +1,43 @@
+import * as SecureStore from 'expo-secure-store';
+import { getLocales } from 'expo-localization';
+
+export type GccCountryCode = 'AE' | 'SA' | 'KW' | 'QA' | 'BH' | 'OM';
+
+export const GCC_COUNTRIES: ReadonlyArray<{ code: GccCountryCode; ar: string; en: string; currency: string; timezone: string; prefix: string }> = [
+  { code: 'AE', ar: 'الإمارات', en: 'United Arab Emirates', currency: 'AED', timezone: 'Asia/Dubai', prefix: '+971' },
+  { code: 'SA', ar: 'السعودية', en: 'Saudi Arabia', currency: 'SAR', timezone: 'Asia/Riyadh', prefix: '+966' },
+  { code: 'KW', ar: 'الكويت', en: 'Kuwait', currency: 'KWD', timezone: 'Asia/Kuwait', prefix: '+965' },
+  { code: 'QA', ar: 'قطر', en: 'Qatar', currency: 'QAR', timezone: 'Asia/Qatar', prefix: '+974' },
+  { code: 'BH', ar: 'البحرين', en: 'Bahrain', currency: 'BHD', timezone: 'Asia/Bahrain', prefix: '+973' },
+  { code: 'OM', ar: 'عُمان', en: 'Oman', currency: 'OMR', timezone: 'Asia/Muscat', prefix: '+968' },
+];
+
+const COUNTRY_KEY = 'dabbir.country.v1';
+const VALID = new Set<GccCountryCode>(GCC_COUNTRIES.map(item => item.code));
+
+export function isGccCountryCode(value: unknown): value is GccCountryCode {
+  return VALID.has(String(value || '').toUpperCase() as GccCountryCode);
+}
+
+export function inferDeviceCountry(): GccCountryCode {
+  const region = String(getLocales()[0]?.regionCode || '').toUpperCase();
+  return isGccCountryCode(region) ? region : 'AE';
+}
+
+export async function loadSelectedCountry(): Promise<GccCountryCode | null> {
+  const raw = String(await SecureStore.getItemAsync(COUNTRY_KEY) || '').toUpperCase();
+  return isGccCountryCode(raw) ? raw : null;
+}
+
+export async function resolveSelectedCountry(): Promise<GccCountryCode> {
+  return (await loadSelectedCountry()) || inferDeviceCountry();
+}
+
+export async function saveSelectedCountry(country: GccCountryCode): Promise<void> {
+  if (!isGccCountryCode(country)) throw new Error('UNSUPPORTED_GCC_COUNTRY');
+  await SecureStore.setItemAsync(COUNTRY_KEY, country, { keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY });
+}
+
+export function countryProfile(country: GccCountryCode) {
+  return GCC_COUNTRIES.find(item => item.code === country) || GCC_COUNTRIES[0];
+}

--- a/test/dabbir-native-gcc-authority.test.mjs
+++ b/test/dabbir-native-gcc-authority.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const read = relative => fs.readFileSync(path.join(root, relative), 'utf8');
+
+test('native country authority covers every GCC state and infers the iPhone region only when no persisted choice exists', () => {
+  const source = read('mobile/src/country.ts');
+  for (const token of ["'AE'", "'SA'", "'KW'", "'QA'", "'BH'", "'OM'", 'AED', 'SAR', 'KWD', 'QAR', 'BHD', 'OMR', 'Asia/Dubai', 'Asia/Riyadh', 'Asia/Kuwait', 'Asia/Qatar', 'Asia/Bahrain', 'Asia/Muscat', '+971', '+966', '+965', '+974', '+973', '+968']) {
+    assert.match(source, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(source, /getLocales\(\)\[0\]\?\.regionCode/);
+  assert.match(source, /return \(await loadSelectedCountry\(\)\) \|\| inferDeviceCountry\(\)/);
+  assert.match(source, /WHEN_UNLOCKED_THIS_DEVICE_ONLY/);
+});
+
+test('native onboarding sends the resolved GCC country instead of trusting the legacy AE locale suffix', () => {
+  const source = read('mobile/src/api.ts');
+  assert.match(source, /resolveSelectedCountry/);
+  assert.match(source, /country_code: resolved/);
+  assert.match(source, /locale: `\$\{language\}-\$\{resolved\}`/);
+  assert.match(source, /business_type: 'store'/);
+  assert.match(source, /saveSelectedCountry\(countryCode\)/);
+});
+
+test('native server verifies persisted country currency timezone and phone prefix and uses the business local day', () => {
+  const source = read('api/mobile/runtime.js');
+  for (const token of ['BUSINESS_COUNTRY_PROFILE_UNVERIFIED', 'BUSINESS_GCC_PROFILE_UNVERIFIED', 'BUSINESS_LOCAL_DAY_FAILED', 'country_code,currency_code,timezone,phone_country_prefix', 'today_appointments:todayAppointments', 'mobile_local_day_verified:true', "p_country_code:countryCode"]) {
+    assert.match(source, new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+  assert.match(source, /simulated=eq\.false/);
+  assert.match(source, /time_zone:business\.timezone/);
+  assert.match(source, /currency_code:business\.currency_code/);
+  assert.match(source, /x-dabbir-mobile-gcc-authority/);
+});


### PR DESCRIPTION
Superseded by #386. Main advanced with calendar durability and historical-booking fixes while #376 was waiting on protected merge checks. #386 reapplies the exact four tested GCC-native blobs on top of the latest main without force-updating the old branch.