### PR TITLE
Harden deposit thresholds and payment replay safety

### DIFF
--- a/supabase/migrations/20260903101500_dabbir_deposit_payment_resilience_v1.sql
+++ b/supabase/migrations/20260903101500_dabbir_deposit_payment_resilience_v1.sql
@@ -1,0 +1,255 @@
+-- DABBIR deposit/payment worst-case resilience v1.
+-- Business truth first: the appointment exists before external payment succeeds.
+-- Deposit satisfaction is deterministic from the payment ledger and a frozen per-booking threshold.
+
+alter table public.dabbir_salon_settings
+  add column if not exists deposit_mode text not null default 'fixed',
+  add column if not exists deposit_value numeric(14,3) not null default 0;
+
+alter table public.dabbir_salon_settings
+  drop constraint if exists dabbir_salon_settings_deposit_mode_check,
+  drop constraint if exists dabbir_salon_settings_deposit_policy_check;
+alter table public.dabbir_salon_settings
+  add constraint dabbir_salon_settings_deposit_mode_check
+    check (deposit_mode in ('fixed','percentage')),
+  add constraint dabbir_salon_settings_deposit_policy_check
+    check (
+      deposit_enabled=false
+      or (deposit_mode='fixed' and deposit_value>0)
+      or (deposit_mode='percentage' and deposit_value>0 and deposit_value<=100)
+    );
+
+alter table public.dabbir_appointments
+  add column if not exists deposit_required_amount numeric(14,3) not null default 0,
+  add column if not exists deposit_currency_code text;
+
+update public.dabbir_appointments a
+set deposit_currency_code=b.currency_code
+from public.dabbir_businesses b
+where b.id=a.business_id and a.deposit_currency_code is null;
+
+alter table public.dabbir_appointments
+  alter column deposit_currency_code set not null;
+alter table public.dabbir_appointments
+  drop constraint if exists dabbir_appointments_deposit_required_amount_check,
+  drop constraint if exists dabbir_appointments_deposit_currency_code_check;
+alter table public.dabbir_appointments
+  add constraint dabbir_appointments_deposit_required_amount_check
+    check (deposit_required_amount>=0),
+  add constraint dabbir_appointments_deposit_currency_code_check
+    check (deposit_currency_code ~ '^[A-Z]{3}$');
+
+-- Freeze the commercial deposit requirement at booking creation. A later settings
+-- change must never silently change what an existing customer owes.
+create or replace function dabbir_private.enforce_external_booking_confirmation_gate()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_deposit_enabled boolean := false;
+  v_deposit_mode text := 'fixed';
+  v_deposit_value numeric := 0;
+  v_currency text;
+  v_minor_units integer := 2;
+  v_due numeric := 0;
+  v_required numeric := 0;
+begin
+  select coalesce(s.deposit_enabled,false),coalesce(s.deposit_mode,'fixed'),coalesce(s.deposit_value,0),
+         b.currency_code,m.currency_minor_units
+    into v_deposit_enabled,v_deposit_mode,v_deposit_value,v_currency,v_minor_units
+  from public.dabbir_businesses b
+  join public.dabbir_markets m on m.country_code=b.country_code and m.is_active=true
+  left join public.dabbir_salon_settings s on s.business_id=b.id
+  where b.id=new.business_id;
+
+  if not found or v_currency is null then raise exception 'BOOKING_CURRENCY_NOT_CONFIGURED'; end if;
+
+  new.deposit_currency_code := v_currency;
+  new.deposit_required_amount := 0;
+
+  if new.booking_source in ('whatsapp','web') then
+    new.owner_approval_status := 'not_required';
+    new.owner_approval_requested_at := null;
+    new.owner_decision_at := null;
+    new.owner_decided_by := null;
+
+    v_due := greatest(0,coalesce(new.quoted_price_aed,0)-coalesce(new.discount_aed,0));
+
+    if v_deposit_enabled and v_due>0 then
+      if v_deposit_mode='fixed' and v_deposit_value>0 then
+        v_required := least(v_deposit_value,v_due);
+      elsif v_deposit_mode='percentage' and v_deposit_value>0 and v_deposit_value<=100 then
+        v_required := v_due*v_deposit_value/100;
+      else
+        raise exception 'DEPOSIT_POLICY_NOT_CONFIGURED';
+      end if;
+      v_required := round(v_required,v_minor_units);
+      if v_required<=0 then raise exception 'DEPOSIT_REQUIRED_AMOUNT_INVALID'; end if;
+
+      new.deposit_required_amount := v_required;
+      new.confirmation_gate := 'deposit';
+      new.payment_status := 'unpaid';
+      new.deposit_paid_at := null;
+      new.status := 'new';
+    else
+      new.confirmation_gate := 'none';
+      new.status := 'confirmed';
+    end if;
+  else
+    new.confirmation_gate := 'none';
+    new.owner_approval_status := 'not_required';
+    new.owner_approval_requested_at := null;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.enforce_external_booking_confirmation_gate() from public,anon,authenticated;
+
+create or replace function dabbir_private.guard_appointment_deposit_snapshot()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  if new.deposit_required_amount is distinct from old.deposit_required_amount
+     or new.deposit_currency_code is distinct from old.deposit_currency_code then
+    raise exception 'BOOKING_DEPOSIT_SNAPSHOT_IMMUTABLE';
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.guard_appointment_deposit_snapshot() from public,anon,authenticated;
+drop trigger if exists dabbir_appointment_deposit_snapshot_guard on public.dabbir_appointments;
+create trigger dabbir_appointment_deposit_snapshot_guard
+before update of deposit_required_amount,deposit_currency_code on public.dabbir_appointments
+for each row execute function dabbir_private.guard_appointment_deposit_snapshot();
+
+-- A duplicate request may replay exactly, but must never mutate the financial identity
+-- of an existing payment row. Status can only move forward: unpaid -> paid -> refunded.
+create or replace function dabbir_private.guard_operational_payment_identity()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+begin
+  if tg_op='UPDATE' then
+    if new.business_id is distinct from old.business_id
+       or new.appointment_id is distinct from old.appointment_id
+       or new.customer_id is distinct from old.customer_id
+       or new.amount_aed is distinct from old.amount_aed
+       or new.method is distinct from old.method
+       or new.idempotency_key is distinct from old.idempotency_key then
+      raise exception 'PAYMENT_IDEMPOTENCY_CONFLICT';
+    end if;
+
+    if not (
+      new.status=old.status
+      or (old.status='unpaid' and new.status='paid')
+      or (old.status='paid' and new.status='refunded')
+    ) then
+      raise exception 'PAYMENT_STATUS_REGRESSION';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.guard_operational_payment_identity() from public,anon,authenticated;
+drop trigger if exists dabbir_operational_payment_identity_guard on public.dabbir_operational_payments;
+create trigger dabbir_operational_payment_identity_guard
+before update on public.dabbir_operational_payments
+for each row execute function dabbir_private.guard_operational_payment_identity();
+
+alter table public.dabbir_operational_payments
+  drop constraint if exists dabbir_operational_payments_idempotency_key_length_check;
+alter table public.dabbir_operational_payments
+  add constraint dabbir_operational_payments_idempotency_key_length_check
+    check (char_length(idempotency_key) between 16 and 180);
+
+-- Deposit state is derived from the immutable requirement plus the net ledger.
+-- Refunds before the appointment starts make the deposit unsatisfied again but never
+-- delete the appointment or free the slot silently.
+create or replace function dabbir_private.auto_confirm_paid_deposit()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare
+  v_net_paid numeric := 0;
+  v_required numeric := 0;
+begin
+  select coalesce(sum(
+    case when p.status='paid' then p.amount_aed
+         when p.status='refunded' then -p.amount_aed
+         else 0 end
+  ),0)
+    into v_net_paid
+  from public.dabbir_operational_payments p
+  where p.business_id=new.business_id and p.appointment_id=new.appointment_id;
+
+  select a.deposit_required_amount into v_required
+  from public.dabbir_appointments a
+  where a.business_id=new.business_id and a.id=new.appointment_id
+    and a.confirmation_gate='deposit';
+  if not found or coalesce(v_required,0)<=0 then return new; end if;
+
+  if v_net_paid>=v_required then
+    update public.dabbir_appointments a
+       set status=case when a.status='new' then 'confirmed' else a.status end,
+           deposit_paid_at=coalesce(a.deposit_paid_at,now()),updated_at=now()
+     where a.business_id=new.business_id and a.id=new.appointment_id
+       and a.confirmation_gate='deposit' and a.status in ('new','confirmed');
+  else
+    update public.dabbir_appointments a
+       set status=case when a.status='confirmed' and a.starts_at>now() then 'new' else a.status end,
+           deposit_paid_at=null,updated_at=now()
+     where a.business_id=new.business_id and a.id=new.appointment_id
+       and a.confirmation_gate='deposit' and a.status in ('new','confirmed');
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.auto_confirm_paid_deposit() from public,anon,authenticated;
+
+-- Owner/admin configuration RPC. Enabling deposit without an explicit valid value is
+-- rejected by the table constraint: no hidden or guessed amount is ever used.
+create or replace function public.dabbir_set_deposit_policy(
+  p_business_id uuid,p_enabled boolean,p_mode text,p_value numeric
+) returns table(deposit_enabled boolean,deposit_mode text,deposit_value numeric,currency_code text)
+language plpgsql
+security invoker
+set search_path='public','pg_temp'
+as $$
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+  if not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id and m.user_id=auth.uid()
+      and m.status='active' and m.role in ('owner','admin')
+  ) then raise exception 'BUSINESS_MANAGEMENT_REQUIRED'; end if;
+
+  insert into public.dabbir_salon_settings(business_id,deposit_enabled,deposit_mode,deposit_value,updated_at)
+  values(p_business_id,coalesce(p_enabled,false),coalesce(nullif(trim(p_mode),''),'fixed'),coalesce(p_value,0),now())
+  on conflict (business_id) do update set
+    deposit_enabled=excluded.deposit_enabled,
+    deposit_mode=excluded.deposit_mode,
+    deposit_value=excluded.deposit_value,
+    updated_at=now();
+
+  return query
+  select s.deposit_enabled,s.deposit_mode,s.deposit_value,b.currency_code
+  from public.dabbir_salon_settings s join public.dabbir_businesses b on b.id=s.business_id
+  where s.business_id=p_business_id;
+end;
+$$;
+revoke all on function public.dabbir_set_deposit_policy(uuid,boolean,text,numeric) from public,anon;
+grant execute on function public.dabbir_set_deposit_policy(uuid,boolean,text,numeric) to authenticated,service_role;
+
+comment on column public.dabbir_appointments.deposit_required_amount is
+  'Frozen required deposit in deposit_currency_code, calculated at booking creation. Never infer deposit satisfaction from payment_status alone.';
+comment on column public.dabbir_appointments.deposit_currency_code is
+  'Business market currency snapshot for the booking deposit requirement.';

--- a/supabase/migrations/20260903101800_dabbir_operational_payment_rpc_v1.sql
+++ b/supabase/migrations/20260903101800_dabbir_operational_payment_rpc_v1.sql
@@ -1,0 +1,147 @@
+-- Canonical operational payment commands for DABBIR.
+-- Callers must supply a stable request id; DB replays exact duplicates and rejects key reuse.
+
+create or replace function public.dabbir_record_operational_payment(
+  p_business_id uuid,
+  p_appointment_id uuid,
+  p_amount numeric,
+  p_method text,
+  p_idempotency_key text,
+  p_reference text default null
+) returns jsonb
+language plpgsql
+security invoker
+set search_path='public','pg_temp'
+as $$
+declare
+  v_user uuid := auth.uid();
+  v_customer uuid;
+  v_existing public.dabbir_operational_payments%rowtype;
+  v_saved public.dabbir_operational_payments%rowtype;
+  v_method text := lower(trim(coalesce(p_method,'')));
+  v_key text := trim(coalesce(p_idempotency_key,''));
+begin
+  if v_user is null and coalesce(auth.role(),'')<>'service_role' then raise exception 'AUTH_REQUIRED'; end if;
+  if v_user is not null and not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id and m.user_id=v_user and m.status='active'
+      and m.role in ('owner','admin','manager','employee','staff')
+  ) then raise exception 'PAYMENT_MANAGEMENT_REQUIRED'; end if;
+
+  if v_method not in ('cash','card','payment_link','other','unpaid') then raise exception 'INVALID_PAYMENT_METHOD'; end if;
+  if p_amount is null or p_amount<0 then raise exception 'INVALID_PAYMENT_AMOUNT'; end if;
+  if v_method='unpaid' and p_amount<>0 then raise exception 'UNPAID_AMOUNT_MUST_BE_ZERO'; end if;
+  if char_length(v_key)<16 or char_length(v_key)>180 then raise exception 'PAYMENT_IDEMPOTENCY_KEY_REQUIRED'; end if;
+
+  select a.customer_id into v_customer
+  from public.dabbir_appointments a
+  where a.business_id=p_business_id and a.id=p_appointment_id;
+  if not found then raise exception 'APPOINTMENT_NOT_FOUND'; end if;
+
+  select * into v_existing
+  from public.dabbir_operational_payments p
+  where p.business_id=p_business_id and p.idempotency_key=v_key
+  for update;
+
+  if found then
+    if v_existing.appointment_id is distinct from p_appointment_id
+       or v_existing.customer_id is distinct from v_customer
+       or v_existing.amount_aed is distinct from p_amount
+       or v_existing.method is distinct from v_method then
+      raise exception 'PAYMENT_IDEMPOTENCY_CONFLICT';
+    end if;
+    return jsonb_build_object(
+      'payment_id',v_existing.id,'appointment_id',v_existing.appointment_id,
+      'amount',v_existing.amount_aed,'method',v_existing.method,'status',v_existing.status,
+      'idempotent_replay',true
+    );
+  end if;
+
+  insert into public.dabbir_operational_payments(
+    business_id,appointment_id,customer_id,amount_aed,method,status,reference,idempotency_key,recorded_by
+  ) values(
+    p_business_id,p_appointment_id,v_customer,p_amount,v_method,
+    case when v_method='unpaid' then 'unpaid' else 'paid' end,
+    nullif(left(trim(coalesce(p_reference,'')),240),''),v_key,v_user
+  ) returning * into v_saved;
+
+  return jsonb_build_object(
+    'payment_id',v_saved.id,'appointment_id',v_saved.appointment_id,
+    'amount',v_saved.amount_aed,'method',v_saved.method,'status',v_saved.status,
+    'idempotent_replay',false
+  );
+end;
+$$;
+revoke all on function public.dabbir_record_operational_payment(uuid,uuid,numeric,text,text,text) from public,anon;
+grant execute on function public.dabbir_record_operational_payment(uuid,uuid,numeric,text,text,text) to authenticated,service_role;
+
+create or replace function public.dabbir_refund_operational_payment(
+  p_business_id uuid,p_payment_id uuid
+) returns jsonb
+language plpgsql
+security invoker
+set search_path='public','pg_temp'
+as $$
+declare
+  v_user uuid := auth.uid();
+  v_payment public.dabbir_operational_payments%rowtype;
+begin
+  if v_user is null and coalesce(auth.role(),'')<>'service_role' then raise exception 'AUTH_REQUIRED'; end if;
+  if v_user is not null and not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id and m.user_id=v_user and m.status='active'
+      and m.role in ('owner','admin','manager')
+  ) then raise exception 'PAYMENT_REFUND_MANAGEMENT_REQUIRED'; end if;
+
+  select * into v_payment from public.dabbir_operational_payments
+  where business_id=p_business_id and id=p_payment_id for update;
+  if not found then raise exception 'PAYMENT_NOT_FOUND'; end if;
+
+  if v_payment.status='refunded' then
+    return jsonb_build_object('payment_id',v_payment.id,'status','refunded','idempotent_replay',true);
+  end if;
+  if v_payment.status<>'paid' then raise exception 'PAYMENT_NOT_REFUNDABLE'; end if;
+
+  update public.dabbir_operational_payments
+  set status='refunded'
+  where business_id=p_business_id and id=p_payment_id
+  returning * into v_payment;
+  return jsonb_build_object('payment_id',v_payment.id,'status',v_payment.status,'idempotent_replay',false);
+end;
+$$;
+revoke all on function public.dabbir_refund_operational_payment(uuid,uuid) from public,anon;
+grant execute on function public.dabbir_refund_operational_payment(uuid,uuid) to authenticated,service_role;
+
+-- Deposit configuration is salon-only and owner/admin controlled.
+create or replace function public.dabbir_set_deposit_policy(
+  p_business_id uuid,p_enabled boolean,p_mode text,p_value numeric
+) returns table(deposit_enabled boolean,deposit_mode text,deposit_value numeric,currency_code text)
+language plpgsql
+security invoker
+set search_path='public','pg_temp'
+as $$
+begin
+  if auth.uid() is null then raise exception 'AUTH_REQUIRED'; end if;
+  if not exists(
+    select 1 from public.dabbir_memberships m
+    join public.dabbir_businesses b on b.id=m.business_id
+    where m.business_id=p_business_id and m.user_id=auth.uid()
+      and m.status='active' and m.role in ('owner','admin') and b.business_type='salon'
+  ) then raise exception 'BUSINESS_MANAGEMENT_REQUIRED'; end if;
+
+  insert into public.dabbir_salon_settings(business_id,deposit_enabled,deposit_mode,deposit_value,updated_at)
+  values(p_business_id,coalesce(p_enabled,false),lower(coalesce(nullif(trim(p_mode),''),'fixed')),coalesce(p_value,0),now())
+  on conflict (business_id) do update set
+    deposit_enabled=excluded.deposit_enabled,
+    deposit_mode=excluded.deposit_mode,
+    deposit_value=excluded.deposit_value,
+    updated_at=now();
+
+  return query
+  select s.deposit_enabled,s.deposit_mode,s.deposit_value,b.currency_code
+  from public.dabbir_salon_settings s join public.dabbir_businesses b on b.id=s.business_id
+  where s.business_id=p_business_id;
+end;
+$$;
+revoke all on function public.dabbir_set_deposit_policy(uuid,boolean,text,numeric) from public,anon;
+grant execute on function public.dabbir_set_deposit_policy(uuid,boolean,text,numeric) to authenticated,service_role;

--- a/test/dabbir-deposit-payment-resilience.test.mjs
+++ b/test/dabbir-deposit-payment-resilience.test.mjs
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const resilience=fs.readFileSync(path.join(root,'supabase/migrations/20260903101500_dabbir_deposit_payment_resilience_v1.sql'),'utf8');
+const commands=fs.readFileSync(path.join(root,'supabase/migrations/20260903101800_dabbir_operational_payment_rpc_v1.sql'),'utf8');
+const sql=resilience+'\n'+commands;
+const has=(...markers)=>{for(const marker of markers)assert.match(sql,new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')))};
+
+test('deposit policy is explicit and fail closed',()=>{
+  has("deposit_mode in ('fixed','percentage')","deposit_enabled=false","deposit_mode='fixed' and deposit_value>0","deposit_mode='percentage' and deposit_value>0 and deposit_value<=100",'DEPOSIT_POLICY_NOT_CONFIGURED');
+});
+
+test('booking freezes deposit amount and business currency',()=>{
+  has('deposit_required_amount','deposit_currency_code','b.currency_code','m.currency_minor_units','round(v_required,v_minor_units)','BOOKING_DEPOSIT_SNAPSHOT_IMMUTABLE');
+  assert.match(resilience,/v_required := least\(v_deposit_value,v_due\)/);
+  assert.match(resilience,/v_required := v_due\*v_deposit_value\/100/);
+});
+
+test('external deposit booking never trusts caller payment status',()=>{
+  has("new.confirmation_gate := 'deposit'","new.payment_status := 'unpaid'","new.deposit_paid_at := null","new.status := 'new'");
+  assert.doesNotMatch(resilience,/new\.payment_status in \('partial','paid'\)/);
+});
+
+test('partial payment cannot confirm below frozen deposit threshold',()=>{
+  has('v_net_paid>=v_required','a.deposit_required_amount',"a.confirmation_gate='deposit'");
+  assert.doesNotMatch(resilience,/if v_net_paid>0 then/);
+});
+
+test('refund makes a future confirmed deposit booking unsatisfied without deleting it',()=>{
+  has("when p.status='refunded' then -p.amount_aed","a.status='confirmed' and a.starts_at>now() then 'new'","deposit_paid_at=null");
+  assert.doesNotMatch(resilience,/delete from public\.dabbir_appointments/i);
+});
+
+test('payment financial identity is immutable and status cannot regress',()=>{
+  has('PAYMENT_IDEMPOTENCY_CONFLICT','PAYMENT_STATUS_REGRESSION',"old.status='unpaid' and new.status='paid'","old.status='paid' and new.status='refunded'");
+});
+
+test('canonical payment command requires explicit stable idempotency key',()=>{
+  has('dabbir_record_operational_payment','PAYMENT_IDEMPOTENCY_KEY_REQUIRED','for update','idempotent_replay','PAYMENT_IDEMPOTENCY_CONFLICT');
+  assert.match(commands,/char_length\(v_key\)<16 or char_length\(v_key\)>180/);
+});
+
+test('same payment request replays while a reused key with changed identity fails',()=>{
+  assert.match(commands,/where p\.business_id=p_business_id and p\.idempotency_key=v_key[\s\S]+for update/);
+  assert.match(commands,/v_existing\.appointment_id is distinct from p_appointment_id[\s\S]+v_existing\.amount_aed is distinct from p_amount[\s\S]+raise exception 'PAYMENT_IDEMPOTENCY_CONFLICT'/);
+  assert.match(commands,/'idempotent_replay',true/);
+});
+
+test('refund command is itself replay safe',()=>{
+  has('dabbir_refund_operational_payment',"v_payment.status='refunded'",'PAYMENT_NOT_REFUNDABLE',"set status='refunded'",'idempotent_replay');
+});
+
+test('deposit settings remain owner/admin and salon scoped',()=>{
+  assert.match(commands,/m\.role in \('owner','admin'\) and b\.business_type='salon'/);
+  assert.match(commands,/grant execute on function public\.dabbir_set_deposit_policy/);
+});


### PR DESCRIPTION
Worst-case deposit/payment hardening.

- Explicit fixed/percentage deposit policy with fail-closed validation.
- Frozen per-booking required deposit amount + authoritative business currency.
- External deposit bookings never trust caller-supplied payment_status.
- Deposit confirmation derives from net payment ledger and required threshold, not `> 0`.
- Refunds can make a future booking deposit-unsatisfied without deleting the booking.
- Operational payment identity is immutable and status is monotonic.
- Canonical payment/refund RPCs are idempotent and require stable request IDs.
- Regression tests lock all invariants.