### PR TITLE
Fix booking edit authority and GCC timezone handling

### DIFF
--- a/api/car-wash-booking-edit-ui.js
+++ b/api/car-wash-booking-edit-ui.js
@@ -9,17 +9,29 @@ const script=String.raw`(()=>{
   const copy=()=>ar()?{title:'تعديل الحجز',customer:'العميل',time:'الموعد',status:'الحالة',save:'حفظ التعديل',cancel:'إلغاء',requested:'مطلوب',confirmed:'مؤكد',rescheduled:'أعيدت جدولته',completed:'مكتمل',cancelled:'ملغي',saved:'تم تعديل الحجز.',failed:'تعذر تعديل الحجز.'}:{title:'Edit booking',customer:'Customer',time:'Booking',status:'Status',save:'Save changes',cancel:'Cancel',requested:'Requested',confirmed:'Confirmed',rescheduled:'Rescheduled',completed:'Completed',cancelled:'Cancelled',saved:'Booking updated.',failed:'Could not update booking.'};
   let busy=false;
 
-  function dubaiLocalMinute(value){
+  function businessTimezone(){
+    const business=workspaceNow()?.business||{};
+    return String(business.timezone||document.documentElement.dataset.dabbirTimezone||window.__dabbirTimeZone||'Asia/Dubai');
+  }
+  function businessLocalMinute(value){
     const date=value instanceof Date?value:new Date(value);
-    const f=new Intl.DateTimeFormat('en-CA',{timeZone:'Asia/Dubai',year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',hourCycle:'h23'});
+    const f=new Intl.DateTimeFormat('en-CA',{timeZone:businessTimezone(),year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',hourCycle:'h23'});
     const p=Object.fromEntries(f.formatToParts(date).filter(x=>x.type!=='literal').map(x=>[x.type,x.value]));
     return p.year+'-'+p.month+'-'+p.day+'T'+p.hour+':'+p.minute;
   }
-  function isoFromDubaiLocal(value){
+  function offsetMinutesAt(instantMs,timeZone){
+    const date=new Date(instantMs);
+    const parts=Object.fromEntries(new Intl.DateTimeFormat('en-US',{timeZone,year:'numeric',month:'2-digit',day:'2-digit',hour:'2-digit',minute:'2-digit',second:'2-digit',hourCycle:'h23'}).formatToParts(date).filter(part=>part.type!=='literal').map(part=>[part.type,part.value]));
+    const represented=Date.UTC(Number(parts.year),Number(parts.month)-1,Number(parts.day),Number(parts.hour),Number(parts.minute),Number(parts.second));
+    return Math.round((represented-Math.floor(instantMs/1000)*1000)/60000);
+  }
+  function isoFromBusinessLocal(value){
     const raw=String(value||'').trim();
     if(!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/.test(raw))return null;
-    const date=new Date(raw+':00+04:00');
-    return Number.isNaN(date.getTime())?null:date.toISOString();
+    try{if(typeof window.dabbirLocalTimeToIso==='function'){const canonical=window.dabbirLocalTimeToIso(raw);if(canonical)return canonical}}catch{}
+    const match=raw.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})$/);if(!match)return null;
+    const [,year,month,day,hour,minute]=match,wallUtc=Date.UTC(Number(year),Number(month)-1,Number(day),Number(hour),Number(minute),0),zone=businessTimezone();
+    try{let offset=offsetMinutesAt(wallUtc,zone),instant=wallUtc-offset*60000,corrected=offsetMinutesAt(instant,zone);if(corrected!==offset)instant=wallUtc-corrected*60000;const date=new Date(instant);return Number.isNaN(date.getTime())?null:date.toISOString()}catch{return null}
   }
   function customerName(id){
     const customer=(workspaceNow()?.customers||[]).find(row=>row?.id===id);
@@ -45,12 +57,12 @@ const script=String.raw`(()=>{
     if(!isCarWash())return;
     const row=appointment(id),w=workspaceNow();if(!row||!w?.business?.id)return;
     const c=copy(),modal=ensureModal(),status=String(row.status||'requested').toLowerCase();
-    modal.innerHTML='<form class="dabbirCarWashPastEditBox" id="dabbirCarWashPastEditForm"><h3>'+esc(c.title)+'</h3><div class="dabbirCarWashPastEditField"><label>'+esc(c.customer)+'</label><input value="'+esc(customerName(row.customer_id))+'" disabled></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.time)+'</label><input id="dabbirCarWashPastEditTime" type="datetime-local" value="'+esc(dubaiLocalMinute(row.starts_at))+'" required></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.status)+'</label><select id="dabbirCarWashPastEditStatus"><option value="requested" '+(status==='requested'?'selected':'')+'>'+esc(c.requested)+'</option><option value="confirmed" '+(status==='confirmed'?'selected':'')+'>'+esc(c.confirmed)+'</option><option value="rescheduled" '+(status==='rescheduled'?'selected':'')+'>'+esc(c.rescheduled)+'</option><option value="completed" '+(status==='completed'?'selected':'')+'>'+esc(c.completed)+'</option><option value="cancelled" '+(status==='cancelled'?'selected':'')+'>'+esc(c.cancelled)+'</option></select></div><div class="dabbirCarWashPastEditActions"><button type="button" class="dabbirCarWashPastEditCancel" id="dabbirCarWashPastEditCancel">'+esc(c.cancel)+'</button><button type="submit" class="dabbirCarWashPastEditSave">'+esc(c.save)+'</button></div></form>';
+    modal.innerHTML='<form class="dabbirCarWashPastEditBox" id="dabbirCarWashPastEditForm"><h3>'+esc(c.title)+'</h3><div class="dabbirCarWashPastEditField"><label>'+esc(c.customer)+'</label><input value="'+esc(customerName(row.customer_id))+'" disabled></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.time)+'</label><input id="dabbirCarWashPastEditTime" type="datetime-local" value="'+esc(businessLocalMinute(row.starts_at))+'" required></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.status)+'</label><select id="dabbirCarWashPastEditStatus"><option value="requested" '+(status==='requested'?'selected':'')+'>'+esc(c.requested)+'</option><option value="confirmed" '+(status==='confirmed'?'selected':'')+'>'+esc(c.confirmed)+'</option><option value="rescheduled" '+(status==='rescheduled'?'selected':'')+'>'+esc(c.rescheduled)+'</option><option value="completed" '+(status==='completed'?'selected':'')+'>'+esc(c.completed)+'</option><option value="cancelled" '+(status==='cancelled'?'selected':'')+'>'+esc(c.cancelled)+'</option></select></div><div class="dabbirCarWashPastEditActions"><button type="button" class="dabbirCarWashPastEditCancel" id="dabbirCarWashPastEditCancel">'+esc(c.cancel)+'</button><button type="submit" class="dabbirCarWashPastEditSave">'+esc(c.save)+'</button></div></form>';
     q('#dabbirCarWashPastEditCancel').onclick=close;
     modal.onclick=event=>{if(event.target===modal)close()};
     q('#dabbirCarWashPastEditForm').onsubmit=async event=>{
       event.preventDefault();if(busy)return;
-      const start=isoFromDubaiLocal(q('#dabbirCarWashPastEditTime')?.value),nextStatus=q('#dabbirCarWashPastEditStatus')?.value;
+      const start=isoFromBusinessLocal(q('#dabbirCarWashPastEditTime')?.value),nextStatus=q('#dabbirCarWashPastEditStatus')?.value;
       if(!start)return;
       busy=true;const submit=event.submitter;if(submit)submit.disabled=true;
       try{
@@ -65,12 +77,14 @@ const script=String.raw`(()=>{
 
   function repairButtons(){
     if(!isCarWash())return;
-    document.querySelectorAll('#dabbirApptManage [data-appt-edit][disabled]').forEach(button=>{
-      button.disabled=false;button.removeAttribute('title');button.dataset.dabbirHistoricalEdit='1';
+    document.querySelectorAll('#dabbirApptManage [data-appt-edit]').forEach(button=>{
+      const row=appointment(button.dataset.apptEdit);if(!row||!isHistorical(row))return;
+      if(button.disabled)button.disabled=false;
+      button.removeAttribute('title');button.dataset.dabbirHistoricalEdit='1';
     });
   }
   document.addEventListener('click',event=>{
-    const button=event.target?.closest?.('[data-appt-edit][data-dabbir-historical-edit="1"],[data-calendar-appt]');if(!button||!isCarWash())return;
+    const button=event.target?.closest?.('[data-appt-edit],[data-calendar-appt]');if(!button||!isCarWash())return;
     const id=button.dataset.apptEdit||button.dataset.calendarAppt,row=appointment(id);
     if(!row||!isHistorical(row))return;
     event.preventDefault();event.stopImmediatePropagation();openEditor(id);
@@ -79,13 +93,13 @@ const script=String.raw`(()=>{
   const observer=new MutationObserver(repairButtons);observer.observe(document.body,{subtree:true,childList:true});
   window.addEventListener('focus',repairButtons,{passive:true});
   setTimeout(repairButtons,0);setTimeout(repairButtons,700);
-  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v2-historical-calendar'};
+  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v3-market-timezone'};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v2-historical-calendar');
+  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v3-market-timezone');
   return res.status(200).send(script);
 }

--- a/api/car-wash-loader-ui.js
+++ b/api/car-wash-loader-ui.js
@@ -39,7 +39,7 @@ const script=String.raw`(()=>{
     if(!isCarWash()||window.__dabbirCarWashBookingEditFix)return false;
     if(document.querySelector('script[data-dabbir-car-wash-booking-edit-ui="1"]'))return true;
     const node=document.createElement('script');
-    node.src='/api/car-wash-booking-edit-ui?v=20260903-2-historical-calendar';
+    node.src='/api/car-wash-booking-edit-ui?v=20260903-3-market-timezone';
     node.async=true;
     node.dataset.dabbirCarWashBookingEditUi='1';
     node.onerror=()=>console.error('dabbir_car_wash_booking_edit_ui_load_failed');
@@ -78,6 +78,6 @@ export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-loader-ui','v8-historical-calendar-edit');
+  res.setHeader('x-dabbir-car-wash-loader-ui','v9-market-timezone-edit');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-historical-booking-edit.test.mjs
+++ b/test/dabbir-car-wash-historical-booking-edit.test.mjs
@@ -21,10 +21,12 @@ test('database guard allows correction of an already historical appointment but 
   assert.match(migration,/before insert or update of starts_at/);
 });
 
-test('car-wash historical editor repairs disabled edit controls instead of hiding them',()=>{
-  assert.match(ui,/#dabbirApptManage \[data-appt-edit\]\[disabled\]/);
-  assert.match(ui,/button\.disabled=false/);
-  assert.match(ui,/data-dabbir-historical-edit/);
+test('car-wash historical editor repairs every historical edit control and wins click races',()=>{
+  assert.match(ui,/#dabbirApptManage \[data-appt-edit\]/);
+  assert.match(ui,/isHistorical\(row\)/);
+  assert.match(ui,/if\(button\.disabled\)button\.disabled=false/);
+  assert.match(ui,/dataset\.dabbirHistoricalEdit/);
+  assert.match(ui,/closest\?\.\('\[data-appt-edit\],\[data-calendar-appt\]'\)/);
   assert.match(ui,/event\.stopImmediatePropagation\(\)/);
 });
 
@@ -41,6 +43,17 @@ test('car-wash historical editor persists date and status through the canonical 
   assert.match(ui,/starts_at:start,status:nextStatus/);
   assert.match(ui,/data\?\.detail\|\|data\?\.error/);
   assert.match(ui,/location\.reload\(\)/);
+});
+
+test('historical booking editor follows the selected GCC business timezone authority',()=>{
+  assert.match(ui,/function businessTimezone\(\)/);
+  assert.match(ui,/business\.timezone\|\|document\.documentElement\.dataset\.dabbirTimezone\|\|window\.__dabbirTimeZone/);
+  assert.match(ui,/window\.dabbirLocalTimeToIso/);
+  assert.match(ui,/function offsetMinutesAt\(/);
+  assert.match(ui,/businessLocalMinute\(row\.starts_at\)/);
+  assert.match(ui,/isoFromBusinessLocal/);
+  assert.doesNotMatch(ui,/timeZone:'Asia\/Dubai'/);
+  assert.doesNotMatch(ui,/\+04:00/);
 });
 
 test('historical booking editor is event-driven without a continuous interval',()=>{

--- a/test/dabbir-car-wash-lazy-loader.test.mjs
+++ b/test/dabbir-car-wash-lazy-loader.test.mjs
@@ -33,7 +33,7 @@ test('car-wash calendar observer is idempotent and never observes hidden mutatio
   assert.match(loader,/dabbirCarWashDuplicate!=='hidden'/);
   assert.match(loader,/calendarObserver\.observe\(document\.documentElement,\{subtree:true,childList:true\}\)/);
   assert.doesNotMatch(loader,/calendarObserver\.observe[^\n]+attributeFilter:\[[^\]]*hidden/);
-  assert.match(loader,/v8-historical-calendar-edit/);
+  assert.match(loader,/v9-market-timezone-edit/);
 });
 
 test('car-wash manual booking cache key changes for the iPhone customer combobox fix',()=>{
@@ -41,9 +41,9 @@ test('car-wash manual booking cache key changes for the iPhone customer combobox
   assert.match(loader,/car-wash-manual-booking-ui\?v=20260903-3-native-combobox/);
 });
 
-test('car-wash loader mounts the historical booking editor with the calendar-edit cache key',()=>{
+test('car-wash loader mounts the GCC-aware historical booking editor',()=>{
   const loader=read('api/car-wash-loader-ui.js');
   assert.match(loader,/function loadBookingEdit\(\)/);
-  assert.match(loader,/car-wash-booking-edit-ui\?v=20260903-2-historical-calendar/);
+  assert.match(loader,/car-wash-booking-edit-ui\?v=20260903-3-market-timezone/);
   assert.match(loader,/data-dabbir-car-wash-booking-edit-ui/);
 });

--- a/test/dabbir-car-wash-manual-booking-selectors.test.mjs
+++ b/test/dabbir-car-wash-manual-booking-selectors.test.mjs
@@ -47,5 +47,5 @@ test('car-wash loader mounts the mobile-safe manual booking enhancement only for
   assert.match(loader,/function loadManualBooking\(\)/);
   assert.match(loader,/\/api\/car-wash-manual-booking-ui/);
   assert.match(loader,/20260903-3-native-combobox/);
-  assert.match(loader,/v8-historical-calendar-edit/);
+  assert.match(loader,/v9-market-timezone-edit/);
 });


### PR DESCRIPTION
Clean current-main rebuild of the booking fix after GitHub failed to recognize the required check on the prior PR.

- Historical car-wash edit clicks are intercepted consistently from both management rows and calendar events.
- Historical edit controls remain usable even if another UI layer changes disabled state.
- The editor follows the selected business timezone instead of hard-coding Dubai +04:00.
- Canonical appointment writes remain unchanged and new bookings still cannot be created in the past.
- Regression tests cover click authority, timezone conversion, and cache delivery.