### PR TITLE
Make native store metrics follow GCC business profile

### DIFF
--- a/api/mobile/owner-operations.js
+++ b/api/mobile/owner-operations.js
@@ -1,11 +1,104 @@
 import ownerOperationsHandler from '../owner-operations.js';
 import { requireNativeBearer } from './_native-core.js';
-import { json } from '../_auth-core.js';
+import { accessTokenFromRequest, json, supabaseRest } from '../_auth-core.js';
+
+const clean=(value,max=80)=>String(value??'').trim().slice(0,max);
+const number=value=>Number.isFinite(Number(value))?Number(value):0;
+const enc=value=>encodeURIComponent(String(value));
+
+async function readData(response,fallback){
+  const text=await response.text();let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{}
+  if(!response.ok){const error=new Error(fallback);error.status=response.status;throw error}
+  return payload;
+}
+
+function captureOwnerOperations(req){
+  return new Promise((resolve,reject)=>{
+    const headers=new Map();let settled=false;
+    const proxy={
+      statusCode:200,
+      setHeader(name,value){headers.set(String(name).toLowerCase(),value);return proxy},
+      getHeader(name){return headers.get(String(name).toLowerCase())},
+      removeHeader(name){headers.delete(String(name).toLowerCase())},
+      end(body=''){
+        if(!settled){settled=true;resolve({statusCode:proxy.statusCode,headers,body:String(body??'')})}
+        return proxy;
+      },
+    };
+    Promise.resolve(ownerOperationsHandler(req,proxy)).then(()=>{if(!settled)reject(new Error('OWNER_OPERATIONS_NO_RESPONSE'))}).catch(reject);
+  });
+}
+
+function forward(res,captured,payload=null){
+  res.statusCode=Number(captured.statusCode||200);
+  for(const [name,value] of captured.headers.entries()){
+    if(name==='content-length'||name==='transfer-encoding')continue;
+    res.setHeader(name,value);
+  }
+  res.setHeader('x-dabbir-native-store-gcc','v1');
+  return res.end(payload==null?captured.body:JSON.stringify(payload));
+}
+
+function localDateKey(value,timezone){
+  try{return new Intl.DateTimeFormat('en-CA',{timeZone:timezone,year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date(value))}catch{return null}
+}
+
+async function enrichGet(req,res){
+  const captured=await captureOwnerOperations(req);
+  if(Number(captured.statusCode)!==200)return forward(res,captured);
+  let payload=null;
+  try{payload=captured.body?JSON.parse(captured.body):null}catch{return forward(res,captured)}
+  const businessId=clean(payload?.business_id,64);
+  const token=accessTokenFromRequest(req);
+  if(!businessId||!token)return json(res,502,{ok:false,error:'NATIVE_STORE_PROFILE_CONTEXT_UNVERIFIED'});
+
+  const rows=await readData(await supabaseRest(`dabbir_businesses?select=id,country_code,currency_code,timezone,phone_country_prefix&id=eq.${enc(businessId)}&limit=1`,token),'BUSINESS_PROFILE_LOOKUP_FAILED');
+  const business=Array.isArray(rows)?rows[0]:null;
+  if(!business?.id||!business.currency_code||!business.timezone)return json(res,502,{ok:false,error:'BUSINESS_GCC_PROFILE_UNVERIFIED'});
+
+  const businessDate=localDateKey(new Date(),business.timezone);
+  if(!businessDate)return json(res,502,{ok:false,error:'BUSINESS_LOCAL_DAY_UNVERIFIED'});
+  const orders=Array.isArray(payload.orders)?payload.orders:[];
+  const returns=Array.isArray(payload.returns)?payload.returns:[];
+  const expenses=Array.isArray(payload.expenses)?payload.expenses:[];
+  const realOrders=orders.filter(order=>order.simulated===false);
+  const recognized=realOrders.filter(order=>['confirmed','completed'].includes(String(order.status||'').toLowerCase()));
+  const todayOrders=recognized.filter(order=>localDateKey(order.completed_at||order.created_at,business.timezone)===businessDate);
+  const todayReturns=returns.filter(item=>localDateKey(item.created_at,business.timezone)===businessDate);
+  const salesToday=Number(todayOrders.reduce((sum,order)=>sum+number(order.total_aed),0).toFixed(2));
+  const returnedToday=Number(todayReturns.reduce((sum,item)=>sum+number(item.refund_aed),0).toFixed(2));
+  const expensesToday=Number(expenses.filter(item=>item.occurred_on===businessDate).reduce((sum,item)=>sum+number(item.amount_aed),0).toFixed(2));
+  const metrics={...(payload.metrics||{}),sales_today_aed:salesToday,returned_today_aed:returnedToday,net_sales_today_aed:Math.max(0,Number((salesToday-returnedToday).toFixed(2))),today_expenses_aed:expensesToday};
+  metrics.sales_today=metrics.sales_today_aed;
+  metrics.returned_today=metrics.returned_today_aed;
+  metrics.net_sales_today=metrics.net_sales_today_aed;
+  metrics.today_expenses=metrics.today_expenses_aed;
+  metrics.recognized_sales=metrics.recognized_sales_aed;
+  metrics.cash_collected=metrics.cash_collected_aed;
+  metrics.receivables=metrics.receivables_aed;
+  metrics.expenses=metrics.expenses_aed;
+
+  payload.metrics=metrics;
+  payload.country_code=business.country_code;
+  payload.currency_code=business.currency_code;
+  payload.timezone=business.timezone;
+  payload.business_date=businessDate;
+  payload.business_profile=business;
+  payload.truth={...(payload.truth||{}),store_metrics_are_business_day_facts:true,legacy_aed_field_names_are_storage_compatibility:true,currency_code_from_business_profile:true};
+  return forward(res,captured,payload);
+}
 
 export default async function handler(req, res) {
   if (!['GET', 'POST'].includes(req.method)) {
     return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'GET, POST' });
   }
   if (!requireNativeBearer(req, res)) return;
+  if(req.method==='GET'){
+    try{return await enrichGet(req,res)}catch(error){
+      const status=[400,401,403,404,409,413,429,502,503,504].includes(Number(error?.status))?Number(error.status):500;
+      return json(res,status,{ok:false,error:String(error?.message||'NATIVE_STORE_GCC_ENRICH_FAILED').slice(0,120)});
+    }
+  }
   return ownerOperationsHandler(req, res);
 }

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -1,7 +1,32 @@
 import type { DabbirSession } from './session';
-import { isGccCountryCode, resolveSelectedCountry, saveSelectedCountry, type GccCountryCode } from './country';
+import { countryProfile, inferDeviceCountry, isGccCountryCode, resolveSelectedCountry, saveSelectedCountry, type GccCountryCode } from './country';
 
 const configuredBase = String(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL || '').trim().replace(/\/$/, '');
+const deviceProfile = countryProfile(inferDeviceCountry()) || countryProfile('AE');
+if (!deviceProfile) throw new Error('GCC_DEVICE_PROFILE_UNAVAILABLE');
+let runtimeCurrencyCode = deviceProfile.currency;
+let runtimeTimezone = deviceProfile.timezone;
+
+function syncBusinessProfile(payload: any): void {
+  const currency = String(payload?.currency_code || payload?.business?.currency_code || payload?.business_profile?.currency_code || '').toUpperCase();
+  const timezone = String(payload?.timezone || payload?.business?.timezone || payload?.business_profile?.timezone || '').trim();
+  if (/^[A-Z]{3}$/.test(currency)) runtimeCurrencyCode = currency;
+  if (timezone) {
+    try { new Intl.DateTimeFormat('en-CA', { timeZone: timezone }).format(new Date()); runtimeTimezone = timezone; } catch {}
+  }
+}
+
+export function currentCurrencyCode(): string {
+  return runtimeCurrencyCode;
+}
+
+export function formatAmount(value: unknown): string {
+  return `${Number(value || 0).toFixed(2)} ${runtimeCurrencyCode}`;
+}
+
+export function businessDateToday(): string {
+  return new Intl.DateTimeFormat('en-CA', { timeZone: runtimeTimezone, year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
+}
 
 function apiBase(): string {
   if (!configuredBase || !/^https:\/\//i.test(configuredBase)) {
@@ -74,6 +99,7 @@ export async function loadRuntime(accessToken: string): Promise<any> {
     headers: { accept: 'application/json', authorization: `Bearer ${accessToken}` },
   });
   const payload = await parseJson(response);
+  syncBusinessProfile(payload);
   const countryCode = String(payload?.business?.country_code || '').toUpperCase();
   if (isGccCountryCode(countryCode)) await saveSelectedCountry(countryCode).catch(() => undefined);
   return payload;
@@ -92,6 +118,7 @@ export async function createBusiness(accessToken: string, name: string, business
   const resolved = await resolvedCountry(countryCode);
   const language = String(locale || '').toLowerCase().startsWith('en') ? 'en' : 'ar';
   const payload = await post('/api/mobile/runtime', { action: 'create_business', name, business_type: businessType, locale: `${language}-${resolved}`, country_code: resolved }, accessToken);
+  syncBusinessProfile(payload);
   await saveSelectedCountry(resolved).catch(() => undefined);
   return payload;
 }
@@ -100,6 +127,7 @@ export async function createStore(accessToken: string, name: string, locale: Dab
   const resolved = await resolvedCountry(countryCode);
   const language = String(locale || '').toLowerCase().startsWith('en') ? 'en' : 'ar';
   const payload = await post('/api/mobile/runtime', { action: 'create_business', name, business_type: 'store', locale: `${language}-${resolved}`, country_code: resolved }, accessToken);
+  syncBusinessProfile(payload);
   await saveSelectedCountry(resolved).catch(() => undefined);
   return payload;
 }
@@ -124,7 +152,9 @@ export async function loadOwnerOperations(accessToken: string, businessId?: stri
   const response = await fetch(`${apiBase()}/api/mobile/owner-operations${query}`, {
     headers: { accept: 'application/json', authorization: `Bearer ${accessToken}` },
   });
-  return parseJson(response);
+  const payload = await parseJson(response);
+  syncBusinessProfile(payload);
+  return payload;
 }
 
 export async function mutateOwnerOperations(accessToken: string, payload: Record<string, unknown>): Promise<any> {

--- a/test/dabbir-native-store-gcc-metrics.test.mjs
+++ b/test/dabbir-native-store-gcc-metrics.test.mjs
@@ -1,0 +1,19 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const read=relative=>fs.readFileSync(path.join(root,relative),'utf8');
+
+test('native store GET preserves the tenant handler but recalculates day metrics from the business timezone',()=>{
+  const source=read('api/mobile/owner-operations.js');
+  for(const token of ['ownerOperationsHandler','requireNativeBearer','currency_code,timezone,phone_country_prefix','localDateKey','businessDate','todayOrders','todayReturns','today_expenses_aed','store_metrics_are_business_day_facts:true'])assert.match(source,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+  assert.match(source,/timeZone:timezone/);
+  assert.doesNotMatch(source,/timeZone:'Asia\/Dubai'/);
+});
+
+test('native store response exposes currency-aware aliases without renaming the legacy ledger columns',()=>{
+  const source=read('api/mobile/owner-operations.js');
+  for(const token of ['sales_today=','returned_today=','net_sales_today=','today_expenses=','recognized_sales=','cash_collected=','receivables=','currency_code=business.currency_code','legacy_aed_field_names_are_storage_compatibility:true'])assert.match(source,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+});


### PR DESCRIPTION
Superseded by #390. #390 carries the same three-file native GCC financial slice on top of the clean #386 authority branch, avoiding stale-base merges while preserving the latest calendar and booking fixes.