### PR TITLE
Harden DABBIR for worst-case failures

### DIFF
--- a/.github/workflows/dabbir-runtime-guardian.yml
+++ b/.github/workflows/dabbir-runtime-guardian.yml
@@ -1,0 +1,81 @@
+name: DABBIR Runtime Guardian
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '*/5 * * * *'
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: dabbir-runtime-guardian
+  cancel-in-progress: true
+
+jobs:
+  production-health:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      BASE_URL: https://dabbir.bmalman.com
+      ISSUE_TITLE: '[Runtime Guardian] DABBIR production health failure'
+    steps:
+      - name: Probe production with retries
+        id: probe
+        shell: bash
+        run: |
+          set +e
+          failed=''
+          details=''
+          for path in / /team /owner /api/runtime-health; do
+            ok=0
+            for attempt in 1 2 3; do
+              code="$(curl -sS -L --max-time 15 -o /tmp/dabbir-body -w '%{http_code}' "${BASE_URL}${path}")"
+              if [[ "$code" =~ ^2[0-9][0-9]$ || "$code" =~ ^3[0-9][0-9]$ ]]; then ok=1; break; fi
+              sleep $((attempt * 3))
+            done
+            if [ "$ok" -ne 1 ]; then
+              failed="${failed} ${path}"
+              details="${details}${path}=HTTP_${code}; "
+            fi
+          done
+          if [ -n "$failed" ]; then
+            echo "healthy=false" >> "$GITHUB_OUTPUT"
+            echo "details=${details}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "healthy=true" >> "$GITHUB_OUTPUT"
+          echo "details=all production probes passed" >> "$GITHUB_OUTPUT"
+
+      - name: Open or refresh incident issue
+        if: steps.probe.outputs.healthy != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          DETAILS: ${{ steps.probe.outputs.details }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$ISSUE_TITLE in:title" --json number --jq '.[0].number // empty')"
+          body="Production Runtime Guardian detected a persistent DABBIR failure after 3 retries.\n\nEvidence: ${DETAILS}\nRun: ${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}\nDetected (UTC): $(date -u +%FT%TZ)\n\nBooking truth must remain in Supabase; external integrations are expected to degrade/retry rather than block booking."
+          if [ -n "$existing" ]; then
+            gh issue edit "$existing" --repo "$GITHUB_REPOSITORY" --body "$body"
+          else
+            gh issue create --repo "$GITHUB_REPOSITORY" --title "$ISSUE_TITLE" --body "$body"
+          fi
+
+      - name: Close recovered incident issue
+        if: steps.probe.outputs.healthy == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          existing="$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --search "$ISSUE_TITLE in:title" --json number --jq '.[0].number // empty')"
+          if [ -n "$existing" ]; then
+            gh issue close "$existing" --repo "$GITHUB_REPOSITORY" --comment "Runtime Guardian recovery verified at $(date -u +%FT%TZ). All production probes passed."
+          fi
+
+      - name: Fail the guardian run on incident
+        if: steps.probe.outputs.healthy != 'true'
+        run: exit 1

--- a/api/_calendar-sync-core.js
+++ b/api/_calendar-sync-core.js
@@ -16,11 +16,21 @@ function iso(value){const d=value instanceof Date?value:new Date(value);return N
 function hash(value){return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex')}
 function eventCancelled(provider,event){return provider==='google'?String(event?.status||'').toLowerCase()==='cancelled':Boolean(event?.isCancelled)}
 function outlookIso(value){const raw=String(value||'').trim();if(!raw)return null;return /(?:z|[+\-]\d\d:\d\d)$/i.test(raw)?raw:`${raw}Z`}
+function googleEventId(appointmentId){return `dabbir${crypto.createHash('sha256').update(String(appointmentId)).digest('hex').slice(0,40)}`}
+function retryableProviderStatus(status){return status===408||status===425||status===429||status>=500}
 
 async function providerJson(url,options={},fallback='CALENDAR_PROVIDER_REQUEST_FAILED'){
-  const response=await fetch(url,{...options,cache:'no-store',signal:options.signal||AbortSignal.timeout(15000)});
+  let response;
+  try{response=await fetch(url,{...options,cache:'no-store',signal:options.signal||AbortSignal.timeout(15000)})}
+  catch(error){const out=calendarError(fallback,503);out.retryable=true;out.providerStatus=0;out.detail=String(error?.name||'NETWORK_FAILURE');throw out}
   const text=await response.text();let data=null;try{data=text?JSON.parse(text):null}catch{}
-  if(!response.ok){const error=calendarError(fallback,[400,401,403,404,409,429,503].includes(response.status)?response.status:502);error.detail=data?.error?.message||data?.error_description||data?.message||null;throw error}
+  if(!response.ok){
+    const error=calendarError(fallback,[400,401,403,404,409,429,503].includes(response.status)?response.status:502);
+    error.detail=data?.error?.message||data?.error_description||data?.message||null;
+    error.providerStatus=response.status;
+    error.retryable=retryableProviderStatus(response.status);
+    throw error;
+  }
   return data;
 }
 
@@ -71,15 +81,26 @@ function eventTimes(provider,event){
 }
 
 function providerEventPayload(provider,appointment,title){
-  const start=iso(appointment.starts_at),end=iso(new Date(new Date(start).getTime()+DEFAULT_DURATION_MS));
+  const start=iso(appointment.starts_at),end=iso(appointment.ends_at||new Date(new Date(start).getTime()+DEFAULT_DURATION_MS));
   if(provider==='google')return {summary:title,description:`DABBIR appointment ${appointment.id}`,start:{dateTime:start},end:{dateTime:end},extendedProperties:{private:{dabbir_appointment_id:appointment.id}}};
   const graphStart=start.replace(/Z$/,''),graphEnd=end.replace(/Z$/,'');
   return {subject:title,body:{contentType:'text',content:`DABBIR_APPOINTMENT_ID:${appointment.id}`},start:{dateTime:graphStart,timeZone:'UTC'},end:{dateTime:graphEnd,timeZone:'UTC'},transactionId:appointment.id.replace(/-/g,'').slice(0,32)};
 }
 
-async function createProviderEvent(provider,accessToken,payload){
+async function getGoogleEvent(accessToken,eventId){
+  return providerJson(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${enc(eventId)}`,{headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'}},'GOOGLE_CALENDAR_GET_FAILED');
+}
+
+async function createProviderEvent(provider,accessToken,payload,appointmentId){
   const url=provider==='google'?'https://www.googleapis.com/calendar/v3/calendars/primary/events':'https://graph.microsoft.com/v1.0/me/events';
-  return providerJson(url,{method:'POST',headers:{authorization:`Bearer ${accessToken}`,'content-type':'application/json',accept:'application/json'},body:JSON.stringify(payload)},provider==='google'?'GOOGLE_CALENDAR_CREATE_FAILED':'OUTLOOK_CALENDAR_CREATE_FAILED');
+  const body=provider==='google'?{id:googleEventId(appointmentId),...payload}:payload;
+  try{
+    return await providerJson(url,{method:'POST',headers:{authorization:`Bearer ${accessToken}`,'content-type':'application/json',accept:'application/json'},body:JSON.stringify(body)},provider==='google'?'GOOGLE_CALENDAR_CREATE_FAILED':'OUTLOOK_CALENDAR_CREATE_FAILED');
+  }catch(error){
+    // A timed-out/duplicated Google create is reconciled by deterministic event id.
+    if(provider==='google'&&Number(error?.providerStatus||error?.code)===409)return getGoogleEvent(accessToken,googleEventId(appointmentId));
+    throw error;
+  }
 }
 
 async function updateProviderEvent(provider,accessToken,eventId,payload){
@@ -89,9 +110,11 @@ async function updateProviderEvent(provider,accessToken,eventId,payload){
 
 async function deleteProviderEvent(provider,accessToken,eventId){
   const url=provider==='google'?`https://www.googleapis.com/calendar/v3/calendars/primary/events/${enc(eventId)}`:`https://graph.microsoft.com/v1.0/me/events/${enc(eventId)}`;
-  const response=await fetch(url,{method:'DELETE',headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)});
+  let response;
+  try{response=await fetch(url,{method:'DELETE',headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)})}
+  catch(error){const out=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',503);out.retryable=true;out.detail=String(error?.name||'NETWORK_FAILURE');throw out}
   if(response.ok||response.status===404||response.status===410)return true;
-  const text=await response.text().catch(()=>null);const error=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',[400,401,403,409,429,503].includes(response.status)?response.status:502);error.detail=String(text||'').slice(0,240);throw error;
+  const text=await response.text().catch(()=>null);const error=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',[400,401,403,409,429,503].includes(response.status)?response.status:502);error.detail=String(text||'').slice(0,240);error.providerStatus=response.status;error.retryable=retryableProviderStatus(response.status);throw error;
 }
 
 async function upsertLink(connectionId,appointmentId,event,syncHash){
@@ -106,7 +129,7 @@ export async function syncCalendarConnection(req,connection){
   const accessToken=await refreshAccessToken(req,connection,credential);
   const now=Date.now(),start=new Date(now-SYNC_PAST_DAYS*86400000).toISOString(),end=new Date(now+SYNC_FUTURE_DAYS*86400000).toISOString();
   const [appointments,customers,links,events]=await Promise.all([
-    serviceRest(`dabbir_appointments?select=id,customer_id,starts_at,status&business_id=eq.${enc(businessId)}&starts_at=gte.${enc(start)}&starts_at=lt.${enc(end)}&order=starts_at.asc&limit=1000`),
+    serviceRest(`dabbir_appointments?select=id,customer_id,starts_at,ends_at,status&business_id=eq.${enc(businessId)}&starts_at=gte.${enc(start)}&starts_at=lt.${enc(end)}&order=starts_at.asc&limit=1000`),
     serviceRest(`dabbir_customers?select=id,display_name&business_id=eq.${enc(businessId)}&limit=1000`),
     serviceRest(`dabbir_calendar_event_links?select=connection_id,appointment_id,provider_event_id,provider_etag,sync_hash,last_provider_start,last_synced_at&connection_id=eq.${enc(connection.id)}&limit=2000`),
     listProviderEvents(provider,accessToken,start,end),
@@ -138,9 +161,9 @@ export async function syncCalendarConnection(req,connection){
       if(link&&event&&!eventCancelled(provider,event))await deleteProviderEvent(provider,accessToken,link.provider_event_id).catch(error=>{if(error?.code!==404)throw error});
       continue;
     }
-    const title=String(customerMap.get(appointment.customer_id)||'Customer').slice(0,160),payload=providerEventPayload(provider,appointment,title),syncHash=hash({start:appointment.starts_at,status:appointment.status,title});
+    const title=String(customerMap.get(appointment.customer_id)||'Customer').slice(0,160),payload=providerEventPayload(provider,appointment,title),syncHash=hash({start:appointment.starts_at,end:appointment.ends_at,status:appointment.status,title});
     if(!link||!event){
-      event=await createProviderEvent(provider,accessToken,payload);event.__provider=provider;
+      event=await createProviderEvent(provider,accessToken,payload,appointment.id);event.__provider=provider;
       await upsertLink(connection.id,appointment.id,event,syncHash);link={connection_id:connection.id,appointment_id:appointment.id,provider_event_id:event.id,sync_hash:syncHash};linkMap.set(appointment.id,link);eventMap.set(String(event.id),event);pushed++;continue;
     }
     if(link.sync_hash!==syncHash){
@@ -165,14 +188,16 @@ export async function syncCalendarConnection(req,connection){
 }
 
 export async function syncBusinessCalendars(req,businessId){
-  const rows=await serviceRest(`dabbir_calendar_connections?select=id,business_id,provider,status,sync_enabled,sync_direction,provider_email&business_id=eq.${enc(businessId)}&status=eq.active&sync_enabled=eq.true&order=provider.asc`);
+  const rows=await serviceRest(`dabbir_calendar_connections?select=id,business_id,provider,status,sync_enabled,sync_direction,provider_email&business_id=eq.${enc(businessId)}&status=in.(active,error)&sync_enabled=eq.true&order=provider.asc`);
   const results=[];
   for(const connection of rows||[]){
     try{results.push({ok:true,...await syncCalendarConnection(req,connection)})}
     catch(error){
       const message=String(error?.message||'CALENDAR_SYNC_FAILED').slice(0,160);
+      const code=Number(error?.providerStatus||error?.code||500);
+      const retryable=error?.retryable===true||retryableProviderStatus(code);
       await serviceRest(`dabbir_calendar_connections?id=eq.${enc(connection.id)}`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({status:'error',last_error:message,updated_at:new Date().toISOString()})}).catch(()=>null);
-      results.push({ok:false,connection_id:connection.id,provider:connection.provider,error:message});
+      results.push({ok:false,connection_id:connection.id,provider:connection.provider,error:message,code,retryable});
     }
   }
   return results;

--- a/api/_rate-limit.js
+++ b/api/_rate-limit.js
@@ -1,0 +1,42 @@
+import crypto from 'node:crypto';
+import { SUPABASE_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+
+const clean=(value,max=500)=>String(value??'').trim().slice(0,max);
+function key(){
+  const value=clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
+  if(!value||value.startsWith('sb_publishable_'))throw Object.assign(new Error('RATE_LIMIT_STORAGE_NOT_CONFIGURED'),{status:503});
+  return value;
+}
+function clientAddress(req){
+  const raw=clean(req.headers?.['x-forwarded-for']||req.socket?.remoteAddress||'',400);
+  return raw.split(',')[0].trim().slice(0,120)||'unknown';
+}
+function digest(value){return crypto.createHash('sha256').update(String(value)).digest('hex')}
+async function read(response){
+  const text=await response.text();let payload=null;try{payload=text?JSON.parse(text):null}catch{}
+  if(!response.ok)throw Object.assign(new Error(payload?.message||payload?.code||'RATE_LIMIT_FAILED'),{status:response.status});
+  return Array.isArray(payload)?payload[0]||null:payload;
+}
+
+export async function consumeRateLimit(req,{action,limit,windowSeconds,subject=null,failClosed=true}={}){
+  const name=clean(action,80);if(!name)throw Object.assign(new Error('RATE_LIMIT_ACTION_REQUIRED'),{status:500});
+  const identity=subject?clean(subject,300):clientAddress(req);
+  const keyHash=digest(`${name}:${identity}`);
+  try{
+    const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/dabbir_consume_rate_limit`,{
+      method:'POST',cache:'no-store',signal:AbortSignal.timeout(5000),
+      headers:supabaseKeyHeaders(key(),{'content-type':'application/json',accept:'application/json'}),
+      body:JSON.stringify({p_action:name,p_key_hash:keyHash,p_limit:Number(limit||30),p_window_seconds:Number(windowSeconds||60)}),
+    });
+    const row=await read(response);
+    return {allowed:row?.allowed===true,remaining:Number(row?.remaining||0),retryAfter:Number(row?.retry_after||1)};
+  }catch(error){
+    if(failClosed)throw Object.assign(new Error('RATE_LIMIT_UNAVAILABLE'),{status:503,cause:error});
+    return {allowed:true,remaining:0,retryAfter:0,degraded:true};
+  }
+}
+
+export function rateLimitHeaders(result){
+  return result?.allowed===false?{'retry-after':String(Math.max(1,Number(result.retryAfter||1)))}:{};
+}

--- a/api/public-car-wash.js
+++ b/api/public-car-wash.js
@@ -1,4 +1,5 @@
 import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+import { consumeRateLimit, rateLimitHeaders } from './_rate-limit.js';
 
 const SUPABASE_URL=String(process.env.SUPABASE_URL||'').replace(/\/$/,'');
 const SLUG_RE=/^[a-z0-9][a-z0-9_-]{2,119}$/i;
@@ -56,6 +57,8 @@ export default async function handler(req,res){
     }
     if(req.method==='POST'){
       if(!sameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+      const throttle=await consumeRateLimit(req,{action:'public_car_wash_booking',limit:20,windowSeconds:300,failClosed:true});
+      if(!throttle.allowed)return json(res,429,{ok:false,error:'BOOKING_RATE_LIMITED'},rateLimitHeaders(throttle));
       const body=await readBody(req);
       const pSlug=slug(body.slug),offer=clean(body.offer_id,80),vehicle=clean(body.vehicle_type,16).toLowerCase();
       const starts=clean(body.starts_at,40),name=clean(body.customer_name,120),phone=clean(body.customer_phone,30),label=clean(body.location_label,240);

--- a/api/resilience-worker-cron.js
+++ b/api/resilience-worker-cron.js
@@ -45,8 +45,9 @@ export default async function handler(req,res){
   try{
     const claimed=await rpc(key,'dabbir_claim_integration_jobs',{p_limit:50});
     const jobs=Array.isArray(claimed)?claimed:[];
+    const groups=groupByBusiness(jobs);
     const results=[];
-    for(const [businessId,businessJobs] of groupByBusiness(jobs)){
+    for(const [businessId,businessJobs] of groups){
       if(!businessJobs.every(job=>job.destination==='calendar_sync')){
         for(const job of businessJobs){const state=await finalize(key,job,{success:false,retryable:false,error:'UNSUPPORTED_OUTBOX_DESTINATION'});results.push({job_id:job.job_id,state})}
         continue;
@@ -69,7 +70,11 @@ export default async function handler(req,res){
       }
     }
     const cleanup=await rpc(key,'dabbir_cleanup_resilience_state',{}).catch(()=>null);
-    const summary={ok:true,claimed:jobs.length,businesses:groupByBusiness(jobs).size,succeeded:results.filter(x=>x.state==='succeeded').length,retry:results.filter(x=>x.state==='retry').length,dead:results.filter(x=>x.state==='dead').length,cleanup};
+    let recovery=null;
+    if(new Date().getUTCMinutes()===0){
+      recovery=await rpc(key,'dabbir_owner_recovery_maintenance_v1',{}).catch(error=>({ok:false,error:clean(error?.message||'RECOVERY_DRY_RUN_FAILED',200)}));
+    }
+    const summary={ok:true,claimed:jobs.length,businesses:groups.size,succeeded:results.filter(x=>x.state==='succeeded').length,retry:results.filter(x=>x.state==='retry').length,dead:results.filter(x=>x.state==='dead').length,cleanup,recovery};
     console.info('dabbir_resilience_worker',{auth_mode:authMode,...summary});
     return json(res,200,summary);
   }catch(error){

--- a/api/resilience-worker-cron.js
+++ b/api/resilience-worker-cron.js
@@ -1,0 +1,78 @@
+import { timingSafeEqual } from 'node:crypto';
+import { json, SUPABASE_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+import { syncBusinessCalendars } from './_calendar-sync-core.js';
+
+const EXPECTED_SCHEDULE='* * * * *';
+const clean=(value,max=500)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+function serviceKey(){
+  const key=clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
+  if(!key||key.startsWith('sb_publishable_'))throw Object.assign(new Error('RESILIENCE_STORAGE_NOT_CONFIGURED'),{status:503});
+  return key;
+}
+function sameSecret(left,right){const a=Buffer.from(String(left||'')),b=Buffer.from(String(right||''));return a.length===b.length&&a.length>0&&timingSafeEqual(a,b)}
+export function cronAuthMode(req,env=process.env){
+  const secret=clean(env.CRON_SECRET,4096),authorization=clean(req.headers?.authorization,8192);
+  if(secret)return sameSecret(authorization,`Bearer ${secret}`)?'secret':null;
+  return clean(env.VERCEL_ENV,32)==='production'&&clean(req.headers?.['user-agent'],120).toLowerCase()==='vercel-cron/1.0'&&clean(req.headers?.['x-vercel-cron-schedule'],120)===EXPECTED_SCHEDULE?'vercel_schedule':null;
+}
+async function rpc(key,name,params={}){
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{
+    method:'POST',cache:'no-store',signal:AbortSignal.timeout(10000),
+    headers:supabaseKeyHeaders(key,{'content-type':'application/json',accept:'application/json'}),
+    body:JSON.stringify(params),
+  });
+  const text=await response.text();let payload=null;try{payload=text?JSON.parse(text):null}catch{}
+  if(!response.ok)throw Object.assign(new Error(payload?.message||payload?.code||`${name.toUpperCase()}_FAILED`),{status:response.status});
+  return payload;
+}
+async function finalize(key,job,{success,retryable=false,error=null,correlation=null}){
+  return rpc(key,'dabbir_finalize_integration_job',{
+    p_job_id:job.job_id,p_lock_token:job.lock_token,p_success:success,p_retryable:retryable,
+    p_error:error,p_provider_correlation_id:correlation,
+  });
+}
+function groupByBusiness(items){
+  const groups=new Map();
+  for(const item of items||[]){const id=String(item.business_id||'');if(!groups.has(id))groups.set(id,[]);groups.get(id).push(item)}
+  return groups;
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const authMode=cronAuthMode(req);if(!authMode)return json(res,401,{ok:false,error:'CRON_AUTH_REQUIRED'});
+  let key;try{key=serviceKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
+  try{
+    const claimed=await rpc(key,'dabbir_claim_integration_jobs',{p_limit:50});
+    const jobs=Array.isArray(claimed)?claimed:[];
+    const results=[];
+    for(const [businessId,businessJobs] of groupByBusiness(jobs)){
+      if(!businessJobs.every(job=>job.destination==='calendar_sync')){
+        for(const job of businessJobs){const state=await finalize(key,job,{success:false,retryable:false,error:'UNSUPPORTED_OUTBOX_DESTINATION'});results.push({job_id:job.job_id,state})}
+        continue;
+      }
+      try{
+        const sync=await syncBusinessCalendars(req,businessId);
+        const failures=(sync||[]).filter(item=>item.ok===false);
+        if(failures.length){
+          const retryable=failures.some(item=>item.retryable===true);
+          const error=clean(failures.map(item=>`${item.provider||'calendar'}:${item.error||'failed'}`).join('|'),500);
+          for(const job of businessJobs){const state=await finalize(key,job,{success:false,retryable,error});results.push({job_id:job.job_id,state,retryable})}
+        }else{
+          const correlation=`calendar:${businessId}:${Date.now()}`;
+          for(const job of businessJobs){const state=await finalize(key,job,{success:true,correlation});results.push({job_id:job.job_id,state})}
+        }
+      }catch(error){
+        const code=clean(error?.message||'CALENDAR_RETRY_WORKER_FAILED',300);
+        const retryable=error?.retryable===true||Number(error?.code||error?.status||0)>=500;
+        for(const job of businessJobs){const state=await finalize(key,job,{success:false,retryable,error:code}).catch(()=>null);results.push({job_id:job.job_id,state:state||'finalize_failed',retryable})}
+      }
+    }
+    const cleanup=await rpc(key,'dabbir_cleanup_resilience_state',{}).catch(()=>null);
+    const summary={ok:true,claimed:jobs.length,businesses:groupByBusiness(jobs).size,succeeded:results.filter(x=>x.state==='succeeded').length,retry:results.filter(x=>x.state==='retry').length,dead:results.filter(x=>x.state==='dead').length,cleanup};
+    console.info('dabbir_resilience_worker',{auth_mode:authMode,...summary});
+    return json(res,200,summary);
+  }catch(error){
+    const code=clean(error?.message||'RESILIENCE_WORKER_FAILED',240);console.error('dabbir_resilience_worker_failed',{error:code});return json(res,500,{ok:false,error:code});
+  }
+}

--- a/api/runtime-health.js
+++ b/api/runtime-health.js
@@ -1,0 +1,51 @@
+import { json, SUPABASE_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+
+const clean=(value,max=500)=>String(value??'').trim().slice(0,max);
+function key(){
+  const value=clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
+  if(!value||value.startsWith('sb_publishable_'))throw Object.assign(new Error('HEALTH_STORAGE_NOT_CONFIGURED'),{status:503});
+  return value;
+}
+async function snapshot(){
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/dabbir_resilience_health_snapshot`,{
+    method:'POST',cache:'no-store',signal:AbortSignal.timeout(7000),
+    headers:supabaseKeyHeaders(key(),{'content-type':'application/json',accept:'application/json'}),body:'{}',
+  });
+  const text=await response.text();let body=null;try{body=text?JSON.parse(text):null}catch{}
+  if(!response.ok||!body||typeof body!=='object')throw Object.assign(new Error('HEALTH_DATABASE_UNAVAILABLE'),{status:503});
+  return body;
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  res.setHeader('cache-control','no-store');
+  res.setHeader('x-dabbir-health-contract','resilience-v1');
+  try{
+    const health=await snapshot();
+    const coreOk=health.core_ok===true;
+    return json(res,coreOk?200:503,{
+      ok:coreOk,
+      state:String(health.state||'unknown'),
+      core_ok:coreOk,
+      booking_conflict_guard:health.booking_conflict_guard===true,
+      recovery_guard:health.recovery_guard===true,
+      queues:{
+        notification_overdue:Number(health.notification_overdue||0),
+        notification_stale:Number(health.notification_stale||0),
+        notification_failed_or_ambiguous_1h:Number(health.notification_failed_or_ambiguous_1h||0),
+        outbox_due:Number(health.outbox_due||0),
+        outbox_stale:Number(health.outbox_stale||0),
+        outbox_dead_24h:Number(health.outbox_dead_24h||0),
+      },
+      integrations:{
+        calendar_connections_error:Number(health.calendar_connections_error||0),
+        payment_processing_errors_1h:Number(health.payment_processing_errors_1h||0),
+      },
+      checked_at:health.checked_at||new Date().toISOString(),
+    });
+  }catch(error){
+    console.error('dabbir_runtime_health_failed',{error:clean(error?.message||'HEALTH_FAILED',160)});
+    return json(res,503,{ok:false,state:'critical',core_ok:false,error:'RUNTIME_HEALTH_UNAVAILABLE'});
+  }
+}

--- a/api/salon-reminders-cron.js
+++ b/api/salon-reminders-cron.js
@@ -67,26 +67,34 @@ function templateParameters(item){
     clean(datePart(item),160),
   ];
 }
-async function finalize(req,key,item,status,providerMessageId=null,error=null){
-  if(key)return rpc(key,'dabbir_finalize_workflow_notification',{
+function retryableError(error,code){
+  if(error?.ambiguous===true)return false;
+  const status=Number(error?.providerStatus||error?.status||0);
+  if(status===408||status===425||status===429||status>=500)return true;
+  return ['WHATSAPP_TENANT_NOT_LINKED','WHATSAPP_SERVER_DATA_ACCESS_NOT_CONFIGURED'].includes(code);
+}
+async function finalize(req,key,item,status,providerMessageId=null,error=null,retryable=false){
+  if(key)return rpc(key,'dabbir_finalize_workflow_notification_v2',{
     p_notification_id:item.notification_id,
     p_status:status,
     p_provider_message_id:providerMessageId,
     p_error:error,
+    p_retryable:retryable,
   });
   return edge(req,'finalize',{
     notification_id:item.notification_id,
     status,
     provider_message_id:providerMessageId,
     error,
+    retryable,
   });
 }
 async function deliver(req,key,item){
   try{
     const connection=key?await loadBusinessConnectionWithServiceKey(key,item.business_id):item.connection;
     if(!connection||connection.status!=='connected'){
-      await finalize(req,key,item,'failed',null,'WHATSAPP_TENANT_NOT_LINKED');
-      return {id:item.notification_id,status:'failed',error:'WHATSAPP_TENANT_NOT_LINKED'};
+      const state=await finalize(req,key,item,'failed',null,'WHATSAPP_TENANT_NOT_LINKED',true);
+      return {id:item.notification_id,status:String(state||'failed'),error:'WHATSAPP_TENANT_NOT_LINKED'};
     }
     const sent=await sendMetaTemplate({
       connection,
@@ -96,13 +104,15 @@ async function deliver(req,key,item){
       language:item.template_language,
       parameters:templateParameters(item),
     });
-    await finalize(req,key,item,'sent',sent.providerMessageId,null);
+    await finalize(req,key,item,'sent',sent.providerMessageId,null,false);
     return {id:item.notification_id,status:'sent'};
   }catch(error){
     const code=clean(error?.message||'SALON_REMINDER_FAILED',160);
-    const status=error?.ambiguous===true?'ambiguous':'failed';
-    await finalize(req,key,item,status,null,code).catch(()=>null);
-    return {id:item.notification_id,status,error:code};
+    const ambiguous=error?.ambiguous===true;
+    const status=ambiguous?'ambiguous':'failed';
+    const retryable=retryableError(error,code);
+    const state=await finalize(req,key,item,status,null,code,retryable).catch(()=>null);
+    return {id:item.notification_id,status:String(state||status),error:code,retryable};
   }
 }
 
@@ -117,8 +127,15 @@ export default async function handler(req,res){
       :(await edge(req,'claim',{limit:25})).items;
     const results=[];
     for(const item of Array.isArray(claimed)?claimed:[])results.push(await deliver(req,key,item));
-    const summary={ok:true,claimed:results.length,sent:results.filter(x=>x.status==='sent').length,failed:results.filter(x=>x.status==='failed').length,ambiguous:results.filter(x=>x.status==='ambiguous').length,results};
-    console.info('dabbir_salon_reminder_cron',{auth_mode:authMode,claimed:summary.claimed,sent:summary.sent,failed:summary.failed,ambiguous:summary.ambiguous});
+    const summary={
+      ok:true,claimed:results.length,
+      sent:results.filter(x=>x.status==='sent').length,
+      retry:results.filter(x=>x.status==='pending').length,
+      failed:results.filter(x=>x.status==='failed').length,
+      ambiguous:results.filter(x=>x.status==='ambiguous').length,
+      results,
+    };
+    console.info('dabbir_salon_reminder_cron',{auth_mode:authMode,claimed:summary.claimed,sent:summary.sent,retry:summary.retry,failed:summary.failed,ambiguous:summary.ambiguous});
     return json(res,200,summary);
   }catch(error){
     const code=clean(error?.message||'SALON_REMINDER_CRON_FAILED',160);

--- a/api/salon-reminders-cron.js
+++ b/api/salon-reminders-cron.js
@@ -108,11 +108,11 @@ async function deliver(req,key,item){
     return {id:item.notification_id,status:'sent'};
   }catch(error){
     const code=clean(error?.message||'SALON_REMINDER_FAILED',160);
-    const ambiguous=error?.ambiguous===true;
-    const status=ambiguous?'ambiguous':'failed';
+    const status=error?.ambiguous===true?'ambiguous':'failed';
+    const ambiguous=status==='ambiguous';
     const retryable=retryableError(error,code);
     const state=await finalize(req,key,item,status,null,code,retryable).catch(()=>null);
-    return {id:item.notification_id,status:String(state||status),error:code,retryable};
+    return {id:item.notification_id,status:String(state||status),error:code,retryable,ambiguous};
   }
 }
 

--- a/supabase/migrations/20260903200000_dabbir_worst_case_resilience_v1.sql
+++ b/supabase/migrations/20260903200000_dabbir_worst_case_resilience_v1.sql
@@ -1,0 +1,521 @@
+-- DABBIR worst-case resilience v1.
+-- Business truth is committed first; external side effects are retried separately.
+
+alter table public.dabbir_appointments
+  add column if not exists idempotency_key text,
+  add column if not exists idempotency_payload_hash text;
+
+create unique index if not exists dabbir_appointments_business_idempotency_uq
+  on public.dabbir_appointments(business_id,idempotency_key)
+  where idempotency_key is not null;
+
+alter table public.dabbir_appointments
+  drop constraint if exists dabbir_appointments_idempotency_key_check;
+alter table public.dabbir_appointments
+  add constraint dabbir_appointments_idempotency_key_check
+  check (idempotency_key is null or char_length(idempotency_key) between 16 and 160);
+
+alter table public.dabbir_appointments
+  drop constraint if exists dabbir_appointments_idempotency_hash_check;
+alter table public.dabbir_appointments
+  add constraint dabbir_appointments_idempotency_hash_check
+  check (idempotency_payload_hash is null or idempotency_payload_hash ~ '^[0-9a-f]{64}$');
+
+-- Operational bookings are never hard-deleted by normal authenticated users.
+-- Cancellation preserves history, audit, reminders and recovery evidence.
+drop policy if exists dabbir_appointments_delete on public.dabbir_appointments;
+revoke delete on public.dabbir_appointments from authenticated;
+
+create table if not exists public.dabbir_integration_outbox (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  destination text not null check (destination in ('calendar_sync')),
+  aggregate_type text not null default 'appointment' check (char_length(aggregate_type) between 2 and 60),
+  aggregate_id uuid,
+  event_type text not null check (char_length(event_type) between 2 and 80),
+  idempotency_key text not null check (char_length(idempotency_key) between 12 and 200),
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'pending' check (status in ('pending','processing','retry','succeeded','dead','cancelled')),
+  attempts integer not null default 0 check (attempts between 0 and 100),
+  max_attempts integer not null default 8 check (max_attempts between 1 and 20),
+  available_at timestamptz not null default now(),
+  locked_at timestamptz,
+  lock_token uuid,
+  provider_correlation_id text,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz,
+  unique (business_id,destination,idempotency_key)
+);
+
+create index if not exists dabbir_integration_outbox_due_idx
+  on public.dabbir_integration_outbox(status,available_at,created_at)
+  where status in ('pending','retry');
+create index if not exists dabbir_integration_outbox_dead_idx
+  on public.dabbir_integration_outbox(updated_at desc,business_id)
+  where status='dead';
+create index if not exists dabbir_integration_outbox_business_idx
+  on public.dabbir_integration_outbox(business_id,destination,created_at desc);
+
+alter table public.dabbir_integration_outbox enable row level security;
+revoke all on public.dabbir_integration_outbox from public,anon,authenticated;
+grant select,insert,update,delete on public.dabbir_integration_outbox to service_role;
+
+create table if not exists public.dabbir_rate_limit_windows (
+  action text not null check (char_length(action) between 2 and 80),
+  key_hash text not null check (key_hash ~ '^[0-9a-f]{64}$'),
+  window_started_at timestamptz not null,
+  request_count integer not null default 0 check (request_count >= 0),
+  expires_at timestamptz not null,
+  updated_at timestamptz not null default now(),
+  primary key (action,key_hash,window_started_at)
+);
+create index if not exists dabbir_rate_limit_windows_expiry_idx
+  on public.dabbir_rate_limit_windows(expires_at);
+alter table public.dabbir_rate_limit_windows enable row level security;
+revoke all on public.dabbir_rate_limit_windows from public,anon,authenticated;
+grant select,insert,update,delete on public.dabbir_rate_limit_windows to service_role;
+
+alter table public.dabbir_workflow_notifications
+  add column if not exists attempts integer not null default 0,
+  add column if not exists max_attempts integer not null default 6,
+  add column if not exists next_attempt_at timestamptz,
+  add column if not exists last_attempt_at timestamptz;
+
+alter table public.dabbir_workflow_notifications
+  drop constraint if exists dabbir_workflow_notifications_attempts_check;
+alter table public.dabbir_workflow_notifications
+  add constraint dabbir_workflow_notifications_attempts_check check (attempts between 0 and 100);
+alter table public.dabbir_workflow_notifications
+  drop constraint if exists dabbir_workflow_notifications_max_attempts_check;
+alter table public.dabbir_workflow_notifications
+  add constraint dabbir_workflow_notifications_max_attempts_check check (max_attempts between 1 and 20);
+
+create index if not exists dabbir_workflow_notifications_retry_due_idx
+  on public.dabbir_workflow_notifications(status,coalesce(next_attempt_at,scheduled_for),scheduled_for)
+  where status='pending';
+
+create or replace function public.dabbir_create_appointment_idempotent(
+  p_business_id uuid,
+  p_idempotency_key text,
+  p_customer_id uuid default null,
+  p_customer_name text default 'Customer',
+  p_customer_phone text default null,
+  p_service_id uuid default null,
+  p_worker_id uuid default null,
+  p_starts_at timestamptz default null,
+  p_ends_at timestamptz default null,
+  p_source text default 'internal'
+) returns table(appointment_id uuid, customer_id uuid, duplicate boolean, status text)
+language plpgsql
+security invoker
+set search_path=public,extensions,pg_temp
+as $function$
+declare
+  v_key text := trim(coalesce(p_idempotency_key,''));
+  v_customer_id uuid := p_customer_id;
+  v_payload_hash text;
+  v_existing public.dabbir_appointments%rowtype;
+  v_inserted public.dabbir_appointments%rowtype;
+  v_name text := left(coalesce(nullif(trim(p_customer_name),''),'Customer'),120);
+  v_phone text := nullif(left(trim(coalesce(p_customer_phone,'')),30),'');
+  v_end timestamptz;
+begin
+  if p_business_id is null then raise exception 'BUSINESS_REQUIRED'; end if;
+  if char_length(v_key) < 16 or char_length(v_key) > 160 then raise exception 'INVALID_IDEMPOTENCY_KEY'; end if;
+  if p_starts_at is null or p_starts_at <= now() then raise exception 'VALID_FUTURE_START_REQUIRED'; end if;
+  if coalesce(p_source,'internal') not in ('internal','web','whatsapp','phone','walk_in','rebook','waitlist','calendar_sync') then raise exception 'INVALID_BOOKING_SOURCE'; end if;
+  v_end := coalesce(p_ends_at,p_starts_at+interval '60 minutes');
+  if v_end <= p_starts_at then raise exception 'INVALID_APPOINTMENT_RANGE'; end if;
+
+  v_payload_hash := encode(extensions.digest(jsonb_build_object(
+    'business_id',p_business_id,'customer_id',p_customer_id,'customer_name',v_name,
+    'customer_phone',v_phone,'service_id',p_service_id,'worker_id',p_worker_id,
+    'starts_at',p_starts_at,'ends_at',v_end,'source',coalesce(p_source,'internal')
+  )::text,'sha256'),'hex');
+
+  select a.* into v_existing
+  from public.dabbir_appointments a
+  where a.business_id=p_business_id and a.idempotency_key=v_key
+  limit 1;
+  if found then
+    if v_existing.idempotency_payload_hash is distinct from v_payload_hash then
+      raise exception 'IDEMPOTENCY_KEY_REUSE_CONFLICT';
+    end if;
+    return query select v_existing.id,v_existing.customer_id,true,v_existing.status;
+    return;
+  end if;
+
+  begin
+    if v_customer_id is null and v_phone is not null then
+      select c.id into v_customer_id from public.dabbir_customers c
+      where c.business_id=p_business_id and c.phone_e164=v_phone limit 1;
+    end if;
+    if v_customer_id is null then
+      insert into public.dabbir_customers(business_id,display_name,phone_e164,lead_status,metadata)
+      values(p_business_id,v_name,v_phone,'new',jsonb_build_object('source','idempotent_booking_runtime'))
+      on conflict (business_id,phone_e164) where phone_e164 is not null
+      do update set display_name=excluded.display_name,updated_at=now()
+      returning id into v_customer_id;
+    end if;
+
+    insert into public.dabbir_appointments(
+      business_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,
+      booking_source,idempotency_key,idempotency_payload_hash
+    ) values(
+      p_business_id,v_customer_id,p_service_id,p_worker_id,p_starts_at,v_end,'new',false,
+      coalesce(p_source,'internal'),v_key,v_payload_hash
+    ) returning * into v_inserted;
+  exception when unique_violation then
+    select a.* into v_existing
+    from public.dabbir_appointments a
+    where a.business_id=p_business_id and a.idempotency_key=v_key
+    limit 1;
+    if not found then raise; end if;
+    if v_existing.idempotency_payload_hash is distinct from v_payload_hash then
+      raise exception 'IDEMPOTENCY_KEY_REUSE_CONFLICT';
+    end if;
+    return query select v_existing.id,v_existing.customer_id,true,v_existing.status;
+    return;
+  end;
+
+  return query select v_inserted.id,v_inserted.customer_id,false,v_inserted.status;
+end;
+$function$;
+revoke all on function public.dabbir_create_appointment_idempotent(uuid,text,uuid,text,text,uuid,uuid,timestamptz,timestamptz,text) from public,anon;
+grant execute on function public.dabbir_create_appointment_idempotent(uuid,text,uuid,text,text,uuid,uuid,timestamptz,timestamptz,text) to authenticated;
+
+create or replace function dabbir_private.enqueue_calendar_sync_from_appointment()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $function$
+declare
+  v_event text;
+  v_key text;
+begin
+  if tg_op='UPDATE' and row(new.starts_at,new.ends_at,new.status,new.worker_id,new.customer_id,new.service_id)
+     is not distinct from row(old.starts_at,old.ends_at,old.status,old.worker_id,old.customer_id,old.service_id) then
+    return new;
+  end if;
+  if not exists(
+    select 1 from public.dabbir_calendar_connections c
+    where c.business_id=new.business_id and c.status='active' and c.sync_enabled=true
+  ) then return new; end if;
+
+  v_event := case when new.status='cancelled' then 'appointment.cancelled' else 'appointment.upserted' end;
+  v_key := 'appointment:'||new.id||':'||txid_current()::text;
+  insert into public.dabbir_integration_outbox(
+    business_id,destination,aggregate_type,aggregate_id,event_type,idempotency_key,payload
+  ) values(
+    new.business_id,'calendar_sync','appointment',new.id,v_event,v_key,
+    jsonb_build_object('appointment_id',new.id,'status',new.status,'starts_at',new.starts_at,'ends_at',new.ends_at)
+  ) on conflict (business_id,destination,idempotency_key) do nothing;
+  return new;
+end;
+$function$;
+revoke all on function dabbir_private.enqueue_calendar_sync_from_appointment() from public,anon,authenticated;
+
+drop trigger if exists zz_dabbir_appointment_calendar_outbox on public.dabbir_appointments;
+create trigger zz_dabbir_appointment_calendar_outbox
+after insert or update on public.dabbir_appointments
+for each row execute function dabbir_private.enqueue_calendar_sync_from_appointment();
+
+create or replace function public.dabbir_claim_integration_jobs(p_limit integer default 20)
+returns table(
+  job_id uuid,business_id uuid,destination text,aggregate_type text,aggregate_id uuid,
+  event_type text,payload jsonb,attempts integer,max_attempts integer,lock_token uuid
+)
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+begin
+  update public.dabbir_integration_outbox o
+  set status=case when o.attempts>=o.max_attempts then 'dead' else 'retry' end,
+      available_at=case when o.attempts>=o.max_attempts then o.available_at else now() end,
+      last_error=case when o.attempts>=o.max_attempts then 'STALE_PROCESSING_EXHAUSTED' else 'STALE_PROCESSING_RECOVERED' end,
+      locked_at=null,lock_token=null,updated_at=now(),
+      completed_at=case when o.attempts>=o.max_attempts then now() else null end
+  where o.status='processing' and o.locked_at<now()-interval '5 minutes';
+
+  return query
+  with candidates as (
+    select o.id
+    from public.dabbir_integration_outbox o
+    where o.status in ('pending','retry') and o.available_at<=now()
+    order by o.available_at,o.created_at
+    for update skip locked
+    limit greatest(1,least(coalesce(p_limit,20),100))
+  ), claimed as (
+    update public.dabbir_integration_outbox o
+    set status='processing',attempts=o.attempts+1,locked_at=now(),lock_token=gen_random_uuid(),updated_at=now()
+    from candidates c where o.id=c.id
+    returning o.*
+  )
+  select c.id,c.business_id,c.destination,c.aggregate_type,c.aggregate_id,c.event_type,
+         c.payload,c.attempts,c.max_attempts,c.lock_token
+  from claimed c order by c.available_at,c.created_at;
+end;
+$function$;
+revoke all on function public.dabbir_claim_integration_jobs(integer) from public,anon,authenticated;
+grant execute on function public.dabbir_claim_integration_jobs(integer) to service_role;
+
+create or replace function public.dabbir_finalize_integration_job(
+  p_job_id uuid,p_lock_token uuid,p_success boolean,p_retryable boolean,
+  p_error text default null,p_provider_correlation_id text default null
+) returns text
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+declare
+  v_job public.dabbir_integration_outbox%rowtype;
+  v_state text;
+  v_delay integer;
+begin
+  select o.* into v_job from public.dabbir_integration_outbox o
+  where o.id=p_job_id and o.status='processing' and o.lock_token=p_lock_token for update;
+  if not found then return 'not_owned'; end if;
+
+  if p_success then
+    v_state:='succeeded';
+    update public.dabbir_integration_outbox o set status=v_state,completed_at=now(),locked_at=null,lock_token=null,
+      provider_correlation_id=left(nullif(p_provider_correlation_id,''),320),last_error=null,updated_at=now()
+    where o.id=p_job_id;
+  elsif coalesce(p_retryable,false) and v_job.attempts<v_job.max_attempts then
+    v_state:='retry';
+    v_delay:=least(1800,15*power(2,greatest(0,v_job.attempts-1))::integer);
+    update public.dabbir_integration_outbox o set status=v_state,available_at=now()+make_interval(secs=>v_delay),
+      locked_at=null,lock_token=null,last_error=left(nullif(p_error,''),500),updated_at=now()
+    where o.id=p_job_id;
+  else
+    v_state:='dead';
+    update public.dabbir_integration_outbox o set status=v_state,completed_at=now(),locked_at=null,lock_token=null,
+      last_error=left(nullif(p_error,''),500),updated_at=now()
+    where o.id=p_job_id;
+  end if;
+  return v_state;
+end;
+$function$;
+revoke all on function public.dabbir_finalize_integration_job(uuid,uuid,boolean,boolean,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_finalize_integration_job(uuid,uuid,boolean,boolean,text,text) to service_role;
+
+create or replace function public.dabbir_claim_workflow_notifications(p_limit integer default 25)
+returns table(
+  notification_id uuid,business_id uuid,appointment_id uuid,customer_id uuid,notification_type text,
+  template_name text,template_language text,idempotency_key text,phone_e164 text,business_name text,
+  timezone text,starts_at timestamptz,ends_at timestamptz,service_name_ar text,service_name_en text,worker_name text
+)
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+begin
+  update public.dabbir_workflow_notifications n
+  set status=case when n.attempts>=n.max_attempts then 'failed' else 'pending' end,
+      next_attempt_at=case when n.attempts>=n.max_attempts then n.next_attempt_at else now() end,
+      last_error=case when n.attempts>=n.max_attempts then 'STALE_PROCESSING_EXHAUSTED' else 'STALE_PROCESSING_RECOVERED' end,
+      updated_at=now()
+  where n.status='processing' and n.updated_at<now()-interval '15 minutes';
+
+  update public.dabbir_workflow_notifications n
+  set status='failed',last_error='NOTIFICATION_EXPIRED_BEFORE_DELIVERY',updated_at=now()
+  where n.status='pending' and n.scheduled_for<now()-interval '2 days';
+
+  return query
+  with candidates as (
+    select n.id
+    from public.dabbir_workflow_notifications n
+    where n.status='pending' and n.scheduled_for<=now()
+      and coalesce(n.next_attempt_at,n.scheduled_for)<=now()
+      and n.attempts<n.max_attempts
+    order by coalesce(n.next_attempt_at,n.scheduled_for),n.created_at
+    for update skip locked
+    limit greatest(1,least(coalesce(p_limit,25),100))
+  ), claimed as (
+    update public.dabbir_workflow_notifications n
+    set status='processing',attempts=n.attempts+1,last_attempt_at=now(),updated_at=now(),last_error=null
+    from candidates c where n.id=c.id returning n.*
+  )
+  select n.id,n.business_id,n.appointment_id,n.customer_id,n.notification_type,
+    coalesce(n.template_name,case n.notification_type
+      when 'booking_confirmation' then 'dabbir_salon_booking_confirmation'
+      when 'reminder_24h' then 'dabbir_salon_reminder_24h'
+      when 'reminder_2h' then 'dabbir_salon_reminder_2h'
+      when 'appointment_changed' then 'dabbir_salon_appointment_changed'
+      when 'appointment_cancelled' then 'dabbir_salon_appointment_cancelled'
+      when 'waitlist_offer' then 'dabbir_salon_waitlist_offer'
+      when 'rebooking' then 'dabbir_salon_rebooking'
+      else 'dabbir_salon_follow_up' end),
+    n.template_language,n.idempotency_key,c.phone_e164,b.name,coalesce(ss.timezone,'Asia/Dubai'),a.starts_at,a.ends_at,
+    coalesce(s.name_ar,s.name),coalesce(s.name_en,s.name),w.display_name
+  from claimed n
+  join public.dabbir_businesses b on b.id=n.business_id and b.business_type='salon'
+  left join public.dabbir_salon_settings ss on ss.business_id=n.business_id
+  join public.dabbir_customers c on c.id=n.customer_id and c.business_id=n.business_id
+  left join public.dabbir_appointments a on a.id=n.appointment_id and a.business_id=n.business_id
+  left join public.dabbir_services s on s.id=a.service_id and s.business_id=n.business_id
+  left join public.dabbir_workers w on w.id=a.worker_id and w.business_id=n.business_id
+  where c.phone_e164 is not null;
+end;
+$function$;
+revoke all on function public.dabbir_claim_workflow_notifications(integer) from public,anon,authenticated;
+grant execute on function public.dabbir_claim_workflow_notifications(integer) to service_role;
+
+create or replace function public.dabbir_finalize_workflow_notification_v2(
+  p_notification_id uuid,p_status text,p_provider_message_id text default null,
+  p_error text default null,p_retryable boolean default false
+) returns text
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+declare
+  v_row public.dabbir_workflow_notifications%rowtype;
+  v_state text;
+  v_delay integer;
+begin
+  if p_status not in ('sent','failed','ambiguous') then raise exception 'INVALID_NOTIFICATION_FINAL_STATUS'; end if;
+  select n.* into v_row from public.dabbir_workflow_notifications n
+  where n.id=p_notification_id and n.status='processing' for update;
+  if not found then return 'not_processing'; end if;
+
+  if p_status='sent' then
+    v_state:='sent';
+    update public.dabbir_workflow_notifications n set status='sent',provider_message_id=left(nullif(p_provider_message_id,''),320),
+      sent_at=now(),last_error=null,next_attempt_at=null,updated_at=now() where n.id=p_notification_id;
+  elsif p_status='ambiguous' then
+    v_state:='ambiguous';
+    update public.dabbir_workflow_notifications n set status='ambiguous',last_error=left(nullif(p_error,''),500),
+      next_attempt_at=null,updated_at=now() where n.id=p_notification_id;
+  elsif coalesce(p_retryable,false) and v_row.attempts<v_row.max_attempts then
+    v_state:='pending';
+    v_delay:=least(1800,20*power(2,greatest(0,v_row.attempts-1))::integer);
+    update public.dabbir_workflow_notifications n set status='pending',next_attempt_at=now()+make_interval(secs=>v_delay),
+      last_error=left(nullif(p_error,''),500),updated_at=now() where n.id=p_notification_id;
+  else
+    v_state:='failed';
+    update public.dabbir_workflow_notifications n set status='failed',last_error=left(nullif(p_error,''),500),
+      next_attempt_at=null,updated_at=now() where n.id=p_notification_id;
+  end if;
+
+  insert into public.dabbir_workflow_audit(business_id,action,entity_type,entity_id,after_data)
+  values(v_row.business_id,'notification.'||v_state,'workflow_notification',p_notification_id,
+    jsonb_build_object('status',v_state,'provider_message_id',p_provider_message_id,'error',p_error,'attempts',v_row.attempts));
+  return v_state;
+end;
+$function$;
+revoke all on function public.dabbir_finalize_workflow_notification_v2(uuid,text,text,text,boolean) from public,anon,authenticated;
+grant execute on function public.dabbir_finalize_workflow_notification_v2(uuid,text,text,text,boolean) to service_role;
+
+create or replace function public.dabbir_finalize_workflow_notification(
+  p_notification_id uuid,p_status text,p_provider_message_id text default null,p_error text default null
+) returns boolean
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+declare v_state text;
+begin
+  v_state:=public.dabbir_finalize_workflow_notification_v2(
+    p_notification_id,p_status,p_provider_message_id,p_error,p_status='failed'
+  );
+  return v_state<>'not_processing';
+end;
+$function$;
+revoke all on function public.dabbir_finalize_workflow_notification(uuid,text,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_finalize_workflow_notification(uuid,text,text,text) to service_role;
+
+create or replace function public.dabbir_consume_rate_limit(
+  p_action text,p_key_hash text,p_limit integer,p_window_seconds integer
+) returns table(allowed boolean,remaining integer,retry_after integer)
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+declare
+  v_action text:=left(trim(coalesce(p_action,'')),80);
+  v_hash text:=lower(trim(coalesce(p_key_hash,'')));
+  v_start timestamptz;
+  v_expiry timestamptz;
+  v_count integer;
+begin
+  if char_length(v_action)<2 or v_hash !~ '^[0-9a-f]{64}$' then raise exception 'INVALID_RATE_LIMIT_KEY'; end if;
+  if p_limit<1 or p_limit>10000 or p_window_seconds<1 or p_window_seconds>86400 then raise exception 'INVALID_RATE_LIMIT_POLICY'; end if;
+  v_start:=to_timestamp(floor(extract(epoch from clock_timestamp())/p_window_seconds)*p_window_seconds);
+  v_expiry:=v_start+make_interval(secs=>p_window_seconds);
+  insert into public.dabbir_rate_limit_windows(action,key_hash,window_started_at,request_count,expires_at)
+  values(v_action,v_hash,v_start,1,v_expiry)
+  on conflict (action,key_hash,window_started_at)
+  do update set request_count=public.dabbir_rate_limit_windows.request_count+1,updated_at=now()
+  returning request_count into v_count;
+  return query select v_count<=p_limit,greatest(0,p_limit-v_count),greatest(1,ceil(extract(epoch from (v_expiry-clock_timestamp())))::integer);
+end;
+$function$;
+revoke all on function public.dabbir_consume_rate_limit(text,text,integer,integer) from public,anon,authenticated;
+grant execute on function public.dabbir_consume_rate_limit(text,text,integer,integer) to service_role;
+
+create or replace function public.dabbir_cleanup_resilience_state()
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $function$
+declare v_rate integer:=0;v_outbox integer:=0;
+begin
+  delete from public.dabbir_rate_limit_windows where expires_at<now()-interval '1 hour';
+  get diagnostics v_rate=row_count;
+  delete from public.dabbir_integration_outbox where status in ('succeeded','cancelled') and completed_at<now()-interval '30 days';
+  get diagnostics v_outbox=row_count;
+  return jsonb_build_object('rate_windows_deleted',v_rate,'outbox_jobs_deleted',v_outbox);
+end;
+$function$;
+revoke all on function public.dabbir_cleanup_resilience_state() from public,anon,authenticated;
+grant execute on function public.dabbir_cleanup_resilience_state() to service_role;
+
+create or replace function public.dabbir_resilience_health_snapshot()
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_catalog,dabbir_private,pg_temp
+as $function$
+declare
+  v_conflict_guard boolean;
+  v_recovery_guard boolean;
+  v_notif_overdue bigint;
+  v_notif_stale bigint;
+  v_notif_bad bigint;
+  v_outbox_due bigint;
+  v_outbox_stale bigint;
+  v_outbox_dead bigint;
+  v_calendar_error bigint;
+  v_payment_error bigint;
+  v_core boolean;
+begin
+  select exists(select 1 from pg_catalog.pg_trigger t where t.tgrelid='public.dabbir_appointments'::regclass and t.tgname='dabbir_appointment_calendar_conflict_guard' and not t.tgisinternal) into v_conflict_guard;
+  select exists(select 1 from dabbir_private.recovery_supported_tables r where r.table_name='dabbir_appointments' and r.journal_enabled and r.snapshot_enabled) into v_recovery_guard;
+  select count(*) into v_notif_overdue from public.dabbir_workflow_notifications n where n.status='pending' and coalesce(n.next_attempt_at,n.scheduled_for)<now()-interval '10 minutes';
+  select count(*) into v_notif_stale from public.dabbir_workflow_notifications n where n.status='processing' and n.updated_at<now()-interval '15 minutes';
+  select count(*) into v_notif_bad from public.dabbir_workflow_notifications n where n.status in ('failed','ambiguous') and n.updated_at>now()-interval '1 hour';
+  select count(*) into v_outbox_due from public.dabbir_integration_outbox o where o.status in ('pending','retry') and o.available_at<=now()-interval '5 minutes';
+  select count(*) into v_outbox_stale from public.dabbir_integration_outbox o where o.status='processing' and o.locked_at<now()-interval '5 minutes';
+  select count(*) into v_outbox_dead from public.dabbir_integration_outbox o where o.status='dead' and o.updated_at>now()-interval '24 hours';
+  select count(*) into v_calendar_error from public.dabbir_calendar_connections c where c.sync_enabled=true and c.status='error';
+  select count(*) into v_payment_error from public.dabbir_payment_events e where e.processing_error is not null and e.received_at>now()-interval '1 hour';
+  v_core:=v_conflict_guard and v_recovery_guard;
+  return jsonb_build_object(
+    'core_ok',v_core,
+    'state',case when not v_core then 'critical' when v_outbox_dead>0 or v_notif_stale>0 or v_outbox_stale>0 or v_payment_error>0 then 'degraded' else 'healthy' end,
+    'booking_conflict_guard',v_conflict_guard,'recovery_guard',v_recovery_guard,
+    'notification_overdue',v_notif_overdue,'notification_stale',v_notif_stale,'notification_failed_or_ambiguous_1h',v_notif_bad,
+    'outbox_due',v_outbox_due,'outbox_stale',v_outbox_stale,'outbox_dead_24h',v_outbox_dead,
+    'calendar_connections_error',v_calendar_error,'payment_processing_errors_1h',v_payment_error,
+    'checked_at',now()
+  );
+end;
+$function$;
+revoke all on function public.dabbir_resilience_health_snapshot() from public,anon,authenticated;
+grant execute on function public.dabbir_resilience_health_snapshot() to service_role;

--- a/supabase/migrations/20260903200500_dabbir_resilience_recovery_health_v1.sql
+++ b/supabase/migrations/20260903200500_dabbir_resilience_recovery_health_v1.sql
@@ -1,0 +1,46 @@
+-- Recovery integrity is a core health gate, not an informational metric.
+create or replace function public.dabbir_resilience_health_snapshot()
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_catalog,dabbir_private,pg_temp
+as $function$
+declare
+  v_conflict_guard boolean;
+  v_recovery_health jsonb;
+  v_recovery_guard boolean;
+  v_notif_overdue bigint;
+  v_notif_stale bigint;
+  v_notif_bad bigint;
+  v_outbox_due bigint;
+  v_outbox_stale bigint;
+  v_outbox_dead bigint;
+  v_calendar_error bigint;
+  v_payment_error bigint;
+  v_core boolean;
+begin
+  select exists(select 1 from pg_catalog.pg_trigger t where t.tgrelid='public.dabbir_appointments'::regclass and t.tgname='dabbir_appointment_calendar_conflict_guard' and not t.tgisinternal) into v_conflict_guard;
+  v_recovery_health:=dabbir_private.recovery_health_check();
+  v_recovery_guard:=coalesce((v_recovery_health->>'ok')::boolean,false);
+  select count(*) into v_notif_overdue from public.dabbir_workflow_notifications n where n.status='pending' and coalesce(n.next_attempt_at,n.scheduled_for)<now()-interval '10 minutes';
+  select count(*) into v_notif_stale from public.dabbir_workflow_notifications n where n.status='processing' and n.updated_at<now()-interval '15 minutes';
+  select count(*) into v_notif_bad from public.dabbir_workflow_notifications n where n.status in ('failed','ambiguous') and n.updated_at>now()-interval '1 hour';
+  select count(*) into v_outbox_due from public.dabbir_integration_outbox o where o.status in ('pending','retry') and o.available_at<=now()-interval '5 minutes';
+  select count(*) into v_outbox_stale from public.dabbir_integration_outbox o where o.status='processing' and o.locked_at<now()-interval '5 minutes';
+  select count(*) into v_outbox_dead from public.dabbir_integration_outbox o where o.status='dead' and o.updated_at>now()-interval '24 hours';
+  select count(*) into v_calendar_error from public.dabbir_calendar_connections c where c.sync_enabled=true and c.status='error';
+  select count(*) into v_payment_error from public.dabbir_payment_events e where e.processing_error is not null and e.received_at>now()-interval '1 hour';
+  v_core:=v_conflict_guard and v_recovery_guard;
+  return jsonb_build_object(
+    'core_ok',v_core,
+    'state',case when not v_core then 'critical' when v_outbox_dead>0 or v_notif_stale>0 or v_outbox_stale>0 or v_payment_error>0 then 'degraded' else 'healthy' end,
+    'booking_conflict_guard',v_conflict_guard,'recovery_guard',v_recovery_guard,'recovery_health',v_recovery_health,
+    'notification_overdue',v_notif_overdue,'notification_stale',v_notif_stale,'notification_failed_or_ambiguous_1h',v_notif_bad,
+    'outbox_due',v_outbox_due,'outbox_stale',v_outbox_stale,'outbox_dead_24h',v_outbox_dead,
+    'calendar_connections_error',v_calendar_error,'payment_processing_errors_1h',v_payment_error,
+    'checked_at',now()
+  );
+end;
+$function$;
+revoke all on function public.dabbir_resilience_health_snapshot() from public,anon,authenticated;
+grant execute on function public.dabbir_resilience_health_snapshot() to service_role;

--- a/supabase/migrations/20260903201000_dabbir_active_booking_duplicate_guard_v1.sql
+++ b/supabase/migrations/20260903201000_dabbir_active_booking_duplicate_guard_v1.sql
@@ -1,0 +1,12 @@
+-- Fail closed against repeated active booking writes, including legacy writers
+-- that have not yet supplied an explicit idempotency key.
+create unique index if not exists dabbir_appointments_active_customer_slot_uq
+  on public.dabbir_appointments(
+    business_id,
+    customer_id,
+    (coalesce(service_id,'00000000-0000-0000-0000-000000000000'::uuid)),
+    starts_at
+  )
+  where customer_id is not null
+    and starts_at is not null
+    and status not in ('cancelled','completed','no_show');

--- a/test/dabbir-worst-case-resilience.test.mjs
+++ b/test/dabbir-worst-case-resilience.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const read=file=>readFileSync(path.join(root,file),'utf8');
+const base=read('supabase/migrations/20260903200000_dabbir_worst_case_resilience_v1.sql');
+const recovery=read('supabase/migrations/20260903200500_dabbir_resilience_recovery_health_v1.sql');
+const duplicate=read('supabase/migrations/20260903201000_dabbir_active_booking_duplicate_guard_v1.sql');
+const calendar=read('api/_calendar-sync-core.js');
+const reminder=read('api/salon-reminders-cron.js');
+const worker=read('api/resilience-worker-cron.js');
+const health=read('api/runtime-health.js');
+const limiter=read('api/_rate-limit.js');
+const publicBooking=read('api/public-car-wash.js');
+const guardian=read('.github/workflows/dabbir-runtime-guardian.yml');
+const releaseGuardian=read('.github/workflows/dabbir-release-guardian.yml');
+const vercel=JSON.parse(read('vercel.json'));
+const salonBase=read('supabase/migrations/20260831090000_dabbir_salon_mode_p0.sql');
+const whatsapp=read('api/dabbir-whatsapp-webhook.js');
+const stripe=read('supabase/functions/barman-stripe-checkout/index.ts');
+
+const has=(source,...markers)=>{for(const marker of markers)assert.ok(source.includes(marker),`missing ${marker}`)};
+
+test('booking truth is idempotent and active duplicates fail closed',()=>{
+  has(base,'idempotency_key text','dabbir_appointments_business_idempotency_uq','dabbir_create_appointment_idempotent','IDEMPOTENCY_KEY_REUSE_CONFLICT');
+  has(duplicate,'dabbir_appointments_active_customer_slot_uq',"status not in ('cancelled','completed','no_show')");
+  has(salonBase,'pg_advisory_xact_lock','prevent_appointment_calendar_conflict','APPOINTMENT_CONFLICT');
+});
+
+test('appointments are cancelled, never hard deleted by normal authenticated users',()=>{
+  has(base,'drop policy if exists dabbir_appointments_delete','revoke delete on public.dabbir_appointments from authenticated');
+});
+
+test('calendar side effects use a durable outbox with retry and dead letter semantics',()=>{
+  has(base,'dabbir_integration_outbox',"'pending','processing','retry','succeeded','dead','cancelled'",'for update skip locked','dabbir_finalize_integration_job','max_attempts','available_at');
+  has(base,'zz_dabbir_appointment_calendar_outbox','appointment.cancelled','appointment.upserted');
+  has(worker,'dabbir_claim_integration_jobs','syncBusinessCalendars','dabbir_finalize_integration_job');
+});
+
+test('calendar provider creation is idempotent under ambiguous responses',()=>{
+  has(calendar,'function googleEventId','id:googleEventId(appointmentId)','providerStatus','retryableProviderStatus');
+  assert.match(calendar,/provider==='google'.*409/s);
+  has(calendar,'transactionId:appointment.id.replace');
+});
+
+test('WhatsApp reminders retry confirmed failures but never blindly retry ambiguous sends',()=>{
+  has(base,'attempts integer not null default 0','max_attempts integer not null default 6','next_attempt_at','dabbir_finalize_workflow_notification_v2');
+  has(base,"elsif p_status='ambiguous' then","status='ambiguous'","v_state:='pending'");
+  has(reminder,'error?.ambiguous===true)return false','p_retryable:retryable','WHATSAPP_TENANT_NOT_LINKED');
+});
+
+test('public booking abuse is bounded by a database backed fail-closed limiter',()=>{
+  has(base,'dabbir_rate_limit_windows','dabbir_consume_rate_limit');
+  has(limiter,'crypto.createHash','RATE_LIMIT_UNAVAILABLE','failClosed=true');
+  has(publicBooking,"action:'public_car_wash_booking'",'BOOKING_RATE_LIMITED');
+});
+
+test('runtime health treats booking and recovery integrity as core gates',()=>{
+  has(recovery,'recovery_health_check','v_core:=v_conflict_guard and v_recovery_guard');
+  has(health,'dabbir_resilience_health_snapshot','core_ok','RUNTIME_HEALTH_UNAVAILABLE');
+});
+
+test('recovery snapshots and dry-run verification are exercised hourly',()=>{
+  has(worker,"getUTCMinutes()===0",'dabbir_owner_recovery_maintenance_v1','RECOVERY_DRY_RUN_FAILED');
+});
+
+test('runtime worker executes every minute while reminders remain five minute cadence',()=>{
+  const resilience=vercel.crons.find(item=>item.path==='/api/resilience-worker-cron');
+  const reminders=vercel.crons.find(item=>item.path==='/api/salon-reminders-cron');
+  assert.equal(resilience?.schedule,'* * * * *');
+  assert.equal(reminders?.schedule,'*/5 * * * *');
+  assert.equal(vercel.functions['api/resilience-worker-cron.js']?.maxDuration,60);
+});
+
+test('external guardian detects production failure without unsafe provider-outage rollback',()=>{
+  has(guardian,'*/5 * * * *','/api/runtime-health','for attempt in 1 2 3','gh issue create','gh issue close');
+  assert.ok(!releaseGuardian.includes('DABBIR Runtime Guardian'),'runtime provider health must not trigger blind code rollback');
+  has(releaseGuardian,'revert-failed-main','git revert','FAILED_SHA');
+});
+
+test('WhatsApp inbound remains unacknowledged if real persistence fails',()=>{
+  has(whatsapp,'persistSignedInbound','SIGNED_EVENT_PERSISTENCE_FAILED');
+});
+
+test('payment creation remains provider-idempotent',()=>{
+  has(stripe,"headers['Idempotency-Key']=idempotencyKey",'dabbir_checkout_');
+});
+
+test('service-only resilience tables are not writable by customer roles',()=>{
+  has(base,'revoke all on public.dabbir_integration_outbox from public,anon,authenticated','revoke all on public.dabbir_rate_limit_windows from public,anon,authenticated');
+  has(base,'grant execute on function public.dabbir_claim_integration_jobs(integer) to service_role','grant execute on function public.dabbir_consume_rate_limit(text,text,integer,integer) to service_role');
+});

--- a/test/dabbir-worst-case-resilience.test.mjs
+++ b/test/dabbir-worst-case-resilience.test.mjs
@@ -17,6 +17,7 @@ const publicBooking=read('api/public-car-wash.js');
 const guardian=read('.github/workflows/dabbir-runtime-guardian.yml');
 const releaseGuardian=read('.github/workflows/dabbir-release-guardian.yml');
 const vercel=JSON.parse(read('vercel.json'));
+const bookingLock=read('supabase/migrations/20260902073500_dabbir_booking_calendar_transaction_lock_v1.sql');
 const salonBase=read('supabase/migrations/20260831090000_dabbir_salon_mode_p0.sql');
 const whatsapp=read('api/dabbir-whatsapp-webhook.js');
 const stripe=read('supabase/functions/barman-stripe-checkout/index.ts');
@@ -26,7 +27,8 @@ const has=(source,...markers)=>{for(const marker of markers)assert.ok(source.inc
 test('booking truth is idempotent and active duplicates fail closed',()=>{
   has(base,'idempotency_key text','dabbir_appointments_business_idempotency_uq','dabbir_create_appointment_idempotent','IDEMPOTENCY_KEY_REUSE_CONFLICT');
   has(duplicate,'dabbir_appointments_active_customer_slot_uq',"status not in ('cancelled','completed','no_show')");
-  has(salonBase,'pg_advisory_xact_lock','prevent_appointment_calendar_conflict','APPOINTMENT_CONFLICT');
+  has(bookingLock,'pg_advisory_xact_lock','lock_booking_calendar_business');
+  has(salonBase,'prevent_appointment_calendar_conflict');
 });
 
 test('appointments are cancelled, never hard deleted by normal authenticated users',()=>{

--- a/vercel.json
+++ b/vercel.json
@@ -9,6 +9,10 @@
   },
   "crons": [
     {
+      "path": "/api/resilience-worker-cron",
+      "schedule": "* * * * *"
+    },
+    {
       "path": "/api/salon-reminders-cron",
       "schedule": "*/5 * * * *"
     },
@@ -18,6 +22,9 @@
     }
   ],
   "functions": {
+    "api/resilience-worker-cron.js": {
+      "maxDuration": 60
+    },
     "api/salon-reminders-cron.js": {
       "maxDuration": 60
     },


### PR DESCRIPTION
Worst-case resilience hardening for DABBIR.

- Durable calendar integration outbox with retry/backoff/dead-letter semantics.
- Google deterministic event IDs + Outlook transaction idempotency.
- WhatsApp notification retries for confirmed failures; ambiguous sends remain terminal to avoid duplicates.
- Idempotent appointment command + active duplicate booking DB guard.
- Hard-delete blocked for operational appointments; cancellation preserves history.
- DB-backed fail-closed public booking rate limit.
- Runtime health contract with booking-conflict and recovery-integrity gates.
- Recovery snapshots + restore dry-run maintenance exercised hourly.
- One-minute resilience worker that keeps external failures out of the booking transaction.
- External GitHub Runtime Guardian retries probes and opens/closes an incident issue without blindly rolling back for provider outages.
- Regression coverage locks the existing Release Guardian, inbound WhatsApp persistence, and Stripe idempotency protections.

Production migrations will be applied to DABBIR Mumbai only after required CI passes.