### PR TITLE
Route salon payments through canonical idempotent RPC

### DIFF
--- a/api/calendar-live-ui.js
+++ b/api/calendar-live-ui.js
@@ -1,6 +1,7 @@
 import activityProfileHandler from './activity-profile-ui.js';
 import appointmentManagementUiHandler from './appointment-management-ui.js';
 import salonModeUiHandler from './salon-mode-ui.js';
+import salonPaymentIdempotencyUiHandler from './salon-payment-idempotency-ui.js';
 import clinicModeUiHandler from './clinic-mode-ui.js';
 import businessActivityProfileUiHandler from './business-activity-profile-ui.js';
 
@@ -143,13 +144,14 @@ function captureResponse(){return {statusCode:200,headers:{},body:'',status(code
 
 export default async function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
-  const activityCaptured=captureResponse(),managementCaptured=captureResponse(),salonCaptured=captureResponse(),clinicCaptured=captureResponse(),businessActivityCaptured=captureResponse();
-  await activityProfileHandler(req,activityCaptured);await appointmentManagementUiHandler(req,managementCaptured);await salonModeUiHandler(req,salonCaptured);await clinicModeUiHandler(req,clinicCaptured);await businessActivityProfileUiHandler(req,businessActivityCaptured);
+  const activityCaptured=captureResponse(),managementCaptured=captureResponse(),salonCaptured=captureResponse(),paymentCaptured=captureResponse(),clinicCaptured=captureResponse(),businessActivityCaptured=captureResponse();
+  await activityProfileHandler(req,activityCaptured);await appointmentManagementUiHandler(req,managementCaptured);await salonModeUiHandler(req,salonCaptured);await salonPaymentIdempotencyUiHandler(req,paymentCaptured);await clinicModeUiHandler(req,clinicCaptured);await businessActivityProfileUiHandler(req,businessActivityCaptured);
   if(activityCaptured.statusCode!==200||!activityCaptured.body)return res.status(500).end('Activity profile UI unavailable');
   if(managementCaptured.statusCode!==200||!managementCaptured.body)return res.status(500).end('Appointment management UI unavailable');
   if(salonCaptured.statusCode!==200||!salonCaptured.body)return res.status(500).end('Salon Mode UI unavailable');
+  if(paymentCaptured.statusCode!==200||!paymentCaptured.body)return res.status(500).end('Salon payment idempotency UI unavailable');
   if(clinicCaptured.statusCode!==200||!clinicCaptured.body)return res.status(500).end('Clinic Mode UI unavailable');
   if(businessActivityCaptured.statusCode!==200||!businessActivityCaptured.body)return res.status(500).end('Business activity profile UI unavailable');
-  res.setHeader('content-type','application/javascript; charset=utf-8');res.setHeader('cache-control','public, max-age=300');res.setHeader('x-dabbir-calendar-live-ui','v12-salon-single-booking-surface');
-  return res.status(200).send(activityCaptured.body+'\n'+liveScript+'\n'+managementCaptured.body+'\n'+salonCaptured.body+'\n'+clinicCaptured.body+'\n'+businessActivityCaptured.body);
+  res.setHeader('content-type','application/javascript; charset=utf-8');res.setHeader('cache-control','public, max-age=300');res.setHeader('x-dabbir-calendar-live-ui','v13-salon-payment-idempotency');
+  return res.status(200).send(activityCaptured.body+'\n'+liveScript+'\n'+managementCaptured.body+'\n'+salonCaptured.body+'\n'+paymentCaptured.body+'\n'+clinicCaptured.body+'\n'+businessActivityCaptured.body);
 }

--- a/api/salon-operations.js
+++ b/api/salon-operations.js
@@ -172,11 +172,18 @@ async function handlePost(req,ctx,businessId,membership,body){
   }
   if(action==='record_payment'){
     const appointmentId=safeId(body.appointment_id),method=clean(body.method,30);if(!appointmentId||!PAYMENT_METHODS.has(method))return {status:400,body:{ok:false,error:'VALID_PAYMENT_REQUIRED'}};
-    const appointments=await rest(ctx.token,`dabbir_appointments?select=id,customer_id&business_id=eq.${enc(businessId)}&id=eq.${enc(appointmentId)}&limit=1`,{},'APPOINTMENT_LOOKUP_FAILED');if(!appointments?.[0])return {status:404,body:{ok:false,error:'APPOINTMENT_NOT_FOUND'}};
     const amount=method==='unpaid'?0:number(body.amount_aed,{min:0,max:1e7,fallback:-1});if(amount<0)return {status:400,body:{ok:false,error:'VALID_PAYMENT_AMOUNT_REQUIRED'}};
-    const idempotency=clean(body.idempotency_key||`appointment:${appointmentId}:${method}:${amount}`,180);
-    const rows=await rest(ctx.token,'dabbir_operational_payments?on_conflict=business_id,idempotency_key&select=id,appointment_id,customer_id,amount_aed,method,status,created_at',{method:'POST',headers:{prefer:'resolution=merge-duplicates,return=representation'},body:JSON.stringify({business_id:businessId,appointment_id:appointmentId,customer_id:appointments[0].customer_id,amount_aed:amount,method,status:method==='unpaid'?'unpaid':'paid',reference:clean(body.reference,240)||null,idempotency_key:idempotency,recorded_by:ctx.user.id})},'PAYMENT_RECORD_FAILED');
-    return {status:201,body:{ok:true,payment:rows?.[0]||null}};
+    const idempotencyKey=clean(body.idempotency_key||body.request_id,160);
+    if(!idempotencyKey||!IDEMPOTENCY_RE.test(idempotencyKey))return {status:400,body:{ok:false,error:'PAYMENT_REQUEST_ID_REQUIRED'}};
+    const payment=await rpc(ctx.token,'dabbir_record_operational_payment',{
+      p_business_id:businessId,
+      p_appointment_id:appointmentId,
+      p_amount:amount,
+      p_method:method,
+      p_idempotency_key:idempotencyKey,
+      p_reference:clean(body.reference,240)||null,
+    },'PAYMENT_RECORD_FAILED');
+    return {status:payment?.idempotent_replay?200:201,body:{ok:true,payment}};
   }
   if(action==='save_worker'){
     if(!canManageTeam(membership))return {status:403,body:{ok:false,error:'TEAM_MANAGEMENT_REQUIRED'}};

--- a/api/salon-payment-idempotency-ui.js
+++ b/api/salon-payment-idempotency-ui.js
@@ -1,0 +1,39 @@
+const script=String.raw`(()=>{
+  if(window.__dabbirSalonPaymentIdempotency)return;
+  const nativeFetch=window.fetch.bind(window);
+  const requestIds=new WeakMap();
+  const makeId=()=>{
+    if(globalThis.crypto?.randomUUID)return 'ui-payment:'+globalThis.crypto.randomUUID();
+    const bytes=new Uint8Array(16);globalThis.crypto?.getRandomValues?.(bytes);
+    return 'ui-payment:'+Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('');
+  };
+  window.fetch=function(input,init){
+    let nextInit=init;
+    try{
+      const url=typeof input==='string'?input:input?.url;
+      const path=new URL(String(url||''),location.origin).pathname;
+      if(path==='/api/salon-operations'&&String(init?.method||'GET').toUpperCase()==='POST'&&typeof init?.body==='string'){
+        const payload=JSON.parse(init.body);
+        if(payload?.action==='record_payment'){
+          const form=document.querySelector('#salonPaymentForm');
+          if(form){
+            let requestId=requestIds.get(form);
+            if(!requestId){requestId=makeId();requestIds.set(form,requestId)}
+            payload.idempotency_key=requestId;
+            nextInit={...init,body:JSON.stringify(payload)};
+          }
+        }
+      }
+    }catch{}
+    return nativeFetch(input,nextInit);
+  };
+  window.__dabbirSalonPaymentIdempotency={version:'v1',requestIdForCurrentForm:()=>{const form=document.querySelector('#salonPaymentForm');return form?requestIds.get(form)||null:null}};
+})();`;
+
+export default function handler(req,res){
+  if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','public, max-age=300');
+  res.setHeader('x-dabbir-salon-payment-idempotency','v1');
+  return res.status(200).send(script);
+}

--- a/docs/qa/salon-payment-canonical-route.md
+++ b/docs/qa/salon-payment-canonical-route.md
@@ -1,0 +1,12 @@
+# DABBIR Salon Payment Canonical Route
+
+Normal salon payment recording must follow:
+
+`Salon UI -> /api/salon-operations record_payment -> dabbir_record_operational_payment RPC -> operational payment ledger`
+
+Rules:
+- The API must not POST directly to `dabbir_operational_payments` for `record_payment`.
+- Every real payment attempt gets a unique browser request ID.
+- Retrying the same still-open payment form reuses the same request ID.
+- Closing and reopening the form creates a new request ID, so two legitimate equal payments remain distinct.
+- The database remains the final authority for idempotency conflicts and payment-state transitions.

--- a/test/dabbir-salon-payment-canonical-route.test.mjs
+++ b/test/dabbir-salon-payment-canonical-route.test.mjs
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const read=file=>fs.readFileSync(path.join(root,file),'utf8');
+const api=read('api/salon-operations.js');
+const paymentUi=read('api/salon-payment-idempotency-ui.js');
+const calendarUi=read('api/calendar-live-ui.js');
+
+function recordPaymentBlock(){
+  const start=api.indexOf("if(action==='record_payment')");
+  const end=api.indexOf("if(action==='save_worker')",start);
+  assert.ok(start>=0&&end>start,'record_payment block must exist');
+  return api.slice(start,end);
+}
+
+test('salon record_payment uses only the canonical payment RPC',()=>{
+  const block=recordPaymentBlock();
+  assert.match(block,/PAYMENT_REQUEST_ID_REQUIRED/);
+  assert.match(block,/rpc\(ctx\.token,'dabbir_record_operational_payment'/);
+  assert.match(block,/p_idempotency_key:idempotencyKey/);
+  assert.doesNotMatch(block,/rest\(ctx\.token,'dabbir_operational_payments/);
+  assert.doesNotMatch(block,/on_conflict=business_id,idempotency_key/);
+  assert.doesNotMatch(block,/appointment:\$\{appointmentId\}:\$\{method\}:\$\{amount\}/);
+});
+
+test('browser assigns one random request id per payment form instance',()=>{
+  assert.match(paymentUi,/new WeakMap\(\)/);
+  assert.match(paymentUi,/crypto\?\.randomUUID|crypto\.randomUUID/);
+  assert.match(paymentUi,/payload\?\.action==='record_payment'/);
+  assert.match(paymentUi,/payload\.idempotency_key=requestId/);
+  assert.match(paymentUi,/requestIds\.get\(form\)/);
+  assert.match(paymentUi,/requestIds\.set\(form,requestId\)/);
+});
+
+test('payment idempotency guard loads after Salon Mode UI',()=>{
+  assert.match(calendarUi,/import salonPaymentIdempotencyUiHandler from '\.\/salon-payment-idempotency-ui\.js'/);
+  assert.match(calendarUi,/await salonModeUiHandler\(req,salonCaptured\);await salonPaymentIdempotencyUiHandler\(req,paymentCaptured\)/);
+  assert.match(calendarUi,/salonCaptured\.body\+'\\n'\+paymentCaptured\.body/);
+  assert.match(calendarUi,/v13-salon-payment-idempotency/);
+});


### PR DESCRIPTION
Closes the last legacy salon payment write path.

- `record_payment` now requires a stable request ID and calls `dabbir_record_operational_payment` only.
- No direct POST to `dabbir_operational_payments` remains in the salon payment action.
- Browser payment submissions get one random request ID per payment-form instance: retrying the same form replays safely, while closing/reopening permits a second legitimate equal payment.
- Calendar composite loads the payment idempotency guard after Salon Mode UI.
- Regression tests lock the canonical route and request-ID behavior.