### PR TITLE
Fix historical booking edits and completed status updates

### DIFF
--- a/api/appointment-management.js
+++ b/api/appointment-management.js
@@ -68,14 +68,27 @@ async function updateAppointment(req,ctx,body,businessId,appointmentId){
   if(body.starts_at!==undefined){
     const start=validStart(body.starts_at);
     if(start===null)return {status:400,body:{ok:false,error:'VALID_START_TIME_REQUIRED'}};
-    patch.starts_at=start.toISOString();
+    const currentStart=validStart(current.starts_at);
+    if(!currentStart||start.getTime()!==currentStart.getTime())patch.starts_at=start.toISOString();
   }
   if(body.status!==undefined){
     const status=String(body.status||'').trim().toLowerCase();
     if(!ALLOWED_STATUS.has(status))return {status:400,body:{ok:false,error:'INVALID_APPOINTMENT_STATUS'}};
-    patch.status=status;
+    if(status!==String(current.status||'').trim().toLowerCase())patch.status=status;
   }
-  if(!Object.keys(patch).length)return {status:400,body:{ok:false,error:'NO_APPOINTMENT_CHANGES'}};
+  if(!Object.keys(patch).length){
+    return {
+      status:200,
+      body:{
+        ok:true,
+        action:'update',
+        state:'NO_CHANGE',
+        appointment:current,
+        calendar_sync:[],
+        truth:{state:'VERIFIED',source:'SUPABASE_READ',entity:'appointment',entity_id:current.id,verified_at:new Date().toISOString()},
+      },
+    };
+  }
 
   const rows=await rest(
     ctx.token,

--- a/api/car-wash-booking-edit-ui.js
+++ b/api/car-wash-booking-edit-ui.js
@@ -26,6 +26,7 @@ const script=String.raw`(()=>{
     return customer?.display_name||(ar()?'عميل':'Customer');
   }
   function appointment(id){return (workspaceNow()?.appointments||[]).find(row=>row?.id===id)||null}
+  function isHistorical(row){const time=new Date(row?.starts_at||0).getTime();return Number.isFinite(time)&&time<Date.now()}
 
   function ensureStyle(){
     if(q('#dabbirCarWashPastEditStyle'))return;
@@ -54,7 +55,7 @@ const script=String.raw`(()=>{
       busy=true;const submit=event.submitter;if(submit)submit.disabled=true;
       try{
         const response=await fetch('/api/appointment-management',{method:'POST',credentials:'same-origin',cache:'no-store',headers:{'content-type':'application/json',accept:'application/json'},body:JSON.stringify({action:'update',business_id:w.business.id,appointment_id:id,starts_at:start,status:nextStatus})});
-        const data=await response.json().catch(()=>({}));if(!response.ok||!data?.ok)throw new Error(data?.error||'APPOINTMENT_UPDATE_FAILED');
+        const data=await response.json().catch(()=>({}));if(!response.ok||!data?.ok)throw new Error(data?.detail||data?.error||'APPOINTMENT_UPDATE_FAILED');
         close();toast(c.saved);setTimeout(()=>location.reload(),180);
       }catch(error){toast(c.failed+' '+String(error?.message||''))}
       finally{busy=false;if(submit)submit.disabled=false}
@@ -69,20 +70,22 @@ const script=String.raw`(()=>{
     });
   }
   document.addEventListener('click',event=>{
-    const button=event.target?.closest?.('[data-appt-edit][data-dabbir-historical-edit="1"]');if(!button)return;
-    event.preventDefault();event.stopImmediatePropagation();openEditor(button.dataset.apptEdit);
+    const button=event.target?.closest?.('[data-appt-edit][data-dabbir-historical-edit="1"],[data-calendar-appt]');if(!button||!isCarWash())return;
+    const id=button.dataset.apptEdit||button.dataset.calendarAppt,row=appointment(id);
+    if(!row||!isHistorical(row))return;
+    event.preventDefault();event.stopImmediatePropagation();openEditor(id);
   },true);
   document.addEventListener('keydown',event=>{if(event.key==='Escape')close()});
   const observer=new MutationObserver(repairButtons);observer.observe(document.body,{subtree:true,childList:true});
   window.addEventListener('focus',repairButtons,{passive:true});
   setTimeout(repairButtons,0);setTimeout(repairButtons,700);
-  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v1-historical'};
+  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v2-historical-calendar'};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v1-historical');
+  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v2-historical-calendar');
   return res.status(200).send(script);
 }

--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -39,7 +39,7 @@ const script=String.raw`(()=>{
     if(!isCarWash()||window.__dabbirCarWashBookingEditFix)return false;
     if(document.querySelector('script[data-dabbir-car-wash-booking-edit-ui="1"]'))return true;
     const node=document.createElement('script');
-    node.src='/api/car-wash-booking-edit-ui?v=20260903-1-historical';
+    node.src='/api/car-wash-booking-edit-ui?v=20260903-2-historical-calendar';
     node.async=true;
     node.dataset.dabbirCarWashBookingEditUi='1';
     node.onerror=()=>console.error('dabbir_car_wash_booking_edit_ui_load_failed');
@@ -78,6 +78,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v7-historical-booking-edit');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v8-historical-calendar-edit');
   return res.status(200).send(script);
 }

--- a/supabase/migrations/20260903131500_dabbir_historical_appointment_correction_v1.sql
+++ b/supabase/migrations/20260903131500_dabbir_historical_appointment_correction_v1.sql
@@ -1,0 +1,37 @@
+create or replace function dabbir_private.prevent_past_appointment()
+returns trigger
+language plpgsql
+set search_path = public, pg_temp
+as $$
+declare
+  v_now_minute timestamptz := date_trunc('minute', now());
+begin
+  if new.starts_at is null then
+    return new;
+  end if;
+
+  -- New bookings and future bookings may never be moved into the past.
+  if new.starts_at >= v_now_minute then
+    return new;
+  end if;
+
+  -- Once an appointment is already historical, its owner may correct the
+  -- historical timestamp or status without the booking-creation guard
+  -- blocking the update. This preserves owner authority while keeping the
+  -- no-new-past-booking invariant fail-closed.
+  if tg_op = 'UPDATE'
+     and old.starts_at is not null
+     and old.starts_at < v_now_minute then
+    return new;
+  end if;
+
+  raise exception 'APPOINTMENT_TIME_IN_PAST'
+    using errcode = '22007';
+end;
+$$;
+
+drop trigger if exists dabbir_appointment_past_time_guard on public.dabbir_appointments;
+create trigger dabbir_appointment_past_time_guard
+before insert or update of starts_at on public.dabbir_appointments
+for each row
+execute function dabbir_private.prevent_past_appointment();

--- a/test/dabbir-car-wash-historical-booking-edit.test.mjs
+++ b/test/dabbir-car-wash-historical-booking-edit.test.mjs
@@ -4,12 +4,21 @@ import fs from 'node:fs';
 
 const api=fs.readFileSync('api/appointment-management.js','utf8');
 const ui=fs.readFileSync('api/car-wash-booking-edit-ui.js','utf8');
+const migration=fs.readFileSync('supabase/migrations/20260903131500_dabbir_historical_appointment_correction_v1.sql','utf8');
 
-test('appointment management accepts valid historical timestamps for correction',()=>{
+test('appointment management does not rewrite an unchanged historical timestamp',()=>{
   assert.match(api,/function validStart\(value\)/);
-  assert.doesNotMatch(api,/PAST_APPOINTMENT_NOT_ALLOWED/);
-  assert.doesNotMatch(api,/date\.getTime\(\)<Date\.now\(\)/);
+  assert.match(api,/const currentStart=validStart\(current\.starts_at\)/);
+  assert.match(api,/start\.getTime\(\)!==currentStart\.getTime\(\)/);
   assert.match(api,/patch\.starts_at=start\.toISOString\(\)/);
+  assert.match(api,/state:'NO_CHANGE'/);
+});
+
+test('database guard allows correction of an already historical appointment but blocks new past bookings',()=>{
+  assert.match(migration,/tg_op = 'UPDATE'/i);
+  assert.match(migration,/old\.starts_at < v_now_minute/);
+  assert.match(migration,/APPOINTMENT_TIME_IN_PAST/);
+  assert.match(migration,/before insert or update of starts_at/);
 });
 
 test('car-wash historical editor repairs disabled edit controls instead of hiding them',()=>{
@@ -19,10 +28,18 @@ test('car-wash historical editor repairs disabled edit controls instead of hidin
   assert.match(ui,/event\.stopImmediatePropagation\(\)/);
 });
 
+test('past calendar events open the same historical editor',()=>{
+  assert.match(ui,/\[data-calendar-appt\]/);
+  assert.match(ui,/button\.dataset\.apptEdit\|\|button\.dataset\.calendarAppt/);
+  assert.match(ui,/isHistorical\(row\)/);
+  assert.match(ui,/openEditor\(id\)/);
+});
+
 test('car-wash historical editor persists date and status through the canonical appointment API',()=>{
   assert.match(ui,/\/api\/appointment-management/);
   assert.match(ui,/action:'update'/);
   assert.match(ui,/starts_at:start,status:nextStatus/);
+  assert.match(ui,/data\?\.detail\|\|data\?\.error/);
   assert.match(ui,/location\.reload\(\)/);
 });
 

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,7 +33,7 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v7-historical-booking-edit/);
+  assert.match(loader,/v8-historical-calendar-edit/);
 });
 
 test('car-wash manual booking cache key changes for the iPhone customer combobox fix',()=>{
@@ -41,9 +41,9 @@ test('car-wash manual booking cache key changes for the iPhone customer combobox
   assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-3-native-combobox/);
 });
 
-test('car-wash loader mounts the historical booking editor',()=>{
+test('car-wash loader mounts the historical booking editor with the calendar-edit cache key',()=>{
   const loader=read('api/car-wash-loader-ui.js');
   assert.match(loader,/function loadBookingEdit\(\)/);
-  assert.match(loader,/car-wash-booking-edit-ui\?v=20260903-1-historical/);
+  assert.match(loader,/car-wash-booking-edit-ui\?v=20260903-2-historical-calendar/);
   assert.match(loader,/data-dabbir-car-wash-booking-edit-ui/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -47,5 +47,5 @@ test('car-wash loader mounts the mobile-safe manual booking enhancement only for
   assert.match(loader,/function loadManualBooking\(\)/);
   assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
   assert.match(loader,/20260903-3-native-combobox/);
-  assert.match(loader,/v7-historical-booking-edit/);
+  assert.match(loader,/v8-historical-calendar-edit/);
 });


### PR DESCRIPTION
Fixes the booking failure reproduced on iPhone where changing a past booking to Confirmed/Completed kept the editor open with APPOINTMENT_UPDATE_FAILED.

- Do not rewrite an unchanged historical `starts_at` when only status changes.
- Treat no-op saves as successful so the editor closes cleanly.
- Allow owners to correct timestamps on already-historical appointments while still rejecting new bookings (or future bookings moved) into the past.
- Let car-wash historical bookings open from both the management list and calendar event surface.
- Bust the car-wash editor cache key and add regression coverage.

The matching Supabase migration has already been applied to DABBIR Mumbai.