### PR TITLE
Make WhatsApp/web booking autonomous by default

### DIFF
--- a/docs/booking-trust-policy-v2.md
+++ b/docs/booking-trust-policy-v2.md
@@ -1,8 +1,10 @@
-# DABBIR Booking Trust Policy v2
+# DABBIR Booking Trust Policy — Autonomous Booking
 
-- External WhatsApp/web booking without a deposit stays pending approval internally.
-- Active operational roles can approve/reject: owner, admin, manager, employee, staff.
-- Customer WhatsApp booking confirmation and future reminders remain active while approval/deposit is pending.
-- Approval clears only the internal approval task; it does not requeue duplicate customer confirmation/reminders.
+- WhatsApp/web bookings never wait for owner, admin, manager, employee, or staff approval.
+- If no deposit is configured, the booking is confirmed immediately and written to the DABBIR calendar.
+- If a deposit is configured, the booking is still created immediately and reserves the slot; confirmation waits only for the deposit state, not a human decision.
+- A paid deposit auto-confirms the booking.
+- The owner/team receives booking notifications only; they are not part of the normal execution path.
+- Customer WhatsApp confirmation/reminders remain active according to the booking state and configured reminder policy.
 - Cancellation still cancels pending customer booking/reminder messages.
-- Deposit-paid bookings still auto-confirm.
+- Historical `owner_approval` columns remain only for backwards-compatible reads; new booking writes must not enter that state.

--- a/supabase/migrations/20260903095500_dabbir_autonomous_booking_confirmation_v1.sql
+++ b/supabase/migrations/20260903095500_dabbir_autonomous_booking_confirmation_v1.sql
@@ -1,0 +1,140 @@
+-- DABBIR autonomous booking confirmation v1.
+-- Product invariant: WhatsApp/web bookings never wait for owner/employee approval.
+-- The booking is written immediately. A configured deposit may gate confirmation,
+-- but the only human-side action in the normal path is a notification.
+
+create or replace function dabbir_private.enforce_external_booking_confirmation_gate()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_deposit_enabled boolean := false;
+begin
+  if new.booking_source in ('whatsapp','web') then
+    select coalesce(s.deposit_enabled,false)
+      into v_deposit_enabled
+    from public.dabbir_salon_settings s
+    where s.business_id=new.business_id;
+
+    new.owner_approval_status := 'not_required';
+    new.owner_approval_requested_at := null;
+    new.owner_decision_at := null;
+    new.owner_decided_by := null;
+
+    if coalesce(v_deposit_enabled,false) then
+      new.confirmation_gate := 'deposit';
+      if new.payment_status in ('partial','paid') then
+        new.status := 'confirmed';
+        new.deposit_paid_at := coalesce(new.deposit_paid_at,now());
+      else
+        -- The appointment exists immediately and reserves the slot, but remains
+        -- awaiting the configured deposit rather than a human approval.
+        new.status := 'new';
+      end if;
+    else
+      new.confirmation_gate := 'none';
+      new.status := 'confirmed';
+    end if;
+  else
+    new.confirmation_gate := 'none';
+    new.owner_approval_status := 'not_required';
+    new.owner_approval_requested_at := null;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.enforce_external_booking_confirmation_gate() from public,anon,authenticated;
+
+-- Owner approval is no longer a valid booking state. Keep the historical columns
+-- for backwards-compatible reads, while making writes fail closed if old code tries
+-- to reintroduce owner approval.
+create or replace function dabbir_private.guard_owner_booking_decision()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  if new.confirmation_gate='owner_approval'
+     or new.owner_approval_status in ('pending_owner','approved','rejected') then
+    raise exception 'BOOKING_OWNER_APPROVAL_DISABLED';
+  end if;
+
+  if old.confirmation_gate='deposit'
+     and new.confirmation_gate is distinct from old.confirmation_gate then
+    raise exception 'BOOKING_CONFIRMATION_GATE_IMMUTABLE';
+  end if;
+
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.guard_owner_booking_decision() from public,anon,authenticated;
+
+-- Retire the old approval RPC from normal authenticated use so stale clients cannot
+-- recreate a human approval dependency.
+revoke all on function public.dabbir_salon_owner_decide_booking(uuid,uuid,text) from public,anon,authenticated;
+
+-- Convert any existing no-deposit external booking still waiting for human approval
+-- into the autonomous path. Cancelled rows stay cancelled; active new rows confirm.
+update public.dabbir_appointments a
+set confirmation_gate='none',
+    owner_approval_status='not_required',
+    owner_approval_requested_at=null,
+    owner_decision_at=null,
+    owner_decided_by=null,
+    status=case when a.status='new' then 'confirmed' else a.status end,
+    updated_at=now()
+where a.booking_source in ('whatsapp','web')
+  and a.confirmation_gate='owner_approval';
+
+-- Remove obsolete internal approval tasks. Customer confirmation/reminders remain
+-- untouched; cancellation logic below still cancels them when the booking is cancelled.
+update public.dabbir_workflow_notifications n
+set status='cancelled',updated_at=now(),last_error=null
+where n.channel='internal'
+  and n.idempotency_key like 'appointment:%:owner_approval_required'
+  and n.status in ('pending','processing');
+
+create or replace function dabbir_private.handle_booking_confirmation_gate_notifications()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  if not exists(
+    select 1 from public.dabbir_businesses b
+    where b.id=new.business_id and b.business_type='salon'
+  ) then return new; end if;
+
+  -- No INSERT path creates a human approval task. The normal booking path is
+  -- autonomous; the team receives ordinary booking notifications only.
+  if tg_op='UPDATE' then
+    if old.confirmation_gate='owner_approval' then
+      update public.dabbir_workflow_notifications n
+         set status='cancelled',updated_at=now(),last_error=null
+       where n.business_id=new.business_id
+         and n.appointment_id=new.id
+         and n.channel='internal'
+         and n.idempotency_key='appointment:'||new.id||':owner_approval_required'
+         and n.status in ('pending','processing');
+    end if;
+
+    if new.status='cancelled' and old.status is distinct from 'cancelled' then
+      update public.dabbir_workflow_notifications n
+         set status='cancelled',updated_at=now()
+       where n.business_id=new.business_id
+         and n.appointment_id=new.id
+         and n.status in ('pending','processing')
+         and (n.channel='internal' or n.notification_type in ('booking_confirmation','reminder_24h','reminder_2h'));
+    end if;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.handle_booking_confirmation_gate_notifications() from public,anon,authenticated;
+
+comment on function dabbir_private.enforce_external_booking_confirmation_gate() is
+  'DABBIR invariant: WhatsApp/web bookings write immediately; no-deposit bookings confirm immediately; configured deposits may gate confirmation; owner approval is never in the normal booking path.';

--- a/test/dabbir-booking-confirmation-gate.test.mjs
+++ b/test/dabbir-booking-confirmation-gate.test.mjs
@@ -4,41 +4,40 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const root=path.resolve(import.meta.dirname,'..');
-const v1=fs.readFileSync(path.join(root,'supabase/migrations/20260903173500_dabbir_booking_confirmation_gate_v1.sql'),'utf8');
-const v2=fs.readFileSync(path.join(root,'supabase/migrations/20260903180500_dabbir_booking_trust_messaging_approvers_v2.sql'),'utf8');
-const sql=v1+'\n'+v2;
+const legacy=fs.readFileSync(path.join(root,'supabase/migrations/20260903173500_dabbir_booking_confirmation_gate_v1.sql'),'utf8');
+const autonomous=fs.readFileSync(path.join(root,'supabase/migrations/20260903095500_dabbir_autonomous_booking_confirmation_v1.sql'),'utf8');
 
-const has=(...markers)=>{for(const marker of markers)assert.match(sql,new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')))};
+const has=(...markers)=>{for(const marker of markers)assert.match(autonomous,new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')))};
 
-test('external bookings still choose exactly one confirmation gate',()=>{
-  has("new.booking_source in ('whatsapp','web')","new.confirmation_gate := 'deposit'","new.confirmation_gate := 'owner_approval'","new.owner_approval_status := 'pending_owner'");
-  assert.match(v1,/if\s+coalesce\(v_deposit_enabled,false\)[\s\S]+confirmation_gate := 'deposit'[\s\S]+else[\s\S]+confirmation_gate := 'owner_approval'/);
+test('external booking never requires human approval',()=>{
+  has("new.booking_source in ('whatsapp','web')","new.owner_approval_status := 'not_required'","new.confirmation_gate := 'none'","new.status := 'confirmed'");
+  assert.match(autonomous,/else\s+new\.confirmation_gate := 'none';\s+new\.status := 'confirmed';/);
+  assert.doesNotMatch(autonomous,/new\.confirmation_gate\s*:=\s*'owner_approval'/);
+  assert.doesNotMatch(autonomous,/new\.owner_approval_status\s*:=\s*'pending_owner'/);
 });
 
-test('active operational team can approve a no-deposit external booking',()=>{
-  has("m.role in ('owner','admin','manager','employee','staff')",'OWNER_APPROVAL_REQUIRED',"new.owner_approval_status := 'approved'","new.status := 'confirmed'");
-  assert.match(v2,/m\.role in \('owner','admin','manager','employee','staff'\)/);
-  assert.doesNotMatch(v2,/m\.role in \([^)]*viewer/i);
-  assert.doesNotMatch(v2,/m\.role in \([^)]*agent/i);
+test('configured deposit is the only external confirmation gate',()=>{
+  has("new.confirmation_gate := 'deposit'","new.payment_status in ('partial','paid')","new.status := 'confirmed'","new.status := 'new'");
+  assert.match(autonomous,/if\s+coalesce\(v_deposit_enabled,false\)[\s\S]+confirmation_gate := 'deposit'/);
 });
 
-test('a positive paid deposit still confirms automatically without approval',()=>{
-  has('auto_confirm_paid_deposit',"when p.status='paid' then p.amount_aed",'v_net_paid>0',"a.confirmation_gate='deposit'","a.status='new' then 'confirmed'");
+test('paid deposit auto-confirm behavior remains present',()=>{
+  assert.match(legacy,/auto_confirm_paid_deposit/);
+  assert.match(legacy,/when p\.status='paid' then p\.amount_aed/);
+  assert.match(legacy,/a\.confirmation_gate='deposit'/);
+  assert.match(legacy,/a\.status='new' then 'confirmed'/);
 });
 
-test('customer booking messages and future reminders stay active while gate is pending',()=>{
-  has('Trust rule: never silence the customer while approval/deposit is pending','team_approval_required',"n.notification_type='booking_confirmation'","n.notification_type in ('reminder_24h','reminder_2h') and n.scheduled_for>now()");
-  assert.doesNotMatch(v2,/tg_op='INSERT'[\s\S]{0,900}set status='cancelled'[\s\S]{0,300}channel='whatsapp'/i);
-  assert.match(v2,/set status='pending',updated_at=now\(\),last_error=null[\s\S]+a\.confirmation_gate in \('owner_approval','deposit'\)/);
+test('stale clients cannot restore owner approval',()=>{
+  has('BOOKING_OWNER_APPROVAL_DISABLED','revoke all on function public.dabbir_salon_owner_decide_booking(uuid,uuid,text) from public,anon,authenticated');
+  assert.match(autonomous,/if new\.confirmation_gate='owner_approval'[\s\S]+raise exception 'BOOKING_OWNER_APPROVAL_DISABLED'/);
 });
 
-test('approval clears only the internal approval task and avoids duplicate customer requeue',()=>{
-  assert.match(v2,/new\.status='confirmed'[\s\S]+n\.channel='internal'[\s\S]+owner_approval_required/);
-  assert.doesNotMatch(v2,/new\.status='confirmed'[\s\S]{0,1800}insert into public\.dabbir_workflow_notifications\([\s\S]{0,800}'whatsapp','booking_confirmation'/i);
+test('existing human-approval bookings are migrated to autonomous truth',()=>{
+  has("where a.booking_source in ('whatsapp','web')","a.confirmation_gate='owner_approval'","confirmation_gate='none'","owner_approval_status='not_required'","a.status='new' then 'confirmed'");
 });
 
-test('decision RPC remains authenticated and accepts operational team roles',()=>{
-  has('dabbir_salon_owner_decide_booking',"p_decision not in ('approve','reject')","owner_approval_status='pending_owner'","confirmation_gate='owner_approval'",'grant execute on function public.dabbir_salon_owner_decide_booking');
-  assert.match(v2,/revoke all on function public\.dabbir_salon_owner_decide_booking\(uuid,uuid,text\) from public,anon/);
-  assert.match(v2,/m\.role in \('owner','admin','manager','employee','staff'\)/);
+test('normal booking path creates no internal approval task',()=>{
+  assert.doesNotMatch(autonomous,/insert into public\.dabbir_workflow_notifications/i);
+  assert.match(autonomous,/idempotency_key like 'appointment:%:owner_approval_required'/);
 });

--- a/test/dabbir-booking-trust-policy-v2.test.mjs
+++ b/test/dabbir-booking-trust-policy-v2.test.mjs
@@ -4,21 +4,27 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const root=path.resolve(import.meta.dirname,'..');
-const sql=fs.readFileSync(path.join(root,'supabase/migrations/20260903180500_dabbir_booking_trust_messaging_approvers_v2.sql'),'utf8');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260903095500_dabbir_autonomous_booking_confirmation_v1.sql'),'utf8');
+const policy=fs.readFileSync(path.join(root,'docs/booking-trust-policy-v2.md'),'utf8');
 
-test('team approval includes operational roles but excludes read-only roles',()=>{
-  assert.match(sql,/m\.role in \('owner','admin','manager','employee','staff'\)/);
-  assert.doesNotMatch(sql,/m\.role in \([^)]*viewer/i);
-  assert.doesNotMatch(sql,/m\.role in \([^)]*agent/i);
+test('policy makes owner notification-only in the normal booking path',()=>{
+  assert.match(policy,/never wait for owner, admin, manager, employee, or staff approval/i);
+  assert.match(policy,/owner\/team receives booking notifications only/i);
 });
 
-test('pending booking does not suppress customer WhatsApp communication',()=>{
-  assert.match(sql,/Trust rule: never silence the customer while approval\/deposit is pending/);
-  assert.doesNotMatch(sql,/tg_op='INSERT'[\s\S]{0,1000}n\.channel='whatsapp'[\s\S]{0,500}set status='cancelled'/i);
+test('no-deposit WhatsApp and web booking confirms immediately',()=>{
+  assert.match(policy,/If no deposit is configured, the booking is confirmed immediately/i);
+  assert.match(migration,/new\.confirmation_gate := 'none';\s+new\.status := 'confirmed';/);
 });
 
-test('previously cancelled pending-gate customer messages are restored',()=>{
-  assert.match(sql,/set status='pending',updated_at=now\(\),last_error=null/);
-  assert.match(sql,/n\.notification_type='booking_confirmation'/);
-  assert.match(sql,/n\.notification_type in \('reminder_24h','reminder_2h'\) and n\.scheduled_for>now\(\)/);
+test('deposit may gate confirmation but never introduces human approval',()=>{
+  assert.match(policy,/confirmation waits only for the deposit state, not a human decision/i);
+  assert.match(migration,/new\.confirmation_gate := 'deposit'/);
+  assert.doesNotMatch(migration,/new\.confirmation_gate\s*:=\s*'owner_approval'/);
+});
+
+test('obsolete approval tasks are cancelled without suppressing customer messaging',()=>{
+  assert.match(migration,/n\.channel='internal'/);
+  assert.match(migration,/owner_approval_required/);
+  assert.doesNotMatch(migration,/channel='whatsapp'[\s\S]{0,500}owner_approval_required/i);
 });


### PR DESCRIPTION
Removes human owner/team approval from the normal DABBIR booking path.

- No-deposit WhatsApp/web bookings confirm immediately.
- Deposit-enabled bookings are created immediately and wait only for deposit state.
- Existing owner_approval bookings are migrated out of the human gate.
- Obsolete internal approval tasks are cancelled.
- The legacy decision RPC is revoked from authenticated users.
- CI tests lock the notification-only owner invariant.