### PR TITLE
DABBIR: prepare market-registry expansion foundation

### DIFF
--- a/api/_market-core.js
+++ b/api/_market-core.js
@@ -1,0 +1,51 @@
+const profiles = {
+  AE:{country_code:'AE',region:'AE',currency_code:'AED',currency_minor_units:2,timezone:'Asia/Dubai',offset:'+04:00',phone_country_prefix:'+971',vat_status:'implemented',default_vat_rate:5,ar:'الإمارات العربية المتحدة',en:'United Arab Emirates',money_ar:'درهم',active:true},
+  SA:{country_code:'SA',region:'SA',currency_code:'SAR',currency_minor_units:2,timezone:'Asia/Riyadh',offset:'+03:00',phone_country_prefix:'+966',vat_status:'implemented',default_vat_rate:15,ar:'السعودية',en:'Saudi Arabia',money_ar:'ريال سعودي',active:true},
+  KW:{country_code:'KW',region:'KW',currency_code:'KWD',currency_minor_units:3,timezone:'Asia/Kuwait',offset:'+03:00',phone_country_prefix:'+965',vat_status:'not_implemented',default_vat_rate:null,ar:'الكويت',en:'Kuwait',money_ar:'دينار كويتي',active:true},
+  QA:{country_code:'QA',region:'QA',currency_code:'QAR',currency_minor_units:2,timezone:'Asia/Qatar',offset:'+03:00',phone_country_prefix:'+974',vat_status:'not_implemented',default_vat_rate:null,ar:'قطر',en:'Qatar',money_ar:'ريال قطري',active:true},
+  BH:{country_code:'BH',region:'BH',currency_code:'BHD',currency_minor_units:3,timezone:'Asia/Bahrain',offset:'+03:00',phone_country_prefix:'+973',vat_status:'implemented',default_vat_rate:10,ar:'البحرين',en:'Bahrain',money_ar:'دينار بحريني',active:true},
+  OM:{country_code:'OM',region:'OM',currency_code:'OMR',currency_minor_units:3,timezone:'Asia/Muscat',offset:'+04:00',phone_country_prefix:'+968',vat_status:'implemented',default_vat_rate:5,ar:'عُمان',en:'Oman',money_ar:'ريال عماني',active:true},
+};
+
+export const MARKET_PROFILES=Object.freeze(Object.fromEntries(
+  Object.entries(profiles).map(([code,profile])=>[code,Object.freeze({...profile})]),
+));
+
+export const ACTIVE_MARKET_CODES=Object.freeze(
+  Object.values(MARKET_PROFILES).filter(profile=>profile.active).map(profile=>profile.country_code),
+);
+
+export function normalizeMarketCode(value){
+  const code=String(value||'').trim().toUpperCase().slice(0,2);
+  return MARKET_PROFILES[code]?.active?code:null;
+}
+
+export function getMarketProfile(value){
+  const code=normalizeMarketCode(value);
+  return code?MARKET_PROFILES[code]:null;
+}
+
+export function localeForMarket(value,language='ar'){
+  const profile=getMarketProfile(value);
+  if(!profile)return null;
+  return `${String(language||'').toLowerCase().startsWith('en')?'en':'ar'}-${profile.region}`;
+}
+
+export function publicMarketProfiles(){
+  return Object.fromEntries(ACTIVE_MARKET_CODES.map(code=>{
+    const profile=MARKET_PROFILES[code];
+    return [code,{
+      country_code:profile.country_code,
+      currency:profile.currency_code,
+      minorUnits:profile.currency_minor_units,
+      timezone:profile.timezone,
+      offset:profile.offset,
+      prefix:profile.phone_country_prefix,
+      vatStatus:profile.vat_status,
+      vatRate:profile.default_vat_rate,
+      ar:profile.ar,
+      en:profile.en,
+      moneyAr:profile.money_ar,
+    }];
+  }));
+}

--- a/api/gcc-business-profile.js
+++ b/api/gcc-business-profile.js
@@ -8,9 +8,9 @@ import {
   supabaseRest,
   supabaseRpc,
 } from './_auth-core.js';
+import { normalizeMarketCode } from './_market-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const GCC=new Set(['AE','SA','KW','QA','BH','OM']);
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
 async function read(response,fallback){
@@ -46,7 +46,7 @@ async function loadProfile(token,businessId){
   const rows=await read(await supabaseRest(
     `dabbir_businesses?select=id,country_code,currency_code,timezone,phone_country_prefix,vat_status,default_vat_rate,locale,updated_at&id=eq.${encodeURIComponent(businessId)}&limit=1`,
     token,
-  ),'GCC_PROFILE_LOOKUP_FAILED');
+  ),'MARKET_PROFILE_LOOKUP_FAILED');
   return Array.isArray(rows)?rows[0]||null:null;
 }
 
@@ -65,18 +65,18 @@ export default async function handler(req,res){
     if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
     const body=await readJsonBody(req,4096);
     const businessId=safeId(body?.business_id);
-    const countryCode=String(body?.country_code||'').trim().toUpperCase();
+    const countryCode=normalizeMarketCode(body?.country_code);
     if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_ID_REQUIRED'});
-    if(!GCC.has(countryCode))return json(res,400,{ok:false,error:'UNSUPPORTED_GCC_COUNTRY'});
+    if(!countryCode)return json(res,400,{ok:false,error:'UNSUPPORTED_MARKET'});
     const ctx=await context(req,res,businessId);if(!ctx)return;
     const canManage=ctx.membership.role==='owner'||(Array.isArray(ctx.membership.permissions)&&ctx.membership.permissions.includes('manage_business'));
     if(!canManage)return json(res,403,{ok:false,error:'BUSINESS_MANAGE_PERMISSION_REQUIRED'});
 
-    await read(await supabaseRpc('dabbir_set_business_country',ctx.token,{p_business_id:businessId,p_country_code:countryCode}),'GCC_PROFILE_UPDATE_FAILED');
+    await read(await supabaseRpc('dabbir_set_business_country',ctx.token,{p_business_id:businessId,p_country_code:countryCode}),'MARKET_PROFILE_UPDATE_FAILED');
     const profile=await loadProfile(ctx.token,businessId);
-    if(!profile||profile.country_code!==countryCode)return json(res,502,{ok:false,error:'GCC_PROFILE_UPDATE_UNVERIFIED'});
+    if(!profile||profile.country_code!==countryCode)return json(res,502,{ok:false,error:'MARKET_PROFILE_UPDATE_UNVERIFIED'});
     return json(res,200,{ok:true,state:'VERIFIED_PERSISTED',profile});
   }catch(error){
-    return json(res,Number(error?.status||500),{ok:false,error:error?.message||'GCC_PROFILE_FAILED',detail:error?.detail||null});
+    return json(res,Number(error?.status||500),{ok:false,error:error?.message||'MARKET_PROFILE_FAILED',detail:error?.detail||null});
   }
 }

--- a/api/gcc-create-business.js
+++ b/api/gcc-create-business.js
@@ -7,19 +7,11 @@ import {
   supabaseRest,
   supabaseRpc,
 } from './_auth-core.js';
+import { getMarketProfile, localeForMarket, normalizeMarketCode } from './_market-core.js';
 
 const BUSINESS_TYPES = new Set(['store','laundry','car_wash','clinic','creator','salon','real_estate','services','other']);
-const GCC = Object.freeze({
-  AE:{currency_code:'AED',timezone:'Asia/Dubai',phone_country_prefix:'+971',region:'AE'},
-  SA:{currency_code:'SAR',timezone:'Asia/Riyadh',phone_country_prefix:'+966',region:'SA'},
-  KW:{currency_code:'KWD',timezone:'Asia/Kuwait',phone_country_prefix:'+965',region:'KW'},
-  QA:{currency_code:'QAR',timezone:'Asia/Qatar',phone_country_prefix:'+974',region:'QA'},
-  BH:{currency_code:'BHD',timezone:'Asia/Bahrain',phone_country_prefix:'+973',region:'BH'},
-  OM:{currency_code:'OMR',timezone:'Asia/Muscat',phone_country_prefix:'+968',region:'OM'},
-});
 
 function clean(value,max=120){return String(value??'').trim().slice(0,max)}
-function country(value){const code=clean(value,2).toUpperCase();return GCC[code]?code:null}
 function language(value){return String(value||'').toLowerCase().startsWith('en')?'en':'ar'}
 
 async function read(response,fallback){
@@ -48,14 +40,15 @@ export default async function handler(req,res){
     const body=await readJsonBody(req,8192);
     const name=clean(body?.name,120);
     const businessType=clean(body?.business_type,40).toLowerCase();
-    const countryCode=country(body?.country_code);
+    const countryCode=normalizeMarketCode(body?.country_code);
+    const market=getMarketProfile(countryCode);
     const lang=language(body?.locale);
 
     if(!name)return json(res,400,{ok:false,error:'BUSINESS_NAME_REQUIRED'});
     if(!BUSINESS_TYPES.has(businessType))return json(res,400,{ok:false,error:'UNSUPPORTED_BUSINESS_TYPE'});
-    if(!countryCode)return json(res,400,{ok:false,error:'UNSUPPORTED_GCC_COUNTRY'});
+    if(!market)return json(res,400,{ok:false,error:'UNSUPPORTED_MARKET'});
 
-    const locale=`${lang}-${GCC[countryCode].region}`;
+    const locale=localeForMarket(countryCode,lang);
     const created=await read(await supabaseRpc('dabbir_create_business',accessToken,{
       p_name:name,
       p_business_type:businessType,
@@ -70,8 +63,8 @@ export default async function handler(req,res){
       accessToken,
     ),'BUSINESS_PROFILE_VERIFY_FAILED');
     const business=Array.isArray(rows)?rows[0]:null;
-    if(!business?.id||business.country_code!==countryCode||business.currency_code!==GCC[countryCode].currency_code){
-      return json(res,502,{ok:false,error:'BUSINESS_COUNTRY_PROFILE_UNVERIFIED',business_id:businessId});
+    if(!business?.id||business.country_code!==countryCode||business.currency_code!==market.currency_code||business.timezone!==market.timezone||business.phone_country_prefix!==market.phone_country_prefix){
+      return json(res,502,{ok:false,error:'BUSINESS_MARKET_PROFILE_UNVERIFIED',business_id:businessId});
     }
 
     return json(res,200,{
@@ -92,6 +85,6 @@ export default async function handler(req,res){
       truth:{state:'VERIFIED',source:'SUPABASE_RETURN_AND_READBACK',entity:'business',entity_id:businessId,verified_at:new Date().toISOString()},
     });
   }catch(error){
-    return json(res,Number(error?.status||500),{ok:false,error:error?.message||'GCC_BUSINESS_CREATE_FAILED',detail:error?.detail||null});
+    return json(res,Number(error?.status||500),{ok:false,error:error?.message||'MARKET_BUSINESS_CREATE_FAILED',detail:error?.detail||null});
   }
 }

--- a/api/gcc-readiness-ui.js
+++ b/api/gcc-readiness-ui.js
@@ -1,17 +1,12 @@
 import brandUiHandler from './brand-ui.js';
+import { publicMarketProfiles } from './_market-core.js';
 
+const serializedMarkets=JSON.stringify(publicMarketProfiles()).replace(/</g,'\\u003c');
 const script=String.raw`(()=>{
   if(window.__dabbirGccReadinessLoaded)return;
   window.__dabbirGccReadinessLoaded=true;
 
-  const GCC=Object.freeze({
-    AE:{currency:'AED',timezone:'Asia/Dubai',offset:'+04:00',prefix:'+971',ar:'الإمارات العربية المتحدة',en:'United Arab Emirates',moneyAr:'درهم'},
-    SA:{currency:'SAR',timezone:'Asia/Riyadh',offset:'+03:00',prefix:'+966',ar:'السعودية',en:'Saudi Arabia',moneyAr:'ريال سعودي'},
-    KW:{currency:'KWD',timezone:'Asia/Kuwait',offset:'+03:00',prefix:'+965',ar:'الكويت',en:'Kuwait',moneyAr:'دينار كويتي'},
-    QA:{currency:'QAR',timezone:'Asia/Qatar',offset:'+03:00',prefix:'+974',ar:'قطر',en:'Qatar',moneyAr:'ريال قطري'},
-    BH:{currency:'BHD',timezone:'Asia/Bahrain',offset:'+03:00',prefix:'+973',ar:'البحرين',en:'Bahrain',moneyAr:'دينار بحريني'},
-    OM:{currency:'OMR',timezone:'Asia/Muscat',offset:'+04:00',prefix:'+968',ar:'عُمان',en:'Oman',moneyAr:'ريال عماني'},
-  });
+  const GCC=Object.freeze(${serializedMarkets});
   const baseFetch=window.fetch.bind(window);
   const ar=()=>String(document.documentElement.lang||'ar').toLowerCase()!=='en';
   const selectedCountry=()=>{
@@ -33,7 +28,7 @@ const script=String.raw`(()=>{
     if(!select)return;
     const c=copy();
     const label=document.querySelector('#businessCountryLabel');if(label)label.textContent=c.country;
-    [...select.options].forEach(option=>{const p=GCC[option.value];option.textContent=ar()?p.ar:p.en});
+    [...select.options].forEach(option=>{const p=GCC[option.value];if(p)option.textContent=ar()?p.ar:p.en});
     const code=selectedCountry();const p=GCC[code];
     const derived=document.querySelector('#businessCurrencyDerived');
     if(derived)derived.textContent=c.currency+': '+p.currency+' · '+p.timezone+' · '+p.prefix;
@@ -104,7 +99,7 @@ const script=String.raw`(()=>{
   }
   function money(value){
     const g=currentGeo();const n=Number(value||0);
-    try{return new Intl.NumberFormat(runtimeLocale(),{style:'currency',currency:g.currency,maximumFractionDigits:3}).format(n)}catch{return n.toFixed(2)+' '+g.currency}
+    try{return new Intl.NumberFormat(runtimeLocale(),{style:'currency',currency:g.currency,maximumFractionDigits:Number(g.minorUnits??3)}).format(n)}catch{return n.toFixed(Number(g.minorUnits??2))+' '+g.currency}
   }
 
   function reassertAuthorities(){
@@ -171,7 +166,7 @@ export default async function handler(req,res){
     res.setHeader('content-type','application/javascript; charset=utf-8');
     res.setHeader('cache-control','no-store');
     res.setHeader('x-content-type-options','nosniff');
-    res.setHeader('x-dabbir-gcc-readiness','country-authority-v1-composed-brand-slot');
+    res.setHeader('x-dabbir-gcc-readiness','market-registry-v2-composed-brand-slot');
     return res.end(brandScript+'\n'+script);
   }catch(error){
     res.statusCode=Number(error?.status||500);

--- a/api/timezone-ui.js
+++ b/api/timezone-ui.js
@@ -2,28 +2,20 @@ const script=String.raw`(()=>{
   if(window.__dabbirTimezoneLoaded)return;
   window.__dabbirTimezoneLoaded=true;
 
-  const GCC=Object.freeze({
-    AE:{currency:'AED',timezone:'Asia/Dubai',offset:'+04:00',prefix:'+971',moneyAr:'درهم'},
-    SA:{currency:'SAR',timezone:'Asia/Riyadh',offset:'+03:00',prefix:'+966',moneyAr:'ريال سعودي'},
-    KW:{currency:'KWD',timezone:'Asia/Kuwait',offset:'+03:00',prefix:'+965',moneyAr:'دينار كويتي'},
-    QA:{currency:'QAR',timezone:'Asia/Qatar',offset:'+03:00',prefix:'+974',moneyAr:'ريال قطري'},
-    BH:{currency:'BHD',timezone:'Asia/Bahrain',offset:'+03:00',prefix:'+973',moneyAr:'دينار بحريني'},
-    OM:{currency:'OMR',timezone:'Asia/Muscat',offset:'+04:00',prefix:'+968',moneyAr:'ريال عماني'},
-  });
-
+  function currencyMinorUnits(currency){
+    try{return new Intl.NumberFormat('en',{style:'currency',currency}).resolvedOptions().maximumFractionDigits??2}catch{return 2}
+  }
+  function currencyNameAr(currency){
+    try{return new Intl.DisplayNames(['ar'],{type:'currency'}).of(currency)||currency}catch{return currency}
+  }
   function businessGeo(){
     let business=null;
     try{business=workspace?.business||null}catch{}
-    const code=String(business?.country_code||document.documentElement.dataset.dabbirCountry||'AE').toUpperCase();
-    const base=GCC[code]||GCC.AE;
-    return {
-      countryCode:GCC[code]?code:'AE',
-      currency:String(business?.currency_code||base.currency),
-      timezone:String(business?.timezone||base.timezone),
-      offset:base.offset,
-      prefix:String(business?.phone_country_prefix||base.prefix),
-      moneyAr:base.moneyAr,
-    };
+    const countryCode=String(business?.country_code||document.documentElement.dataset.dabbirCountry||'AE').toUpperCase();
+    const currency=String(business?.currency_code||document.documentElement.dataset.dabbirCurrency||'AED').toUpperCase();
+    const timezone=String(business?.timezone||document.documentElement.dataset.dabbirTimezone||'Asia/Dubai');
+    const prefix=String(business?.phone_country_prefix||'');
+    return {countryCode,currency,timezone,prefix,moneyAr:currencyNameAr(currency),minorUnits:currencyMinorUnits(currency)};
   }
 
   function locale(){
@@ -44,6 +36,15 @@ const script=String.raw`(()=>{
     }catch{return String(value)}
   }
 
+  function offsetMinutesAt(instantMs,timeZone){
+    const date=new Date(instantMs);
+    const parts=Object.fromEntries(new Intl.DateTimeFormat('en-US',{
+      timeZone,year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',second:'2-digit',hourCycle:'h23'
+    }).formatToParts(date).filter(part=>part.type!=='literal').map(part=>[part.type,part.value]));
+    const represented=Date.UTC(Number(parts.year),Number(parts.month)-1,Number(parts.day),Number(parts.hour),Number(parts.minute),Number(parts.second));
+    return Math.round((represented-Math.floor(instantMs/1000)*1000)/60000);
+  }
+
   function businessLocalToIso(value){
     const raw=String(value||'').trim();
     if(!raw)return null;
@@ -51,9 +52,19 @@ const script=String.raw`(()=>{
       const absolute=new Date(raw);
       return Number.isNaN(absolute.getTime())?null:absolute.toISOString();
     }
-    const normalized=raw.length===16?raw+':00':raw;
-    const date=new Date(normalized+businessGeo().offset);
-    return Number.isNaN(date.getTime())?null:date.toISOString();
+    const match=raw.match(/^(\d{4})-(\d{2})-(\d{2})[T ](\d{2}):(\d{2})(?::(\d{2}))?$/);
+    if(!match)return null;
+    const [,year,month,day,hour,minute,second='00']=match;
+    const wallUtc=Date.UTC(Number(year),Number(month)-1,Number(day),Number(hour),Number(minute),Number(second));
+    const zone=businessGeo().timezone;
+    try{
+      let offset=offsetMinutesAt(wallUtc,zone);
+      let instant=wallUtc-offset*60000;
+      const corrected=offsetMinutesAt(instant,zone);
+      if(corrected!==offset)instant=wallUtc-corrected*60000;
+      const date=new Date(instant);
+      return Number.isNaN(date.getTime())?null:date.toISOString();
+    }catch{return null}
   }
 
   function syncAuthorities(){
@@ -108,8 +119,8 @@ const script=String.raw`(()=>{
       }else{
         input=document.createElement('input');input.type=type;
         if(type==='text')input.maxLength=500;
-        if(type==='tel'){input.maxLength=40;input.placeholder=geo.prefix+' …';input.inputMode='tel';}
-        if(type==='number'){input.min='0';input.step=key==='price'?'0.001':'5';}
+        if(type==='tel'){input.maxLength=40;input.placeholder=(geo.prefix||'+')+' …';input.inputMode='tel';}
+        if(type==='number'){input.min='0';input.step=key==='price'?(geo.minorUnits===0?'1':'0.'+'0'.repeat(Math.max(0,geo.minorUnits-1))+'1'):'5';}
       }
       input.dataset.apptKey=key;field.append(label,input);wrap.append(field);
     }
@@ -174,7 +185,7 @@ const script=String.raw`(()=>{
   document.addEventListener('click',event=>{if(event.target?.closest?.('#menuBtn,[data-screen="more"],.topActions,#dabbirOwnerCopilot'))setTimeout(refreshMobileUtilityUi,0)},true);
 
   if(appointmentForm&&!appointmentForm.dataset.dabbirBusinessTime){
-    appointmentForm.dataset.dabbirBusinessTime='v3-gcc';
+    appointmentForm.dataset.dabbirBusinessTime='v4-market';
     appointmentForm.addEventListener('submit',async event=>{
       event.preventDefault();
       event.stopImmediatePropagation();
@@ -234,6 +245,6 @@ export default function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-timezone','business-profile');
+  res.setHeader('x-dabbir-timezone','market-agnostic-business-profile');
   return res.end(script);
 }

--- a/supabase/migrations/20260903092251_dabbir_market_registry_expansion_v1.sql
+++ b/supabase/migrations/20260903092251_dabbir_market_registry_expansion_v1.sql
@@ -1,0 +1,187 @@
+create table if not exists public.dabbir_markets (
+  country_code text primary key,
+  region_group text not null default 'GCC',
+  name_ar text not null,
+  name_en text not null,
+  currency_code text not null,
+  currency_minor_units smallint not null default 2,
+  timezone text not null,
+  phone_country_prefix text not null,
+  locale_region text not null,
+  vat_status text not null,
+  default_vat_rate numeric(5,2),
+  is_active boolean not null default true,
+  sort_order smallint not null default 100,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint dabbir_markets_country_code_format check (country_code ~ '^[A-Z]{2}$'),
+  constraint dabbir_markets_currency_code_format check (currency_code ~ '^[A-Z]{3}$'),
+  constraint dabbir_markets_currency_minor_units_check check (currency_minor_units between 0 and 3),
+  constraint dabbir_markets_vat_status_check check (vat_status in ('implemented','not_implemented')),
+  constraint dabbir_markets_vat_shape_check check (
+    (vat_status='implemented' and default_vat_rate is not null and default_vat_rate >= 0 and default_vat_rate <= 100)
+    or (vat_status='not_implemented' and default_vat_rate is null)
+  )
+);
+
+alter table public.dabbir_markets enable row level security;
+revoke all on table public.dabbir_markets from public, anon, authenticated;
+grant select on table public.dabbir_markets to anon, authenticated;
+grant select, insert, update, delete on table public.dabbir_markets to service_role;
+drop policy if exists dabbir_markets_public_read on public.dabbir_markets;
+create policy dabbir_markets_public_read on public.dabbir_markets
+for select to anon, authenticated using (is_active = true);
+
+insert into public.dabbir_markets(
+  country_code,region_group,name_ar,name_en,currency_code,currency_minor_units,timezone,phone_country_prefix,locale_region,vat_status,default_vat_rate,is_active,sort_order
+) values
+  ('AE','GCC','الإمارات العربية المتحدة','United Arab Emirates','AED',2,'Asia/Dubai','+971','AE','implemented',5.00,true,10),
+  ('SA','GCC','السعودية','Saudi Arabia','SAR',2,'Asia/Riyadh','+966','SA','implemented',15.00,true,20),
+  ('KW','GCC','الكويت','Kuwait','KWD',3,'Asia/Kuwait','+965','KW','not_implemented',null,true,30),
+  ('QA','GCC','قطر','Qatar','QAR',2,'Asia/Qatar','+974','QA','not_implemented',null,true,40),
+  ('BH','GCC','البحرين','Bahrain','BHD',3,'Asia/Bahrain','+973','BH','implemented',10.00,true,50),
+  ('OM','GCC','عُمان','Oman','OMR',3,'Asia/Muscat','+968','OM','implemented',5.00,true,60)
+on conflict (country_code) do update set
+  region_group=excluded.region_group,
+  name_ar=excluded.name_ar,
+  name_en=excluded.name_en,
+  currency_code=excluded.currency_code,
+  currency_minor_units=excluded.currency_minor_units,
+  timezone=excluded.timezone,
+  phone_country_prefix=excluded.phone_country_prefix,
+  locale_region=excluded.locale_region,
+  vat_status=excluded.vat_status,
+  default_vat_rate=excluded.default_vat_rate,
+  is_active=excluded.is_active,
+  sort_order=excluded.sort_order,
+  updated_at=now();
+
+alter table public.dabbir_businesses drop constraint if exists dabbir_businesses_country_code_check;
+alter table public.dabbir_businesses drop constraint if exists dabbir_businesses_gcc_profile_check;
+alter table public.dabbir_businesses drop constraint if exists dabbir_businesses_country_market_fkey;
+alter table public.dabbir_businesses add constraint dabbir_businesses_country_market_fkey
+  foreign key (country_code) references public.dabbir_markets(country_code) on update cascade on delete restrict not valid;
+alter table public.dabbir_businesses validate constraint dabbir_businesses_country_market_fkey;
+
+create or replace function dabbir_private.sync_gcc_business_profile()
+returns trigger
+language plpgsql
+security invoker
+set search_path to 'public', 'dabbir_private', 'pg_temp'
+as $function$
+declare
+  v_market public.dabbir_markets%rowtype;
+begin
+  new.country_code := upper(trim(coalesce(new.country_code, 'AE')));
+
+  select * into v_market
+  from public.dabbir_markets
+  where country_code = new.country_code and is_active = true;
+
+  if not found then
+    raise exception 'UNSUPPORTED_MARKET';
+  end if;
+
+  new.currency_code := v_market.currency_code;
+  new.timezone := v_market.timezone;
+  new.phone_country_prefix := v_market.phone_country_prefix;
+  new.vat_status := v_market.vat_status;
+  new.default_vat_rate := v_market.default_vat_rate;
+  return new;
+end;
+$function$;
+
+revoke all on function dabbir_private.sync_gcc_business_profile() from public, anon, authenticated;
+grant execute on function dabbir_private.sync_gcc_business_profile() to service_role;
+
+drop trigger if exists dabbir_sync_gcc_business_profile on public.dabbir_businesses;
+create trigger dabbir_sync_gcc_business_profile
+before insert or update of country_code, currency_code, timezone, phone_country_prefix, vat_status, default_vat_rate
+on public.dabbir_businesses
+for each row execute function dabbir_private.sync_gcc_business_profile();
+
+create or replace function public.dabbir_create_business(
+  p_name text,
+  p_business_type text,
+  p_locale text,
+  p_country_code text
+)
+returns table(business_id uuid, business_slug text)
+language plpgsql
+security invoker
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_user uuid := auth.uid();
+  v_id uuid := gen_random_uuid();
+  v_slug text;
+  v_name text;
+  v_country text := upper(trim(coalesce(p_country_code, '')));
+  v_timezone text;
+  v_locale_region text;
+begin
+  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+  v_name := left(trim(p_name), 120);
+  if nullif(v_name, '') is null then raise exception 'BUSINESS_NAME_REQUIRED'; end if;
+  if p_business_type not in ('store','laundry','car_wash','clinic','creator','salon','real_estate','services','other') then raise exception 'UNSUPPORTED_BUSINESS_TYPE'; end if;
+
+  select timezone, locale_region into v_timezone, v_locale_region
+  from public.dabbir_markets
+  where country_code=v_country and is_active=true;
+  if not found then raise exception 'UNSUPPORTED_MARKET'; end if;
+
+  v_slug := 'dabbir-' || substr(replace(v_id::text, '-', ''), 1, 16);
+
+  insert into public.dabbir_businesses(id,slug,name,business_type,owner_id,locale,demo_mode,country_code)
+  values(v_id,v_slug,v_name,p_business_type,v_user,coalesce(nullif(trim(p_locale),''),'ar-'||v_locale_region),false,v_country);
+
+  insert into public.dabbir_memberships(business_id,user_id,role,status,accepted_at)
+  values(v_id,v_user,'owner','active',now());
+
+  insert into public.dabbir_business_branches(business_id,name,status,timezone,is_primary,created_by)
+  values(v_id,v_name,'active',v_timezone,true,v_user);
+
+  return query select v_id, v_slug;
+end;
+$function$;
+
+revoke all on function public.dabbir_create_business(text,text,text,text) from public, anon;
+grant execute on function public.dabbir_create_business(text,text,text,text) to authenticated, service_role;
+
+create or replace function public.dabbir_set_business_country(p_business_id uuid, p_country_code text)
+returns table(country_code text,currency_code text,timezone text,phone_country_prefix text,vat_status text,default_vat_rate numeric)
+language plpgsql
+security invoker
+set search_path to 'public', 'pg_temp'
+as $function$
+declare
+  v_country text := upper(trim(coalesce(p_country_code,'')));
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+  if not exists(select 1 from public.dabbir_markets where country_code=v_country and is_active=true) then
+    raise exception 'UNSUPPORTED_MARKET';
+  end if;
+
+  update public.dabbir_businesses b
+  set country_code=v_country, updated_at=now()
+  where b.id=p_business_id;
+
+  if not found then raise exception 'BUSINESS_ACCESS_DENIED'; end if;
+
+  update public.dabbir_business_branches br
+  set timezone=b.timezone, updated_at=now()
+  from public.dabbir_businesses b
+  where b.id=p_business_id and br.business_id=b.id and br.is_primary=true;
+
+  return query
+  select b.country_code,b.currency_code,b.timezone,b.phone_country_prefix,b.vat_status,b.default_vat_rate
+  from public.dabbir_businesses b where b.id=p_business_id;
+end;
+$function$;
+
+revoke all on function public.dabbir_set_business_country(uuid,text) from public, anon;
+grant execute on function public.dabbir_set_business_country(uuid,text) to authenticated, service_role;
+
+comment on table public.dabbir_markets is 'DABBIR market registry. Add or disable markets here instead of duplicating country rules across product code.';
+comment on column public.dabbir_markets.currency_minor_units is 'ISO currency minor-unit precision used for display and payment amount conversion.';
+comment on column public.dabbir_businesses.country_code is 'ISO 3166-1 alpha-2 market code referencing dabbir_markets; authoritative source for derived business localization.';

--- a/test/dabbir-gcc-readiness.test.mjs
+++ b/test/dabbir-gcc-readiness.test.mjs
@@ -7,7 +7,9 @@ import { fileURLToPath } from 'node:url';
 const here=dirname(fileURLToPath(import.meta.url));
 const read=path=>readFileSync(resolve(here,'..',path),'utf8');
 const migration=read('supabase/migrations/20260903092000_dabbir_gcc_business_profile_v1.sql');
+const marketMigration=read('supabase/migrations/20260903092251_dabbir_market_registry_expansion_v1.sql');
 const publicBookingMigration=read('supabase/migrations/20260903060929_dabbir_public_booking_gcc_timezone.sql');
+const marketCore=read('api/_market-core.js');
 const createApi=read('api/gcc-create-business.js');
 const profileApi=read('api/gcc-business-profile.js');
 const adaptiveAppointment=read('api/adaptive-appointment.js');
@@ -19,55 +21,77 @@ const timezoneUi=read('api/timezone-ui.js');
 const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
 
 const expected={
-  AE:['AED','Asia/Dubai','+971'],
-  SA:['SAR','Asia/Riyadh','+966'],
-  KW:['KWD','Asia/Kuwait','+965'],
-  QA:['QAR','Asia/Qatar','+974'],
-  BH:['BHD','Asia/Bahrain','+973'],
-  OM:['OMR','Asia/Muscat','+968'],
+  AE:['AED','Asia/Dubai','+971',2],
+  SA:['SAR','Asia/Riyadh','+966',2],
+  KW:['KWD','Asia/Kuwait','+965',3],
+  QA:['QAR','Asia/Qatar','+974',2],
+  BH:['BHD','Asia/Bahrain','+973',3],
+  OM:['OMR','Asia/Muscat','+968',3],
 };
 
-test('database makes GCC country authoritative over currency, timezone and phone prefix',()=>{
+test('legacy GCC migration remains backward-compatible',()=>{
   assert.match(migration,/dabbir_sync_gcc_business_profile/);
   assert.match(migration,/before insert or update of country_code, currency_code, timezone, phone_country_prefix/);
-  for(const [country,[currency,timezone,prefix]] of Object.entries(expected)){
-    assert.match(migration,new RegExp(`country_code='${country}'.*currency_code='${currency}'.*timezone='${timezone}'.*phone_country_prefix='\\${prefix}'`,'s'));
-  }
 });
 
-test('GCC onboarding accepts country but never accepts currency from the browser as authority',()=>{
+test('market registry replaces fixed GCC CHECK/CASE as the expansion authority',()=>{
+  assert.match(marketMigration,/create table if not exists public\.dabbir_markets/);
+  assert.match(marketMigration,/foreign key \(country_code\) references public\.dabbir_markets\(country_code\)/);
+  assert.match(marketMigration,/from public\.dabbir_markets/);
+  assert.match(marketMigration,/UNSUPPORTED_MARKET/);
+  assert.match(marketMigration,/enable row level security/);
+  assert.match(marketMigration,/for select to anon, authenticated using \(is_active = true\)/);
+  assert.doesNotMatch(marketMigration,/country_code in \('AE','SA','KW','QA','BH','OM'\)/);
+});
+
+test('central market core carries localization and ISO currency precision for launch markets',()=>{
+  for(const [country,[currency,timezone,prefix,minorUnits]] of Object.entries(expected)){
+    assert.match(marketCore,new RegExp(`${country}:\\{[^}]*currency_code:'${currency}'[^}]*currency_minor_units:${minorUnits}[^}]*timezone:'${timezone}'[^}]*phone_country_prefix:'\\${prefix}'`));
+  }
+  assert.match(marketCore,/normalizeMarketCode/);
+  assert.match(marketCore,/publicMarketProfiles/);
+});
+
+test('onboarding accepts market but never accepts currency from the browser as authority',()=>{
+  assert.match(createApi,/from '\.\/_market-core\.js'/);
   assert.match(createApi,/p_country_code:countryCode/);
   assert.doesNotMatch(createApi,/body\?\.currency_code/);
-  assert.match(createApi,/BUSINESS_COUNTRY_PROFILE_UNVERIFIED/);
+  assert.match(createApi,/BUSINESS_MARKET_PROFILE_UNVERIFIED/);
+  assert.match(ui,/from '\.\/_market-core\.js'/);
   assert.match(ui,/id='businessCountry'|select\.id='businessCountry'/);
   assert.doesNotMatch(ui,/select\.id='businessCurrency'/);
   assert.match(ui,/Currency is set automatically from the selected country/);
 });
 
-test('web create-business is rerouted atomically through the GCC-aware endpoint',()=>{
+test('web create-business is rerouted atomically through the market-aware endpoint',()=>{
   assert.match(ui,/body\?\.action==='create_business'/);
   assert.match(ui,/baseFetch\('\/api\/gcc-create-business'/);
   assert.match(ui,/country_code:code/);
 });
 
-test('runtime is enriched with tenant-scoped country profile and dynamic time/money formatting',()=>{
+test('runtime profile validates market through the shared registry',()=>{
   assert.match(ui,/gcc-business-profile\?business_id=/);
   assert.match(ui,/style:'currency',currency:g\.currency/);
   assert.match(ui,/timeZone:g\.timezone/);
+  assert.match(profileApi,/normalizeMarketCode/);
   assert.match(profileApi,/getBusinessMemberships/);
   assert.match(profileApi,/BUSINESS_ACCESS_DENIED/);
+  assert.doesNotMatch(profileApi,/new Set\(\['AE','SA','KW','QA','BH','OM'\]\)/);
 });
 
-test('deferred appointment UI cannot overwrite GCC timezone or price labels with UAE-only constants',()=>{
+test('appointment UI is market-agnostic and timezone conversion is IANA/DST aware',()=>{
   assert.match(timezoneUi,/function businessGeo\(\)/);
-  assert.match(timezoneUi,/business\?\.timezone\|\|base\.timezone/);
-  assert.match(timezoneUi,/business\?\.currency_code\|\|base\.currency/);
+  assert.match(timezoneUi,/business\?\.timezone\|\|document\.documentElement\.dataset\.dabbirTimezone/);
+  assert.match(timezoneUi,/business\?\.currency_code\|\|document\.documentElement\.dataset\.dabbirCurrency/);
+  assert.match(timezoneUi,/offsetMinutesAt/);
+  assert.match(timezoneUi,/Intl\.DateTimeFormat\('en-US'/);
+  assert.match(timezoneUi,/currencyMinorUnits/);
   assert.match(timezoneUi,/businessLocalToIso/);
-  assert.match(timezoneUi,/geo\.prefix/);
+  assert.doesNotMatch(timezoneUi,/const GCC=Object\.freeze/);
   assert.doesNotMatch(timezoneUi,/const DABBIR_TIME_ZONE='Asia\/Dubai'/);
   assert.doesNotMatch(timezoneUi,/Price \(AED\)/);
   assert.doesNotMatch(timezoneUi,/السعر \(درهم\)/);
-  assert.match(timezoneUi,/x-dabbir-timezone','business-profile/);
+  assert.match(timezoneUi,/market-agnostic-business-profile/);
 });
 
 test('appointment phone normalization follows business prefix but remains optional',()=>{
@@ -103,6 +127,7 @@ test('public booking page renders currency, timezone and phone prefix from catal
   assert.match(publicBookingUi,/data-slot/);
 });
 
-test('GCC readiness loads in the critical bundle so country is available during onboarding',()=>{
+test('market readiness loads before deferred timezone UI during onboarding',()=>{
   assert.ok(bundles.critical.includes('/api/gcc-readiness-ui'));
+  assert.ok(bundles.deferred.includes('/api/timezone-ui'));
 });


### PR DESCRIPTION
## What changes
- Adds a single market profile core for country/currency/timezone/phone/VAT metadata.
- Records the already-applied `dabbir_market_registry_expansion_v1` database migration in source control.
- Replaces fixed GCC validation in business creation/profile APIs with the market registry.
- Drives onboarding country UI from the shared market profiles.
- Makes appointment timezone conversion market-agnostic using IANA timezones instead of fixed UTC offsets, including future DST markets.
- Uses ISO currency minor units so KWD/BHD/OMR use 3 decimal places while AED/SAR/QAR use 2.
- Updates GCC readiness tests to guard against reintroducing fixed six-country CHECK/CASE logic.

## Database state
The migration is already applied and verified on `DABBIR Mumbai` (Supabase project `fphpoysqdsceniwduxjq`). Existing GCC values remain unchanged and `dabbir_businesses.country_code` now references `dabbir_markets(country_code)`.

## Compatibility
- Existing six GCC markets stay active and unchanged.
- Legacy API endpoint names remain intact.
- Existing UAE-default legacy create-business overload remains database-compatible.
- This branch is based on the latest `main` after the historical-booking/calendar-outbox merges.