### PR TITLE
Decouple bookings from calendar outages

### DIFF
--- a/api/_calendar-sync-core.js
+++ b/api/_calendar-sync-core.js
@@ -16,11 +16,24 @@ function iso(value){const d=value instanceof Date?value:new Date(value);return N
 function hash(value){return crypto.createHash('sha256').update(JSON.stringify(value)).digest('hex')}
 function eventCancelled(provider,event){return provider==='google'?String(event?.status||'').toLowerCase()==='cancelled':Boolean(event?.isCancelled)}
 function outlookIso(value){const raw=String(value||'').trim();if(!raw)return null;return /(?:z|[+\-]\d\d:\d\d)$/i.test(raw)?raw:`${raw}Z`}
+function googleEventId(appointmentId){return `dabbir${crypto.createHash('sha256').update(String(appointmentId)).digest('hex').slice(0,40)}`}
+function retryableProviderStatus(status){return status===408||status===425||status===429||status>=500}
 
 async function providerJson(url,options={},fallback='CALENDAR_PROVIDER_REQUEST_FAILED'){
-  const response=await fetch(url,{...options,cache:'no-store',signal:options.signal||AbortSignal.timeout(15000)});
+  let response;
+  try{
+    response=await fetch(url,{...options,cache:'no-store',signal:options.signal||AbortSignal.timeout(15000)});
+  }catch(error){
+    const out=calendarError(fallback,503);out.retryable=true;out.providerStatus=0;out.detail=String(error?.name||'NETWORK_FAILURE');throw out;
+  }
   const text=await response.text();let data=null;try{data=text?JSON.parse(text):null}catch{}
-  if(!response.ok){const error=calendarError(fallback,[400,401,403,404,409,429,503].includes(response.status)?response.status:502);error.detail=data?.error?.message||data?.error_description||data?.message||null;throw error}
+  if(!response.ok){
+    const error=calendarError(fallback,[400,401,403,404,409,429,503].includes(response.status)?response.status:502);
+    error.detail=data?.error?.message||data?.error_description||data?.message||null;
+    error.providerStatus=response.status;
+    error.retryable=retryableProviderStatus(response.status);
+    throw error;
+  }
   return data;
 }
 
@@ -71,15 +84,27 @@ function eventTimes(provider,event){
 }
 
 function providerEventPayload(provider,appointment,title){
-  const start=iso(appointment.starts_at),end=iso(new Date(new Date(start).getTime()+DEFAULT_DURATION_MS));
+  const start=iso(appointment.starts_at),end=iso(appointment.ends_at||new Date(new Date(start).getTime()+DEFAULT_DURATION_MS));
   if(provider==='google')return {summary:title,description:`DABBIR appointment ${appointment.id}`,start:{dateTime:start},end:{dateTime:end},extendedProperties:{private:{dabbir_appointment_id:appointment.id}}};
   const graphStart=start.replace(/Z$/,''),graphEnd=end.replace(/Z$/,'');
   return {subject:title,body:{contentType:'text',content:`DABBIR_APPOINTMENT_ID:${appointment.id}`},start:{dateTime:graphStart,timeZone:'UTC'},end:{dateTime:graphEnd,timeZone:'UTC'},transactionId:appointment.id.replace(/-/g,'').slice(0,32)};
 }
 
-async function createProviderEvent(provider,accessToken,payload){
+async function getGoogleEvent(accessToken,eventId){
+  return providerJson(`https://www.googleapis.com/calendar/v3/calendars/primary/events/${enc(eventId)}`,{headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'}},'GOOGLE_CALENDAR_GET_FAILED');
+}
+
+async function createProviderEvent(provider,accessToken,payload,appointmentId){
   const url=provider==='google'?'https://www.googleapis.com/calendar/v3/calendars/primary/events':'https://graph.microsoft.com/v1.0/me/events';
-  return providerJson(url,{method:'POST',headers:{authorization:`Bearer ${accessToken}`,'content-type':'application/json',accept:'application/json'},body:JSON.stringify(payload)},provider==='google'?'GOOGLE_CALENDAR_CREATE_FAILED':'OUTLOOK_CALENDAR_CREATE_FAILED');
+  const body=provider==='google'?{id:googleEventId(appointmentId),...payload}:payload;
+  try{
+    return await providerJson(url,{method:'POST',headers:{authorization:`Bearer ${accessToken}`,'content-type':'application/json',accept:'application/json'},body:JSON.stringify(body)},provider==='google'?'GOOGLE_CALENDAR_CREATE_FAILED':'OUTLOOK_CALENDAR_CREATE_FAILED');
+  }catch(error){
+    // If Google accepted a previous request but DABBIR lost the response, the deterministic
+    // event id turns the retry into 409; fetch that same event instead of creating a duplicate.
+    if(provider==='google'&&Number(error?.providerStatus||error?.code)===409)return getGoogleEvent(accessToken,googleEventId(appointmentId));
+    throw error;
+  }
 }
 
 async function updateProviderEvent(provider,accessToken,eventId,payload){
@@ -89,9 +114,16 @@ async function updateProviderEvent(provider,accessToken,eventId,payload){
 
 async function deleteProviderEvent(provider,accessToken,eventId){
   const url=provider==='google'?`https://www.googleapis.com/calendar/v3/calendars/primary/events/${enc(eventId)}`:`https://graph.microsoft.com/v1.0/me/events/${enc(eventId)}`;
-  const response=await fetch(url,{method:'DELETE',headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)});
+  let response;
+  try{
+    response=await fetch(url,{method:'DELETE',headers:{authorization:`Bearer ${accessToken}`,accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000)});
+  }catch(error){
+    const out=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',503);out.retryable=true;out.providerStatus=0;out.detail=String(error?.name||'NETWORK_FAILURE');throw out;
+  }
   if(response.ok||response.status===404||response.status===410)return true;
-  const text=await response.text().catch(()=>null);const error=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',[400,401,403,409,429,503].includes(response.status)?response.status:502);error.detail=String(text||'').slice(0,240);throw error;
+  const text=await response.text().catch(()=>null);
+  const error=calendarError(provider==='google'?'GOOGLE_CALENDAR_DELETE_FAILED':'OUTLOOK_CALENDAR_DELETE_FAILED',[400,401,403,409,429,503].includes(response.status)?response.status:502);
+  error.detail=String(text||'').slice(0,240);error.providerStatus=response.status;error.retryable=retryableProviderStatus(response.status);throw error;
 }
 
 async function upsertLink(connectionId,appointmentId,event,syncHash){
@@ -106,7 +138,7 @@ export async function syncCalendarConnection(req,connection){
   const accessToken=await refreshAccessToken(req,connection,credential);
   const now=Date.now(),start=new Date(now-SYNC_PAST_DAYS*86400000).toISOString(),end=new Date(now+SYNC_FUTURE_DAYS*86400000).toISOString();
   const [appointments,customers,links,events]=await Promise.all([
-    serviceRest(`dabbir_appointments?select=id,customer_id,starts_at,status&business_id=eq.${enc(businessId)}&starts_at=gte.${enc(start)}&starts_at=lt.${enc(end)}&order=starts_at.asc&limit=1000`),
+    serviceRest(`dabbir_appointments?select=id,customer_id,starts_at,ends_at,status&business_id=eq.${enc(businessId)}&starts_at=gte.${enc(start)}&starts_at=lt.${enc(end)}&order=starts_at.asc&limit=1000`),
     serviceRest(`dabbir_customers?select=id,display_name&business_id=eq.${enc(businessId)}&limit=1000`),
     serviceRest(`dabbir_calendar_event_links?select=connection_id,appointment_id,provider_event_id,provider_etag,sync_hash,last_provider_start,last_synced_at&connection_id=eq.${enc(connection.id)}&limit=2000`),
     listProviderEvents(provider,accessToken,start,end),
@@ -138,9 +170,9 @@ export async function syncCalendarConnection(req,connection){
       if(link&&event&&!eventCancelled(provider,event))await deleteProviderEvent(provider,accessToken,link.provider_event_id).catch(error=>{if(error?.code!==404)throw error});
       continue;
     }
-    const title=String(customerMap.get(appointment.customer_id)||'Customer').slice(0,160),payload=providerEventPayload(provider,appointment,title),syncHash=hash({start:appointment.starts_at,status:appointment.status,title});
+    const title=String(customerMap.get(appointment.customer_id)||'Customer').slice(0,160),payload=providerEventPayload(provider,appointment,title),syncHash=hash({start:appointment.starts_at,end:appointment.ends_at,status:appointment.status,title});
     if(!link||!event){
-      event=await createProviderEvent(provider,accessToken,payload);event.__provider=provider;
+      event=await createProviderEvent(provider,accessToken,payload,appointment.id);event.__provider=provider;
       await upsertLink(connection.id,appointment.id,event,syncHash);link={connection_id:connection.id,appointment_id:appointment.id,provider_event_id:event.id,sync_hash:syncHash};linkMap.set(appointment.id,link);eventMap.set(String(event.id),event);pushed++;continue;
     }
     if(link.sync_hash!==syncHash){
@@ -165,14 +197,16 @@ export async function syncCalendarConnection(req,connection){
 }
 
 export async function syncBusinessCalendars(req,businessId){
-  const rows=await serviceRest(`dabbir_calendar_connections?select=id,business_id,provider,status,sync_enabled,sync_direction,provider_email&business_id=eq.${enc(businessId)}&status=eq.active&sync_enabled=eq.true&order=provider.asc`);
+  const rows=await serviceRest(`dabbir_calendar_connections?select=id,business_id,provider,status,sync_enabled,sync_direction,provider_email&business_id=eq.${enc(businessId)}&status=in.(active,error)&sync_enabled=eq.true&order=provider.asc`);
   const results=[];
   for(const connection of rows||[]){
     try{results.push({ok:true,...await syncCalendarConnection(req,connection)})}
     catch(error){
       const message=String(error?.message||'CALENDAR_SYNC_FAILED').slice(0,160);
+      const code=Number(error?.providerStatus||error?.code||500);
+      const retryable=error?.retryable===true||retryableProviderStatus(code);
       await serviceRest(`dabbir_calendar_connections?id=eq.${enc(connection.id)}`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({status:'error',last_error:message,updated_at:new Date().toISOString()})}).catch(()=>null);
-      results.push({ok:false,connection_id:connection.id,provider:connection.provider,error:message});
+      results.push({ok:false,connection_id:connection.id,provider:connection.provider,error:message,code,retryable});
     }
   }
   return results;

--- a/api/appointment-management.js
+++ b/api/appointment-management.js
@@ -7,7 +7,6 @@ import {
   requireSameOrigin,
   supabaseRest,
 } from './_auth-core.js';
-import { syncBusinessCalendars } from './_calendar-sync-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
@@ -47,7 +46,7 @@ function membershipFor(memberships,businessId){
 async function appointmentFor(token,businessId,appointmentId){
   const rows=await rest(
     token,
-    `dabbir_appointments?select=id,business_id,customer_id,service_id,starts_at,status,simulated,created_at&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&limit=1`,
+    `dabbir_appointments?select=id,business_id,customer_id,service_id,starts_at,ends_at,status,simulated,created_at&business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&limit=1`,
     {},
     'APPOINTMENT_LOOKUP_FAILED',
   );
@@ -59,6 +58,12 @@ function validStart(value){
   if(Number.isNaN(date.getTime()))return null;
   return date;
 }
+function durationMs(appointment){
+  const start=new Date(appointment?.starts_at||0).getTime(),end=new Date(appointment?.ends_at||0).getTime();
+  const duration=end-start;
+  return Number.isFinite(duration)&&duration>=5*60000&&duration<=24*60*60000?duration:60*60000;
+}
+const calendarOutboxTruth=()=>({mode:'durable_outbox',business_truth_committed_first:true,external_sync_async:true});
 
 async function updateAppointment(req,ctx,body,businessId,appointmentId){
   const current=await appointmentFor(ctx.token,businessId,appointmentId);
@@ -69,6 +74,7 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
     const start=validStart(body.starts_at);
     if(start===null)return {status:400,body:{ok:false,error:'VALID_START_TIME_REQUIRED'}};
     patch.starts_at=start.toISOString();
+    patch.ends_at=new Date(start.getTime()+durationMs(current)).toISOString();
   }
   if(body.status!==undefined){
     const status=String(body.status||'').trim().toLowerCase();
@@ -79,7 +85,7 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
 
   const rows=await rest(
     ctx.token,
-    `dabbir_appointments?business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&select=id,customer_id,service_id,starts_at,status,simulated,created_at`,
+    `dabbir_appointments?business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&select=id,customer_id,service_id,starts_at,ends_at,status,simulated,created_at`,
     {
       method:'PATCH',
       headers:{prefer:'return=representation'},
@@ -90,10 +96,6 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
   const updated=rows?.[0]||null;
   if(!updated)return {status:403,body:{ok:false,error:'APPOINTMENT_MANAGEMENT_REQUIRED'}};
 
-  let calendarSync=[];
-  try{calendarSync=await syncBusinessCalendars(req,businessId)}catch(error){
-    calendarSync=[{ok:false,error:String(error?.message||'CALENDAR_SYNC_FAILED').slice(0,140)}];
-  }
   return {
     status:200,
     body:{
@@ -101,7 +103,7 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
       action:'update',
       state:'VERIFIED_PERSISTED',
       appointment:updated,
-      calendar_sync:calendarSync,
+      calendar_sync:calendarOutboxTruth(),
       truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',entity:'appointment',entity_id:updated.id,verified_at:new Date().toISOString()},
     },
   };
@@ -111,55 +113,31 @@ async function deleteAppointment(req,ctx,businessId,appointmentId){
   const current=await appointmentFor(ctx.token,businessId,appointmentId);
   if(!current)return {status:404,body:{ok:false,error:'APPOINTMENT_NOT_FOUND'}};
 
-  // Cancel first so Google/Outlook receive a provider-side delete before the
-  // internal appointment and its calendar link are removed.
+  // "Delete" is intentionally a cancellation. Operational history is retained and
+  // the database trigger queues Google/Outlook reconciliation independently.
+  let row=current;
   if(String(current.status||'').toLowerCase()!=='cancelled'){
     const cancelled=await rest(
       ctx.token,
-      `dabbir_appointments?business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&select=id,status`,
+      `dabbir_appointments?business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&select=id,customer_id,service_id,starts_at,ends_at,status,simulated,created_at`,
       {method:'PATCH',headers:{prefer:'return=representation'},body:JSON.stringify({status:'cancelled'})},
-      'APPOINTMENT_CANCEL_BEFORE_DELETE_FAILED',
+      'APPOINTMENT_CANCEL_FAILED',
     );
-    if(!cancelled?.[0]?.id)return {status:403,body:{ok:false,error:'APPOINTMENT_MANAGEMENT_REQUIRED'}};
+    row=cancelled?.[0]||null;
+    if(!row)return {status:403,body:{ok:false,error:'APPOINTMENT_MANAGEMENT_REQUIRED'}};
   }
-
-  let calendarSync=[];
-  try{calendarSync=await syncBusinessCalendars(req,businessId)}catch(error){
-    calendarSync=[{ok:false,error:String(error?.message||'CALENDAR_SYNC_FAILED').slice(0,140)}];
-  }
-  const syncFailed=calendarSync.some(item=>item?.ok===false);
-  if(syncFailed){
-    return {
-      status:502,
-      body:{
-        ok:false,
-        action:'delete',
-        state:'CANCELLED_PENDING_EXTERNAL_DELETE',
-        error:'CALENDAR_DELETE_NOT_VERIFIED',
-        appointment_id:appointmentId,
-        calendar_sync:calendarSync,
-      },
-    };
-  }
-
-  const deleted=await rest(
-    ctx.token,
-    `dabbir_appointments?business_id=eq.${encodeURIComponent(businessId)}&id=eq.${encodeURIComponent(appointmentId)}&select=id,starts_at,status`,
-    {method:'DELETE',headers:{prefer:'return=representation'}},
-    'APPOINTMENT_DELETE_FAILED',
-  );
-  const row=deleted?.[0]||null;
-  if(!row)return {status:403,body:{ok:false,error:'APPOINTMENT_MANAGEMENT_REQUIRED'}};
 
   return {
     status:200,
     body:{
       ok:true,
       action:'delete',
-      state:'VERIFIED_DELETED',
+      state:'VERIFIED_CANCELLED',
       appointment_id:appointmentId,
-      calendar_sync:calendarSync,
-      truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',entity:'appointment',entity_id:appointmentId,deleted:true,verified_at:new Date().toISOString()},
+      appointment:row,
+      retained_history:true,
+      calendar_sync:calendarOutboxTruth(),
+      truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',entity:'appointment',entity_id:appointmentId,cancelled:true,hard_deleted:false,verified_at:new Date().toISOString()},
     },
   };
 }

--- a/api/calendar-outbox-cron.js
+++ b/api/calendar-outbox-cron.js
@@ -1,0 +1,102 @@
+import { timingSafeEqual } from 'node:crypto';
+import { json, SUPABASE_URL } from './_auth-core.js';
+import { supabaseKeyHeaders } from './_supabase-key-auth.js';
+import { syncBusinessCalendars } from './_calendar-sync-core.js';
+
+const EXPECTED_SCHEDULE='*/5 * * * *';
+const clean=(value,max=500)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+
+function serviceKey(){
+  const key=clean(process.env.SUPABASE_SERVICE_ROLE_KEY,8192);
+  if(!key||key.startsWith('sb_publishable_'))throw Object.assign(new Error('CALENDAR_OUTBOX_STORAGE_NOT_CONFIGURED'),{status:503});
+  return key;
+}
+function sameSecret(left,right){const a=Buffer.from(String(left||'')),b=Buffer.from(String(right||''));return a.length===b.length&&a.length>0&&timingSafeEqual(a,b)}
+export function cronAuthMode(req,env=process.env){
+  const secret=clean(env.CRON_SECRET,4096),authorization=clean(req.headers?.authorization,8192);
+  if(secret)return sameSecret(authorization,`Bearer ${secret}`)?'secret':null;
+  return clean(env.VERCEL_ENV,32)==='production'&&clean(req.headers?.['user-agent'],120).toLowerCase()==='vercel-cron/1.0'&&clean(req.headers?.['x-vercel-cron-schedule'],120)===EXPECTED_SCHEDULE?'vercel_schedule':null;
+}
+async function rpc(key,name,params={}){
+  const response=await fetch(`${SUPABASE_URL}/rest/v1/rpc/${encodeURIComponent(name)}`,{
+    method:'POST',cache:'no-store',signal:AbortSignal.timeout(10000),
+    headers:supabaseKeyHeaders(key,{'content-type':'application/json',accept:'application/json'}),
+    body:JSON.stringify(params),
+  });
+  const text=await response.text();let payload=null;try{payload=text?JSON.parse(text):null}catch{}
+  if(!response.ok)throw Object.assign(new Error(payload?.message||payload?.code||`${name.toUpperCase()}_FAILED`),{status:response.status});
+  return payload;
+}
+async function finalize(key,job,{success,retryable=false,error=null,correlation=null}){
+  return rpc(key,'dabbir_finalize_integration_job',{
+    p_job_id:job.job_id,p_lock_token:job.lock_token,p_success:success,p_retryable:retryable,
+    p_error:error,p_provider_correlation_id:correlation,
+  });
+}
+function groupByBusiness(items){
+  const groups=new Map();
+  for(const item of items||[]){const id=String(item.business_id||'');if(!groups.has(id))groups.set(id,[]);groups.get(id).push(item)}
+  return groups;
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const authMode=cronAuthMode(req);if(!authMode)return json(res,401,{ok:false,error:'CRON_AUTH_REQUIRED'});
+  let key;try{key=serviceKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
+  try{
+    const claimed=await rpc(key,'dabbir_claim_integration_jobs',{p_limit:50});
+    const jobs=Array.isArray(claimed)?claimed:[];
+    const groups=groupByBusiness(jobs);
+    const results=[];
+
+    for(const [businessId,businessJobs] of groups){
+      if(!businessJobs.every(job=>job.destination==='calendar_sync')){
+        for(const job of businessJobs){
+          const state=await finalize(key,job,{success:false,retryable:false,error:'UNSUPPORTED_OUTBOX_DESTINATION'});
+          results.push({job_id:job.job_id,state});
+        }
+        continue;
+      }
+      try{
+        const sync=await syncBusinessCalendars(req,businessId);
+        const failures=(sync||[]).filter(item=>item.ok===false);
+        if(failures.length){
+          const retryable=failures.some(item=>item.retryable===true);
+          const error=clean(failures.map(item=>`${item.provider||'calendar'}:${item.error||'failed'}`).join('|'),500);
+          for(const job of businessJobs){
+            const state=await finalize(key,job,{success:false,retryable,error});
+            results.push({job_id:job.job_id,state,retryable});
+          }
+        }else{
+          const correlation=`calendar:${businessId}:${Date.now()}`;
+          for(const job of businessJobs){
+            const state=await finalize(key,job,{success:true,correlation});
+            results.push({job_id:job.job_id,state});
+          }
+        }
+      }catch(error){
+        const code=clean(error?.message||'CALENDAR_OUTBOX_WORKER_FAILED',300);
+        const retryable=error?.retryable===true||Number(error?.providerStatus||error?.code||error?.status||0)>=500;
+        for(const job of businessJobs){
+          const state=await finalize(key,job,{success:false,retryable,error:code}).catch(()=>null);
+          results.push({job_id:job.job_id,state:state||'finalize_failed',retryable});
+        }
+      }
+    }
+
+    const cleanup=await rpc(key,'dabbir_cleanup_calendar_outbox',{}).catch(()=>null);
+    const summary={
+      ok:true,claimed:jobs.length,businesses:groups.size,
+      succeeded:results.filter(x=>x.state==='succeeded').length,
+      retry:results.filter(x=>x.state==='retry').length,
+      dead:results.filter(x=>x.state==='dead').length,
+      cleanup,
+    };
+    console.info('dabbir_calendar_outbox_worker',{auth_mode:authMode,...summary});
+    return json(res,200,summary);
+  }catch(error){
+    const code=clean(error?.message||'CALENDAR_OUTBOX_WORKER_FAILED',240);
+    console.error('dabbir_calendar_outbox_worker_failed',{error:code});
+    return json(res,500,{ok:false,error:code});
+  }
+}

--- a/supabase/migrations/20260903131500_dabbir_calendar_outbox_resilience_v1.sql
+++ b/supabase/migrations/20260903131500_dabbir_calendar_outbox_resilience_v1.sql
@@ -1,0 +1,191 @@
+-- DABBIR calendar resilience: business truth commits first; external calendar side effects retry separately.
+
+-- Operational appointments are never hard-deleted by normal authenticated users.
+-- Cancellation preserves audit/history and lets the outbox reconcile provider state later.
+drop policy if exists dabbir_appointments_delete on public.dabbir_appointments;
+revoke delete on public.dabbir_appointments from authenticated;
+
+create table if not exists public.dabbir_integration_outbox (
+  id uuid primary key default gen_random_uuid(),
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  destination text not null check (destination in ('calendar_sync')),
+  aggregate_type text not null default 'appointment' check (char_length(aggregate_type) between 2 and 60),
+  aggregate_id uuid,
+  event_type text not null check (char_length(event_type) between 2 and 80),
+  idempotency_key text not null check (char_length(idempotency_key) between 12 and 200),
+  payload jsonb not null default '{}'::jsonb,
+  status text not null default 'pending' check (status in ('pending','processing','retry','succeeded','dead','cancelled')),
+  attempts integer not null default 0 check (attempts between 0 and 100),
+  max_attempts integer not null default 8 check (max_attempts between 1 and 20),
+  available_at timestamptz not null default now(),
+  locked_at timestamptz,
+  lock_token uuid,
+  provider_correlation_id text,
+  last_error text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  completed_at timestamptz,
+  unique (business_id,destination,idempotency_key)
+);
+
+create index if not exists dabbir_integration_outbox_due_idx
+  on public.dabbir_integration_outbox(status,available_at,created_at)
+  where status in ('pending','retry');
+create index if not exists dabbir_integration_outbox_dead_idx
+  on public.dabbir_integration_outbox(updated_at desc,business_id)
+  where status='dead';
+create index if not exists dabbir_integration_outbox_business_idx
+  on public.dabbir_integration_outbox(business_id,destination,created_at desc);
+
+alter table public.dabbir_integration_outbox enable row level security;
+revoke all on public.dabbir_integration_outbox from public,anon,authenticated;
+grant select,insert,update,delete on public.dabbir_integration_outbox to service_role;
+
+create or replace function dabbir_private.enqueue_calendar_sync_from_appointment()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_event text;
+  v_key text;
+begin
+  if tg_op='UPDATE' and row(new.starts_at,new.ends_at,new.status,new.worker_id,new.customer_id,new.service_id)
+     is not distinct from row(old.starts_at,old.ends_at,old.status,old.worker_id,old.customer_id,old.service_id) then
+    return new;
+  end if;
+
+  if not exists(
+    select 1 from public.dabbir_calendar_connections c
+    where c.business_id=new.business_id
+      and c.status in ('active','error')
+      and c.sync_enabled=true
+  ) then return new; end if;
+
+  v_event := case when new.status='cancelled' then 'appointment.cancelled' else 'appointment.upserted' end;
+  -- Transaction id makes every committed appointment mutation independently recoverable.
+  -- Multiple mutations inside one transaction coalesce into the final state.
+  v_key := 'appointment:'||new.id||':'||txid_current()::text;
+
+  insert into public.dabbir_integration_outbox(
+    business_id,destination,aggregate_type,aggregate_id,event_type,idempotency_key,payload
+  ) values(
+    new.business_id,'calendar_sync','appointment',new.id,v_event,v_key,
+    jsonb_build_object(
+      'appointment_id',new.id,'status',new.status,'starts_at',new.starts_at,'ends_at',new.ends_at,
+      'worker_id',new.worker_id,'customer_id',new.customer_id,'service_id',new.service_id
+    )
+  ) on conflict (business_id,destination,idempotency_key) do update
+    set event_type=excluded.event_type,payload=excluded.payload,updated_at=now();
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.enqueue_calendar_sync_from_appointment() from public,anon,authenticated;
+
+drop trigger if exists zz_dabbir_appointment_calendar_outbox on public.dabbir_appointments;
+create trigger zz_dabbir_appointment_calendar_outbox
+after insert or update on public.dabbir_appointments
+for each row execute function dabbir_private.enqueue_calendar_sync_from_appointment();
+
+create or replace function public.dabbir_claim_integration_jobs(p_limit integer default 20)
+returns table(
+  job_id uuid,business_id uuid,destination text,aggregate_type text,aggregate_id uuid,
+  event_type text,payload jsonb,attempts integer,max_attempts integer,lock_token uuid
+)
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+begin
+  -- Calendar writes are provider-idempotent. A worker that disappears can therefore
+  -- be retried safely after its lease expires.
+  update public.dabbir_integration_outbox o
+  set status=case when o.attempts>=o.max_attempts then 'dead' else 'retry' end,
+      available_at=case when o.attempts>=o.max_attempts then o.available_at else now() end,
+      last_error=case when o.attempts>=o.max_attempts then 'STALE_PROCESSING_EXHAUSTED' else 'STALE_PROCESSING_RECOVERED' end,
+      locked_at=null,lock_token=null,updated_at=now(),
+      completed_at=case when o.attempts>=o.max_attempts then now() else null end
+  where o.status='processing' and o.locked_at<now()-interval '5 minutes';
+
+  return query
+  with candidates as (
+    select o.id
+    from public.dabbir_integration_outbox o
+    where o.status in ('pending','retry') and o.available_at<=now()
+    order by o.available_at,o.created_at
+    for update skip locked
+    limit greatest(1,least(coalesce(p_limit,20),100))
+  ), claimed as (
+    update public.dabbir_integration_outbox o
+    set status='processing',attempts=o.attempts+1,locked_at=now(),lock_token=gen_random_uuid(),updated_at=now()
+    from candidates c where o.id=c.id
+    returning o.*
+  )
+  select c.id,c.business_id,c.destination,c.aggregate_type,c.aggregate_id,c.event_type,
+         c.payload,c.attempts,c.max_attempts,c.lock_token
+  from claimed c order by c.available_at,c.created_at;
+end;
+$$;
+revoke all on function public.dabbir_claim_integration_jobs(integer) from public,anon,authenticated;
+grant execute on function public.dabbir_claim_integration_jobs(integer) to service_role;
+
+create or replace function public.dabbir_finalize_integration_job(
+  p_job_id uuid,p_lock_token uuid,p_success boolean,p_retryable boolean,
+  p_error text default null,p_provider_correlation_id text default null
+) returns text
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare
+  v_job public.dabbir_integration_outbox%rowtype;
+  v_state text;
+  v_delay integer;
+begin
+  select o.* into v_job from public.dabbir_integration_outbox o
+  where o.id=p_job_id and o.status='processing' and o.lock_token=p_lock_token for update;
+  if not found then return 'not_owned'; end if;
+
+  if p_success then
+    v_state:='succeeded';
+    update public.dabbir_integration_outbox o
+    set status=v_state,completed_at=now(),locked_at=null,lock_token=null,
+        provider_correlation_id=left(nullif(p_provider_correlation_id,''),320),last_error=null,updated_at=now()
+    where o.id=p_job_id;
+  elsif coalesce(p_retryable,false) and v_job.attempts<v_job.max_attempts then
+    v_state:='retry';
+    v_delay:=least(1800,30*power(2,greatest(0,v_job.attempts-1))::integer);
+    update public.dabbir_integration_outbox o
+    set status=v_state,available_at=now()+make_interval(secs=>v_delay),
+        locked_at=null,lock_token=null,last_error=left(nullif(p_error,''),500),updated_at=now()
+    where o.id=p_job_id;
+  else
+    v_state:='dead';
+    update public.dabbir_integration_outbox o
+    set status=v_state,completed_at=now(),locked_at=null,lock_token=null,
+        last_error=left(nullif(p_error,''),500),updated_at=now()
+    where o.id=p_job_id;
+  end if;
+  return v_state;
+end;
+$$;
+revoke all on function public.dabbir_finalize_integration_job(uuid,uuid,boolean,boolean,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_finalize_integration_job(uuid,uuid,boolean,boolean,text,text) to service_role;
+
+create or replace function public.dabbir_cleanup_calendar_outbox()
+returns jsonb
+language plpgsql
+security definer
+set search_path=public,pg_temp
+as $$
+declare v_deleted integer:=0;
+begin
+  delete from public.dabbir_integration_outbox
+  where status in ('succeeded','cancelled') and completed_at<now()-interval '30 days';
+  get diagnostics v_deleted=row_count;
+  return jsonb_build_object('deleted',v_deleted);
+end;
+$$;
+revoke all on function public.dabbir_cleanup_calendar_outbox() from public,anon,authenticated;
+grant execute on function public.dabbir_cleanup_calendar_outbox() to service_role;

--- a/test/dabbir-calendar-outbox-resilience.test.mjs
+++ b/test/dabbir-calendar-outbox-resilience.test.mjs
@@ -1,0 +1,71 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const root=new URL('../',import.meta.url);
+const read=path=>readFile(new URL(path,root),'utf8');
+
+const migration=await read('supabase/migrations/20260903131500_dabbir_calendar_outbox_resilience_v1.sql');
+const calendar=await read('api/_calendar-sync-core.js');
+const worker=await read('api/calendar-outbox-cron.js');
+const appointmentApi=await read('api/appointment-management.js');
+const vercel=JSON.parse(await read('vercel.json'));
+
+test('calendar mutations commit to a durable transactional outbox',()=>{
+  assert.match(migration,/create table if not exists public\.dabbir_integration_outbox/);
+  assert.match(migration,/after insert or update on public\.dabbir_appointments/);
+  assert.match(migration,/enqueue_calendar_sync_from_appointment/);
+  assert.match(migration,/appointment\.cancelled/);
+  assert.match(migration,/appointment\.upserted/);
+  assert.match(migration,/unique \(business_id,destination,idempotency_key\)/);
+});
+
+test('calendar outbox uses leases, bounded retries and dead-letter state',()=>{
+  assert.match(migration,/for update skip locked/);
+  assert.match(migration,/lock_token=gen_random_uuid\(\)/);
+  assert.match(migration,/status=case when o\.attempts>=o\.max_attempts then 'dead' else 'retry' end/);
+  assert.match(migration,/least\(1800,30\*power\(2/);
+  assert.match(migration,/where o\.id=p_job_id and o\.status='processing' and o\.lock_token=p_lock_token/);
+  assert.match(migration,/grant execute on function public\.dabbir_claim_integration_jobs\(integer\) to service_role/);
+});
+
+test('calendar provider writes are safe to repeat after timeouts',()=>{
+  assert.match(calendar,/function googleEventId\(appointmentId\)/);
+  assert.match(calendar,/id:googleEventId\(appointmentId\)/);
+  assert.match(calendar,/transactionId:appointment\.id\.replace/);
+  assert.match(calendar,/provider==='google'&&Number\(error\?\.providerStatus\|\|error\?\.code\)===409/);
+  assert.match(calendar,/retryableProviderStatus/);
+  assert.match(calendar,/status=in\.\(active,error\)/);
+  assert.match(calendar,/appointment\.ends_at/);
+});
+
+test('appointment truth no longer waits for Google or Outlook',()=>{
+  assert.doesNotMatch(appointmentApi,/syncBusinessCalendars/);
+  assert.match(appointmentApi,/mode:'durable_outbox'/);
+  assert.match(appointmentApi,/business_truth_committed_first:true/);
+  assert.match(appointmentApi,/external_sync_async:true/);
+});
+
+test('appointment delete preserves operational history as cancellation',()=>{
+  assert.match(migration,/revoke delete on public\.dabbir_appointments from authenticated/);
+  assert.doesNotMatch(appointmentApi,/method:'DELETE'/);
+  assert.match(appointmentApi,/state:'VERIFIED_CANCELLED'/);
+  assert.match(appointmentApi,/retained_history:true/);
+  assert.match(appointmentApi,/hard_deleted:false/);
+});
+
+test('rescheduling preserves appointment duration',()=>{
+  assert.match(appointmentApi,/function durationMs\(appointment\)/);
+  assert.match(appointmentApi,/patch\.ends_at=new Date\(start\.getTime\(\)\+durationMs\(current\)\)/);
+});
+
+test('calendar outbox worker is authenticated and scheduled within five minutes',()=>{
+  assert.match(worker,/CRON_AUTH_REQUIRED/);
+  assert.match(worker,/dabbir_claim_integration_jobs/);
+  assert.match(worker,/dabbir_finalize_integration_job/);
+  assert.match(worker,/syncBusinessCalendars/);
+  assert.match(worker,/retryable/);
+  const cron=(vercel.crons||[]).find(item=>item.path==='/api/calendar-outbox-cron');
+  assert.deepEqual(cron,{path:'/api/calendar-outbox-cron',schedule:'*/5 * * * *'});
+  assert.equal(vercel.functions?.['api/calendar-outbox-cron.js']?.maxDuration,60);
+});

--- a/vercel.json
+++ b/vercel.json
@@ -13,12 +13,19 @@
       "schedule": "*/5 * * * *"
     },
     {
+      "path": "/api/calendar-outbox-cron",
+      "schedule": "*/5 * * * *"
+    },
+    {
       "path": "/api/barman-executive-cron",
       "schedule": "*/5 * * * *"
     }
   ],
   "functions": {
     "api/salon-reminders-cron.js": {
+      "maxDuration": 60
+    },
+    "api/calendar-outbox-cron.js": {
       "maxDuration": 60
     },
     "api/barman-executive-cron.js": {


### PR DESCRIPTION
Second worst-case resilience layer for DABBIR.

- Transactional calendar outbox is written with appointment mutations.
- Google creates use deterministic event IDs; Outlook keeps deterministic transaction IDs.
- Provider timeout/429/5xx failures are classified retryable and retried by an authenticated worker.
- Failed calendar connections remain eligible for recovery instead of dropping out of sync.
- Appointment update/cancel commits business truth first and does not wait for Google/Outlook.
- Appointment "delete" becomes durable cancellation; hard delete is revoked for authenticated users.
- Rescheduling preserves appointment duration.
- Calendar outbox worker runs every 5 minutes with lease, backoff and dead-letter behavior.
- Regression tests lock all of these guarantees.