### PR TITLE
Fix store item form and stale service ownership

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
+const UI_CACHE_BUST = '20260903-store-item-form-v1';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,6 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 
-const UI_CACHE_BUST = '20260903-store-item-form-v1';
+const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -8,18 +8,20 @@ const script=String.raw`(()=>{
   const text=()=>ar()?{
     nav:'العمليات',title:'مركز العمليات',desc:'السلع والمخزون والطلبات من بيانات نشاطك الفعلية.',
     products:'السلع',stock:'المخزون',available:'المتاح',low:'مخزون منخفض',orders:'الطلبات',sales:'المبيعات المؤكدة',
-    add:'إضافة سلعة',name:'اسم السلعة',price:'القيمة',qty:'الكمية',reserved:'محجوز',status:'الحالة',customer:'العميل',date:'التاريخ',
+    add:'إضافة سلعة',edit:'تعديل',delete:'حذف',editTitle:'تعديل السلعة',name:'اسم السلعة',price:'القيمة',qty:'الكمية',status:'الحالة',customer:'العميل',date:'التاريخ',
     noProducts:'لا توجد سلع بعد.',noOrders:'لا توجد طلبات فعلية بعد.',lowTitle:'تحتاج انتباه',lowNone:'لا يوجد نقص مخزون حاليًا.',
-    simulated:'الطلبات التجريبية مستبعدة من المبيعات.',save:'حفظ',cancel:'إلغاء',editStock:'تعديل المخزون',update:'تحديث',
-    created:'تمت إضافة السلعة.',updated:'تم تحديث المخزون.',orderUpdated:'تم تحديث حالة الطلب.',failed:'تعذر إكمال العملية.',
+    simulated:'الطلبات التجريبية مستبعدة من المبيعات.',save:'حفظ',cancel:'إلغاء',update:'تحديث',
+    created:'تمت إضافة السلعة.',itemUpdated:'تم تعديل السلعة.',itemDeleted:'تم حذف السلعة.',orderUpdated:'تم تحديث حالة الطلب.',failed:'تعذر إكمال العملية.',
+    deleteConfirm:'هل تريد حذف هذه السلعة من النشاط؟',reservedDelete:'لا يمكن حذف السلعة لأن لها كمية محجوزة.',reservedQty:'الكمية لا يمكن أن تكون أقل من الكمية المحجوزة.',
     draft:'مسودة',reservedStatus:'محجوز',confirmed:'مؤكد',cancelled:'ملغي',completed:'مكتمل',loading:'جارٍ تحميل العمليات...'
   }:{
     nav:'Operations',title:'Owner operations',desc:'Items, inventory, and orders from your real business data.',
     products:'Items',stock:'Inventory',available:'Available',low:'Low stock',orders:'Orders',sales:'Recognized sales',
-    add:'Add item',name:'Item name',price:'Value',qty:'Quantity',reserved:'Reserved',status:'Status',customer:'Customer',date:'Date',
+    add:'Add item',edit:'Edit',delete:'Delete',editTitle:'Edit item',name:'Item name',price:'Value',qty:'Quantity',status:'Status',customer:'Customer',date:'Date',
     noProducts:'No items yet.',noOrders:'No real orders yet.',lowTitle:'Needs attention',lowNone:'No low-stock items right now.',
-    simulated:'Simulated orders are excluded from recognized sales.',save:'Save',cancel:'Cancel',editStock:'Edit inventory',update:'Update',
-    created:'Item added.',updated:'Inventory updated.',orderUpdated:'Order status updated.',failed:'Operation failed.',
+    simulated:'Simulated orders are excluded from recognized sales.',save:'Save',cancel:'Cancel',update:'Update',
+    created:'Item added.',itemUpdated:'Item updated.',itemDeleted:'Item deleted.',orderUpdated:'Order status updated.',failed:'Operation failed.',
+    deleteConfirm:'Delete this item from the business?',reservedDelete:'This item cannot be deleted while stock is reserved.',reservedQty:'Quantity cannot be lower than reserved stock.',
     draft:'Draft',reservedStatus:'Reserved',confirmed:'Confirmed',cancelled:'Cancelled',completed:'Completed',loading:'Loading operations...'
   };
 
@@ -30,21 +32,24 @@ const script=String.raw`(()=>{
     '.opsMetric span{display:block;color:var(--muted);font-size:12px;line-height:1.45}.opsMetric strong{display:block;font-size:22px;margin-top:6px}',
     '.opsGrid{display:grid;grid-template-columns:1fr 1fr;gap:12px}',
     '.opsTable{border:1px solid var(--line);border-radius:16px;overflow:hidden;background:#111315}',
-    '.opsRow{display:grid;grid-template-columns:minmax(130px,1.5fr) .8fr .7fr .7fr auto;gap:8px;align-items:center;padding:11px;border-bottom:1px solid #24282d;font-size:12px;line-height:1.45}',
+    '.opsRow{display:grid;grid-template-columns:minmax(130px,1.5fr) .8fr .7fr minmax(128px,auto);gap:8px;align-items:center;padding:11px;border-bottom:1px solid #24282d;font-size:12px;line-height:1.45}',
     '.opsRow:last-child{border-bottom:0}.opsRow.head{color:var(--muted);background:#15181b;font-size:11px;font-weight:800}',
     '.opsOrderRow{grid-template-columns:minmax(120px,1.2fr) .9fr .8fr .8fr}',
-    '.opsName b{display:block;font-size:13px}.opsName small{color:var(--muted);font-size:11px;line-height:1.4}',
+    '.opsName b{display:block;font-size:13px}',
     '.opsLow{border:1px solid #5b4b20;background:#2b2516;border-radius:14px;padding:11px;margin-bottom:12px;color:#f4d991;font-size:12px;line-height:1.55}',
+    '.opsActions{display:flex;gap:6px;justify-content:flex-end;flex-wrap:wrap}',
     '.opsAction{border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:8px 10px;min-height:44px;font-size:12px;font-weight:800}',
+    '.opsAction.danger{border-color:#5c3034;background:#281719;color:#ffb4ba}',
     '.opsOrderSelect{width:100%;min-height:44px;border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:9px;padding:7px;font-size:12px}',
     '.opsSection{margin-top:12px}.opsSection h2{font-size:14px;margin:0 0 9px}',
-    '@media(max-width:800px){.opsMetrics{grid-template-columns:repeat(2,1fr)}.opsGrid{grid-template-columns:1fr}.opsRow{grid-template-columns:minmax(110px,1.4fr) .7fr .7fr auto;gap:7px}.opsRow .opsReserved{display:none}.opsOrderRow{grid-template-columns:minmax(105px,1.1fr) .8fr .8fr}.opsOrderRow .opsDate{display:none}.opsAction,.opsOrderSelect{min-height:44px;font-size:12px}}'
+    '@media(max-width:800px){.opsMetrics{grid-template-columns:repeat(2,1fr)}.opsGrid{grid-template-columns:1fr}.opsRow{grid-template-columns:minmax(105px,1.3fr) .7fr .6fr minmax(112px,auto);gap:6px}.opsOrderRow{grid-template-columns:minmax(105px,1.1fr) .8fr .8fr}.opsOrderRow .opsDate{display:none}.opsAction,.opsOrderSelect{min-height:44px;font-size:12px;padding:8px}.opsActions{gap:4px}}'
   ].join('');
   document.head.appendChild(style);
 
   let data=null;
   let loading=false;
   let businessId=null;
+  let editingProductId=null;
 
   function escapeHtml(value){return String(value??'').replace(/[&<>\"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c]))}
   function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' '+currencyCode()}catch{return Number(value||0).toFixed(2)+' '+currencyCode()}}
@@ -53,6 +58,12 @@ const script=String.raw`(()=>{
   function currencyCode(){try{return String(workspace?.business?.currency_code||'AED').trim().toUpperCase()||'AED'}catch{return 'AED'}}
   function notify(message){try{if(typeof toast==='function')toast(message)}catch{}}
   function productSku(){return 'DAB-'+Date.now().toString(36).toUpperCase()+'-'+Math.random().toString(36).slice(2,6).toUpperCase()}
+  function errorText(error){
+    const t=text();const code=String(error?.message||error||'');
+    if(code.includes('PRODUCT_HAS_RESERVED_STOCK'))return t.reservedDelete;
+    if(code.includes('QUANTITY_BELOW_RESERVED'))return t.reservedQty;
+    return t.failed+' — '+code;
+  }
 
   function ensureScreen(){
     let screen=q('#screen-operations');
@@ -64,8 +75,6 @@ const script=String.raw`(()=>{
     }
     if(!isStore())return screen;
 
-    // A service business may have owned this shared screen before the workspace switched to Store.
-    // Store mode must reclaim it instead of leaving the stale service form in place.
     if(!q('#opsBody')){
       screen.innerHTML='<div class=\"hero\"><div><h1 id=\"opsTitle\"></h1><p id=\"opsDesc\"></p></div><button class=\"primary\" id=\"opsAddProduct\" type=\"button\"></button></div><div id=\"opsBody\"></div>';
     }
@@ -74,23 +83,39 @@ const script=String.raw`(()=>{
     if(!q('#opsProductModal')){
       const productModal=document.createElement('div');
       productModal.className='modal';productModal.id='opsProductModal';
-      productModal.innerHTML='<form class=\"modalBox\" id=\"opsProductForm\"><h3 id=\"opsProductModalTitle\"></h3><div class=\"field\"><label id=\"opsNameLabel\"></label><input id=\"opsName\" maxlength=\"160\" required></div><div class=\"field\"><label id=\"opsPriceLabel\"></label><input id=\"opsPrice\" type=\"number\" min=\"0\" step=\"0.01\" required></div><div class=\"field\"><label id=\"opsQtyLabel\"></label><input id=\"opsQty\" type=\"number\" min=\"0\" step=\"1\" required></div><div class=\"modalActions\"><button type=\"button\" class=\"secondary\" id=\"opsProductCancel\"></button><button class=\"primary\" id=\"opsProductSave\" type=\"submit\"></button></div></form>';
+      productModal.innerHTML='<form class=\"modalBox\" id=\"opsProductForm\"><h3 id=\"opsProductModalTitle\"></h3><div class=\"field\"><label id=\"opsNameLabel\"></label><input id=\"opsName\" maxlength=\"160\" required></div><div class=\"field\"><label id=\"opsPriceLabel\"></label><input id=\"opsPrice\" type=\"number\" min=\"0\" max=\"10000000\" step=\"0.01\" required></div><div class=\"field\"><label id=\"opsQtyLabel\"></label><input id=\"opsQty\" type=\"number\" min=\"0\" max=\"1000000\" step=\"1\" required></div><div class=\"modalActions\"><button type=\"button\" class=\"secondary\" id=\"opsProductCancel\"></button><button class=\"primary\" id=\"opsProductSave\" type=\"submit\"></button></div></form>';
       document.body.appendChild(productModal);
-
-      const stockModal=document.createElement('div');
-      stockModal.className='modal';stockModal.id='opsStockModal';
-      stockModal.innerHTML='<form class=\"modalBox\" id=\"opsStockForm\"><h3 id=\"opsStockTitle\"></h3><input id=\"opsStockProductId\" type=\"hidden\"><div class=\"field\"><label id=\"opsStockQtyLabel\"></label><input id=\"opsStockQty\" type=\"number\" min=\"0\" step=\"1\" required></div><div class=\"modalActions\"><button type=\"button\" class=\"secondary\" id=\"opsStockCancel\"></button><button class=\"primary\" id=\"opsStockSave\" type=\"submit\"></button></div></form>';
-      document.body.appendChild(stockModal);
-
-      q('#opsProductCancel').onclick=()=>q('#opsProductModal').classList.remove('open');
-      q('#opsStockCancel').onclick=()=>q('#opsStockModal').classList.remove('open');
-      q('#opsProductForm').onsubmit=createProduct;
-      q('#opsStockForm').onsubmit=saveStock;
-      [productModal,stockModal].forEach(modal=>modal.addEventListener('click',event=>{if(event.target===modal)modal.classList.remove('open')}));
+      q('#opsProductCancel').onclick=closeProductModal;
+      q('#opsProductForm').onsubmit=submitProduct;
+      productModal.addEventListener('click',event=>{if(event.target===productModal)closeProductModal()});
     }
-    q('#opsAddProduct').onclick=()=>q('#opsProductModal').classList.add('open');
+    q('#opsAddProduct').onclick=openNewProduct;
     applyCopy();
     return screen;
+  }
+
+  function openNewProduct(){
+    editingProductId=null;
+    q('#opsProductForm')?.reset();
+    applyCopy();
+    q('#opsProductModal')?.classList.add('open');
+  }
+
+  function openEditProduct(product){
+    if(!product)return;
+    editingProductId=product.id;
+    q('#opsName').value=product.name||'';
+    q('#opsPrice').value=Number(product.price_aed||0).toFixed(2).replace(/\.00$/,'');
+    q('#opsQty').value=Number(product.quantity||0);
+    applyCopy();
+    q('#opsProductModal')?.classList.add('open');
+  }
+
+  function closeProductModal(){
+    q('#opsProductModal')?.classList.remove('open');
+    q('#opsProductForm')?.reset();
+    editingProductId=null;
+    applyCopy();
   }
 
   function applyCopy(){
@@ -99,16 +124,12 @@ const script=String.raw`(()=>{
     if(q('#opsTitle'))q('#opsTitle').textContent=t.title;
     if(q('#opsDesc'))q('#opsDesc').textContent=t.desc;
     if(q('#opsAddProduct'))q('#opsAddProduct').textContent=t.add;
-    if(q('#opsProductModalTitle'))q('#opsProductModalTitle').textContent=t.add;
+    if(q('#opsProductModalTitle'))q('#opsProductModalTitle').textContent=editingProductId?t.editTitle:t.add;
     if(q('#opsNameLabel'))q('#opsNameLabel').textContent=t.name;
     if(q('#opsPriceLabel'))q('#opsPriceLabel').textContent=t.price+' ('+currencyCode()+')';
     if(q('#opsQtyLabel'))q('#opsQtyLabel').textContent=t.qty;
     if(q('#opsProductCancel'))q('#opsProductCancel').textContent=t.cancel;
-    if(q('#opsProductSave'))q('#opsProductSave').textContent=t.save;
-    if(q('#opsStockTitle'))q('#opsStockTitle').textContent=t.editStock;
-    if(q('#opsStockQtyLabel'))q('#opsStockQtyLabel').textContent=t.qty;
-    if(q('#opsStockCancel'))q('#opsStockCancel').textContent=t.cancel;
-    if(q('#opsStockSave'))q('#opsStockSave').textContent=t.update;
+    if(q('#opsProductSave'))q('#opsProductSave').textContent=editingProductId?t.update:t.save;
     if(current==='operations'&&q('#pageTitle'))q('#pageTitle').textContent=t.nav;
     render();
   }
@@ -143,30 +164,27 @@ const script=String.raw`(()=>{
     if(loading&&!data){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.loading)+'</div>';return}
     if(data?.error){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.failed)+' — '+escapeHtml(data.error)+'</div>';return}
     if(!data){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.loading)+'</div>';return}
-    const m=data.metrics||{};
-    const low=data.low_stock||[];
+    const low=(data.low_stock||[]).filter(product=>product.active!==false);
     const realOrders=(data.orders||[]).filter(order=>order.simulated===false);
-    const products=data.products||[];
+    const products=(data.products||[]).filter(product=>product.active!==false);
+    const inventoryUnits=products.reduce((sum,product)=>sum+Number(product.quantity||0),0);
     if(q('#opsAddProduct'))q('#opsAddProduct').style.display=data.can_manage?'inline-flex':'none';
 
     const metrics=[
-      [t.products,m.active_products||0],[t.stock,m.inventory_units||0],[t.low,m.low_stock_products||0],[t.sales,money(m.recognized_sales_aed||0)]
+      [t.products,products.length],[t.stock,inventoryUnits],[t.low,low.length],[t.sales,money(data.metrics?.recognized_sales_aed||0)]
     ].map(([label,value])=>'<div class=\"opsMetric\"><span>'+escapeHtml(label)+'</span><strong>'+escapeHtml(value)+'</strong></div>').join('');
 
-    const lowHtml='<div class=\"opsLow\"><b>'+escapeHtml(t.lowTitle)+'</b><div style=\"margin-top:5px\">'+(low.length?low.slice(0,8).map(p=>escapeHtml(p.name)+' · '+escapeHtml(p.available)+' '+escapeHtml(t.available)).join('<br>'):escapeHtml(t.lowNone))+'</div></div>';
+    const lowHtml='<div class=\"opsLow\"><b>'+escapeHtml(t.lowTitle)+'</b><div style=\"margin-top:5px\">'+(low.length?low.slice(0,8).map(product=>escapeHtml(product.name)+' · '+escapeHtml(product.available)+' '+escapeHtml(t.available)).join('<br>'):escapeHtml(t.lowNone))+'</div></div>';
 
-    const productRows=products.length?products.map(product=>'<div class=\"opsRow\"><div class=\"opsName\"><b>'+escapeHtml(product.name)+'</b><small>'+escapeHtml(product.sku)+'</small></div><span>'+escapeHtml(money(product.price_aed))+'</span><span>'+escapeHtml(product.available)+'</span><span class=\"opsReserved\">'+escapeHtml(product.reserved)+'</span>'+(data.can_manage?'<button class=\"opsAction\" data-ops-stock=\"'+escapeHtml(product.id)+'\" data-ops-qty=\"'+escapeHtml(product.quantity)+'\">'+escapeHtml(t.editStock)+'</button>':'<span></span>')+'</div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noProducts)+'</div>';
-    const productsHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.products)+'</h2><div class=\"opsTable\"><div class=\"opsRow head\"><span>'+escapeHtml(t.name)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.available)+'</span><span class=\"opsReserved\">'+escapeHtml(t.reserved)+'</span><span></span></div>'+productRows+'</div></div>';
+    const productRows=products.length?products.map(product=>'<div class=\"opsRow\"><div class=\"opsName\"><b>'+escapeHtml(product.name)+'</b></div><span>'+escapeHtml(money(product.price_aed))+'</span><span>'+escapeHtml(product.quantity)+'</span>'+(data.can_manage?'<div class=\"opsActions\"><button class=\"opsAction\" type=\"button\" data-ops-edit=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.edit)+'</button><button class=\"opsAction danger\" type=\"button\" data-ops-delete=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.delete)+'</button></div>':'<span></span>')+'</div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noProducts)+'</div>';
+    const productsHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.products)+'</h2><div class=\"opsTable\"><div class=\"opsRow head\"><span>'+escapeHtml(t.name)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.qty)+'</span><span></span></div>'+productRows+'</div></div>';
 
-    const orderRows=realOrders.length?realOrders.map(order=>'<div class=\"opsRow opsOrderRow\"><div class=\"opsName\"><b>'+escapeHtml(order.customer_name||t.customer)+'</b><small>'+escapeHtml(String(order.id||'').slice(0,8))+'</small></div><span>'+escapeHtml(money(order.total_aed))+'</span>'+(data.can_manage?'<select class=\"opsOrderSelect\" data-ops-order=\"'+escapeHtml(order.id)+'\">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class=\"opsDate\">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noOrders)+'</div>';
+    const orderRows=realOrders.length?realOrders.map(order=>'<div class=\"opsRow opsOrderRow\"><div class=\"opsName\"><b>'+escapeHtml(order.customer_name||t.customer)+'</b></div><span>'+escapeHtml(money(order.total_aed))+'</span>'+(data.can_manage?'<select class=\"opsOrderSelect\" data-ops-order=\"'+escapeHtml(order.id)+'\">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class=\"opsDate\">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noOrders)+'</div>';
     const ordersHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.orders)+'</h2><div class=\"opsTable\"><div class=\"opsRow opsOrderRow head\"><span>'+escapeHtml(t.customer)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.status)+'</span><span class=\"opsDate\">'+escapeHtml(t.date)+'</span></div>'+orderRows+'</div><div class=\"truth\" style=\"margin-top:9px\">'+escapeHtml(t.simulated)+'</div></div>';
 
     body.innerHTML='<div class=\"opsMetrics\">'+metrics+'</div>'+lowHtml+'<div class=\"opsGrid\"><div>'+productsHtml+'</div><div>'+ordersHtml+'</div></div>';
-    qa('[data-ops-stock]').forEach(button=>button.onclick=()=>{
-      q('#opsStockProductId').value=button.dataset.opsStock;
-      q('#opsStockQty').value=button.dataset.opsQty||0;
-      q('#opsStockModal').classList.add('open');
-    });
+    qa('[data-ops-edit]').forEach(button=>button.onclick=()=>openEditProduct(products.find(product=>product.id===button.dataset.opsEdit)));
+    qa('[data-ops-delete]').forEach(button=>button.onclick=()=>deleteProduct(products.find(product=>product.id===button.dataset.opsDelete)));
     qa('[data-ops-order]').forEach(select=>select.onchange=()=>updateOrder(select.dataset.opsOrder,select.value));
   }
 
@@ -177,22 +195,38 @@ const script=String.raw`(()=>{
     return result;
   }
 
-  async function createProduct(event){
+  async function manageProduct(payload){
+    const response=await fetch('/api/owner-product-management',{method:'POST',cache:'no-store',headers:{'content-type':'application/json'},body:JSON.stringify({business_id:businessId,...payload})});
+    const result=await response.json().catch(()=>({}));
+    if(!response.ok||!result.ok)throw new Error(result.error||result.detail||'OWNER_PRODUCT_MANAGEMENT_FAILED');
+    return result;
+  }
+
+  async function submitProduct(event){
     event.preventDefault();
     const t=text();const button=q('#opsProductSave');if(button)button.disabled=true;
     try{
-      await mutate({action:'create_product',sku:productSku(),name:q('#opsName').value,price_aed:q('#opsPrice').value,quantity:q('#opsQty').value});
-      q('#opsProductForm').reset();q('#opsProductModal').classList.remove('open');notify(t.created);data=null;await load(true);
-    }catch(error){notify(t.failed+' — '+error.message)}finally{if(button)button.disabled=false}
+      const values={name:q('#opsName').value,price_aed:q('#opsPrice').value,quantity:q('#opsQty').value};
+      if(editingProductId){
+        await manageProduct({action:'update_product',product_id:editingProductId,...values});
+        notify(t.itemUpdated);
+      }else{
+        await mutate({action:'create_product',sku:productSku(),...values});
+        notify(t.created);
+      }
+      closeProductModal();data=null;await load(true);
+    }catch(error){notify(errorText(error))}finally{if(button)button.disabled=false}
   }
 
-  async function saveStock(event){
-    event.preventDefault();
-    const t=text();const button=q('#opsStockSave');if(button)button.disabled=true;
+  async function deleteProduct(product){
+    if(!product)return;
+    const t=text();
+    if(!window.confirm(t.deleteConfirm))return;
     try{
-      await mutate({action:'set_inventory',product_id:q('#opsStockProductId').value,quantity:q('#opsStockQty').value});
-      q('#opsStockModal').classList.remove('open');notify(t.updated);data=null;await load(true);
-    }catch(error){notify(t.failed+' — '+error.message)}finally{if(button)button.disabled=false}
+      await manageProduct({action:'delete_product',product_id:product.id});
+      if(editingProductId===product.id)closeProductModal();
+      notify(t.itemDeleted);data=null;await load(true);
+    }catch(error){notify(errorText(error))}
   }
 
   async function updateOrder(orderId,status){

--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -36,6 +36,7 @@ const script=String.raw`(()=>{
     '.opsRow:last-child{border-bottom:0}.opsRow.head{color:var(--muted);background:#15181b;font-size:11px;font-weight:800}',
     '.opsOrderRow{grid-template-columns:minmax(120px,1.2fr) .9fr .8fr .8fr}',
     '.opsName b{display:block;font-size:13px}',
+    '.opsName small{color:var(--muted);font-size:11px;line-height:1.4}',
     '.opsLow{border:1px solid #5b4b20;background:#2b2516;border-radius:14px;padding:11px;margin-bottom:12px;color:#f4d991;font-size:12px;line-height:1.55}',
     '.opsActions{display:flex;gap:6px;justify-content:flex-end;flex-wrap:wrap}',
     '.opsAction{border:1px solid var(--line);background:#181b1f;color:#fff;border-radius:10px;padding:8px 10px;min-height:44px;font-size:12px;font-weight:800}',

--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -6,20 +6,20 @@ const script=String.raw`(()=>{
   const qa=s=>[...document.querySelectorAll(s)];
   const ar=()=>document.documentElement.lang!=='en';
   const text=()=>ar()?{
-    nav:'العمليات',title:'مركز العمليات',desc:'المنتجات والمخزون والطلبات من بيانات نشاطك الفعلية.',
-    products:'المنتجات',stock:'المخزون',available:'المتاح',low:'مخزون منخفض',orders:'الطلبات',sales:'المبيعات المؤكدة',
-    add:'إضافة منتج',sku:'SKU',name:'اسم المنتج',price:'السعر (درهم)',qty:'الكمية',reserved:'محجوز',status:'الحالة',customer:'العميل',date:'التاريخ',
-    noProducts:'لا توجد منتجات بعد.',noOrders:'لا توجد طلبات فعلية بعد.',lowTitle:'تحتاج انتباه',lowNone:'لا يوجد نقص مخزون حاليًا.',
+    nav:'العمليات',title:'مركز العمليات',desc:'السلع والمخزون والطلبات من بيانات نشاطك الفعلية.',
+    products:'السلع',stock:'المخزون',available:'المتاح',low:'مخزون منخفض',orders:'الطلبات',sales:'المبيعات المؤكدة',
+    add:'إضافة سلعة',name:'اسم السلعة',price:'القيمة',qty:'الكمية',reserved:'محجوز',status:'الحالة',customer:'العميل',date:'التاريخ',
+    noProducts:'لا توجد سلع بعد.',noOrders:'لا توجد طلبات فعلية بعد.',lowTitle:'تحتاج انتباه',lowNone:'لا يوجد نقص مخزون حاليًا.',
     simulated:'الطلبات التجريبية مستبعدة من المبيعات.',save:'حفظ',cancel:'إلغاء',editStock:'تعديل المخزون',update:'تحديث',
-    created:'تمت إضافة المنتج.',updated:'تم تحديث المخزون.',orderUpdated:'تم تحديث حالة الطلب.',failed:'تعذر إكمال العملية.',
+    created:'تمت إضافة السلعة.',updated:'تم تحديث المخزون.',orderUpdated:'تم تحديث حالة الطلب.',failed:'تعذر إكمال العملية.',
     draft:'مسودة',reservedStatus:'محجوز',confirmed:'مؤكد',cancelled:'ملغي',completed:'مكتمل',loading:'جارٍ تحميل العمليات...'
   }:{
-    nav:'Operations',title:'Owner operations',desc:'Products, inventory, and orders from your real business data.',
-    products:'Products',stock:'Inventory',available:'Available',low:'Low stock',orders:'Orders',sales:'Recognized sales',
-    add:'Add product',sku:'SKU',name:'Product name',price:'Price (AED)',qty:'Quantity',reserved:'Reserved',status:'Status',customer:'Customer',date:'Date',
-    noProducts:'No products yet.',noOrders:'No real orders yet.',lowTitle:'Needs attention',lowNone:'No low-stock items right now.',
+    nav:'Operations',title:'Owner operations',desc:'Items, inventory, and orders from your real business data.',
+    products:'Items',stock:'Inventory',available:'Available',low:'Low stock',orders:'Orders',sales:'Recognized sales',
+    add:'Add item',name:'Item name',price:'Value',qty:'Quantity',reserved:'Reserved',status:'Status',customer:'Customer',date:'Date',
+    noProducts:'No items yet.',noOrders:'No real orders yet.',lowTitle:'Needs attention',lowNone:'No low-stock items right now.',
     simulated:'Simulated orders are excluded from recognized sales.',save:'Save',cancel:'Cancel',editStock:'Edit inventory',update:'Update',
-    created:'Product added.',updated:'Inventory updated.',orderUpdated:'Order status updated.',failed:'Operation failed.',
+    created:'Item added.',updated:'Inventory updated.',orderUpdated:'Order status updated.',failed:'Operation failed.',
     draft:'Draft',reservedStatus:'Reserved',confirmed:'Confirmed',cancelled:'Cancelled',completed:'Completed',loading:'Loading operations...'
   };
 
@@ -46,50 +46,62 @@ const script=String.raw`(()=>{
   let loading=false;
   let businessId=null;
 
-  function escapeHtml(value){return String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]))}
-  function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' AED'}catch{return Number(value||0).toFixed(2)+' AED'}}
+  function escapeHtml(value){return String(value??'').replace(/[&<>\"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c]))}
+  function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' '+currencyCode()}catch{return Number(value||0).toFixed(2)+' '+currencyCode()}}
   function date(value){if(!value)return '—';try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{dateStyle:'medium'}).format(new Date(value))}catch{return String(value)}}
   function isStore(){try{return String(workspace?.business?.business_type||'').toLowerCase()==='store'}catch{return false}}
+  function currencyCode(){try{return String(workspace?.business?.currency_code||'AED').trim().toUpperCase()||'AED'}catch{return 'AED'}}
   function notify(message){try{if(typeof toast==='function')toast(message)}catch{}}
+  function productSku(){return 'DAB-'+Date.now().toString(36).toUpperCase()+'-'+Math.random().toString(36).slice(2,6).toUpperCase()}
 
   function ensureScreen(){
     let screen=q('#screen-operations');
-    if(screen)return screen;
-    screen=document.createElement('section');
-    screen.className='screen';
-    screen.id='screen-operations';
-    screen.innerHTML='<div class="hero"><div><h1 id="opsTitle"></h1><p id="opsDesc"></p></div><button class="primary" id="opsAddProduct" type="button"></button></div><div id="opsBody"></div>';
-    q('.content')?.appendChild(screen);
+    if(!screen){
+      screen=document.createElement('section');
+      screen.className='screen';
+      screen.id='screen-operations';
+      q('.content')?.appendChild(screen);
+    }
+    if(!isStore())return screen;
 
-    const productModal=document.createElement('div');
-    productModal.className='modal';productModal.id='opsProductModal';
-    productModal.innerHTML='<form class="modalBox" id="opsProductForm"><h3 id="opsProductModalTitle"></h3><div class="field"><label id="opsSkuLabel"></label><input id="opsSku" maxlength="80" required></div><div class="field"><label id="opsNameLabel"></label><input id="opsName" maxlength="160" required></div><div class="field"><label id="opsPriceLabel"></label><input id="opsPrice" type="number" min="0" step="0.01" required></div><div class="field"><label id="opsQtyLabel"></label><input id="opsQty" type="number" min="0" step="1" required></div><div class="modalActions"><button type="button" class="secondary" id="opsProductCancel"></button><button class="primary" id="opsProductSave" type="submit"></button></div></form>';
-    document.body.appendChild(productModal);
+    // A service business may have owned this shared screen before the workspace switched to Store.
+    // Store mode must reclaim it instead of leaving the stale service form in place.
+    if(!q('#opsBody')){
+      screen.innerHTML='<div class=\"hero\"><div><h1 id=\"opsTitle\"></h1><p id=\"opsDesc\"></p></div><button class=\"primary\" id=\"opsAddProduct\" type=\"button\"></button></div><div id=\"opsBody\"></div>';
+    }
+    q('#svcModal')?.classList.remove('open');
 
-    const stockModal=document.createElement('div');
-    stockModal.className='modal';stockModal.id='opsStockModal';
-    stockModal.innerHTML='<form class="modalBox" id="opsStockForm"><h3 id="opsStockTitle"></h3><input id="opsStockProductId" type="hidden"><div class="field"><label id="opsStockQtyLabel"></label><input id="opsStockQty" type="number" min="0" step="1" required></div><div class="modalActions"><button type="button" class="secondary" id="opsStockCancel"></button><button class="primary" id="opsStockSave" type="submit"></button></div></form>';
-    document.body.appendChild(stockModal);
+    if(!q('#opsProductModal')){
+      const productModal=document.createElement('div');
+      productModal.className='modal';productModal.id='opsProductModal';
+      productModal.innerHTML='<form class=\"modalBox\" id=\"opsProductForm\"><h3 id=\"opsProductModalTitle\"></h3><div class=\"field\"><label id=\"opsNameLabel\"></label><input id=\"opsName\" maxlength=\"160\" required></div><div class=\"field\"><label id=\"opsPriceLabel\"></label><input id=\"opsPrice\" type=\"number\" min=\"0\" step=\"0.01\" required></div><div class=\"field\"><label id=\"opsQtyLabel\"></label><input id=\"opsQty\" type=\"number\" min=\"0\" step=\"1\" required></div><div class=\"modalActions\"><button type=\"button\" class=\"secondary\" id=\"opsProductCancel\"></button><button class=\"primary\" id=\"opsProductSave\" type=\"submit\"></button></div></form>';
+      document.body.appendChild(productModal);
 
+      const stockModal=document.createElement('div');
+      stockModal.className='modal';stockModal.id='opsStockModal';
+      stockModal.innerHTML='<form class=\"modalBox\" id=\"opsStockForm\"><h3 id=\"opsStockTitle\"></h3><input id=\"opsStockProductId\" type=\"hidden\"><div class=\"field\"><label id=\"opsStockQtyLabel\"></label><input id=\"opsStockQty\" type=\"number\" min=\"0\" step=\"1\" required></div><div class=\"modalActions\"><button type=\"button\" class=\"secondary\" id=\"opsStockCancel\"></button><button class=\"primary\" id=\"opsStockSave\" type=\"submit\"></button></div></form>';
+      document.body.appendChild(stockModal);
+
+      q('#opsProductCancel').onclick=()=>q('#opsProductModal').classList.remove('open');
+      q('#opsStockCancel').onclick=()=>q('#opsStockModal').classList.remove('open');
+      q('#opsProductForm').onsubmit=createProduct;
+      q('#opsStockForm').onsubmit=saveStock;
+      [productModal,stockModal].forEach(modal=>modal.addEventListener('click',event=>{if(event.target===modal)modal.classList.remove('open')}));
+    }
     q('#opsAddProduct').onclick=()=>q('#opsProductModal').classList.add('open');
-    q('#opsProductCancel').onclick=()=>q('#opsProductModal').classList.remove('open');
-    q('#opsStockCancel').onclick=()=>q('#opsStockModal').classList.remove('open');
-    q('#opsProductForm').onsubmit=createProduct;
-    q('#opsStockForm').onsubmit=saveStock;
-    [productModal,stockModal].forEach(modal=>modal.addEventListener('click',event=>{if(event.target===modal)modal.classList.remove('open')}));
     applyCopy();
     return screen;
   }
 
   function applyCopy(){
+    if(!isStore())return;
     const t=text();
     if(q('#opsTitle'))q('#opsTitle').textContent=t.title;
     if(q('#opsDesc'))q('#opsDesc').textContent=t.desc;
     if(q('#opsAddProduct'))q('#opsAddProduct').textContent=t.add;
     if(q('#opsProductModalTitle'))q('#opsProductModalTitle').textContent=t.add;
-    if(q('#opsSkuLabel'))q('#opsSkuLabel').textContent=t.sku;
     if(q('#opsNameLabel'))q('#opsNameLabel').textContent=t.name;
-    if(q('#opsPriceLabel'))q('#opsPriceLabel').textContent=t.price;
+    if(q('#opsPriceLabel'))q('#opsPriceLabel').textContent=t.price+' ('+currencyCode()+')';
     if(q('#opsQtyLabel'))q('#opsQtyLabel').textContent=t.qty;
     if(q('#opsProductCancel'))q('#opsProductCancel').textContent=t.cancel;
     if(q('#opsProductSave'))q('#opsProductSave').textContent=t.save;
@@ -121,16 +133,16 @@ const script=String.raw`(()=>{
   function statusOptions(current){
     const t=text();
     const labels={draft:t.draft,reserved:t.reservedStatus,confirmed:t.confirmed,cancelled:t.cancelled,completed:t.completed};
-    return Object.entries(labels).map(([value,label])=>'<option value="'+value+'" '+(value===current?'selected':'')+'>'+escapeHtml(label)+'</option>').join('');
+    return Object.entries(labels).map(([value,label])=>'<option value=\"'+value+'\" '+(value===current?'selected':'')+'>'+escapeHtml(label)+'</option>').join('');
   }
 
   function render(){
     const body=q('#opsBody');
-    if(!body)return;
+    if(!body||!isStore())return;
     const t=text();
-    if(loading&&!data){body.innerHTML='<div class="empty">'+escapeHtml(t.loading)+'</div>';return}
-    if(data?.error){body.innerHTML='<div class="empty">'+escapeHtml(t.failed)+' — '+escapeHtml(data.error)+'</div>';return}
-    if(!data){body.innerHTML='<div class="empty">'+escapeHtml(t.loading)+'</div>';return}
+    if(loading&&!data){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.loading)+'</div>';return}
+    if(data?.error){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.failed)+' — '+escapeHtml(data.error)+'</div>';return}
+    if(!data){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.loading)+'</div>';return}
     const m=data.metrics||{};
     const low=data.low_stock||[];
     const realOrders=(data.orders||[]).filter(order=>order.simulated===false);
@@ -139,17 +151,17 @@ const script=String.raw`(()=>{
 
     const metrics=[
       [t.products,m.active_products||0],[t.stock,m.inventory_units||0],[t.low,m.low_stock_products||0],[t.sales,money(m.recognized_sales_aed||0)]
-    ].map(([label,value])=>'<div class="opsMetric"><span>'+escapeHtml(label)+'</span><strong>'+escapeHtml(value)+'</strong></div>').join('');
+    ].map(([label,value])=>'<div class=\"opsMetric\"><span>'+escapeHtml(label)+'</span><strong>'+escapeHtml(value)+'</strong></div>').join('');
 
-    const lowHtml='<div class="opsLow"><b>'+escapeHtml(t.lowTitle)+'</b><div style="margin-top:5px">'+(low.length?low.slice(0,8).map(p=>escapeHtml(p.name)+' · '+escapeHtml(p.available)+' '+escapeHtml(t.available)).join('<br>'):escapeHtml(t.lowNone))+'</div></div>';
+    const lowHtml='<div class=\"opsLow\"><b>'+escapeHtml(t.lowTitle)+'</b><div style=\"margin-top:5px\">'+(low.length?low.slice(0,8).map(p=>escapeHtml(p.name)+' · '+escapeHtml(p.available)+' '+escapeHtml(t.available)).join('<br>'):escapeHtml(t.lowNone))+'</div></div>';
 
-    const productRows=products.length?products.map(product=>'<div class="opsRow"><div class="opsName"><b>'+escapeHtml(product.name)+'</b><small>'+escapeHtml(product.sku)+'</small></div><span>'+escapeHtml(money(product.price_aed))+'</span><span>'+escapeHtml(product.available)+'</span><span class="opsReserved">'+escapeHtml(product.reserved)+'</span>'+(data.can_manage?'<button class="opsAction" data-ops-stock="'+escapeHtml(product.id)+'" data-ops-qty="'+escapeHtml(product.quantity)+'">'+escapeHtml(t.editStock)+'</button>':'<span></span>')+'</div>').join(''):'<div class="empty">'+escapeHtml(t.noProducts)+'</div>';
-    const productsHtml='<div class="opsSection"><h2>'+escapeHtml(t.products)+'</h2><div class="opsTable"><div class="opsRow head"><span>'+escapeHtml(t.name)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.available)+'</span><span class="opsReserved">'+escapeHtml(t.reserved)+'</span><span></span></div>'+productRows+'</div></div>';
+    const productRows=products.length?products.map(product=>'<div class=\"opsRow\"><div class=\"opsName\"><b>'+escapeHtml(product.name)+'</b><small>'+escapeHtml(product.sku)+'</small></div><span>'+escapeHtml(money(product.price_aed))+'</span><span>'+escapeHtml(product.available)+'</span><span class=\"opsReserved\">'+escapeHtml(product.reserved)+'</span>'+(data.can_manage?'<button class=\"opsAction\" data-ops-stock=\"'+escapeHtml(product.id)+'\" data-ops-qty=\"'+escapeHtml(product.quantity)+'\">'+escapeHtml(t.editStock)+'</button>':'<span></span>')+'</div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noProducts)+'</div>';
+    const productsHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.products)+'</h2><div class=\"opsTable\"><div class=\"opsRow head\"><span>'+escapeHtml(t.name)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.available)+'</span><span class=\"opsReserved\">'+escapeHtml(t.reserved)+'</span><span></span></div>'+productRows+'</div></div>';
 
-    const orderRows=realOrders.length?realOrders.map(order=>'<div class="opsRow opsOrderRow"><div class="opsName"><b>'+escapeHtml(order.customer_name||t.customer)+'</b><small>'+escapeHtml(String(order.id||'').slice(0,8))+'</small></div><span>'+escapeHtml(money(order.total_aed))+'</span>'+(data.can_manage?'<select class="opsOrderSelect" data-ops-order="'+escapeHtml(order.id)+'">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class="opsDate">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class="empty">'+escapeHtml(t.noOrders)+'</div>';
-    const ordersHtml='<div class="opsSection"><h2>'+escapeHtml(t.orders)+'</h2><div class="opsTable"><div class="opsRow opsOrderRow head"><span>'+escapeHtml(t.customer)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.status)+'</span><span class="opsDate">'+escapeHtml(t.date)+'</span></div>'+orderRows+'</div><div class="truth" style="margin-top:9px">'+escapeHtml(t.simulated)+'</div></div>';
+    const orderRows=realOrders.length?realOrders.map(order=>'<div class=\"opsRow opsOrderRow\"><div class=\"opsName\"><b>'+escapeHtml(order.customer_name||t.customer)+'</b><small>'+escapeHtml(String(order.id||'').slice(0,8))+'</small></div><span>'+escapeHtml(money(order.total_aed))+'</span>'+(data.can_manage?'<select class=\"opsOrderSelect\" data-ops-order=\"'+escapeHtml(order.id)+'\">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class=\"opsDate\">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noOrders)+'</div>';
+    const ordersHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.orders)+'</h2><div class=\"opsTable\"><div class=\"opsRow opsOrderRow head\"><span>'+escapeHtml(t.customer)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.status)+'</span><span class=\"opsDate\">'+escapeHtml(t.date)+'</span></div>'+orderRows+'</div><div class=\"truth\" style=\"margin-top:9px\">'+escapeHtml(t.simulated)+'</div></div>';
 
-    body.innerHTML='<div class="opsMetrics">'+metrics+'</div>'+lowHtml+'<div class="opsGrid"><div>'+productsHtml+'</div><div>'+ordersHtml+'</div></div>';
+    body.innerHTML='<div class=\"opsMetrics\">'+metrics+'</div>'+lowHtml+'<div class=\"opsGrid\"><div>'+productsHtml+'</div><div>'+ordersHtml+'</div></div>';
     qa('[data-ops-stock]').forEach(button=>button.onclick=()=>{
       q('#opsStockProductId').value=button.dataset.opsStock;
       q('#opsStockQty').value=button.dataset.opsQty||0;
@@ -169,7 +181,7 @@ const script=String.raw`(()=>{
     event.preventDefault();
     const t=text();const button=q('#opsProductSave');if(button)button.disabled=true;
     try{
-      await mutate({action:'create_product',sku:q('#opsSku').value,name:q('#opsName').value,price_aed:q('#opsPrice').value,quantity:q('#opsQty').value});
+      await mutate({action:'create_product',sku:productSku(),name:q('#opsName').value,price_aed:q('#opsPrice').value,quantity:q('#opsQty').value});
       q('#opsProductForm').reset();q('#opsProductModal').classList.remove('open');notify(t.created);data=null;await load(true);
     }catch(error){notify(t.failed+' — '+error.message)}finally{if(button)button.disabled=false}
   }
@@ -189,27 +201,27 @@ const script=String.raw`(()=>{
   }
 
   function syncOperationsUi(){
+    if(!isStore())return;
     ensureScreen();
     applyCopy();
     if(current==='operations')load();
   }
 
   function activateOperations({target}={}){
-    if(target!=='operations')return;
+    if(target!=='operations'||!isStore())return;
     ensureScreen();
     if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;
     load();
   }
 
-  ensureScreen();
   const lifecycle=window.__dabbirUiLifecycle;
   if(lifecycle?.on){
     lifecycle.on('afterRender','owner-operations',syncOperationsUi);
     lifecycle.on('afterNavigate','owner-operations',activateOperations);
+    lifecycle.on('afterLanguage','owner-operations-language',syncOperationsUi);
   }
 
-  new MutationObserver(applyCopy).observe(document.documentElement,{attributes:true,attributeFilter:['lang','dir']});
-  setTimeout(()=>{ensureScreen();if(isStore())load()},600);
+  setTimeout(()=>{if(isStore()){ensureScreen();load()}},600);
 })();`;
 
 export default function handler(req,res){

--- a/api/owner-product-management.js
+++ b/api/owner-product-management.js
@@ -1,0 +1,127 @@
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+  supabaseRpc,
+} from './_auth-core.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const clean=(value,max=160)=>String(value||'').trim().slice(0,max);
+const number=value=>Number.isFinite(Number(value))?Number(value):NaN;
+
+async function readData(response,fallback){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=response.status;
+    error.detail=payload?.message||payload?.code||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=(token,path,fallback)=>supabaseRest(path,token).then(response=>readData(response,fallback));
+const write=(token,path,options,fallback)=>supabaseRest(path,token,options).then(response=>readData(response,fallback));
+const rpc=(token,name,params,fallback)=>supabaseRpc(name,token,params).then(response=>readData(response,fallback));
+
+function membershipFor(memberships,businessId){
+  return memberships.find(membership=>membership.business_id===businessId)||null;
+}
+
+function canManageBusiness(membership){
+  if(!membership)return false;
+  const permissions=Array.isArray(membership.permissions)?membership.permissions:[];
+  if(permissions.length)return permissions.includes('manage_business');
+  return ['owner','admin'].includes(String(membership.role||'').toLowerCase());
+}
+
+async function authenticatedContext(req,res){
+  const token=accessTokenFromRequest(req);
+  if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
+  return {token,user,memberships};
+}
+
+async function productContext(token,businessId,productId){
+  const [products,inventory]=await Promise.all([
+    rest(token,`dabbir_products?select=id,business_id,sku,name,price_aed,active,metadata&business_id=eq.${businessId}&id=eq.${productId}&limit=1`,'PRODUCT_LOOKUP_FAILED'),
+    rest(token,`dabbir_inventory?select=quantity,reserved&business_id=eq.${businessId}&product_id=eq.${productId}&limit=1`,'INVENTORY_LOOKUP_FAILED'),
+  ]);
+  return {product:products?.[0]||null,inventory:inventory?.[0]||{quantity:0,reserved:0}};
+}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+
+  const context=await authenticatedContext(req,res);
+  if(!context)return;
+
+  try{
+    const body=await readJsonBody(req);
+    const businessId=safeId(body.business_id);
+    const productId=safeId(body.product_id);
+    const membership=membershipFor(context.memberships,businessId);
+    if(!businessId||!productId||!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+    if(!canManageBusiness(membership))return json(res,403,{ok:false,error:'BUSINESS_MANAGEMENT_REQUIRED'});
+
+    const {product,inventory}=await productContext(context.token,businessId,productId);
+    if(!product)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
+
+    const action=clean(body.action,40);
+    if(action==='update_product'){
+      const name=clean(body.name,160);
+      const price=number(body.price_aed);
+      const quantity=Math.trunc(number(body.quantity));
+      if(!name||!Number.isFinite(price)||price<0||price>10000000||!Number.isFinite(quantity)||quantity<0||quantity>1000000){
+        return json(res,400,{ok:false,error:'INVALID_PRODUCT_INPUT'});
+      }
+      if(quantity<Number(inventory.reserved||0))return json(res,409,{ok:false,error:'QUANTITY_BELOW_RESERVED'});
+
+      const metadata={...(product.metadata&&typeof product.metadata==='object'?product.metadata:{}),source:'dabbir_owner_operations',updated_at:new Date().toISOString()};
+      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_aed,active,metadata`,{
+        method:'PATCH',
+        headers:{prefer:'return=representation'},
+        body:JSON.stringify({name,price_aed:Number(price.toFixed(2)),metadata}),
+      },'PRODUCT_UPDATE_FAILED');
+      const updated=rows?.[0]||null;
+      if(!updated)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
+
+      const stock=await rpc(context.token,'dabbir_owner_set_inventory',{
+        p_business_id:businessId,
+        p_product_id:productId,
+        p_quantity:quantity,
+      },'INVENTORY_UPDATE_FAILED');
+      return json(res,200,{ok:true,action,result:{...updated,quantity,reserved:Number(inventory.reserved||0),stock}});
+    }
+
+    if(action==='delete_product'){
+      if(Number(inventory.reserved||0)>0)return json(res,409,{ok:false,error:'PRODUCT_HAS_RESERVED_STOCK'});
+      const metadata={...(product.metadata&&typeof product.metadata==='object'?product.metadata:{}),source:'dabbir_owner_operations',deleted_at:new Date().toISOString(),deleted_by:context.user.id||null};
+      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_aed,active,metadata`,{
+        method:'PATCH',
+        headers:{prefer:'return=representation'},
+        body:JSON.stringify({active:false,metadata}),
+      },'PRODUCT_DELETE_FAILED');
+      const deleted=rows?.[0]||null;
+      if(!deleted)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
+      return json(res,200,{ok:true,action,result:{...deleted,deleted:true}});
+    }
+
+    return json(res,400,{ok:false,error:'UNSUPPORTED_PRODUCT_OPERATION'});
+  }catch(error){
+    const status=Number(error?.status)||500;
+    return json(res,status,{ok:false,error:error?.message||'OWNER_PRODUCT_MANAGEMENT_FAILED',detail:error?.detail||null});
+  }
+}

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-store-item-form-v1'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-store-item-form-v1'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);

--- a/test/dabbir-store-item-form-ownership.test.mjs
+++ b/test/dabbir-store-item-form-ownership.test.mjs
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 
 const source=fs.readFileSync(new URL('../api/owner-operations-ui.js',import.meta.url),'utf8');
+const productManagement=fs.readFileSync(new URL('../api/owner-product-management.js',import.meta.url),'utf8');
 
 test('store add form is item value and quantity only',()=>{
   assert.match(source,/add:'إضافة سلعة'/);
@@ -11,6 +12,30 @@ test('store add form is item value and quantity only',()=>{
   assert.match(source,/qty:'الكمية'/);
   assert.doesNotMatch(source,/id=\\?"opsSku/);
   assert.match(source,/sku:productSku\(\)/);
+});
+
+test('store owner can edit and delete items from the activity',()=>{
+  assert.match(source,/edit:'تعديل'/);
+  assert.match(source,/delete:'حذف'/);
+  assert.match(source,/data-ops-edit/);
+  assert.match(source,/data-ops-delete/);
+  assert.match(source,/\/api\/owner-product-management/);
+  assert.match(source,/action:'update_product'/);
+  assert.match(source,/action:'delete_product'/);
+  assert.match(source,/window\.confirm\(t\.deleteConfirm\)/);
+  assert.match(source,/filter\(product=>product\.active!==false\)/);
+});
+
+test('owner product management is permission gated and preserves history on delete',()=>{
+  assert.match(productManagement,/requireSameOrigin\(req\)/);
+  assert.match(productManagement,/permissions\.includes\('manage_business'\)/);
+  assert.match(productManagement,/\['owner','admin'\]/);
+  assert.match(productManagement,/action==='update_product'/);
+  assert.match(productManagement,/dabbir_owner_set_inventory/);
+  assert.match(productManagement,/action==='delete_product'/);
+  assert.match(productManagement,/PRODUCT_HAS_RESERVED_STOCK/);
+  assert.match(productManagement,/active:false/);
+  assert.doesNotMatch(productManagement,/method:'DELETE'/);
 });
 
 test('store mode reclaims the shared operations screen from stale service UI',()=>{

--- a/test/dabbir-store-item-form-ownership.test.mjs
+++ b/test/dabbir-store-item-form-ownership.test.mjs
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const source=fs.readFileSync(new URL('../api/owner-operations-ui.js',import.meta.url),'utf8');
+
+test('store add form is item value and quantity only',()=>{
+  assert.match(source,/add:'إضافة سلعة'/);
+  assert.match(source,/name:'اسم السلعة'/);
+  assert.match(source,/price:'القيمة'/);
+  assert.match(source,/qty:'الكمية'/);
+  assert.doesNotMatch(source,/id=\\?"opsSku/);
+  assert.match(source,/sku:productSku\(\)/);
+});
+
+test('store mode reclaims the shared operations screen from stale service UI',()=>{
+  assert.match(source,/if\(!q\('#opsBody'\)\)/);
+  assert.match(source,/q\('#svcModal'\)\?\.classList\.remove\('open'\)/);
+  assert.match(source,/if\(!isStore\(\)\)return;/);
+  assert.match(source,/lifecycle\.on\('afterLanguage','owner-operations-language',syncOperationsUi\)/);
+});
+
+test('store values follow the selected business currency label',()=>{
+  assert.match(source,/workspace\?\.business\?\.currency_code/);
+  assert.match(source,/t\.price\+' \('\+currencyCode\(\)\+'\)'/);
+});


### PR DESCRIPTION
Store mode could retain the shared Operations screen previously owned by the service UI, leaving an incorrect “Add service / duration” modal visible. This change makes Store reclaim the shared screen, removes the manual SKU field from the owner flow, auto-generates the internal SKU, and presents the requested item/value/quantity form. It also labels monetary values with the selected business currency and bumps the Safari UI cache token. Regression coverage added for the store form and screen-ownership handoff.