### PR TITLE
Harden DABBIR root owner authority and branch isolation

### DIFF
--- a/api/_branch-scope.js
+++ b/api/_branch-scope.js
@@ -1,0 +1,106 @@
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const ALL_BRANCHES='all';
+
+export function branchId(value){
+  const raw=String(value??'').trim();
+  return UUID_RE.test(raw)?raw:null;
+}
+
+function permissionsOf(membership){
+  return Array.isArray(membership?.permissions)?membership.permissions.map(String):[];
+}
+
+export function canUseAllBranches(membership){
+  const role=String(membership?.role||'').toLowerCase();
+  if(role==='owner'||role==='admin')return true;
+  const permissions=permissionsOf(membership);
+  return permissions.includes('manage_business')||permissions.includes('manage_team');
+}
+
+async function readJson(response,code){
+  const text=await response.text();
+  let body=null;
+  try{body=text?JSON.parse(text):null}catch{body=null}
+  if(!response.ok){
+    const error=new Error(code);
+    error.status=Number(response.status||500);
+    throw error;
+  }
+  return Array.isArray(body)?body:[];
+}
+
+/**
+ * Resolve branch scope on the server. `rest` must be the caller's normal
+ * RLS-scoped Supabase REST wrapper: (path, code) => Promise<Response|rows>.
+ *
+ * `requestedBranch` accepts a UUID or "all". Omitted scope defaults to all
+ * only for owner/admin/manage roles. Restricted staff default to their sole
+ * assignment and must choose explicitly if they have multiple assignments.
+ */
+export async function resolveBranchScope({businessId,membership,userId,requestedBranch,fetchRows}){
+  if(!branchId(businessId)||!membership||membership.business_id!==businessId){
+    throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+  }
+  const requested=String(requestedBranch??'').trim().toLowerCase();
+  const allAllowed=canUseAllBranches(membership);
+
+  const branches=await fetchRows(
+    `dabbir_business_branches?select=id,business_id,name,status,is_primary,timezone&business_id=eq.${encodeURIComponent(businessId)}&status=eq.active&order=is_primary.desc,created_at.asc`,
+    'BRANCH_LOOKUP_FAILED',
+  );
+  const active=(Array.isArray(branches)?branches:[]).filter(row=>row?.business_id===businessId&&branchId(row?.id));
+  if(!active.length)throw Object.assign(new Error('ACTIVE_BRANCH_REQUIRED'),{status:409});
+
+  if(requested===ALL_BRANCHES){
+    if(!allAllowed)throw Object.assign(new Error('ALL_BRANCHES_ACCESS_DENIED'),{status:403});
+    return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+  }
+
+  const requestedId=branchId(requestedBranch);
+  if(requestedBranch!=null&&String(requestedBranch).trim()&&!requestedId){
+    throw Object.assign(new Error('INVALID_BRANCH_ID'),{status:400});
+  }
+
+  if(allAllowed&&!requestedId){
+    return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+  }
+
+  const assignments=await fetchRows(
+    `dabbir_membership_branches?select=business_id,user_id,branch_id&business_id=eq.${encodeURIComponent(businessId)}&user_id=eq.${encodeURIComponent(userId)}&order=created_at.asc`,
+    'BRANCH_ASSIGNMENTS_LOOKUP_FAILED',
+  );
+  const assignedIds=new Set((Array.isArray(assignments)?assignments:[]).filter(row=>row?.business_id===businessId&&row?.user_id===userId).map(row=>row.branch_id));
+  const allowed=active.filter(row=>assignedIds.has(row.id));
+  if(!allowed.length)throw Object.assign(new Error('BRANCH_ASSIGNMENT_REQUIRED'),{status:403});
+
+  if(requestedId){
+    const selected=active.find(row=>row.id===requestedId);
+    if(!selected)throw Object.assign(new Error('BRANCH_NOT_FOUND'),{status:404});
+    if(!assignedIds.has(requestedId))throw Object.assign(new Error('BRANCH_ACCESS_DENIED'),{status:403});
+    return {mode:'selected',branch_id:selected.id,branch_ids:[selected.id],branch:selected,all_allowed:false};
+  }
+
+  if(allowed.length!==1){
+    throw Object.assign(new Error('BRANCH_SELECTION_REQUIRED'),{status:409,branches:allowed.map(row=>row.id)});
+  }
+  return {mode:'selected',branch_id:allowed[0].id,branch_ids:[allowed[0].id],branch:allowed[0],all_allowed:false};
+}
+
+export function branchFilter(scope,column='branch_id'){
+  if(!scope||scope.mode==='all')return '';
+  const id=branchId(scope.branch_id);
+  if(!id)throw Object.assign(new Error('BRANCH_SCOPE_INVALID'),{status:500});
+  return `&${encodeURIComponent(column)}=eq.${encodeURIComponent(id)}`;
+}
+
+export function branchWrite(scope){
+  if(!scope||scope.mode!=='selected'||!branchId(scope.branch_id)){
+    throw Object.assign(new Error('SELECTED_BRANCH_REQUIRED'),{status:409});
+  }
+  return scope.branch_id;
+}
+
+export async function rowsFromSupabaseResponse(response,code='BRANCH_SCOPE_LOOKUP_FAILED'){
+  return readJson(response,code);
+}

--- a/api/_branch-scope.js
+++ b/api/_branch-scope.js
@@ -18,25 +18,10 @@ export function canUseAllBranches(membership){
   return permissions.includes('manage_business')||permissions.includes('manage_team');
 }
 
-async function readJson(response,code){
-  const text=await response.text();
-  let body=null;
-  try{body=text?JSON.parse(text):null}catch{body=null}
-  if(!response.ok){
-    const error=new Error(code);
-    error.status=Number(response.status||500);
-    throw error;
-  }
-  return Array.isArray(body)?body:[];
-}
-
 /**
- * Resolve branch scope on the server. `rest` must be the caller's normal
- * RLS-scoped Supabase REST wrapper: (path, code) => Promise<Response|rows>.
- *
- * `requestedBranch` accepts a UUID or "all". Omitted scope defaults to all
- * only for owner/admin/manage roles. Restricted staff default to their sole
- * assignment and must choose explicitly if they have multiple assignments.
+ * Resolve branch scope on the server using RLS-scoped branch and assignment rows.
+ * Owners/admins may use all branches or any active branch. Restricted staff may
+ * only use branches explicitly assigned to their own membership.
  */
 export async function resolveBranchScope({businessId,membership,userId,requestedBranch,fetchRows}){
   if(!branchId(businessId)||!membership||membership.business_id!==businessId){
@@ -62,8 +47,11 @@ export async function resolveBranchScope({businessId,membership,userId,requested
     throw Object.assign(new Error('INVALID_BRANCH_ID'),{status:400});
   }
 
-  if(allAllowed&&!requestedId){
-    return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+  if(allAllowed){
+    if(!requestedId)return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+    const selected=active.find(row=>row.id===requestedId);
+    if(!selected)throw Object.assign(new Error('BRANCH_NOT_FOUND'),{status:404});
+    return {mode:'selected',branch_id:selected.id,branch_ids:[selected.id],branch:selected,all_allowed:true};
   }
 
   const assignments=await fetchRows(
@@ -99,8 +87,4 @@ export function branchWrite(scope){
     throw Object.assign(new Error('SELECTED_BRANCH_REQUIRED'),{status:409});
   }
   return scope.branch_id;
-}
-
-export async function rowsFromSupabaseResponse(response,code='BRANCH_SCOPE_LOOKUP_FAILED'){
-  return readJson(response,code);
 }

--- a/api/_whatsapp-branch-connection.js
+++ b/api/_whatsapp-branch-connection.js
@@ -12,12 +12,12 @@ const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 const SELECT='id,business_id,branch_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error';
 
-async function readRows(response,code){
+async function readRows(response,code,{max=1}={}){
   const text=await response.text();
   let rows=null;
   try{rows=text?JSON.parse(text):null}catch{rows=null}
   if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||502)});
-  if(!Array.isArray(rows)||rows.length>1)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_RESPONSE_MALFORMED'),{status:502});
+  if(!Array.isArray(rows)||rows.length>max)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_RESPONSE_MALFORMED'),{status:502});
   return rows;
 }
 
@@ -46,11 +46,9 @@ async function rotateExact(accessToken,row,config,options={}){
   });
 }
 
-export async function loadExactBusinessConnection(accessToken,businessId,connectionId,options={}){
-  const business=safeId(businessId),connection=safeId(connectionId);
-  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+async function loadConnection(accessToken,business,filter,options={}){
   let row=await withServerReadTimeout(async signal=>{
-    const path=`dabbir_whatsapp_connections?select=${SELECT}&id=eq.${encodeURIComponent(connection)}&business_id=eq.${encodeURIComponent(business)}&limit=1`;
+    const path=`dabbir_whatsapp_connections?select=${SELECT}&business_id=eq.${encodeURIComponent(business)}&${filter}&limit=1`;
     const response=await supabaseRest(path,accessToken,{signal});
     const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_READ_FAILED');
     return rows[0]||null;
@@ -60,9 +58,61 @@ export async function loadExactBusinessConnection(accessToken,businessId,connect
     timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
   });
   if(!row)return null;
-  if(row.id!==connection||row.business_id!==business||!safeId(row.branch_id)){
+  if(row.business_id!==business||!safeId(row.id)||!safeId(row.branch_id)){
     throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH'),{status:502});
   }
   row=await rotateExact(accessToken,row,embeddedPlatformConfig(),options);
   return row;
+}
+
+export async function loadExactBusinessConnection(accessToken,businessId,connectionId,options={}){
+  const business=safeId(businessId),connection=safeId(connectionId);
+  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+  const row=await loadConnection(accessToken,business,`id=eq.${encodeURIComponent(connection)}`,options);
+  if(row&&row.id!==connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  return row;
+}
+
+export async function loadBusinessBranchConnection(accessToken,businessId,branchId,options={}){
+  const business=safeId(businessId),branch=safeId(branchId);
+  if(!business||!branch)throw Object.assign(new Error('WHATSAPP_BRANCH_CONNECTION_ID_REQUIRED'),{status:400});
+  const row=await loadConnection(accessToken,business,`branch_id=eq.${encodeURIComponent(branch)}`,options);
+  if(row&&row.branch_id!==branch)throw Object.assign(new Error('WHATSAPP_BRANCH_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  return row;
+}
+
+export async function loadPrimaryBusinessConnection(accessToken,businessId,options={}){
+  const business=safeId(businessId);
+  if(!business)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const branch=await withServerReadTimeout(async signal=>{
+    const path=`dabbir_business_branches?select=id,business_id,status,is_primary&business_id=eq.${encodeURIComponent(business)}&status=eq.active&is_primary=eq.true&limit=1`;
+    const response=await supabaseRest(path,accessToken,{signal});
+    const rows=await readRows(response,'WHATSAPP_PRIMARY_BRANCH_READ_FAILED');
+    return rows[0]||null;
+  },{
+    label:'WHATSAPP_PRIMARY_BRANCH_READ',
+    errorCode:'WHATSAPP_PRIMARY_BRANCH_READ_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+  if(!branch?.id||branch.business_id!==business)throw Object.assign(new Error('WHATSAPP_PRIMARY_BRANCH_REQUIRED'),{status:409});
+  return loadBusinessBranchConnection(accessToken,business,branch.id,options);
+}
+
+export async function deleteExactBusinessConnection(accessToken,businessId,connectionId,options={}){
+  const business=safeId(businessId),connection=safeId(connectionId);
+  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+  return withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?id=eq.${encodeURIComponent(connection)}&business_id=eq.${encodeURIComponent(business)}&select=id,business_id,branch_id,waba_id,phone_number_id`;
+    const response=await supabaseRest(path,accessToken,{method:'DELETE',headers:{prefer:'return=representation'},signal});
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_DELETE_FAILED');
+    const deleted=rows[0]||null;
+    if(!deleted||deleted.id!==connection||deleted.business_id!==business){
+      throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_DELETE_UNVERIFIED'),{status:502});
+    }
+    return deleted;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_DELETE',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_DELETE_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
 }

--- a/api/_whatsapp-branch-connection.js
+++ b/api/_whatsapp-branch-connection.js
@@ -1,0 +1,68 @@
+import { supabaseRest } from './_auth-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
+import {
+  embeddedPlatformConfig,
+  openAccessToken,
+  sealAccessToken,
+  tokenNeedsRotation,
+} from './_whatsapp-embedded-core.js';
+
+const READ_TIMEOUT_MS=10_000;
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const SELECT='id,business_id,branch_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error';
+
+async function readRows(response,code){
+  const text=await response.text();
+  let rows=null;
+  try{rows=text?JSON.parse(text):null}catch{rows=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||502)});
+  if(!Array.isArray(rows)||rows.length>1)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_RESPONSE_MALFORMED'),{status:502});
+  return rows;
+}
+
+async function rotateExact(accessToken,row,config,options={}){
+  if(!row||!tokenNeedsRotation(row,config)||!config.rotationReady)return row;
+  const plaintext=openAccessToken(row,config,row.business_id);
+  const sealed=sealAccessToken(plaintext,config,row.business_id);
+  return withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?id=eq.${encodeURIComponent(row.id)}&business_id=eq.${encodeURIComponent(row.business_id)}&select=${SELECT}`;
+    const response=await supabaseRest(path,accessToken,{
+      method:'PATCH',
+      headers:{prefer:'return=representation'},
+      body:JSON.stringify(sealed),
+      signal,
+    });
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_ROTATION_FAILED');
+    const rotated=rows[0]||null;
+    if(!rotated||rotated.id!==row.id||rotated.business_id!==row.business_id){
+      throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ROTATION_UNVERIFIED'),{status:502});
+    }
+    return rotated;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_ROTATION',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_ROTATION_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+}
+
+export async function loadExactBusinessConnection(accessToken,businessId,connectionId,options={}){
+  const business=safeId(businessId),connection=safeId(connectionId);
+  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+  let row=await withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?select=${SELECT}&id=eq.${encodeURIComponent(connection)}&business_id=eq.${encodeURIComponent(business)}&limit=1`;
+    const response=await supabaseRest(path,accessToken,{signal});
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_READ_FAILED');
+    return rows[0]||null;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_READ',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_READ_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+  if(!row)return null;
+  if(row.id!==connection||row.business_id!==business||!safeId(row.branch_id)){
+    throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  }
+  row=await rotateExact(accessToken,row,embeddedPlatformConfig(),options);
+  return row;
+}

--- a/api/branch-context-ui.js
+++ b/api/branch-context-ui.js
@@ -1,0 +1,150 @@
+const css=String.raw`
+.dbBranchScope{margin-top:8px}.dbBranchScope label{display:block;color:#8f969e;font-size:8px;margin:0 0 4px}.dbBranchScope select{width:100%;min-height:40px;border:1px solid #30363d;background:#15181b;color:#fff;border-radius:10px;padding:7px 9px;font-size:10px}.dbBranchScope small{display:block;margin-top:4px;color:#767d85;font-size:7px}.dbBranchScope[data-state="error"] small{color:#ffb4ba}
+@media(max-width:700px){.dbBranchScope select{min-height:44px;font-size:12px}}
+`;
+
+const script=String.raw`(()=>{
+  if(window.__dabbirBranchContextUi)return;
+  window.__dabbirBranchContextUi='v1-server-scoped';
+  const PREFIX='dabbir_active_branch_scope:';
+  let activeBusiness=null,context=null,loading=null,apiPatched=false;
+  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v1';document.head.append(style);
+
+  function businessId(){try{return String(workspace?.business?.id||'').trim()}catch{return''}}
+  function key(id){return PREFIX+String(id||'')}
+  function stored(id){try{return localStorage.getItem(key(id))||''}catch{return''}}
+  function save(id,value){try{localStorage.setItem(key(id),String(value||''))}catch{}}
+  function isAr(){return document.documentElement.lang!=='en'}
+  function copy(){return isAr()?{label:'نطاق الفرع',all:'كل الفروع',hint:'ما يظهر هنا يحدد بيانات التشغيل المعروضة.',error:'تعذر تحميل صلاحيات الفروع'}:{label:'Branch scope',all:'All branches',hint:'This controls which operational data is loaded.',error:'Could not load branch permissions'}}
+  function parseBody(options){try{return options?.body?JSON.parse(options.body):null}catch{return null}}
+
+  function currentScope(id){
+    const value=stored(id);
+    if(value)return value;
+    if(context?.business_id===id&&context.default_scope)return String(context.default_scope);
+    return 'all';
+  }
+
+  function routedApi(original,url,options){
+    const raw=String(url||'');
+    if(!raw.startsWith('/api/dabbir-runtime'))return original(url,options);
+    let parsed;
+    try{parsed=new URL(raw,location.origin)}catch{return original(url,options)}
+    const body=parseBody(options);
+    const method=String(options?.method||'GET').toUpperCase();
+    const bid=String(parsed.searchParams.get('business_id')||body?.business_id||businessId()||'').trim();
+    if(!bid)return original(url,options);
+    const scope=currentScope(bid);
+    if(!scope||scope==='all')return original(url,options);
+
+    if(method==='GET'){
+      const target=new URL('/api/branch-workspace',location.origin);
+      target.searchParams.set('business_id',bid);
+      target.searchParams.set('branch_id',scope);
+      const cid=parsed.searchParams.get('conversation_id');if(cid)target.searchParams.set('conversation_id',cid);
+      return original(target.pathname+target.search,options);
+    }
+
+    if(method==='POST'&&body&&['start_conversation','create_appointment'].includes(String(body.action||''))){
+      const next=Object.assign({},body,{business_id:bid,branch_id:scope});
+      return original('/api/branch-operations',Object.assign({},options,{body:JSON.stringify(next)}));
+    }
+    return original(url,options);
+  }
+
+  function patchApi(){
+    if(apiPatched)return true;
+    if(typeof window.api!=='function')return false;
+    const original=window.api.bind(window);
+    window.api=function(url,options){return routedApi(original,url,options)};
+    window.api.__dabbirBranchScoped=true;
+    apiPatched=true;
+    return true;
+  }
+
+  async function loadContext(id){
+    if(!id)return null;
+    if(loading)return loading;
+    loading=(async()=>{
+      const response=await fetch('/api/branch-context?business_id='+encodeURIComponent(id),{cache:'no-store',headers:{accept:'application/json','x-dabbir-client':'web'}});
+      const payload=await response.json().catch(()=>({}));
+      if(!response.ok||!payload.ok)throw new Error(payload.error||'BRANCH_CONTEXT_FAILED');
+      context=payload;
+      const valid=new Set((payload.branches||[]).map(row=>String(row.id)));
+      let value=stored(id);
+      if(value==='all'&&!payload.all_allowed)value='';
+      if(value!=='all'&&value&&!valid.has(value))value='';
+      if(!value)value=String(payload.default_scope||payload.branches?.[0]?.id||'');
+      if(value)save(id,value);
+      document.documentElement.dataset.dabbirBranchScope=value||'unselected';
+      return payload;
+    })().finally(()=>{loading=null});
+    return loading;
+  }
+
+  function ensureUi(){
+    const host=document.querySelector('.side .workspace');
+    if(!host)return null;
+    let box=host.querySelector('#dbBranchScope');
+    if(!box){
+      box=document.createElement('div');box.id='dbBranchScope';box.className='dbBranchScope';
+      box.innerHTML='<label></label><select aria-label="Branch scope"></select><small></small>';
+      host.append(box);
+      box.querySelector('select').addEventListener('change',async event=>{
+        const id=businessId();if(!id)return;
+        const value=String(event.target.value||'');if(!value)return;
+        save(id,value);document.documentElement.dataset.dabbirBranchScope=value;
+        window.dispatchEvent(new CustomEvent('dabbir:branch-scope-changed',{detail:{business_id:id,branch_id:value==='all'?null:value,mode:value==='all'?'all':'selected'}}));
+        try{if(typeof window.loadRuntime==='function')await window.loadRuntime(id)}catch{}
+      });
+    }
+    return box;
+  }
+
+  function render(){
+    const box=ensureUi();if(!box)return;
+    const t=copy();box.querySelector('label').textContent=t.label;box.querySelector('small').textContent=t.hint;
+    const select=box.querySelector('select');
+    const id=businessId();
+    if(!context||context.business_id!==id){select.innerHTML='';select.disabled=true;return}
+    const options=[];
+    if(context.all_allowed)options.push('<option value="all">'+t.all+'</option>');
+    for(const branch of context.branches||[])options.push('<option value="'+String(branch.id).replace(/"/g,'')+'">'+String(branch.name||'Branch').replace(/[&<>]/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[ch]))+'</option>');
+    select.innerHTML=options.join('');select.disabled=false;
+    const value=currentScope(id);if([...select.options].some(o=>o.value===value))select.value=value;
+    box.dataset.state='ready';
+  }
+
+  async function sync(){
+    patchApi();
+    const id=businessId();
+    if(!id){activeBusiness=null;context=null;render();return}
+    if(id!==activeBusiness){
+      activeBusiness=id;context=null;render();
+      try{await loadContext(id);render()}catch{const box=ensureUi();if(box){box.dataset.state='error';box.querySelector('small').textContent=copy().error}}
+    }else render();
+  }
+
+  window.dabbirBranchContext={
+    scope:()=>{const id=businessId();const value=currentScope(id);return {business_id:id,mode:value==='all'?'all':'selected',branch_id:value==='all'?null:value}},
+    query(url){const id=businessId(),value=currentScope(id);if(!id||!value||value==='all')return url;const u=new URL(url,location.origin);u.searchParams.set('branch_id',value);return u.pathname+u.search},
+    refresh:sync,
+  };
+
+  let ticks=0;const timer=setInterval(()=>{sync();ticks++;if(ticks>120&&apiPatched&&businessId())clearInterval(timer)},250);
+  document.addEventListener('click',()=>setTimeout(sync,0),true);
+  window.addEventListener('dabbir:language-changed',render);
+  sync();
+})();`;
+
+export default async function handler(req,res){
+  if(req.method!=='GET'){
+    res.statusCode=405;res.setHeader('allow','GET');return res.end('Method Not Allowed');
+  }
+  res.statusCode=200;
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','no-store');
+  res.setHeader('x-content-type-options','nosniff');
+  res.setHeader('x-dabbir-branch-context','server-scoped-v1');
+  return res.end(script);
+}

--- a/api/branch-context-ui.js
+++ b/api/branch-context-ui.js
@@ -5,10 +5,10 @@ const css=String.raw`
 
 const script=String.raw`(()=>{
   if(window.__dabbirBranchContextUi)return;
-  window.__dabbirBranchContextUi='v1-server-scoped';
+  window.__dabbirBranchContextUi='v2-server-scoped-whatsapp';
   const PREFIX='dabbir_active_branch_scope:';
-  let activeBusiness=null,context=null,loading=null,apiPatched=false;
-  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v1';document.head.append(style);
+  let activeBusiness=null,context=null,loading=null,apiPatched=false,fetchPatched=false;
+  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v2';document.head.append(style);
 
   function businessId(){try{return String(workspace?.business?.id||'').trim()}catch{return''}}
   function key(id){return PREFIX+String(id||'')}
@@ -59,6 +59,59 @@ const script=String.raw`(()=>{
     window.api=function(url,options){return routedApi(original,url,options)};
     window.api.__dabbirBranchScoped=true;
     apiPatched=true;
+    return true;
+  }
+
+  async function persistWhatsAppIntent(original,bid,scope){
+    const response=await original('/api/whatsapp-branch-intent',{
+      method:'POST',cache:'no-store',
+      headers:{'content-type':'application/json','accept':'application/json','x-dabbir-client':'web'},
+      body:JSON.stringify({business_id:bid,branch_id:scope&&scope!=='all'?scope:null}),
+    });
+    const payload=await response.clone().json().catch(()=>({}));
+    if(!response.ok||!payload.ok)throw new Error(payload.error||'WHATSAPP_BRANCH_INTENT_REQUIRED');
+    return payload;
+  }
+
+  function patchFetch(){
+    if(fetchPatched)return true;
+    if(typeof window.fetch!=='function')return false;
+    const original=window.fetch.bind(window);
+    window.fetch=async function(input,options){
+      const raw=typeof input==='string'?input:String(input?.url||'');
+      let parsed;try{parsed=new URL(raw,location.origin)}catch{return original(input,options)}
+      const path=parsed.pathname;
+      if(!['/api/dabbir-whatsapp-embedded-complete','/api/dabbir-whatsapp-status','/api/dabbir-whatsapp-disconnect'].includes(path)){
+        return original(input,options);
+      }
+      const body=parseBody(options);
+      const method=String(options?.method||'GET').toUpperCase();
+      const bid=String(parsed.searchParams.get('business_id')||body?.business_id||businessId()||'').trim();
+      if(!bid)return original(input,options);
+      const scope=currentScope(bid);
+
+      if(path==='/api/dabbir-whatsapp-embedded-complete'&&method==='POST'){
+        try{await persistWhatsAppIntent(original,bid,scope)}catch(error){
+          return new Response(JSON.stringify({ok:false,error:String(error?.message||'WHATSAPP_BRANCH_INTENT_REQUIRED')}),{
+            status:409,headers:{'content-type':'application/json'}
+          });
+        }
+        return original(input,options);
+      }
+
+      if(scope&&scope!=='all'&&path==='/api/dabbir-whatsapp-status'&&method==='GET'){
+        parsed.searchParams.set('business_id',bid);parsed.searchParams.set('branch_id',scope);
+        return original(parsed.pathname+parsed.search,options);
+      }
+
+      if(scope&&scope!=='all'&&path==='/api/dabbir-whatsapp-disconnect'&&method==='POST'&&body){
+        const next=Object.assign({},body,{business_id:bid,branch_id:scope});
+        return original(input,Object.assign({},options,{body:JSON.stringify(next)}));
+      }
+      return original(input,options);
+    };
+    window.fetch.__dabbirWhatsAppBranchScoped=true;
+    fetchPatched=true;
     return true;
   }
 
@@ -116,7 +169,7 @@ const script=String.raw`(()=>{
   }
 
   async function sync(){
-    patchApi();
+    patchFetch();patchApi();
     const id=businessId();
     if(!id){activeBusiness=null;context=null;render();return}
     if(id!==activeBusiness){
@@ -131,7 +184,7 @@ const script=String.raw`(()=>{
     refresh:sync,
   };
 
-  let ticks=0;const timer=setInterval(()=>{sync();ticks++;if(ticks>120&&apiPatched&&businessId())clearInterval(timer)},250);
+  let ticks=0;const timer=setInterval(()=>{sync();ticks++;if(ticks>120&&apiPatched&&fetchPatched&&businessId())clearInterval(timer)},250);
   document.addEventListener('click',()=>setTimeout(sync,0),true);
   window.addEventListener('dabbir:language-changed',render);
   sync();
@@ -145,6 +198,6 @@ export default async function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-branch-context','server-scoped-v1');
+  res.setHeader('x-dabbir-branch-context','server-scoped-v2-whatsapp');
   return res.end(script);
 }

--- a/api/branch-context-ui.js
+++ b/api/branch-context-ui.js
@@ -5,10 +5,10 @@ const css=String.raw`
 
 const script=String.raw`(()=>{
   if(window.__dabbirBranchContextUi)return;
-  window.__dabbirBranchContextUi='v2-server-scoped-whatsapp';
+  window.__dabbirBranchContextUi='v3-server-scoped-whatsapp';
   const PREFIX='dabbir_active_branch_scope:';
   let activeBusiness=null,context=null,loading=null,apiPatched=false,fetchPatched=false;
-  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v2';document.head.append(style);
+  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v3';document.head.append(style);
 
   function businessId(){try{return String(workspace?.business?.id||'').trim()}catch{return''}}
   function key(id){return PREFIX+String(id||'')}
@@ -81,7 +81,7 @@ const script=String.raw`(()=>{
       const raw=typeof input==='string'?input:String(input?.url||'');
       let parsed;try{parsed=new URL(raw,location.origin)}catch{return original(input,options)}
       const path=parsed.pathname;
-      if(!['/api/dabbir-whatsapp-embedded-complete','/api/dabbir-whatsapp-status','/api/dabbir-whatsapp-disconnect'].includes(path)){
+      if(!['/api/dabbir-whatsapp-embedded-complete','/api/dabbir-whatsapp-embedded-config','/api/dabbir-whatsapp-status','/api/dabbir-whatsapp-disconnect'].includes(path)){
         return original(input,options);
       }
       const body=parseBody(options);
@@ -99,7 +99,7 @@ const script=String.raw`(()=>{
         return original(input,options);
       }
 
-      if(scope&&scope!=='all'&&path==='/api/dabbir-whatsapp-status'&&method==='GET'){
+      if(scope&&scope!=='all'&&['/api/dabbir-whatsapp-embedded-config','/api/dabbir-whatsapp-status'].includes(path)&&method==='GET'){
         parsed.searchParams.set('business_id',bid);parsed.searchParams.set('branch_id',scope);
         return original(parsed.pathname+parsed.search,options);
       }
@@ -198,6 +198,6 @@ export default async function handler(req,res){
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');
   res.setHeader('x-content-type-options','nosniff');
-  res.setHeader('x-dabbir-branch-context','server-scoped-v2-whatsapp');
+  res.setHeader('x-dabbir-branch-context','server-scoped-v3-whatsapp');
   return res.end(script);
 }

--- a/api/branch-context.js
+++ b/api/branch-context.js
@@ -1,0 +1,67 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  supabaseRest,
+} from './_auth-core.js';
+import { canUseAllBranches } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const enc=value=>encodeURIComponent(String(value));
+
+async function readData(response,code){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||500)});
+  return Array.isArray(payload)?payload:[];
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const token=accessTokenFromRequest(req);
+  if(!token)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  try{
+    const businessId=safeId(singleQueryValue(req,'business_id'));
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_ID_REQUIRED'});
+    const membership=(Array.isArray(memberships)?memberships:[]).find(row=>row.business_id===businessId&&row.status==='active');
+    if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+
+    const allAllowed=canUseAllBranches(membership);
+    const branches=await readData(await supabaseRest(
+      `dabbir_business_branches?select=id,business_id,name,status,is_primary,timezone,address_text&business_id=eq.${enc(businessId)}&status=eq.active&order=is_primary.desc,created_at.asc`,
+      token,
+    ),'BRANCH_LOOKUP_FAILED');
+    let allowed=branches;
+    if(!allAllowed){
+      const assignments=await readData(await supabaseRest(
+        `dabbir_membership_branches?select=business_id,user_id,branch_id&business_id=eq.${enc(businessId)}&user_id=eq.${enc(user.id)}`,
+        token,
+      ),'BRANCH_ASSIGNMENTS_LOOKUP_FAILED');
+      const ids=new Set(assignments.filter(row=>row.business_id===businessId&&row.user_id===user.id).map(row=>row.branch_id));
+      allowed=branches.filter(row=>ids.has(row.id));
+    }
+    if(!allowed.length)return json(res,403,{ok:false,error:'BRANCH_ASSIGNMENT_REQUIRED'});
+    return json(res,200,{
+      ok:true,
+      business_id:businessId,
+      role:membership.role,
+      all_allowed:allAllowed,
+      branches:allowed,
+      default_scope:allAllowed?'all':allowed.length===1?allowed[0].id:null,
+      selection_required:!allAllowed&&allowed.length>1,
+      truth:{state:'VERIFIED',source:'SERVER_RLS_BRANCH_ASSIGNMENTS'},
+    });
+  }catch(error){
+    const status=Number(error?.status||500);
+    return json(res,[400,401,403,404,409,502,503].includes(status)?status:500,{ok:false,error:String(error?.message||'BRANCH_CONTEXT_FAILED')});
+  }
+}

--- a/api/branch-operations.js
+++ b/api/branch-operations.js
@@ -1,0 +1,167 @@
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+} from './_auth-core.js';
+import { branchWrite, resolveBranchScope } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const clean=(value,max=500)=>String(value??'').trim().slice(0,max);
+
+async function readData(response,fallback='DATA_REQUEST_FAILED'){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=Number(response.status||500);
+    error.detail=payload?.code||payload?.message||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=async(token,path,options={},fallback)=>readData(await supabaseRest(path,token,options),fallback);
+
+async function context(req){
+  const token=accessTokenFromRequest(req);
+  if(!token)return null;
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return null;
+  return {token,user,memberships:Array.isArray(memberships)?memberships:[]};
+}
+
+function membershipFor(ctx,businessId){
+  return ctx.memberships.find(row=>row.business_id===businessId&&row.status==='active')||null;
+}
+
+function persisted(rows,code){
+  const row=Array.isArray(rows)?rows[0]:null;
+  if(!row?.id)throw Object.assign(new Error(code),{status:502});
+  return row;
+}
+
+async function selectedScope(ctx,body){
+  const businessId=safeId(body?.business_id);
+  if(!businessId)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const membership=membershipFor(ctx,businessId);
+  if(!membership)throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+  const scope=await resolveBranchScope({
+    businessId,
+    membership,
+    userId:ctx.user.id,
+    requestedBranch:body?.branch_id,
+    fetchRows:(path,code)=>rest(ctx.token,path,{},code),
+  });
+  return {businessId,branchId:branchWrite(scope),scope};
+}
+
+async function createCustomer(ctx,businessId,name,source){
+  const rows=await rest(ctx.token,'dabbir_customers?select=id,display_name,lead_status,created_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      display_name:clean(name||'Customer',120)||'Customer',
+      lead_status:'new',
+      metadata:{source},
+    }),
+  },'CUSTOMER_CREATE_FAILED');
+  return persisted(rows,'CUSTOMER_CREATE_UNVERIFIED');
+}
+
+async function startConversation(ctx,body){
+  const {businessId,branchId}=await selectedScope(ctx,body);
+  const customer=await createCustomer(ctx,businessId,body?.display_name||'Web Customer','dabbir_branch_web_runtime');
+  const rows=await rest(ctx.token,'dabbir_conversations?select=id,business_id,branch_id,customer_id,channel_type,state,demo_mode,created_at,updated_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      branch_id:branchId,
+      customer_id:customer.id,
+      channel_type:'web',
+      state:'ai_active',
+      demo_mode:false,
+    }),
+  },'CONVERSATION_CREATE_FAILED');
+  const conversation=persisted(rows,'CONVERSATION_CREATE_UNVERIFIED');
+  if(conversation.branch_id!==branchId)throw Object.assign(new Error('CONVERSATION_BRANCH_UNVERIFIED'),{status:502});
+  return {
+    ok:true,
+    action:'start_conversation',
+    state:'VERIFIED_PERSISTED',
+    customer,
+    conversation,
+    channel:'web',
+    branch_id:branchId,
+    verified_persisted:true,
+    truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',branch_id:branchId,entity_id:conversation.id,verified_at:new Date().toISOString()},
+    external_side_effects:false,
+  };
+}
+
+async function createAppointment(ctx,body){
+  const {businessId,branchId}=await selectedScope(ctx,body);
+  let customerId=safeId(body?.customer_id);
+  const startsAt=new Date(String(body?.starts_at||''));
+  if(Number.isNaN(startsAt.getTime()))throw Object.assign(new Error('VALID_START_TIME_REQUIRED'),{status:400});
+  if(!customerId){
+    const customer=await createCustomer(ctx,businessId,body?.customer_name||'Customer','dabbir_branch_appointment_runtime');
+    customerId=customer.id;
+  }
+  const rows=await rest(ctx.token,'dabbir_appointments?select=id,business_id,branch_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,created_at,updated_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      branch_id:branchId,
+      customer_id:customerId,
+      service_id:safeId(body?.service_id),
+      starts_at:startsAt.toISOString(),
+      status:'requested',
+      simulated:false,
+    }),
+  },'APPOINTMENT_CREATE_FAILED');
+  const appointment=persisted(rows,'APPOINTMENT_PERSISTENCE_UNVERIFIED');
+  if(appointment.branch_id!==branchId)throw Object.assign(new Error('APPOINTMENT_BRANCH_UNVERIFIED'),{status:502});
+  return {
+    ok:true,
+    action:'create_appointment',
+    state:'VERIFIED_PERSISTED',
+    appointment,
+    branch_id:branchId,
+    verified_persisted:true,
+    truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',branch_id:branchId,entity_id:appointment.id,verified_at:new Date().toISOString()},
+    external_side_effects:false,
+  };
+}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+  const ctx=await context(req);
+  if(!ctx)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  try{
+    const body=await readJsonBody(req);
+    const action=clean(body?.action,60);
+    let result;
+    if(action==='start_conversation')result=await startConversation(ctx,body);
+    else if(action==='create_appointment')result=await createAppointment(ctx,body);
+    else return json(res,400,{ok:false,error:'UNSUPPORTED_BRANCH_ACTION'});
+    res.setHeader('x-dabbir-branch-write','verified');
+    return json(res,200,result);
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,413,429,502,503].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'BRANCH_OPERATION_FAILED'),detail:error?.detail||null});
+  }
+}

--- a/api/branch-workspace.js
+++ b/api/branch-workspace.js
@@ -1,0 +1,142 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  supabaseRest,
+} from './_auth-core.js';
+import { getDABBIRAiConfig } from './_ai-core.js';
+import { branchFilter, resolveBranchScope } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const enc=value=>encodeURIComponent(String(value));
+
+async function readData(response,fallback='DATA_REQUEST_FAILED'){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=Number(response.status||500);
+    error.detail=payload?.code||payload?.message||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=(token,path,fallback)=>readData(supabaseRest(path,token),fallback);
+
+async function identity(req){
+  const token=accessTokenFromRequest(req);
+  if(!token)return null;
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return null;
+  return {token,user,memberships:Array.isArray(memberships)?memberships:[]};
+}
+
+function membershipFor(memberships,businessId){
+  return memberships.find(row=>row.business_id===businessId&&row.status==='active')||null;
+}
+
+function idsFilter(ids){
+  const clean=[...new Set(ids.map(safeId).filter(Boolean))];
+  return clean.length?`(${clean.map(enc).join(',')})`:null;
+}
+
+async function workspace(req,ctx){
+  const businessId=safeId(singleQueryValue(req,'business_id'));
+  if(!businessId)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const membership=membershipFor(ctx.memberships,businessId);
+  if(!membership)throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+
+  const requestedBranch=singleQueryValue(req,'branch_id');
+  const fetchRows=(path,code)=>rest(ctx.token,path,code);
+  const scope=await resolveBranchScope({
+    businessId,
+    membership,
+    userId:ctx.user.id,
+    requestedBranch,
+    fetchRows,
+  });
+  const suffix=branchFilter(scope);
+
+  const [businessRows,conversations,appointments]=await Promise.all([
+    rest(ctx.token,`dabbir_businesses?select=id,slug,name,business_type,locale,demo_mode,country_code,currency_code,timezone,phone_country_prefix,created_at,updated_at&id=eq.${enc(businessId)}&limit=1`,'BUSINESS_LOOKUP_FAILED'),
+    rest(ctx.token,`dabbir_conversations?select=id,branch_id,customer_id,channel_type,state,demo_mode,created_at,updated_at&business_id=eq.${enc(businessId)}${suffix}&channel_type=eq.web&order=updated_at.desc&limit=50`,'CONVERSATIONS_LOOKUP_FAILED'),
+    rest(ctx.token,`dabbir_appointments?select=id,branch_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,created_at,updated_at&business_id=eq.${enc(businessId)}${suffix}&order=starts_at.desc&limit=100`,'APPOINTMENTS_LOOKUP_FAILED'),
+  ]);
+  const business=businessRows?.[0]||null;
+  if(!business)throw Object.assign(new Error('BUSINESS_NOT_FOUND'),{status:404});
+
+  const conversationIds=idsFilter((conversations||[]).map(row=>row.id));
+  const customerIds=idsFilter([
+    ...(conversations||[]).map(row=>row.customer_id),
+    ...(appointments||[]).map(row=>row.customer_id),
+  ]);
+  const requestedConversation=safeId(singleQueryValue(req,'conversation_id'));
+  let selectedConversationId=requestedConversation&&conversations?.some(row=>row.id===requestedConversation)?requestedConversation:null;
+  if(!selectedConversationId)selectedConversationId=conversations?.[0]?.id||null;
+
+  const [customers,handoffs,followups,messages]=await Promise.all([
+    customerIds?rest(ctx.token,`dabbir_customers?select=id,display_name,phone_e164,lead_status,metadata,created_at,updated_at&business_id=eq.${enc(businessId)}&id=in.${customerIds}&order=updated_at.desc&limit=200`,'CUSTOMERS_LOOKUP_FAILED'):[],
+    conversationIds?rest(ctx.token,`dabbir_handoffs?select=id,conversation_id,customer_id,route_class,reason,state,priority,summary,created_at,updated_at&business_id=eq.${enc(businessId)}&conversation_id=in.${conversationIds}&order=updated_at.desc&limit=100`,'HANDOFFS_LOOKUP_FAILED'):[],
+    conversationIds?rest(ctx.token,`dabbir_followups?select=id,conversation_id,customer_id,channel_type,reason,status,due_at,recommended_message,blocked_reason,created_at,updated_at&business_id=eq.${enc(businessId)}&conversation_id=in.${conversationIds}&order=updated_at.desc&limit=100`,'FOLLOWUPS_LOOKUP_FAILED'):[],
+    selectedConversationId?rest(ctx.token,`dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at&business_id=eq.${enc(businessId)}&conversation_id=eq.${enc(selectedConversationId)}&order=created_at.asc&limit=100`,'MESSAGES_LOOKUP_FAILED'):[],
+  ]);
+
+  const ai=getDABBIRAiConfig();
+  return {
+    ok:true,
+    authenticated:true,
+    user:ctx.user,
+    needs_onboarding:false,
+    operational_mode:'AUTHENTICATED_BRANCH_RUNTIME',
+    truth_mode:'FAIL_CLOSED_BRANCH_SCOPED_READS',
+    membership,
+    memberships:ctx.memberships,
+    business,
+    branch_scope:{
+      mode:scope.mode,
+      branch_id:scope.branch_id,
+      branch_ids:scope.branch_ids,
+      branch:scope.branch,
+      all_allowed:scope.all_allowed,
+      source:'SERVER_RLS_BRANCH_SCOPE',
+    },
+    conversations:Array.isArray(conversations)?conversations:[],
+    selected_conversation_id:selectedConversationId,
+    messages:Array.isArray(messages)?messages:[],
+    customers:Array.isArray(customers)?customers:[],
+    appointments:Array.isArray(appointments)?appointments:[],
+    handoffs:Array.isArray(handoffs)?handoffs:[],
+    followups:Array.isArray(followups)?followups:[],
+    ai:{
+      provider:ai.provider,
+      model:ai.model,
+      configured:ai.configured,
+      cost_mode:ai.cost_mode,
+      state:ai.configured?'OPERATIONAL_PROVIDER_READY':'UNCONFIGURED',
+    },
+    whatsapp:{state:'NOT_OPERATIONAL',blocker:'META_AUTHORIZATION_NOT_COMPLETED'},
+  };
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const ctx=await identity(req);
+  if(!ctx)return json(res,401,{ok:false,authenticated:false,error:'AUTH_REQUIRED'});
+  try{
+    const payload=await workspace(req,ctx);
+    res.setHeader('x-dabbir-branch-scope',payload.branch_scope?.mode||'unknown');
+    return json(res,200,payload);
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,429,502,503].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'BRANCH_WORKSPACE_FAILED'),detail:error?.detail||null});
+  }
+}

--- a/api/branch-workspace.js
+++ b/api/branch-workspace.js
@@ -26,7 +26,7 @@ async function readData(response,fallback='DATA_REQUEST_FAILED'){
   return payload;
 }
 
-const rest=(token,path,fallback)=>readData(supabaseRest(path,token),fallback);
+const rest=async(token,path,fallback)=>readData(await supabaseRest(path,token),fallback);
 
 async function identity(req){
   const token=accessTokenFromRequest(req);

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -1,21 +1,24 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
 import {
-  embeddedPlatformConfig,
-  loadBusinessConnection,
-  openAccessToken,
-  ownerContext,
-  removeBusinessConnection,
-  unsubscribeWaba,
-} from './_whatsapp-embedded-core.js';
+  deleteExactBusinessConnection,
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
 
-export function verifiedDeletion(rows, businessId) {
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+
+export function verifiedDeletion(value, businessId, connectionId = null) {
+  const rows=Array.isArray(value)?value:[value].filter(Boolean);
+  if(rows.length!==1)return false;
+  const row=rows[0];
   return Boolean(
-    Array.isArray(rows)
-    && rows.length === 1
-    && rows[0]
-    && typeof rows[0] === 'object'
-    && !Array.isArray(rows[0])
-    && String(rows[0].business_id || '') === String(businessId)
+    row
+    && typeof row==='object'
+    && !Array.isArray(row)
+    && String(row.business_id||'')===String(businessId)
+    && (!connectionId||String(row.id||'')===String(connectionId))
   );
 }
 
@@ -25,32 +28,33 @@ export default async function handler(req, res) {
 
   try {
     const body = await readJsonBody(req, 4096);
-    const businessId = String(body?.business_id || '').trim();
+    const businessId = safeId(body?.business_id);
+    const branchRaw=String(body?.branch_id||'').trim();
+    const branchId=branchRaw?safeId(branchRaw):null;
     if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+    if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
 
     const owner = await ownerContext(req, businessId);
-    const row = await loadBusinessConnection(owner.accessToken, businessId);
-    if (!row) return json(res, 200, { ok: true, connected: false, already_disconnected: true });
+    // Backward-compatible callers without branch_id operate on the primary branch only.
+    // A branch disconnect must never delete all connections for the business.
+    const row = branchId
+      ? await loadBusinessBranchConnection(owner.accessToken,businessId,branchId)
+      : await loadPrimaryBusinessConnection(owner.accessToken,businessId);
+    if (!row) return json(res, 200, { ok: true, connected: false, already_disconnected: true, branch_id: branchId });
 
-    const platform = embeddedPlatformConfig();
-    let remoteUnsubscribed = false;
-    if (platform.appSecret && platform.encryptionSecret) {
-      try {
-        const token = openAccessToken(row, platform, businessId);
-        remoteUnsubscribed = await unsubscribeWaba(platform, token, row.waba_id);
-      } catch {
-        remoteUnsubscribed = false;
-      }
-    }
-
-    const deleted = await removeBusinessConnection(owner.accessToken, businessId);
-    if (!verifiedDeletion(deleted, businessId)) {
+    const deleted = await deleteExactBusinessConnection(owner.accessToken,businessId,row.id);
+    if (!verifiedDeletion(deleted, businessId, row.id)) {
       throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_UNVERIFIED'), { status: 502 });
     }
+
     return json(res, 200, {
       ok: true,
       connected: false,
-      remote_unsubscribed: remoteUnsubscribed,
+      branch_id: row.branch_id,
+      connection_id: row.id,
+      phone_number_id: row.phone_number_id,
+      remote_unsubscribed: false,
+      remote_unsubscribe_skipped_reason: 'BRANCH_SAFE_LOCAL_DISCONNECT',
       secrets_exposed: false,
     });
   } catch (error) {

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,7 +1,14 @@
 import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
 import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
-import { loadBusinessConnection, ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
+import { ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
+import {
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
 function readiness(platform) {
   return {
@@ -35,11 +42,16 @@ export default async function handler(req, res) {
   }
 
   const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
+  const branchRaw=String(singleQueryValue(req,'branch_id')||'').trim();
+  const branchId=branchRaw?safeId(branchRaw):null;
   if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+  if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
 
   try {
     await ownerContext(req, businessId);
-    const connection = await loadBusinessConnection(accessToken, businessId);
+    const connection = branchId
+      ? await loadBusinessBranchConnection(accessToken,businessId,branchId)
+      : await loadPrimaryBusinessConnection(accessToken,businessId);
     return json(res, 200, {
       ok: true,
       auth_required: false,
@@ -49,8 +61,12 @@ export default async function handler(req, res) {
       config_id: platform.ready ? platform.configId : null,
       graph_version: platform.graphVersion,
       sdk_locale: 'en_US',
+      branch_id: connection?.branch_id || branchId || null,
+      connection_id: connection?.id || null,
       connected: Boolean(connection && connection.status !== 'disconnected'),
       connection: connection ? {
+        id: connection.id,
+        branch_id: connection.branch_id,
         status: connection.status,
         waba_id: connection.waba_id,
         phone_number_id: connection.phone_number_id,

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
-import { loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
+import { loadExactBusinessConnection } from './_whatsapp-branch-connection.js';
 import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   finalizeOutboundReply,
@@ -101,9 +102,9 @@ export default async function handler(req, res) {
     }
 
     const owner = await ownerContext(req, businessId);
-    const connection = await loadBusinessConnection(owner.accessToken, businessId);
-    if (!connection || connection.status !== 'connected') return json(res, 409, { ok: false, error: 'WHATSAPP_TENANT_NOT_LINKED' });
 
+    // The database resolves conversation.branch_id first and reserves the exact
+    // WhatsApp connection for that branch. Never choose a connection by business alone.
     reservation = await reserveOutboundReply({
       businessId,
       conversationId,
@@ -144,6 +145,16 @@ export default async function handler(req, res) {
         retry_requires_new_operation: true,
         automatic_resend_blocked: true,
       });
+    }
+
+    const connection = await loadExactBusinessConnection(
+      owner.accessToken,
+      businessId,
+      reservation.connectionId,
+    );
+    if (!connection || connection.status !== 'connected') {
+      await markOutboundResult(reservation.reservationId, 'FAILED', 'WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION');
+      return json(res, 409, { ok: false, state: 'FAILED', error: 'WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION' });
     }
 
     if (String(connection.id) !== String(reservation.connectionId)
@@ -200,7 +211,7 @@ export default async function handler(req, res) {
       message: persisted,
       truth: {
         state: 'VERIFIED_PERSISTED_PROVIDER_ACCEPTED',
-        source: 'RESERVATION_META_SEND_FINALIZE_READBACK',
+        source: 'BRANCH_RESERVATION_EXACT_CONNECTION_META_SEND_FINALIZE_READBACK',
         verified_at: new Date().toISOString(),
       },
       automatic_resend_blocked: true,

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -5,12 +5,17 @@ import { serviceRpc, whatsappLiveServerCapability } from './_whatsapp-live-core.
 import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   embeddedPlatformConfig,
-  loadBusinessConnection,
   ownerContext,
   verifyStoredConnection,
 } from './_whatsapp-embedded-core.js';
+import {
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
 
 const WHATSAPP_STATUS_TIMEOUT_MS = 10_000;
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
 function firstEnv(...names) {
   for (const name of names) {
@@ -59,9 +64,13 @@ function emptyOperationalEvidence(available = true) {
   };
 }
 
-export async function loadOperationalEvidence(businessId) {
+export async function loadOperationalEvidence(businessId,branchId) {
+  if(!safeId(businessId)||!safeId(branchId))return emptyOperationalEvidence(false);
   try {
-    const rows = await serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: businessId });
+    const rows = await serviceRpc('dabbir_whatsapp_branch_operational_evidence', {
+      p_business_id: businessId,
+      p_branch_id: branchId,
+    });
     const row = Array.isArray(rows) ? rows[0] : rows;
     if (!row) return emptyOperationalEvidence(false);
     return {
@@ -76,12 +85,13 @@ export async function loadOperationalEvidence(businessId) {
   }
 }
 
-export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') {
+export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED',branchId=null) {
   const machine = deriveWhatsAppOperationalState({ hasConnection: false });
   return {
     ok: true,
     channel: 'whatsapp',
     source: 'embedded_signup',
+    branch_id: branchId,
     configured: false,
     connected: false,
     webhook_configured: false,
@@ -130,15 +140,17 @@ export async function verifyMetaAuthorization(config = getWhatsAppConfig()) {
   }
 }
 
-async function embeddedStatus(req, accessToken, businessId) {
+async function embeddedStatus(req, accessToken, businessId, branchId=null) {
   await ownerContext(req, businessId);
-  const row = await loadBusinessConnection(accessToken, businessId);
+  const row = branchId
+    ? await loadBusinessBranchConnection(accessToken,businessId,branchId)
+    : await loadPrimaryBusinessConnection(accessToken,businessId);
   if (!row) return null;
   const platform = embeddedPlatformConfig();
   try {
     const [verified, evidence] = await Promise.all([
       verifyStoredConnection(platform, row),
-      loadOperationalEvidence(businessId),
+      loadOperationalEvidence(businessId,row.branch_id),
     ]);
     const machine = deriveWhatsAppOperationalState({
       hasConnection: true,
@@ -149,6 +161,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       ok: true,
       channel: 'whatsapp',
       source: 'embedded_signup',
+      branch_id: row.branch_id,
+      connection_id: row.id,
       configured: true,
       connected: Boolean(verified.authorized),
       webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
@@ -186,6 +200,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       ok: true,
       channel: 'whatsapp',
       source: 'embedded_signup',
+      branch_id: row.branch_id,
+      connection_id: row.id,
       configured: true,
       connected: false,
       webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
@@ -211,9 +227,9 @@ async function embeddedStatus(req, accessToken, businessId) {
   }
 }
 
-async function tenantStatus(req, accessToken, businessId) {
-  const tenant = await embeddedStatus(req, accessToken, businessId);
-  return tenant || tenantUnconfiguredStatus();
+async function tenantStatus(req, accessToken, businessId, branchId=null) {
+  const tenant = await embeddedStatus(req, accessToken, businessId,branchId);
+  return tenant || tenantUnconfiguredStatus('TENANT_WHATSAPP_NOT_LINKED',branchId);
 }
 
 export default async function handler(req, res) {
@@ -233,9 +249,12 @@ export default async function handler(req, res) {
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
   const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
+  const branchRaw=String(singleQueryValue(req,'branch_id')||'').trim();
+  const branchId=branchRaw?safeId(branchRaw):null;
+  if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
   if (businessId) {
     try {
-      return json(res, 200, await tenantStatus(req, accessToken, businessId));
+      return json(res, 200, await tenantStatus(req, accessToken, businessId,branchId));
     } catch (error) {
       return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.safeCode || error?.message || 'REQUEST_FAILED' });
     }
@@ -243,7 +262,7 @@ export default async function handler(req, res) {
 
   // The authenticated DABBIR UI must never inherit a global/server WhatsApp
   // identity. Platform-level credentials remain webhook/runtime infrastructure
-  // only; tenant display state always resolves from the tenant connection row.
+  // only; tenant display state always resolves from a tenant branch connection row.
   try {
     const memberships = await withServerReadTimeout(
       signal => getBusinessMemberships(accessToken, { signal }),
@@ -253,7 +272,7 @@ export default async function handler(req, res) {
       .map(item => String(item?.business_id || '').trim())
       .filter(Boolean))];
     if (businessIds.length === 1) {
-      return json(res, 200, await tenantStatus(req, accessToken, businessIds[0]));
+      return json(res, 200, await tenantStatus(req, accessToken, businessIds[0],null));
     }
     return json(res, 200, tenantUnconfiguredStatus(businessIds.length > 1 ? 'BUSINESS_CONTEXT_REQUIRED' : 'TENANT_WHATSAPP_NOT_LINKED'));
   } catch (error) {

--- a/api/whatsapp-branch-intent.js
+++ b/api/whatsapp-branch-intent.js
@@ -1,0 +1,68 @@
+import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+
+async function readRows(response,code){
+  const text=await response.text();
+  let rows=null;
+  try{rows=text?JSON.parse(text):null}catch{rows=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||502)});
+  return Array.isArray(rows)?rows:[];
+}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'SAME_ORIGIN_REQUIRED'});
+  try{
+    const body=await readJsonBody(req,4096);
+    const businessId=safeId(body?.business_id);
+    const branchRaw=String(body?.branch_id||'').trim();
+    const branchId=branchRaw?safeId(branchRaw):null;
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_REQUIRED'});
+    if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
+    const owner=await ownerContext(req,businessId);
+
+    if(!branchId){
+      const response=await supabaseRest(
+        `dabbir_whatsapp_branch_intents?business_id=eq.${encodeURIComponent(businessId)}&user_id=eq.${encodeURIComponent(owner.user.id)}`,
+        owner.accessToken,{method:'DELETE',headers:{prefer:'return=minimal'}},
+      );
+      if(!response.ok)throw Object.assign(new Error('WHATSAPP_BRANCH_INTENT_CLEAR_FAILED'),{status:Number(response.status||502)});
+      return json(res,200,{ok:true,cleared:true,business_id:businessId,branch_id:null});
+    }
+
+    const branches=await readRows(await supabaseRest(
+      `dabbir_business_branches?select=id,business_id,status&id=eq.${encodeURIComponent(branchId)}&business_id=eq.${encodeURIComponent(businessId)}&status=eq.active&limit=1`,
+      owner.accessToken,
+    ),'WHATSAPP_BRANCH_INTENT_BRANCH_LOOKUP_FAILED');
+    if(!branches[0]?.id)return json(res,404,{ok:false,error:'ACTIVE_BRANCH_NOT_FOUND'});
+
+    const expiresAt=new Date(Date.now()+10*60*1000).toISOString();
+    const response=await supabaseRest(
+      'dabbir_whatsapp_branch_intents?on_conflict=business_id,user_id&select=business_id,user_id,branch_id,expires_at,updated_at',
+      owner.accessToken,{
+        method:'POST',
+        headers:{prefer:'resolution=merge-duplicates,return=representation'},
+        body:JSON.stringify({
+          business_id:businessId,
+          user_id:owner.user.id,
+          branch_id:branchId,
+          expires_at:expiresAt,
+          updated_at:new Date().toISOString(),
+        }),
+      },
+    );
+    const rows=await readRows(response,'WHATSAPP_BRANCH_INTENT_STORE_FAILED');
+    const stored=rows[0]||null;
+    if(!stored||stored.business_id!==businessId||stored.branch_id!==branchId||stored.user_id!==owner.user.id){
+      throw Object.assign(new Error('WHATSAPP_BRANCH_INTENT_STORE_UNVERIFIED'),{status:502});
+    }
+    return json(res,200,{ok:true,business_id:businessId,branch_id:branchId,expires_at:stored.expires_at,truth:{state:'VERIFIED_PERSISTED',source:'SUPABASE_RLS_RETURN_REPRESENTATION'}});
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,413,429,502,503,504].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'WHATSAPP_BRANCH_INTENT_FAILED').slice(0,180)});
+  }
+}

--- a/config/dabbir-ui-bundles.json
+++ b/config/dabbir-ui-bundles.json
@@ -3,10 +3,10 @@
   "critical": [
     "/api/gcc-readiness-ui",
     "/api/auth/recovery-ui",
-    "/api/auth-session-stability-ui",
-    "/api/branch-context-ui"
+    "/api/auth-session-stability-ui"
   ],
   "deferred": [
+    "/api/branch-context-ui",
     "/api/dabbir-whatsapp-embedded-ui",
     "/api/dabbir-whatsapp-connect-guard-ui",
     "/api/timezone-ui",
@@ -26,7 +26,6 @@
     "/api/platform-recovery-reconciliation-ui",
     "/api/verified-metrics-ui",
     "/api/customer-activation-ui",
-    "/api/owner-copilot-ui",
     "/api/dabbir-contextual-navigation-ui",
     "/api/dabbir-navigation-event-bridge-ui",
     "/api/car-wash-loader-ui"

--- a/config/dabbir-ui-bundles.json
+++ b/config/dabbir-ui-bundles.json
@@ -3,7 +3,8 @@
   "critical": [
     "/api/gcc-readiness-ui",
     "/api/auth/recovery-ui",
-    "/api/auth-session-stability-ui"
+    "/api/auth-session-stability-ui",
+    "/api/branch-context-ui"
   ],
   "deferred": [
     "/api/dabbir-whatsapp-embedded-ui",

--- a/supabase/functions/dabbir-owner-broker/index.ts
+++ b/supabase/functions/dabbir-owner-broker/index.ts
@@ -4,135 +4,24 @@ const JSON_HEADERS={'content-type':'application/json','cache-control':'no-store'
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const CUSTOMER_NO_RE=/^DAB-[0-9]{6,}$/i;
 const serviceKeyIsJwt=()=>SERVICE_KEY.split('.').length===3;
-const sbHeaders=()=>{const headers:Record<string,string>={'apikey':SERVICE_KEY,'content-type':'application/json'};if(serviceKeyIsJwt())headers.authorization=`Bearer ${SERVICE_KEY}`;return headers};
+const sbHeaders=()=>{const h:Record<string,string>={'apikey':SERVICE_KEY,'content-type':'application/json'};if(serviceKeyIsJwt())h.authorization=`Bearer ${SERVICE_KEY}`;return h};
 const reply=(status:number,body:unknown)=>new Response(JSON.stringify(body),{status,headers:JSON_HEADERS});
-const bytesToHex=(bytes:Uint8Array)=>Array.from(bytes,b=>b.toString(16).padStart(2,'0')).join('');
-async function sha(value:string){return bytesToHex(new Uint8Array(await crypto.subtle.digest('SHA-256',new TextEncoder().encode(value))))}
+const hex=(b:Uint8Array)=>Array.from(b,x=>x.toString(16).padStart(2,'0')).join('');
+async function sha(v:string){return hex(new Uint8Array(await crypto.subtle.digest('SHA-256',new TextEncoder().encode(v))))}
 async function otpHash(id:string,otp:string){return sha(`${SERVICE_KEY}:dabbir-owner-otp:${id}:${otp}`)}
-async function tokenHash(token:string){return sha(`${SERVICE_KEY}:dabbir-owner-session:${token}`)}
-function randomToken(bytes=36){const data=new Uint8Array(bytes);crypto.getRandomValues(data);return btoa(String.fromCharCode(...data)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
+async function tokenHash(t:string){return sha(`${SERVICE_KEY}:dabbir-owner-session:${t}`)}
+function randomToken(bytes=36){const d=new Uint8Array(bytes);crypto.getRandomValues(d);return btoa(String.fromCharCode(...d)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
 function randomOtp(){const x=new Uint32Array(1);crypto.getRandomValues(x);return String(x[0]%1000000).padStart(6,'0')}
-function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let out=0;for(let i=0;i<a.length;i++)out|=a.charCodeAt(i)^b.charCodeAt(i);return out===0}
+function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let o=0;for(let i=0;i<a.length;i++)o|=a.charCodeAt(i)^b.charCodeAt(i);return o===0}
 function clean(v:unknown,max=4000){return String(v??'').trim().slice(0,max)}
 async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
-async function activeAdmin(){
- const r=await sb('/rest/v1/dabbir_platform_admins?active=eq.true&select=user_id&order=created_at.asc&limit=1');
- if(!r.ok)return null;const rows=await r.json().catch(()=>[]);return Array.isArray(rows)&&rows[0]?.user_id?String(rows[0].user_id):null;
-}
-async function adminEmail(userId:string){
- const r=await sb(`/auth/v1/admin/users/${encodeURIComponent(userId)}`);
- if(!r.ok)return null;const u=await r.json().catch(()=>null);return u?.email?String(u.email):null;
-}
-async function verifySession(token:string){
- if(!token||token.length<24||token.length>256)return null;
- const h=await tokenHash(token);
- const r=await sb('/rest/v1/rpc/dabbir_owner_session_verify_v1',{method:'POST',body:JSON.stringify({p_token_hash:h})});
- if(!r.ok)return null;const p=await r.json().catch(()=>null);return p?.authenticated===true&&p?.role==='platform_owner'&&p?.actor_user_id?p:null;
-}
-async function requestOtp(body:any){
- const resendKey=String(body?.resend_key||'').trim();
- if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
- const since=new Date(Date.now()-10*60*1000).toISOString();
- const countRes=await sb(`/rest/v1/dabbir_owner_otp_challenges?created_at=gte.${encodeURIComponent(since)}&select=id`,{headers:{prefer:'count=exact'}});
- if(countRes.ok){const range=countRes.headers.get('content-range')||'';const total=Number(range.split('/')[1]);if(Number.isFinite(total)&&total>=3)return reply(429,{ok:false,error:'OTP_RATE_LIMITED'})}
- const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});
- const email=await adminEmail(actor);if(!email)return reply(503,{ok:false,error:'PLATFORM_OWNER_EMAIL_NOT_CONFIGURED'});
- const id=crypto.randomUUID(),otp=randomOtp(),expires=new Date(Date.now()+10*60*1000).toISOString();
- const insert=await sb('/rest/v1/dabbir_owner_otp_challenges',{method:'POST',headers:{prefer:'return=minimal'},body:JSON.stringify({id,otp_hash:await otpHash(id,otp),token_hash:await sha(`${SERVICE_KEY}:challenge:${id}:${randomToken(18)}`),expires_at:expires,attempts:0})});
- if(!insert.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});
- const from=String(Deno.env.get('DABBIR_RESEND_FROM')||'DABBIR <onboarding@resend.dev>');
- const sent=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${resendKey}`,'content-type':'application/json'},body:JSON.stringify({from,to:[email],subject:'DABBIR owner verification code',text:`رمز دخول مالك دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR owner verification code: ${otp}\nExpires in 10 minutes.`})});
- if(!sent.ok){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}`,{method:'DELETE'});return reply(503,{ok:false,error:'OWNER_OTP_DELIVERY_FAILED'})}
- return reply(200,{ok:true,challenge_id:id,otp_required:true});
-}
-async function verifyOtp(body:any){
- const id=String(body?.challenge_id||'').trim(),otp=String(body?.otp||'').trim();
- if(!/^[0-9a-f-]{36}$/i.test(id)||!/^\d{6}$/.test(otp))return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});
- const r=await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&select=id,otp_hash,expires_at,attempts,consumed_at&limit=1`);
- if(!r.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});const rows=await r.json().catch(()=>[]),row=Array.isArray(rows)?rows[0]:null;
- if(!row||row.consumed_at||new Date(row.expires_at).getTime()<=Date.now()||Number(row.attempts||0)>=5)return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});
- const good=safeEqual(String(row.otp_hash||''),await otpHash(id,otp));
- if(!good){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({attempts:Number(row.attempts||0)+1})});return reply(401,{ok:false,error:'INVALID_OWNER_OTP'})}
- const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});
- const sessionToken=randomToken(48),h=await tokenHash(sessionToken),expiresIn=43200,sessionExpires=new Date(Date.now()+expiresIn*1000).toISOString();
- const issue=await sb('/rest/v1/rpc/dabbir_owner_session_issue_v1',{method:'POST',body:JSON.stringify({p_actor_user_id:actor,p_token_hash:h,p_expires_at:sessionExpires})});
- if(!issue.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});
- await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({consumed_at:new Date().toISOString(),attempts:Number(row.attempts||0)+1})});
- return reply(200,{ok:true,authenticated:true,role:'platform_owner',session_token:sessionToken,expires_in:expiresIn});
-}
-async function incidentRead(body:any){
- const incidentId=clean(body?.incident_id,80),customerNo=clean(body?.customer_no,40).toUpperCase(),businessId=clean(body?.business_id,80);
- if(incidentId&&!UUID_RE.test(incidentId))return reply(400,{ok:false,error:'INVALID_INCIDENT_ID'});
- if(customerNo&&!CUSTOMER_NO_RE.test(customerNo))return reply(400,{ok:false,error:'INVALID_CUSTOMER_NUMBER'});
- if(businessId&&!UUID_RE.test(businessId))return reply(400,{ok:false,error:'INVALID_BUSINESS_ID'});
- const q=new URLSearchParams({select:'*',order:'updated_at.desc',limit:'100'});
- if(incidentId)q.set('id',`eq.${incidentId}`);
- if(customerNo)q.set('customer_no',`eq.${customerNo}`);
- if(businessId)q.set('business_id',`eq.${businessId}`);
- const r=await sb(`/rest/v1/dabbir_platform_owner_incidents?${q.toString()}`);
- if(!r.ok)return reply(503,{ok:false,error:'INCIDENT_READ_FAILED'});
- const incidents=await r.json().catch(()=>[]);
- let events:any[]=[];
- if(incidentId){
-  const e=await sb(`/rest/v1/dabbir_platform_owner_incident_events?incident_id=eq.${encodeURIComponent(incidentId)}&select=*&order=created_at.asc&limit=200`);
-  if(!e.ok)return reply(503,{ok:false,error:'INCIDENT_EVENT_READ_FAILED'});
-  const rows=await e.json().catch(()=>[]);events=Array.isArray(rows)?rows:[];
- }
- return reply(200,{ok:true,payload:{incidents:Array.isArray(incidents)?incidents:[],events}});
-}
-async function incidentAction(body:any){
- const operation=clean(body?.operation,20).toLowerCase();
- if(operation==='create'){
-  const customerNo=clean(body?.customer_no,40).toUpperCase(),businessId=clean(body?.business_id,80);
-  if(!CUSTOMER_NO_RE.test(customerNo))return reply(400,{ok:false,error:'INVALID_CUSTOMER_NUMBER'});
-  if(businessId&&!UUID_RE.test(businessId))return reply(400,{ok:false,error:'INVALID_BUSINESS_ID'});
-  const r=await sb('/rest/v1/rpc/dabbir_platform_owner_incident_create_v1',{method:'POST',body:JSON.stringify({p_customer_no:customerNo,p_business_id:businessId||null,p_category:clean(body?.category,30),p_priority:clean(body?.priority,20),p_summary:clean(body?.summary,200),p_description:clean(body?.description,4000)||null,p_assigned_queue:clean(body?.assigned_queue,40)||'owner'})});
-  if(!r.ok)return reply(503,{ok:false,error:'INCIDENT_CREATE_FAILED'});const payload=await r.json().catch(()=>null);return reply(200,{ok:true,payload});
- }
- if(operation==='update'){
-  const incidentId=clean(body?.incident_id,80);if(!UUID_RE.test(incidentId))return reply(400,{ok:false,error:'INVALID_INCIDENT_ID'});
-  const r=await sb('/rest/v1/rpc/dabbir_platform_owner_incident_update_v1',{method:'POST',body:JSON.stringify({p_incident_id:incidentId,p_status:clean(body?.status,30)||null,p_priority:clean(body?.priority,20)||null,p_assigned_queue:clean(body?.assigned_queue,40)||null,p_root_cause:clean(body?.root_cause,4000)||null,p_resolution:clean(body?.resolution,4000)||null,p_note:clean(body?.note,4000)||null})});
-  if(!r.ok)return reply(503,{ok:false,error:'INCIDENT_UPDATE_FAILED'});const payload=await r.json().catch(()=>null);return reply(200,{ok:true,payload});
- }
- return reply(400,{ok:false,error:'UNKNOWN_INCIDENT_OPERATION'});
-}
-async function ownerData(body:any){
- const session=await verifySession(String(body?.session_token||''));if(!session)return reply(401,{ok:false,error:'OWNER_SESSION_REQUIRED'});
- const action=String(body?.data_action||'overview').trim().toLowerCase();
- if(action==='overview'){
-  const r=await sb('/rest/v1/rpc/dabbir_platform_owner_overview',{method:'POST',body:JSON.stringify({p_actor_user_id:session.actor_user_id})});
-  if(!r.ok)return reply(503,{ok:false,error:'OWNER_DATA_FAILED'});const payload=await r.json().catch(()=>null);return reply(200,{ok:true,payload});
- }
- if(action==='executive'){
-  const started=performance.now();
-  const r=await sb('/rest/v1/rpc/dabbir_platform_owner_executive_v1',{method:'POST',body:JSON.stringify({p_actor_user_id:session.actor_user_id})});
-  const elapsed=Math.round((performance.now()-started)*10)/10;
-  if(!r.ok)return reply(503,{ok:false,error:'OWNER_EXECUTIVE_DATA_FAILED'});
-  const payload=await r.json().catch(()=>null);
-  if(payload&&typeof payload==='object')payload.reliability={...(payload.reliability||{}),database_rpc_latency_ms:elapsed,database_rpc_latency_state:'MEASURED_AT_BROKER'};
-  return reply(200,{ok:true,payload});
- }
- if(action==='search'){
-  const q=String(body?.q||'').trim().slice(0,160);
-  const r=await sb('/rest/v1/rpc/dabbir_platform_customer_search',{method:'POST',body:JSON.stringify({p_actor_user_id:session.actor_user_id,p_query:q,p_limit:50})});
-  if(!r.ok)return reply(503,{ok:false,error:'OWNER_SEARCH_FAILED'});const rows=await r.json().catch(()=>[]);return reply(200,{ok:true,payload:{accounts:Array.isArray(rows)?rows:[]}});
- }
- if(action==='incidents')return incidentRead(body);
- if(action==='incident_action')return incidentAction(body);
- return reply(400,{ok:false,error:'UNKNOWN_OWNER_DATA_ACTION'});
-}
-Deno.serve(async(req:Request)=>{
- if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
- if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_BROKER_NOT_CONFIGURED'});
- let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
- const action=String(body?.action||'').trim().toLowerCase();
- try{
-  if(action==='owner_otp_request')return requestOtp(body);
-  if(action==='owner_otp_verify')return verifyOtp(body);
-  if(action==='owner_session_verify'){
-   const session=await verifySession(String(body?.session_token||''));return session?reply(200,{ok:true,authenticated:true,role:'platform_owner',actor_user_id:session.actor_user_id,expires_at:session.expires_at}):reply(401,{ok:false,authenticated:false,error:'OWNER_SESSION_REQUIRED'});
-  }
-  if(action==='owner_data')return ownerData(body);
-  return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
- }catch{return reply(503,{ok:false,error:'OWNER_BROKER_UNAVAILABLE'})}
-});
+async function rpc(name:string,params:Record<string,unknown>={}){const r=await sb(`/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',body:JSON.stringify(params)});const p=await r.json().catch(()=>null);return{ok:r.ok,status:r.status,payload:p}}
+async function activeAdmin(){const r=await sb('/rest/v1/dabbir_platform_admins?active=eq.true&role=eq.ROOT_OWNER&revoked_at=is.null&suspended_at=is.null&select=user_id&order=created_at.asc&limit=1');if(!r.ok)return null;const rows=await r.json().catch(()=>[]);return Array.isArray(rows)&&rows[0]?.user_id?String(rows[0].user_id):null}
+async function adminEmail(id:string){const r=await sb(`/auth/v1/admin/users/${encodeURIComponent(id)}`);if(!r.ok)return null;const u=await r.json().catch(()=>null);return u?.email?String(u.email):null}
+async function verifySession(t:string){if(!t||t.length<24||t.length>256)return null;const r=await rpc('dabbir_owner_session_verify_v1',{p_token_hash:await tokenHash(t)});const p=r.payload;return r.ok&&p?.authenticated===true&&p?.role==='platform_owner'&&p?.actor_user_id?p:null}
+async function requestOtp(body:any){const resendKey=String(body?.resend_key||'').trim();if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});const since=new Date(Date.now()-600000).toISOString();const c=await sb(`/rest/v1/dabbir_owner_otp_challenges?created_at=gte.${encodeURIComponent(since)}&select=id`,{headers:{prefer:'count=exact'}});if(c.ok){const total=Number((c.headers.get('content-range')||'').split('/')[1]);if(Number.isFinite(total)&&total>=3)return reply(429,{ok:false,error:'OTP_RATE_LIMITED'})}const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});const email=await adminEmail(actor);if(!email)return reply(503,{ok:false,error:'PLATFORM_OWNER_EMAIL_NOT_CONFIGURED'});const id=crypto.randomUUID(),otp=randomOtp(),expires=new Date(Date.now()+600000).toISOString();const ins=await sb('/rest/v1/dabbir_owner_otp_challenges',{method:'POST',headers:{prefer:'return=minimal'},body:JSON.stringify({id,otp_hash:await otpHash(id,otp),token_hash:await sha(`${SERVICE_KEY}:challenge:${id}:${randomToken(18)}`),expires_at:expires,attempts:0})});if(!ins.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});const sent=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${resendKey}`,'content-type':'application/json'},body:JSON.stringify({from:String(Deno.env.get('DABBIR_RESEND_FROM')||'DABBIR <onboarding@resend.dev>'),to:[email],subject:'DABBIR owner verification code',text:`رمز دخول مالك دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR owner verification code: ${otp}\nExpires in 10 minutes.`})});if(!sent.ok){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}`,{method:'DELETE'});return reply(503,{ok:false,error:'OWNER_OTP_DELIVERY_FAILED'})}return reply(200,{ok:true,challenge_id:id,otp_required:true})}
+async function verifyOtp(body:any){const id=String(body?.challenge_id||'').trim(),otp=String(body?.otp||'').trim();if(!/^[0-9a-f-]{36}$/i.test(id)||!/^\d{6}$/.test(otp))return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});const r=await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&select=id,otp_hash,expires_at,attempts,consumed_at&limit=1`);if(!r.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});const rows=await r.json().catch(()=>[]),row=Array.isArray(rows)?rows[0]:null;if(!row||row.consumed_at||new Date(row.expires_at).getTime()<=Date.now()||Number(row.attempts||0)>=5)return reply(401,{ok:false,error:'INVALID_OWNER_OTP'});if(!safeEqual(String(row.otp_hash||''),await otpHash(id,otp))){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({attempts:Number(row.attempts||0)+1})});return reply(401,{ok:false,error:'INVALID_OWNER_OTP'})}const actor=await activeAdmin();if(!actor)return reply(503,{ok:false,error:'PLATFORM_OWNER_NOT_CONFIGURED'});const token=randomToken(48),expiresIn=43200,expires=new Date(Date.now()+expiresIn*1000).toISOString();const issue=await rpc('dabbir_owner_session_issue_v1',{p_actor_user_id:actor,p_token_hash:await tokenHash(token),p_expires_at:expires});if(!issue.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}&consumed_at=is.null`,{method:'PATCH',headers:{prefer:'return=minimal'},body:JSON.stringify({consumed_at:new Date().toISOString(),attempts:Number(row.attempts||0)+1})});return reply(200,{ok:true,authenticated:true,role:'platform_owner',session_token:token,expires_in:expiresIn})}
+async function incidentRead(body:any){const incidentId=clean(body?.incident_id,80),customerNo=clean(body?.customer_no,40).toUpperCase(),businessId=clean(body?.business_id,80);if(incidentId&&!UUID_RE.test(incidentId))return reply(400,{ok:false,error:'INVALID_INCIDENT_ID'});if(customerNo&&!CUSTOMER_NO_RE.test(customerNo))return reply(400,{ok:false,error:'INVALID_CUSTOMER_NUMBER'});if(businessId&&!UUID_RE.test(businessId))return reply(400,{ok:false,error:'INVALID_BUSINESS_ID'});const q=new URLSearchParams({select:'*',order:'updated_at.desc',limit:'100'});if(incidentId)q.set('id',`eq.${incidentId}`);if(customerNo)q.set('customer_no',`eq.${customerNo}`);if(businessId)q.set('business_id',`eq.${businessId}`);const r=await sb(`/rest/v1/dabbir_platform_owner_incidents?${q}`);if(!r.ok)return reply(503,{ok:false,error:'INCIDENT_READ_FAILED'});const incidents=await r.json().catch(()=>[]);let events:any[]=[];if(incidentId){const e=await sb(`/rest/v1/dabbir_platform_owner_incident_events?incident_id=eq.${encodeURIComponent(incidentId)}&select=*&order=created_at.asc&limit=200`);if(!e.ok)return reply(503,{ok:false,error:'INCIDENT_EVENT_READ_FAILED'});events=await e.json().catch(()=>[])}return reply(200,{ok:true,payload:{incidents:Array.isArray(incidents)?incidents:[],events:Array.isArray(events)?events:[]}})}
+async function incidentAction(body:any){const op=clean(body?.operation,20).toLowerCase();if(op==='create'){const customerNo=clean(body?.customer_no,40).toUpperCase(),businessId=clean(body?.business_id,80);if(!CUSTOMER_NO_RE.test(customerNo))return reply(400,{ok:false,error:'INVALID_CUSTOMER_NUMBER'});if(businessId&&!UUID_RE.test(businessId))return reply(400,{ok:false,error:'INVALID_BUSINESS_ID'});const r=await rpc('dabbir_platform_owner_incident_create_v1',{p_customer_no:customerNo,p_business_id:businessId||null,p_category:clean(body?.category,30),p_priority:clean(body?.priority,20),p_summary:clean(body?.summary,200),p_description:clean(body?.description,4000)||null,p_assigned_queue:clean(body?.assigned_queue,40)||'owner'});return r.ok?reply(200,{ok:true,payload:r.payload}):reply(503,{ok:false,error:'INCIDENT_CREATE_FAILED'})}if(op==='update'){const id=clean(body?.incident_id,80);if(!UUID_RE.test(id))return reply(400,{ok:false,error:'INVALID_INCIDENT_ID'});const r=await rpc('dabbir_platform_owner_incident_update_v1',{p_incident_id:id,p_status:clean(body?.status,30)||null,p_priority:clean(body?.priority,20)||null,p_assigned_queue:clean(body?.assigned_queue,40)||null,p_root_cause:clean(body?.root_cause,4000)||null,p_resolution:clean(body?.resolution,4000)||null,p_note:clean(body?.note,4000)||null});return r.ok?reply(200,{ok:true,payload:r.payload}):reply(503,{ok:false,error:'INCIDENT_UPDATE_FAILED'})}return reply(400,{ok:false,error:'UNKNOWN_INCIDENT_OPERATION'})}
+async function ownerData(body:any){const session=await verifySession(String(body?.session_token||''));if(!session)return reply(401,{ok:false,error:'OWNER_SESSION_REQUIRED'});const action=String(body?.data_action||'overview').trim().toLowerCase();if(action==='overview'){const r=await rpc('dabbir_platform_owner_overview',{p_actor_user_id:session.actor_user_id});return r.ok?reply(200,{ok:true,payload:r.payload}):reply(503,{ok:false,error:'OWNER_DATA_FAILED'})}if(action==='executive'){const started=performance.now();const r=await rpc('dabbir_platform_owner_executive_v2',{p_actor_user_id:session.actor_user_id});if(!r.ok)return reply(503,{ok:false,error:'OWNER_EXECUTIVE_DATA_FAILED'});const p=r.payload;if(p&&typeof p==='object')p.reliability={...(p.reliability||{}),database_rpc_latency_ms:Math.round((performance.now()-started)*10)/10,database_rpc_latency_state:'MEASURED_AT_BROKER'};return reply(200,{ok:true,payload:p})}if(action==='search'){const r=await rpc('dabbir_platform_customer_search',{p_actor_user_id:session.actor_user_id,p_query:String(body?.q||'').trim().slice(0,160),p_limit:50});return r.ok?reply(200,{ok:true,payload:{accounts:Array.isArray(r.payload)?r.payload:[]}}):reply(503,{ok:false,error:'OWNER_SEARCH_FAILED'})}if(action==='incidents')return incidentRead(body);if(action==='incident_action')return incidentAction(body);if(action==='ceo_commands'){const r=await rpc('dabbir_ceo_commands_recent_v2',{p_limit:Math.max(1,Math.min(Number(body?.limit)||30,50))});return r.ok?reply(200,{ok:true,payload:{commands:Array.isArray(r.payload)?r.payload:[]}}):reply(503,{ok:false,error:'CEO_COMMAND_READ_FAILED'})}if(action==='ceo_command_create'){const text=clean(body?.command_text,4000),priority=clean(body?.priority,4).toUpperCase()||'P1',objective=clean(body?.objective,1000)||null,due=body?.due_at?String(body.due_at):null;const acceptance=Array.isArray(body?.acceptance_criteria)?body.acceptance_criteria.map((x:any)=>clean(x,500)).filter(Boolean).slice(0,20):[];if(text.length<4)return reply(400,{ok:false,error:'COMMAND_TEXT_INVALID'});if(!['P0','P1','P2','P3'].includes(priority))return reply(400,{ok:false,error:'PRIORITY_INVALID'});const r=await rpc('dabbir_ceo_command_create_v2',{p_created_by:session.actor_user_id,p_command_text:text,p_priority:priority,p_objective:objective,p_acceptance_criteria:acceptance,p_due_at:due});return r.ok?reply(200,{ok:true,payload:{command:r.payload}}):reply(503,{ok:false,error:'CEO_COMMAND_CREATE_FAILED'})}if(action==='ceo_command_update'){const id=clean(body?.command_id,80),op=clean(body?.operation,30).toLowerCase();if(!UUID_RE.test(id))return reply(400,{ok:false,error:'INVALID_COMMAND_ID'});if(!['reprioritize','set_due_at','add_guidance','cancel','resume'].includes(op))return reply(400,{ok:false,error:'UNKNOWN_COMMAND_OPERATION'});const r=await rpc('dabbir_ceo_command_update_v2',{p_actor_user_id:session.actor_user_id,p_command_id:id,p_operation:op,p_priority:body?.priority||null,p_due_at:body?.due_at||null,p_guidance:clean(body?.guidance,2000)||null});return r.ok?reply(200,{ok:true,payload:{command:r.payload}}):reply(503,{ok:false,error:'CEO_COMMAND_UPDATE_FAILED'})}if(action==='decisions'){const r=await rpc('dabbir_owner_decisions_recent_v1',{p_actor_user_id:session.actor_user_id,p_limit:Math.max(1,Math.min(Number(body?.limit)||30,100))});return r.ok?reply(200,{ok:true,payload:{decisions:Array.isArray(r.payload)?r.payload:[]}}):reply(503,{ok:false,error:'OWNER_DECISIONS_READ_FAILED'})}if(action==='decision_resolve'){const id=clean(body?.escalation_id,80),resolution=clean(body?.resolution,20).toLowerCase(),note=clean(body?.note,2000)||null;if(!UUID_RE.test(id))return reply(400,{ok:false,error:'INVALID_ESCALATION_ID'});if(!['approve','reject','modify'].includes(resolution))return reply(400,{ok:false,error:'INVALID_OWNER_RESOLUTION'});const r=await rpc('dabbir_owner_decision_resolve_v1',{p_actor_user_id:session.actor_user_id,p_escalation_id:id,p_resolution:resolution,p_note:note});return r.ok?reply(200,{ok:true,payload:{decision:r.payload}}):reply(503,{ok:false,error:'OWNER_DECISION_UPDATE_FAILED'})}return reply(400,{ok:false,error:'UNKNOWN_OWNER_DATA_ACTION'})}
+Deno.serve(async(req:Request)=>{if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_BROKER_NOT_CONFIGURED'});let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}const action=String(body?.action||'').trim().toLowerCase();try{if(action==='owner_otp_request')return requestOtp(body);if(action==='owner_otp_verify')return verifyOtp(body);if(action==='owner_session_verify'){const s=await verifySession(String(body?.session_token||''));return s?reply(200,{ok:true,authenticated:true,role:'platform_owner',actor_user_id:s.actor_user_id,expires_at:s.expires_at}):reply(401,{ok:false,authenticated:false,error:'OWNER_SESSION_REQUIRED'})}if(action==='owner_data')return ownerData(body);return reply(400,{ok:false,error:'UNKNOWN_ACTION'})}catch{return reply(503,{ok:false,error:'OWNER_BROKER_UNAVAILABLE'})}});

--- a/supabase/migrations/20260903152500_dabbir_branch_scope_foundation_v1.sql
+++ b/supabase/migrations/20260903152500_dabbir_branch_scope_foundation_v1.sql
@@ -1,0 +1,321 @@
+begin;
+
+-- Branch access is explicit for non-owner/admin memberships. Owners/admins retain all-branch access.
+create table if not exists public.dabbir_membership_branches (
+  business_id uuid not null,
+  user_id uuid not null,
+  branch_id uuid not null,
+  created_at timestamptz not null default now(),
+  created_by uuid default auth.uid(),
+  primary key (business_id,user_id,branch_id),
+  foreign key (business_id,user_id) references public.dabbir_memberships(business_id,user_id) on delete cascade,
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade
+);
+alter table public.dabbir_membership_branches enable row level security;
+
+create or replace function dabbir_private.branch_access_allowed(p_business_id uuid,p_branch_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+  select dabbir_private.account_active()
+    and p_branch_id is not null
+    and exists(
+      select 1
+      from public.dabbir_memberships m
+      where m.business_id=p_business_id
+        and m.user_id=(select auth.uid())
+        and m.status='active'
+        and (
+          m.role in ('owner','admin')
+          or exists(
+            select 1 from public.dabbir_membership_branches mb
+            where mb.business_id=p_business_id
+              and mb.user_id=m.user_id
+              and mb.branch_id=p_branch_id
+          )
+        )
+    );
+$$;
+revoke all on function dabbir_private.branch_access_allowed(uuid,uuid) from public,anon;
+grant execute on function dabbir_private.branch_access_allowed(uuid,uuid) to authenticated,service_role;
+
+create policy dabbir_membership_branches_select
+on public.dabbir_membership_branches for select to authenticated
+using (
+  user_id=(select auth.uid())
+  or dabbir_private.has_permission(business_id,'manage_team')
+);
+create policy dabbir_membership_branches_manage
+on public.dabbir_membership_branches for all to authenticated
+using (dabbir_private.has_permission(business_id,'manage_team'))
+with check (dabbir_private.has_permission(business_id,'manage_team'));
+
+-- Business-level catalog with explicit branch availability.
+create unique index if not exists dabbir_services_business_id_id_uq on public.dabbir_services(business_id,id);
+create unique index if not exists dabbir_products_business_id_id_uq on public.dabbir_products(business_id,id);
+
+create table if not exists public.dabbir_branch_services (
+  business_id uuid not null,
+  branch_id uuid not null,
+  service_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,service_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,service_id) references public.dabbir_services(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_services enable row level security;
+create policy dabbir_branch_services_select on public.dabbir_branch_services for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'view_services'));
+create policy dabbir_branch_services_manage on public.dabbir_branch_services for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+
+create table if not exists public.dabbir_branch_products (
+  business_id uuid not null,
+  branch_id uuid not null,
+  product_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,product_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,product_id) references public.dabbir_products(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_products enable row level security;
+create policy dabbir_branch_products_select on public.dabbir_branch_products for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+create policy dabbir_branch_products_manage on public.dabbir_branch_products for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+create table if not exists public.dabbir_worker_branches (
+  business_id uuid not null,
+  branch_id uuid not null,
+  worker_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,worker_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,worker_id) references public.dabbir_workers(business_id,id) on delete cascade
+);
+alter table public.dabbir_worker_branches enable row level security;
+create policy dabbir_worker_branches_select on public.dabbir_worker_branches for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+create policy dabbir_worker_branches_manage on public.dabbir_worker_branches for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+
+-- Branch-specific inventory is introduced without breaking the legacy aggregate table during cutover.
+create table if not exists public.dabbir_branch_inventory (
+  business_id uuid not null,
+  branch_id uuid not null,
+  product_id uuid not null,
+  quantity integer not null default 0 check(quantity>=0),
+  reserved integer not null default 0 check(reserved>=0 and reserved<=quantity),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,product_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,product_id) references public.dabbir_products(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_inventory enable row level security;
+create policy dabbir_branch_inventory_select on public.dabbir_branch_inventory for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+create policy dabbir_branch_inventory_manage on public.dabbir_branch_inventory for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+create or replace function dabbir_private.primary_branch_for_business(p_business_id uuid)
+returns uuid
+language sql
+stable
+security definer
+set search_path='pg_catalog','public'
+as $$
+  select id
+  from public.dabbir_business_branches
+  where business_id=p_business_id and is_primary=true
+  order by created_at,id
+  limit 1
+$$;
+revoke all on function dabbir_private.primary_branch_for_business(uuid) from public,anon,authenticated;
+grant execute on function dabbir_private.primary_branch_for_business(uuid) to service_role;
+
+-- Seed current business-level resources to the primary branch only; secondary branches stay fail-closed until explicitly configured.
+insert into public.dabbir_branch_services(business_id,branch_id,service_id,active)
+select s.business_id,dabbir_private.primary_branch_for_business(s.business_id),s.id,s.active
+from public.dabbir_services s
+where dabbir_private.primary_branch_for_business(s.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_branch_products(business_id,branch_id,product_id,active)
+select p.business_id,dabbir_private.primary_branch_for_business(p.business_id),p.id,p.active
+from public.dabbir_products p
+where dabbir_private.primary_branch_for_business(p.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_worker_branches(business_id,branch_id,worker_id,active)
+select w.business_id,dabbir_private.primary_branch_for_business(w.business_id),w.id,(w.status='active')
+from public.dabbir_workers w
+where dabbir_private.primary_branch_for_business(w.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_branch_inventory(business_id,branch_id,product_id,quantity,reserved,updated_at)
+select i.business_id,dabbir_private.primary_branch_for_business(i.business_id),i.product_id,i.quantity,i.reserved,i.updated_at
+from public.dabbir_inventory i
+where dabbir_private.primary_branch_for_business(i.business_id) is not null
+on conflict (business_id,branch_id,product_id) do update
+set quantity=excluded.quantity,reserved=excluded.reserved,updated_at=excluded.updated_at;
+
+-- Core operational transactions carry an explicit branch. Existing callers may omit it and are safely routed to the primary branch.
+alter table public.dabbir_appointments add column if not exists branch_id uuid;
+alter table public.dabbir_orders add column if not exists branch_id uuid;
+alter table public.dabbir_inventory_movements add column if not exists branch_id uuid;
+alter table public.dabbir_conversations add column if not exists branch_id uuid;
+
+update public.dabbir_appointments set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+update public.dabbir_orders set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+update public.dabbir_inventory_movements set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+
+alter table public.dabbir_appointments alter column branch_id set not null;
+alter table public.dabbir_orders alter column branch_id set not null;
+alter table public.dabbir_inventory_movements alter column branch_id set not null;
+
+alter table public.dabbir_appointments add constraint dabbir_appointments_branch_business_fk
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+alter table public.dabbir_orders add constraint dabbir_orders_branch_business_fk
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+alter table public.dabbir_inventory_movements add constraint dabbir_inventory_movements_branch_business_fk
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+alter table public.dabbir_conversations add constraint dabbir_conversations_branch_business_fk
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+
+create index if not exists dabbir_appointments_business_branch_start_idx on public.dabbir_appointments(business_id,branch_id,starts_at);
+create index if not exists dabbir_orders_business_branch_created_idx on public.dabbir_orders(business_id,branch_id,created_at desc);
+create index if not exists dabbir_inventory_movements_business_branch_product_idx on public.dabbir_inventory_movements(business_id,branch_id,product_id,created_at desc);
+create index if not exists dabbir_conversations_business_branch_updated_idx on public.dabbir_conversations(business_id,branch_id,updated_at desc);
+
+create or replace function dabbir_private.ensure_operational_branch()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+begin
+  if tg_op='INSERT' or new.business_id is distinct from old.business_id or new.branch_id is distinct from old.branch_id then
+    if new.branch_id is null then
+      new.branch_id:=dabbir_private.primary_branch_for_business(new.business_id);
+    end if;
+    if new.branch_id is null or not exists(
+      select 1 from public.dabbir_business_branches b
+      where b.id=new.branch_id and b.business_id=new.business_id and b.status='active'
+    ) then
+      raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.ensure_operational_branch() from public,anon,authenticated;
+
+drop trigger if exists dabbir_appointments_branch_guard on public.dabbir_appointments;
+create trigger dabbir_appointments_branch_guard before insert or update of business_id,branch_id on public.dabbir_appointments
+for each row execute function dabbir_private.ensure_operational_branch();
+drop trigger if exists dabbir_orders_branch_guard on public.dabbir_orders;
+create trigger dabbir_orders_branch_guard before insert or update of business_id,branch_id on public.dabbir_orders
+for each row execute function dabbir_private.ensure_operational_branch();
+drop trigger if exists dabbir_inventory_movements_branch_guard on public.dabbir_inventory_movements;
+create trigger dabbir_inventory_movements_branch_guard before insert or update of business_id,branch_id on public.dabbir_inventory_movements
+for each row execute function dabbir_private.ensure_operational_branch();
+
+create or replace function dabbir_private.validate_appointment_branch_resources()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public'
+as $$
+begin
+  if new.service_id is not null and not exists(
+    select 1 from public.dabbir_branch_services x
+    where x.business_id=new.business_id and x.branch_id=new.branch_id and x.service_id=new.service_id and x.active=true
+  ) then raise exception 'DABBIR_SERVICE_NOT_AVAILABLE_IN_BRANCH'; end if;
+  if new.worker_id is not null and not exists(
+    select 1 from public.dabbir_worker_branches x
+    where x.business_id=new.business_id and x.branch_id=new.branch_id and x.worker_id=new.worker_id and x.active=true
+  ) then raise exception 'DABBIR_WORKER_NOT_ASSIGNED_TO_BRANCH'; end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.validate_appointment_branch_resources() from public,anon,authenticated;
+drop trigger if exists dabbir_appointments_branch_resource_guard on public.dabbir_appointments;
+create trigger dabbir_appointments_branch_resource_guard before insert or update of business_id,branch_id,service_id,worker_id on public.dabbir_appointments
+for each row execute function dabbir_private.validate_appointment_branch_resources();
+
+create or replace function dabbir_private.validate_order_item_branch_product()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public'
+as $$
+declare v_branch uuid; v_business uuid;
+begin
+  select business_id,branch_id into v_business,v_branch from public.dabbir_orders where id=new.order_id;
+  if v_business is null or v_business<>new.business_id then raise exception 'DABBIR_ORDER_BUSINESS_MISMATCH'; end if;
+  if not exists(
+    select 1 from public.dabbir_branch_products x
+    where x.business_id=new.business_id and x.branch_id=v_branch and x.product_id=new.product_id and x.active=true
+  ) then raise exception 'DABBIR_PRODUCT_NOT_AVAILABLE_IN_BRANCH'; end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.validate_order_item_branch_product() from public,anon,authenticated;
+drop trigger if exists dabbir_order_items_branch_product_guard on public.dabbir_order_items;
+create trigger dabbir_order_items_branch_product_guard before insert or update of business_id,order_id,product_id on public.dabbir_order_items
+for each row execute function dabbir_private.validate_order_item_branch_product();
+
+-- Keep new catalog/staff resources usable by existing flows by assigning them to the primary branch by default.
+create or replace function dabbir_private.seed_primary_branch_resource()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+declare v_branch uuid;
+begin
+  v_branch:=dabbir_private.primary_branch_for_business(new.business_id);
+  if v_branch is null then return new; end if;
+  if tg_table_name='dabbir_services' then
+    insert into public.dabbir_branch_services(business_id,branch_id,service_id,active) values(new.business_id,v_branch,new.id,new.active) on conflict do nothing;
+  elsif tg_table_name='dabbir_products' then
+    insert into public.dabbir_branch_products(business_id,branch_id,product_id,active) values(new.business_id,v_branch,new.id,new.active) on conflict do nothing;
+  elsif tg_table_name='dabbir_workers' then
+    insert into public.dabbir_worker_branches(business_id,branch_id,worker_id,active) values(new.business_id,v_branch,new.id,new.status='active') on conflict do nothing;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.seed_primary_branch_resource() from public,anon,authenticated;
+drop trigger if exists dabbir_services_primary_branch_seed on public.dabbir_services;
+create trigger dabbir_services_primary_branch_seed after insert on public.dabbir_services for each row execute function dabbir_private.seed_primary_branch_resource();
+drop trigger if exists dabbir_products_primary_branch_seed on public.dabbir_products;
+create trigger dabbir_products_primary_branch_seed after insert on public.dabbir_products for each row execute function dabbir_private.seed_primary_branch_resource();
+drop trigger if exists dabbir_workers_primary_branch_seed on public.dabbir_workers;
+create trigger dabbir_workers_primary_branch_seed after insert on public.dabbir_workers for each row execute function dabbir_private.seed_primary_branch_resource();
+
+-- Branch isolation is an additional restrictive layer on top of existing business-level RLS.
+drop policy if exists dabbir_appointments_branch_restrict on public.dabbir_appointments;
+create policy dabbir_appointments_branch_restrict on public.dabbir_appointments as restrictive for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+drop policy if exists dabbir_orders_branch_restrict on public.dabbir_orders;
+create policy dabbir_orders_branch_restrict on public.dabbir_orders as restrictive for all to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+commit;

--- a/supabase/migrations/20260903152600_dabbir_owner_authority_source_sync_v1.sql
+++ b/supabase/migrations/20260903152600_dabbir_owner_authority_source_sync_v1.sql
@@ -1,0 +1,144 @@
+begin;
+
+alter table public.dabbir_platform_admins
+  add column if not exists permissions text[] not null default '{}'::text[],
+  add column if not exists display_name text,
+  add column if not exists added_by uuid references auth.users(id) on delete set null,
+  add column if not exists updated_at timestamptz not null default now(),
+  add column if not exists suspended_at timestamptz,
+  add column if not exists revoked_at timestamptz;
+
+alter table public.dabbir_platform_admins drop constraint if exists dabbir_platform_admins_role_check;
+update public.dabbir_platform_admins set role='ROOT_OWNER',permissions='{}'::text[],updated_at=now()
+where role='platform_owner' and active=true;
+update public.dabbir_platform_admins set role='OWNER_DELEGATE',permissions=case when role='support_admin' then array['manage_customers','manage_support','manage_incidents']::text[] else permissions end,updated_at=now()
+where role in ('platform_owner','support_admin');
+alter table public.dabbir_platform_admins add constraint dabbir_platform_admins_role_check check(role in ('ROOT_OWNER','OWNER_DELEGATE'));
+alter table public.dabbir_platform_admins alter column role set default 'OWNER_DELEGATE';
+create unique index if not exists dabbir_platform_single_root_owner_uq on public.dabbir_platform_admins((role)) where role='ROOT_OWNER';
+create index if not exists dabbir_platform_admins_added_by_idx on public.dabbir_platform_admins(added_by);
+
+create or replace function dabbir_private.platform_permission_allowed(p_permission text)
+returns boolean language sql immutable set search_path='pg_catalog','dabbir_private' as $$
+  select coalesce(p_permission,'')=any(array[
+    'manage_customers','manage_businesses','manage_orders','manage_bookings',
+    'manage_products','manage_services','manage_support','manage_incidents',
+    'manage_integrations','manage_employees','manage_system','manage_releases',
+    'manage_ceo_commands','view_financials','manage_financial_operations'
+  ]::text[])
+$$;
+
+create or replace function dabbir_private.platform_permissions_valid(p_permissions text[])
+returns boolean language sql immutable set search_path='pg_catalog','dabbir_private' as $$
+  select coalesce((select bool_and(dabbir_private.platform_permission_allowed(x)) from unnest(coalesce(p_permissions,'{}'::text[])) x),true)
+$$;
+
+alter table public.dabbir_platform_admins drop constraint if exists dabbir_platform_admins_permissions_check;
+alter table public.dabbir_platform_admins add constraint dabbir_platform_admins_permissions_check check(dabbir_private.platform_permissions_valid(permissions));
+
+create or replace function dabbir_private.guard_platform_root_owner()
+returns trigger language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+begin
+  if tg_op='INSERT' and new.role='ROOT_OWNER' then raise exception 'DABBIR_ROOT_OWNER_CREATION_FORBIDDEN'; end if;
+  if tg_op='DELETE' and old.role='ROOT_OWNER' then raise exception 'DABBIR_ROOT_OWNER_PROTECTED'; end if;
+  if tg_op='UPDATE' then
+    if old.role='ROOT_OWNER' and (new.role<>'ROOT_OWNER' or new.active is distinct from true or new.user_id is distinct from old.user_id or new.revoked_at is not null or new.suspended_at is not null) then
+      raise exception 'DABBIR_ROOT_OWNER_PROTECTED';
+    end if;
+    if old.role<>'ROOT_OWNER' and new.role='ROOT_OWNER' then raise exception 'DABBIR_ROOT_OWNER_PROMOTION_FORBIDDEN'; end if;
+  end if;
+  return case when tg_op='DELETE' then old else new end;
+end;
+$$;
+drop trigger if exists dabbir_platform_root_owner_guard on public.dabbir_platform_admins;
+create trigger dabbir_platform_root_owner_guard before insert or update or delete on public.dabbir_platform_admins for each row execute function dabbir_private.guard_platform_root_owner();
+
+create or replace function dabbir_private.platform_identity(p_user_id uuid)
+returns jsonb language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+declare v public.dabbir_platform_admins%rowtype;
+begin
+  select * into v from public.dabbir_platform_admins where user_id=p_user_id and active=true and revoked_at is null and suspended_at is null limit 1;
+  if not found then return jsonb_build_object('active',false); end if;
+  return jsonb_build_object('active',true,'user_id',v.user_id,'role',v.role,'root_owner',v.role='ROOT_OWNER','permissions',case when v.role='ROOT_OWNER' then to_jsonb(array[
+    'manage_customers','manage_businesses','manage_orders','manage_bookings','manage_products','manage_services','manage_support','manage_incidents','manage_integrations','manage_employees','manage_system','manage_releases','manage_ceo_commands','view_financials','manage_financial_operations'
+  ]::text[]) else to_jsonb(v.permissions) end);
+end;
+$$;
+
+create or replace function dabbir_private.platform_has_permission(p_user_id uuid,p_permission text)
+returns boolean language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+declare v_role text; v_permissions text[];
+begin
+  if not dabbir_private.platform_permission_allowed(p_permission) then return false; end if;
+  select role,permissions into v_role,v_permissions from public.dabbir_platform_admins where user_id=p_user_id and active=true and revoked_at is null and suspended_at is null;
+  if not found then return false; end if;
+  if v_role='ROOT_OWNER' then return true; end if;
+  return v_role='OWNER_DELEGATE' and p_permission=any(coalesce(v_permissions,'{}'::text[]));
+end;
+$$;
+
+create or replace function dabbir_private.platform_assert_permission(p_user_id uuid,p_permission text)
+returns void language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+begin
+  if not dabbir_private.platform_has_permission(p_user_id,p_permission) then raise exception 'DABBIR_PLATFORM_PERMISSION_REQUIRED:%',p_permission; end if;
+end;
+$$;
+
+create or replace function dabbir_private.platform_assert_admin(p_user_id uuid)
+returns text language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+declare v_role text;
+begin
+  select role into v_role from public.dabbir_platform_admins where user_id=p_user_id and active=true and revoked_at is null and suspended_at is null;
+  if v_role is distinct from 'ROOT_OWNER' then raise exception 'DABBIR_ROOT_OWNER_REQUIRED'; end if;
+  return v_role;
+end;
+$$;
+
+create or replace function public.dabbir_owner_session_issue_v1(p_actor_user_id uuid,p_token_hash text,p_expires_at timestamptz)
+returns void language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+begin
+  if p_actor_user_id is null or nullif(trim(p_token_hash),'') is null or p_expires_at<=now() then raise exception 'INVALID_OWNER_SESSION'; end if;
+  if not exists(select 1 from public.dabbir_platform_admins where user_id=p_actor_user_id and active=true and role='ROOT_OWNER' and revoked_at is null and suspended_at is null) then raise exception 'ROOT_OWNER_REQUIRED'; end if;
+  delete from dabbir_private.owner_sessions where expires_at<=now() or revoked_at is not null;
+  insert into dabbir_private.owner_sessions(actor_user_id,token_hash,expires_at,last_seen_at) values(p_actor_user_id,p_token_hash,p_expires_at,now());
+end;
+$$;
+
+create or replace function public.dabbir_owner_session_verify_v1(p_token_hash text)
+returns jsonb language plpgsql security definer set search_path='pg_catalog','public','dabbir_private' as $$
+declare v_session dabbir_private.owner_sessions%rowtype;
+begin
+  select * into v_session from dabbir_private.owner_sessions where token_hash=p_token_hash and revoked_at is null and expires_at>now() limit 1;
+  if not found then return jsonb_build_object('authenticated',false); end if;
+  if not exists(select 1 from public.dabbir_platform_admins where user_id=v_session.actor_user_id and active=true and role='ROOT_OWNER' and revoked_at is null and suspended_at is null) then
+    update dabbir_private.owner_sessions set revoked_at=now() where id=v_session.id;
+    return jsonb_build_object('authenticated',false);
+  end if;
+  update dabbir_private.owner_sessions set last_seen_at=now() where id=v_session.id;
+  return jsonb_build_object('authenticated',true,'role','platform_owner','actor_user_id',v_session.actor_user_id,'expires_at',v_session.expires_at);
+end;
+$$;
+
+revoke all on function dabbir_private.platform_permission_allowed(text) from public,anon,authenticated;
+revoke all on function dabbir_private.platform_permissions_valid(text[]) from public,anon,authenticated;
+revoke all on function dabbir_private.guard_platform_root_owner() from public,anon,authenticated;
+revoke all on function dabbir_private.platform_identity(uuid) from public,anon,authenticated;
+revoke all on function dabbir_private.platform_has_permission(uuid,text) from public,anon,authenticated;
+revoke all on function dabbir_private.platform_assert_permission(uuid,text) from public,anon,authenticated;
+revoke all on function dabbir_private.platform_assert_admin(uuid) from public,anon,authenticated;
+revoke all on function public.dabbir_owner_session_issue_v1(uuid,text,timestamptz) from public,anon,authenticated;
+revoke all on function public.dabbir_owner_session_verify_v1(text) from public,anon,authenticated;
+grant execute on function dabbir_private.platform_permission_allowed(text) to service_role;
+grant execute on function dabbir_private.platform_permissions_valid(text[]) to service_role;
+grant execute on function dabbir_private.platform_identity(uuid) to service_role;
+grant execute on function dabbir_private.platform_has_permission(uuid,text) to service_role;
+grant execute on function dabbir_private.platform_assert_permission(uuid,text) to service_role;
+grant execute on function dabbir_private.platform_assert_admin(uuid) to service_role;
+grant execute on function public.dabbir_owner_session_issue_v1(uuid,text,timestamptz) to service_role;
+grant execute on function public.dabbir_owner_session_verify_v1(text) to service_role;
+
+alter table public.dabbir_followups alter column status set default 'CANDIDATE';
+create index if not exists dabbir_ai_action_ledger_conversation_fk_idx on public.dabbir_ai_action_ledger(conversation_id);
+create index if not exists dabbir_ai_conversation_state_conversation_idx on public.dabbir_ai_conversation_state(conversation_id);
+
+commit;

--- a/supabase/migrations/20260903152700_dabbir_branch_scope_perf_hardening_v1.sql
+++ b/supabase/migrations/20260903152700_dabbir_branch_scope_perf_hardening_v1.sql
@@ -1,0 +1,65 @@
+begin;
+
+-- Cover composite FKs in their declared column order.
+create index if not exists dabbir_appointments_branch_business_fk_idx on public.dabbir_appointments(branch_id,business_id);
+create index if not exists dabbir_orders_branch_business_fk_idx on public.dabbir_orders(branch_id,business_id);
+create index if not exists dabbir_inventory_movements_branch_business_fk_idx on public.dabbir_inventory_movements(branch_id,business_id);
+create index if not exists dabbir_conversations_branch_business_fk_idx on public.dabbir_conversations(branch_id,business_id);
+create index if not exists dabbir_membership_branches_branch_business_idx on public.dabbir_membership_branches(branch_id,business_id);
+
+create index if not exists dabbir_branch_services_branch_business_idx on public.dabbir_branch_services(branch_id,business_id);
+create index if not exists dabbir_branch_services_business_service_idx on public.dabbir_branch_services(business_id,service_id);
+create index if not exists dabbir_branch_products_branch_business_idx on public.dabbir_branch_products(branch_id,business_id);
+create index if not exists dabbir_branch_products_business_product_idx on public.dabbir_branch_products(business_id,product_id);
+create index if not exists dabbir_worker_branches_branch_business_idx on public.dabbir_worker_branches(branch_id,business_id);
+create index if not exists dabbir_worker_branches_business_worker_idx on public.dabbir_worker_branches(business_id,worker_id);
+create index if not exists dabbir_branch_inventory_branch_business_idx on public.dabbir_branch_inventory(branch_id,business_id);
+create index if not exists dabbir_branch_inventory_business_product_idx on public.dabbir_branch_inventory(business_id,product_id);
+
+-- Split mutation policies so SELECT has exactly one permissive policy per table.
+drop policy if exists dabbir_membership_branches_manage on public.dabbir_membership_branches;
+create policy dabbir_membership_branches_insert on public.dabbir_membership_branches for insert to authenticated
+with check (dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_membership_branches_update on public.dabbir_membership_branches for update to authenticated
+using (dabbir_private.has_permission(business_id,'manage_team'))
+with check (dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_membership_branches_delete on public.dabbir_membership_branches for delete to authenticated
+using (dabbir_private.has_permission(business_id,'manage_team'));
+
+drop policy if exists dabbir_branch_services_manage on public.dabbir_branch_services;
+create policy dabbir_branch_services_insert on public.dabbir_branch_services for insert to authenticated
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+create policy dabbir_branch_services_update on public.dabbir_branch_services for update to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+create policy dabbir_branch_services_delete on public.dabbir_branch_services for delete to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+
+drop policy if exists dabbir_branch_products_manage on public.dabbir_branch_products;
+create policy dabbir_branch_products_insert on public.dabbir_branch_products for insert to authenticated
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_products_update on public.dabbir_branch_products for update to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_products_delete on public.dabbir_branch_products for delete to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+drop policy if exists dabbir_worker_branches_manage on public.dabbir_worker_branches;
+create policy dabbir_worker_branches_insert on public.dabbir_worker_branches for insert to authenticated
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_worker_branches_update on public.dabbir_worker_branches for update to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_worker_branches_delete on public.dabbir_worker_branches for delete to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+
+drop policy if exists dabbir_branch_inventory_manage on public.dabbir_branch_inventory;
+create policy dabbir_branch_inventory_insert on public.dabbir_branch_inventory for insert to authenticated
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_inventory_update on public.dabbir_branch_inventory for update to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_inventory_delete on public.dabbir_branch_inventory for delete to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+commit;

--- a/supabase/migrations/20260903154000_dabbir_branch_scope_rls_completion_v1.sql
+++ b/supabase/migrations/20260903154000_dabbir_branch_scope_rls_completion_v1.sql
@@ -1,0 +1,43 @@
+begin;
+
+-- Complete fail-closed branch isolation for operational tables omitted by the first branch-scope cutover.
+update public.dabbir_conversations
+set branch_id=dabbir_private.primary_branch_for_business(business_id)
+where branch_id is null;
+
+-- Fail closed rather than leave any conversation outside the branch contract.
+do $$
+begin
+  if exists(select 1 from public.dabbir_conversations where branch_id is null) then
+    raise exception 'DABBIR_CONVERSATION_BRANCH_BACKFILL_INCOMPLETE';
+  end if;
+end
+$$;
+
+alter table public.dabbir_conversations alter column branch_id set not null;
+
+drop trigger if exists dabbir_conversations_branch_guard on public.dabbir_conversations;
+create trigger dabbir_conversations_branch_guard
+before insert or update of business_id,branch_id on public.dabbir_conversations
+for each row execute function dabbir_private.ensure_operational_branch();
+
+-- These RESTRICTIVE policies AND with the existing business permission policies.
+drop policy if exists dabbir_conversations_branch_restrict on public.dabbir_conversations;
+create policy dabbir_conversations_branch_restrict
+on public.dabbir_conversations
+as restrictive
+for all
+to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+drop policy if exists dabbir_inventory_movements_branch_restrict on public.dabbir_inventory_movements;
+create policy dabbir_inventory_movements_branch_restrict
+on public.dabbir_inventory_movements
+as restrictive
+for all
+to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id))
+with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+commit;

--- a/supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql
+++ b/supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql
@@ -1,0 +1,293 @@
+alter table public.dabbir_whatsapp_connections
+  add column if not exists branch_id uuid;
+
+update public.dabbir_whatsapp_connections c
+set branch_id=dabbir_private.primary_branch_for_business(c.business_id)
+where c.branch_id is null;
+
+alter table public.dabbir_whatsapp_connections
+  alter column branch_id set not null;
+
+alter table public.dabbir_whatsapp_connections
+  drop constraint if exists dabbir_whatsapp_connections_business_id_key;
+
+alter table public.dabbir_whatsapp_connections
+  drop constraint if exists dabbir_whatsapp_connections_branch_business_fkey;
+
+alter table public.dabbir_whatsapp_connections
+  add constraint dabbir_whatsapp_connections_branch_business_fkey
+  foreign key (branch_id,business_id)
+  references public.dabbir_business_branches(id,business_id)
+  on delete restrict;
+
+alter table public.dabbir_whatsapp_connections
+  add constraint dabbir_whatsapp_connections_business_branch_key
+  unique (business_id,branch_id);
+
+create index if not exists dabbir_whatsapp_connections_branch_idx
+  on public.dabbir_whatsapp_connections(branch_id);
+
+drop trigger if exists dabbir_whatsapp_connection_branch_guard on public.dabbir_whatsapp_connections;
+create trigger dabbir_whatsapp_connection_branch_guard
+before insert or update of business_id,branch_id on public.dabbir_whatsapp_connections
+for each row execute function dabbir_private.ensure_operational_branch();
+
+create or replace function public.dabbir_whatsapp_upsert_connection(
+  p_business_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+  v_branch_id uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+
+  v_branch_id:=dabbir_private.primary_branch_for_business(p_business_id);
+  if v_branch_id is null then raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=v_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,v_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;
+
+create or replace function public.dabbir_whatsapp_upsert_branch_connection(
+  p_business_id uuid,p_branch_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or p_branch_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+  if not exists (
+    select 1 from public.dabbir_business_branches b
+    where b.id=p_branch_id and b.business_id=p_business_id and b.status='active'
+  ) then raise exception 'WHATSAPP_BRANCH_ACCESS_REQUIRED' using errcode='42501'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=p_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,p_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_branch_connection(uuid,uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_branch_connection(uuid,uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;
+
+create or replace function public.dabbir_whatsapp_ai_connection(p_business_id uuid,p_connection_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_connection public.dabbir_whatsapp_connections%rowtype;
+begin
+  if coalesce((select auth.role()),'')<>'service_role' then raise exception 'SERVICE_ROLE_REQUIRED'; end if;
+  select * into v_connection from public.dabbir_whatsapp_connections
+  where id=p_connection_id and business_id=p_business_id and status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+  return jsonb_build_object(
+    'id',v_connection.id,'business_id',v_connection.business_id,'branch_id',v_connection.branch_id,
+    'status',v_connection.status,'phone_number_id',v_connection.phone_number_id,'waba_id',v_connection.waba_id,
+    'access_token_ciphertext',v_connection.access_token_ciphertext,'access_token_iv',v_connection.access_token_iv,
+    'access_token_tag',v_connection.access_token_tag,'token_key_version',v_connection.token_key_version,
+    'token_expires_at',v_connection.token_expires_at
+  );
+end;
+$$;
+revoke all on function public.dabbir_whatsapp_ai_connection(uuid,uuid) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_ai_connection(uuid,uuid) to service_role;
+
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,p_provider_message_id text,p_sender_handle text,p_display_name text,
+  p_body text,p_intent text,p_occurred_at timestamptz default now()
+)
+returns table(business_id uuid,connection_id uuid,customer_id uuid,conversation_id uuid,message_id uuid,duplicate boolean)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+  v_sender text:=trim(coalesce(p_sender_handle,''));
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id)>320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(v_sender,'') is null or length(v_sender)>160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id) and c.status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key:='inbound:'||trim(p_provider_message_id);
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_event_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_connection.branch_id::text||':wa-sender:'||v_sender,0));
+
+  v_name:=left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,v_sender,'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb)||jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id and c.branch_id=v_connection.branch_id
+    and c.customer_id=v_customer_id and c.channel_type='whatsapp' and c.demo_mode=false and c.state<>'closed'
+  order by c.updated_at desc limit 1 for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,branch_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_connection.branch_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations set state=case when state='waiting_customer' then 'ai_active' else state end,updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id and branch_id=v_connection.branch_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true,'branch_id',v_connection.branch_id)
+  );
+
+  update public.dabbir_whatsapp_connections set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;

--- a/supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql
+++ b/supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql
@@ -1,0 +1,99 @@
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,
+  p_provider_message_id text,
+  p_sender_handle text,
+  p_display_name text,
+  p_body text,
+  p_intent text,
+  p_occurred_at timestamptz default now()
+)
+returns table(
+  business_id uuid,
+  connection_id uuid,
+  customer_id uuid,
+  conversation_id uuid,
+  message_id uuid,
+  duplicate boolean
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+#variable_conflict use_column
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+  v_sender text:=trim(coalesce(p_sender_handle,''));
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id)>320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(v_sender,'') is null or length(v_sender)>160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id) and c.status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key:='inbound:'||trim(p_provider_message_id);
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_event_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_connection.branch_id::text||':wa-sender:'||v_sender,0));
+
+  v_name:=left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,v_sender,'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb)||jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id and c.branch_id=v_connection.branch_id
+    and c.customer_id=v_customer_id and c.channel_type='whatsapp' and c.demo_mode=false and c.state<>'closed'
+  order by c.updated_at desc limit 1 for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,branch_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_connection.branch_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations set state=case when state='waiting_customer' then 'ai_active' else state end,updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id and branch_id=v_connection.branch_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true,'branch_id',v_connection.branch_id)
+  );
+
+  update public.dabbir_whatsapp_connections set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;

--- a/supabase/migrations/20260903155707_dabbir_whatsapp_branch_fk_index_v1.sql
+++ b/supabase/migrations/20260903155707_dabbir_whatsapp_branch_fk_index_v1.sql
@@ -1,0 +1,3 @@
+drop index if exists public.dabbir_whatsapp_connections_branch_idx;
+create index if not exists dabbir_whatsapp_connections_branch_business_fk_idx
+  on public.dabbir_whatsapp_connections(branch_id,business_id);

--- a/supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql
+++ b/supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql
@@ -1,0 +1,97 @@
+create or replace function public.dabbir_whatsapp_reserve_outbound(
+  p_business_id uuid,
+  p_conversation_id uuid,
+  p_sender_user_id uuid,
+  p_idempotency_key text,
+  p_payload_hash text,
+  p_body text
+)
+returns table(
+  reservation_id uuid,
+  should_send boolean,
+  reservation_state text,
+  connection_id uuid,
+  phone_number_id text,
+  recipient_handle text,
+  provider_message_id text,
+  message_id uuid
+)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_conversation public.dabbir_conversations%rowtype;
+  v_existing public.dabbir_whatsapp_outbound_reservations%rowtype;
+  v_recipient text;
+  v_key text:=trim(coalesce(p_idempotency_key,''));
+  v_hash text:=lower(trim(coalesce(p_payload_hash,'')));
+begin
+  if p_business_id is null or p_conversation_id is null or p_sender_user_id is null then raise exception 'WHATSAPP_OUTBOUND_CONTEXT_REQUIRED'; end if;
+  if length(v_key) not between 16 and 160 then raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REQUIRED'; end if;
+  if v_hash !~ '^[0-9a-f]{64}$' then raise exception 'WHATSAPP_PAYLOAD_HASH_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  if exists(select 1 from public.account_access_state s where s.user_id=p_sender_user_id and s.status='suspended') then
+    raise exception 'WHATSAPP_REPLY_ACCOUNT_SUSPENDED';
+  end if;
+  if not exists(
+    select 1 from auth.users u where u.id=p_sender_user_id and u.deleted_at is null and (u.banned_until is null or u.banned_until<=now())
+  ) then raise exception 'WHATSAPP_REPLY_USER_INACTIVE'; end if;
+  if not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id and m.user_id=p_sender_user_id and m.status='active'
+      and m.suspended_at is null and m.removed_at is null and m.role in ('owner','admin')
+  ) then raise exception 'WHATSAPP_REPLY_APPROVER_REQUIRED'; end if;
+
+  select * into v_conversation from public.dabbir_conversations c
+  where c.business_id=p_business_id and c.id=p_conversation_id and c.channel_type='whatsapp' and c.demo_mode=false
+  limit 1;
+  if not found or v_conversation.customer_id is null or v_conversation.branch_id is null then raise exception 'WHATSAPP_CONVERSATION_NOT_FOUND'; end if;
+
+  select nullif(trim(c.channel_handle),'') into v_recipient
+  from public.dabbir_customers c
+  where c.business_id=p_business_id and c.id=v_conversation.customer_id
+  limit 1;
+  if v_recipient is null then raise exception 'WHATSAPP_CUSTOMER_HANDLE_REQUIRED'; end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_business_id::text || ':wa-out:' || v_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_outbound_reservations r
+  where r.business_id=p_business_id and r.idempotency_key=v_key
+  limit 1;
+  if found then
+    if v_existing.conversation_id<>p_conversation_id
+      or v_existing.sender_user_id<>p_sender_user_id
+      or v_existing.payload_hash<>v_hash then
+      raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REUSED_DIFFERENT_REQUEST';
+    end if;
+    select * into v_connection from public.dabbir_whatsapp_connections c
+    where c.id=v_existing.connection_id and c.business_id=p_business_id limit 1;
+    if not found then raise exception 'WHATSAPP_RESERVED_CONNECTION_NOT_FOUND'; end if;
+    return query select v_existing.id,false,v_existing.state,v_existing.connection_id,
+      v_connection.phone_number_id,v_existing.recipient_handle,v_existing.provider_message_id,v_existing.message_id;
+    return;
+  end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.business_id=p_business_id and c.branch_id=v_conversation.branch_id and c.status='connected'
+  limit 1;
+  if not found then raise exception 'WHATSAPP_BRANCH_CONNECTION_NOT_FOUND'; end if;
+
+  insert into public.dabbir_whatsapp_outbound_reservations(
+    business_id,connection_id,conversation_id,sender_user_id,idempotency_key,payload_hash,
+    recipient_handle,body,state,external_attempt_started_at
+  ) values (
+    p_business_id,v_connection.id,p_conversation_id,p_sender_user_id,v_key,v_hash,
+    v_recipient,left(trim(p_body),4000),'SENDING',now()
+  ) returning * into v_existing;
+
+  return query select v_existing.id,true,v_existing.state,v_existing.connection_id,
+    v_connection.phone_number_id,v_existing.recipient_handle,null::text,null::uuid;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) to service_role;

--- a/supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql
+++ b/supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql
@@ -1,0 +1,45 @@
+create or replace function public.dabbir_whatsapp_branch_operational_evidence(p_business_id uuid,p_branch_id uuid)
+returns table(
+  available boolean,
+  real_whatsapp_conversation boolean,
+  real_inbound_message boolean,
+  real_outbound_reply boolean,
+  verified_external_result boolean
+)
+language sql
+stable
+security invoker
+set search_path = pg_catalog, public
+as $$
+  select true,
+    exists(
+      select 1 from public.dabbir_conversations c
+      where c.business_id=p_business_id and c.branch_id=p_branch_id
+        and c.channel_type='whatsapp' and c.demo_mode=false
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_event_ledger e
+      join public.dabbir_conversations c on c.id=e.conversation_id and c.business_id=e.business_id
+      where e.business_id=p_business_id and c.branch_id=p_branch_id
+        and e.direction='inbound' and e.event_type='message' and e.message_id is not null
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_outbound_reservations r
+      join public.dabbir_conversations c on c.id=r.conversation_id and c.business_id=r.business_id
+      where r.business_id=p_business_id and c.branch_id=p_branch_id
+        and r.message_id is not null and r.provider_message_id is not null
+        and r.state in ('PROVIDER_ACCEPTED','SENT','DELIVERED','READ')
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_outbound_reservations r
+      join public.dabbir_conversations c on c.id=r.conversation_id and c.business_id=r.business_id
+      where r.business_id=p_business_id and c.branch_id=p_branch_id
+        and r.provider_verified=true and r.state in ('DELIVERED','READ')
+    );
+$$;
+
+revoke all on function public.dabbir_whatsapp_branch_operational_evidence(uuid,uuid) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_branch_operational_evidence(uuid,uuid) to service_role;

--- a/supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql
+++ b/supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql
@@ -1,0 +1,154 @@
+create table if not exists public.dabbir_whatsapp_branch_intents(
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade default auth.uid(),
+  branch_id uuid not null,
+  expires_at timestamptz not null default (now()+interval '10 minutes'),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key(business_id,user_id),
+  constraint dabbir_whatsapp_branch_intents_branch_business_fkey
+    foreign key(branch_id,business_id)
+    references public.dabbir_business_branches(id,business_id)
+    on delete cascade
+);
+
+create index if not exists dabbir_whatsapp_branch_intents_expiry_idx
+  on public.dabbir_whatsapp_branch_intents(expires_at);
+create index if not exists dabbir_whatsapp_branch_intents_branch_business_fk_idx
+  on public.dabbir_whatsapp_branch_intents(branch_id,business_id);
+
+alter table public.dabbir_whatsapp_branch_intents enable row level security;
+alter table public.dabbir_whatsapp_branch_intents force row level security;
+revoke all on public.dabbir_whatsapp_branch_intents from public,anon;
+grant select,insert,update,delete on public.dabbir_whatsapp_branch_intents to authenticated;
+
+drop policy if exists dabbir_whatsapp_branch_intents_select on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_select on public.dabbir_whatsapp_branch_intents
+for select to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_insert on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_insert on public.dabbir_whatsapp_branch_intents
+for insert to authenticated
+with check (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+  and expires_at>now()
+  and expires_at<=now()+interval '15 minutes'
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_update on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_update on public.dabbir_whatsapp_branch_intents
+for update to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+)
+with check (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+  and expires_at>now()
+  and expires_at<=now()+interval '15 minutes'
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_delete on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_delete on public.dabbir_whatsapp_branch_intents
+for delete to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+);
+
+create or replace function public.dabbir_whatsapp_upsert_connection(
+  p_business_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+  v_branch_id uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+
+  select i.branch_id into v_branch_id
+  from public.dabbir_whatsapp_branch_intents i
+  where i.business_id=p_business_id and i.user_id=v_uid and i.expires_at>now()
+    and exists(
+      select 1 from public.dabbir_business_branches b
+      where b.id=i.branch_id and b.business_id=i.business_id and b.status='active'
+    )
+  order by i.updated_at desc limit 1;
+
+  if v_branch_id is null then v_branch_id:=dabbir_private.primary_branch_for_business(p_business_id); end if;
+  if v_branch_id is null then raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=v_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,v_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+
+  delete from public.dabbir_whatsapp_branch_intents i
+  where i.business_id=p_business_id and i.user_id=v_uid;
+
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;

--- a/supabase/migrations/20260903161347_dabbir_whatsapp_branch_intent_user_index_v1.sql
+++ b/supabase/migrations/20260903161347_dabbir_whatsapp_branch_intent_user_index_v1.sql
@@ -1,0 +1,2 @@
+create index if not exists dabbir_whatsapp_branch_intents_user_idx
+  on public.dabbir_whatsapp_branch_intents(user_id);

--- a/test/dabbir-branch-runtime-integration.test.mjs
+++ b/test/dabbir-branch-runtime-integration.test.mjs
@@ -37,8 +37,11 @@ test('authorized branch options are server-derived, not guessed from the busines
   assert.match(context,/SERVER_RLS_BRANCH_ASSIGNMENTS/);
 });
 
-test('critical branch UI routes selected-branch runtime reads and writes before deferred screens',()=>{
-  assert.ok(bundles.critical.includes('/api/branch-context-ui'));
+test('branch UI reuses the bounded shell by replacing the duplicate owner-copilot presentation slot',()=>{
+  assert.ok(bundles.deferred.includes('/api/branch-context-ui'));
+  assert.ok(!bundles.deferred.includes('/api/owner-copilot-ui'));
+  assert.equal(bundles.critical.length+bundles.deferred.length,26);
+  assert.equal(bundles.critical.at(-1),'/api/auth-session-stability-ui');
   assert.match(ui,/\/api\/branch-workspace/);
   assert.match(ui,/\/api\/branch-operations/);
   assert.match(ui,/\['start_conversation','create_appointment'\]/);

--- a/test/dabbir-branch-runtime-integration.test.mjs
+++ b/test/dabbir-branch-runtime-integration.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read=path=>fs.readFileSync(new URL('../'+path,import.meta.url),'utf8');
+const workspace=read('api/branch-workspace.js');
+const operations=read('api/branch-operations.js');
+const context=read('api/branch-context.js');
+const ui=read('api/branch-context-ui.js');
+const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
+
+test('branch workspace filters branch-owned operational reads on the server',()=>{
+  assert.match(workspace,/resolveBranchScope/);
+  assert.match(workspace,/const suffix=branchFilter\(scope\)/);
+  assert.match(workspace,/dabbir_conversations\?[\s\S]*\$\{suffix\}/);
+  assert.match(workspace,/dabbir_appointments\?[\s\S]*\$\{suffix\}/);
+  assert.match(workspace,/truth_mode:'FAIL_CLOSED_BRANCH_SCOPED_READS'/);
+});
+
+test('branch workspace derives dependent rows from scoped conversation ids',()=>{
+  assert.match(workspace,/conversationIds=idsFilter/);
+  assert.match(workspace,/dabbir_handoffs\?[\s\S]*conversation_id=in\.\$\{conversationIds\}/);
+  assert.match(workspace,/dabbir_followups\?[\s\S]*conversation_id=in\.\$\{conversationIds\}/);
+  assert.match(workspace,/dabbir_messages\?[\s\S]*conversation_id=eq\.\$\{enc\(selectedConversationId\)\}/);
+});
+
+test('branch writes require an explicit selected scope and verify persisted branch id',()=>{
+  assert.match(operations,/branchWrite\(scope\)/);
+  assert.match(operations,/branch_id:branchId/);
+  assert.match(operations,/conversation\.branch_id!==branchId/);
+  assert.match(operations,/appointment\.branch_id!==branchId/);
+});
+
+test('authorized branch options are server-derived, not guessed from the business branch registry',()=>{
+  assert.match(context,/dabbir_membership_branches/);
+  assert.match(context,/all_allowed:allAllowed/);
+  assert.match(context,/SERVER_RLS_BRANCH_ASSIGNMENTS/);
+});
+
+test('critical branch UI routes selected-branch runtime reads and writes before deferred screens',()=>{
+  assert.ok(bundles.critical.includes('/api/branch-context-ui'));
+  assert.match(ui,/\/api\/branch-workspace/);
+  assert.match(ui,/\/api\/branch-operations/);
+  assert.match(ui,/\['start_conversation','create_appointment'\]/);
+  assert.match(ui,/dabbir_active_branch_scope:/);
+  assert.match(ui,/dabbir:branch-scope-changed/);
+});

--- a/test/dabbir-branch-scope-contract.test.mjs
+++ b/test/dabbir-branch-scope-contract.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveBranchScope,branchFilter,branchWrite } from '../api/_branch-scope.js';
+
+const businessId='11111111-1111-4111-8111-111111111111';
+const branchA='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const branchB='bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const userId='22222222-2222-4222-8222-222222222222';
+const activeBranches=[
+  {id:branchA,business_id:businessId,name:'A',status:'active',is_primary:true},
+  {id:branchB,business_id:businessId,name:'B',status:'active',is_primary:false},
+];
+
+function fetcher(assignments=[]){
+  return async path=>path.startsWith('dabbir_business_branches?')?activeBranches:assignments;
+}
+
+test('owner defaults to all branches and may select a branch',async()=>{
+  const membership={business_id:businessId,role:'owner',permissions:[]};
+  const all=await resolveBranchScope({businessId,membership,userId,fetchRows:fetcher()});
+  assert.equal(all.mode,'all');
+  assert.deepEqual(all.branch_ids,[branchA,branchB]);
+  const selected=await resolveBranchScope({businessId,membership,userId,requestedBranch:branchB,fetchRows:fetcher()});
+  assert.equal(selected.mode,'selected');
+  assert.equal(selected.branch_id,branchB);
+  assert.equal(branchFilter(selected),'&branch_id=eq.bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb');
+  assert.equal(branchWrite(selected),branchB);
+});
+
+test('restricted employee defaults to sole assigned branch',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[{business_id:businessId,user_id:userId,branch_id:branchA}];
+  const scope=await resolveBranchScope({businessId,membership,userId,fetchRows:fetcher(assignments)});
+  assert.equal(scope.mode,'selected');
+  assert.equal(scope.branch_id,branchA);
+});
+
+test('restricted employee cannot request all branches or an unassigned branch',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[{business_id:businessId,user_id:userId,branch_id:branchA}];
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,requestedBranch:'all',fetchRows:fetcher(assignments)}),
+    error=>error.message==='ALL_BRANCHES_ACCESS_DENIED'&&error.status===403,
+  );
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,requestedBranch:branchB,fetchRows:fetcher(assignments)}),
+    error=>error.message==='BRANCH_ACCESS_DENIED'&&error.status===403,
+  );
+});
+
+test('multi-assigned restricted employee must choose a branch explicitly',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[
+    {business_id:businessId,user_id:userId,branch_id:branchA},
+    {business_id:businessId,user_id:userId,branch_id:branchB},
+  ];
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,fetchRows:fetcher(assignments)}),
+    error=>error.message==='BRANCH_SELECTION_REQUIRED'&&error.status===409,
+  );
+});
+
+test('selected write is mandatory for branch-owned operational records',()=>{
+  assert.throws(()=>branchWrite({mode:'all',branch_id:null}),/SELECTED_BRANCH_REQUIRED/);
+});

--- a/test/dabbir-branch-scope-foundation.test.mjs
+++ b/test/dabbir-branch-scope-foundation.test.mjs
@@ -1,0 +1,32 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration=fs.readFileSync('supabase/migrations/20260903152500_dabbir_branch_scope_foundation_v1.sql','utf8');
+const broker=fs.readFileSync('supabase/functions/dabbir-owner-broker/index.ts','utf8');
+
+test('branch scope is explicit and fail-closed for non owner/admin memberships',()=>{
+  assert.match(migration,/create table if not exists public\.dabbir_membership_branches/i);
+  assert.match(migration,/m\.role in \('owner','admin'\)/i);
+  assert.match(migration,/dabbir_appointments_branch_restrict[\s\S]*as restrictive/i);
+  assert.match(migration,/dabbir_orders_branch_restrict[\s\S]*as restrictive/i);
+  assert.match(migration,/DABBIR_ACTIVE_BRANCH_REQUIRED/);
+});
+
+test('branch resources are modeled without duplicating business-level catalog/customer identity',()=>{
+  assert.match(migration,/create table if not exists public\.dabbir_branch_services/i);
+  assert.match(migration,/create table if not exists public\.dabbir_branch_products/i);
+  assert.match(migration,/create table if not exists public\.dabbir_worker_branches/i);
+  assert.match(migration,/create table if not exists public\.dabbir_branch_inventory/i);
+  assert.doesNotMatch(migration,/alter table public\.dabbir_customers add column[^;]*branch_id/i);
+  assert.match(migration,/DABBIR_SERVICE_NOT_AVAILABLE_IN_BRANCH/);
+  assert.match(migration,/DABBIR_WORKER_NOT_ASSIGNED_TO_BRANCH/);
+  assert.match(migration,/DABBIR_PRODUCT_NOT_AVAILABLE_IN_BRANCH/);
+});
+
+test('owner broker OTP actor is pinned to active root owner, not arbitrary active admin',()=>{
+  assert.match(broker,/role=eq\.ROOT_OWNER/);
+  assert.match(broker,/revoked_at=is\.null/);
+  assert.match(broker,/suspended_at=is\.null/);
+  assert.doesNotMatch(broker,/dabbir_platform_admins\?active=eq\.true&select=user_id/);
+});

--- a/test/dabbir-branch-scope-rls-completion.test.mjs
+++ b/test/dabbir-branch-scope-rls-completion.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const migration=fs.readFileSync('supabase/migrations/20260903154000_dabbir_branch_scope_rls_completion_v1.sql','utf8');
+
+test('conversations are forced into the branch contract',()=>{
+  assert.match(migration,/update public\.dabbir_conversations[\s\S]*branch_id=dabbir_private\.primary_branch_for_business\(business_id\)[\s\S]*where branch_id is null/i);
+  assert.match(migration,/alter table public\.dabbir_conversations alter column branch_id set not null/i);
+  assert.match(migration,/create trigger dabbir_conversations_branch_guard/i);
+  assert.match(migration,/execute function dabbir_private\.ensure_operational_branch\(\)/i);
+});
+
+test('conversations use restrictive branch access in addition to business permissions',()=>{
+  assert.match(migration,/create policy dabbir_conversations_branch_restrict[\s\S]*as restrictive[\s\S]*for all[\s\S]*to authenticated/i);
+  assert.match(migration,/using \(dabbir_private\.branch_access_allowed\(business_id,branch_id\)\)/i);
+  assert.match(migration,/with check \(dabbir_private\.branch_access_allowed\(business_id,branch_id\)\)/i);
+});
+
+test('inventory movements use restrictive branch access in addition to business permissions',()=>{
+  assert.match(migration,/create policy dabbir_inventory_movements_branch_restrict[\s\S]*as restrictive[\s\S]*for all[\s\S]*to authenticated/i);
+  const branchChecks=migration.match(/dabbir_private\.branch_access_allowed\(business_id,branch_id\)/gi) || [];
+  assert.ok(branchChecks.length>=4,'both restrictive policies must gate USING and WITH CHECK');
+});
+
+test('conversation backfill fails closed if any row remains without a branch',()=>{
+  assert.match(migration,/DABBIR_CONVERSATION_BRANCH_BACKFILL_INCOMPLETE/);
+});

--- a/test/dabbir-owner-executive-dashboard-v23.test.mjs
+++ b/test/dabbir-owner-executive-dashboard-v23.test.mjs
@@ -67,7 +67,7 @@ test('executive data remains brokered and owner-session protected',()=>{
   assert.match(data,/action:'owner_data'/);
   assert.doesNotMatch(data,/SUPABASE_SERVICE_ROLE_KEY|apikey:|authorization:`Bearer/);
   assert.match(broker,/action==='executive'/);
-  assert.match(broker,/dabbir_platform_owner_executive_v1/);
+  assert.match(broker,/dabbir_platform_owner_executive_v2/);
   assert.match(broker,/verifySession/);
   assert.match(broker,/database_rpc_latency_ms/);
 });

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -23,8 +23,11 @@ test('owner broker accepts modern Supabase secret keys without pretending they a
   const source = await read('supabase/functions/dabbir-owner-broker/index.ts');
   assert.match(source, /serviceKeyIsJwt=\(\)=>SERVICE_KEY\.split\('\.'\)\.length===3/);
   assert.match(source, /'apikey':SERVICE_KEY/);
-  assert.match(source, /if\(serviceKeyIsJwt\(\)\)headers\.authorization=`Bearer \$\{SERVICE_KEY\}`/);
+  assert.match(source, /if\(serviceKeyIsJwt\(\)\)[A-Za-z_$][\w$]*\.authorization=`Bearer \$\{SERVICE_KEY\}`/);
   assert.doesNotMatch(source, /sbHeaders=\(\)=>\(\{'apikey':SERVICE_KEY,'authorization':`Bearer \$\{SERVICE_KEY\}`/);
+  assert.match(source, /role=eq\.ROOT_OWNER/);
+  assert.match(source, /revoked_at=is\.null/);
+  assert.match(source, /suspended_at=is\.null/);
   assert.match(source, /if\(action==='incidents'\)return incidentRead\(body\)/);
   assert.match(source, /if\(action==='incident_action'\)return incidentAction\(body\)/);
 });

--- a/test/dabbir-whatsapp-branch-routing.test.mjs
+++ b/test/dabbir-whatsapp-branch-routing.test.mjs
@@ -6,8 +6,14 @@ const read=path=>fs.readFileSync(new URL('../'+path,import.meta.url),'utf8');
 const branchMigration=read('supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql');
 const inboundFix=read('supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql');
 const outboundMigration=read('supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql');
+const evidenceMigration=read('supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql');
+const intentMigration=read('supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql');
 const exactConnection=read('api/_whatsapp-branch-connection.js');
 const reply=read('api/dabbir-whatsapp-reply.js');
+const status=read('api/dabbir-whatsapp-status.js');
+const disconnect=read('api/dabbir-whatsapp-disconnect.js');
+const branchUi=read('api/branch-context-ui.js');
+const intentApi=read('api/whatsapp-branch-intent.js');
 
 test('WhatsApp connections are branch-owned with business/branch integrity',()=>{
   assert.match(branchMigration,/add column if not exists branch_id uuid/);
@@ -34,9 +40,10 @@ test('outbound reservation resolves conversation before selecting its branch con
   assert.doesNotMatch(outboundMigration,/where c\.business_id=p_business_id and c\.status='connected' limit 1;[\s\S]*select \* into v_conversation/);
 });
 
-test('exact connection authority scopes reads and token rotation to one connection id',()=>{
+test('exact connection authority scopes reads rotation and deletion to one connection id',()=>{
   assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(connection\)\}&business_id=eq/);
   assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(row\.id\)\}&business_id=eq/);
+  assert.match(exactConnection,/deleteExactBusinessConnection/);
   assert.match(exactConnection,/WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH/);
   assert.doesNotMatch(exactConnection,/dabbir_whatsapp_connections\?business_id=eq\.\$\{encodeURIComponent\(String\(row\.business_id\)\)\}/);
 });
@@ -50,4 +57,39 @@ test('reply reserves the branch connection before loading and sending through th
   assert.match(reply,/reservation\.connectionId/);
   assert.match(reply,/WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION/);
   assert.doesNotMatch(reply,/loadBusinessConnection\(/);
+});
+
+test('branch status uses branch-specific connection and branch-specific operational evidence',()=>{
+  assert.match(evidenceMigration,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(evidenceMigration,/c\.branch_id=p_branch_id/);
+  assert.match(status,/loadBusinessBranchConnection/);
+  assert.match(status,/loadPrimaryBusinessConnection/);
+  assert.match(status,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(status,/p_branch_id: branchId/);
+  assert.match(status,/branch_id: row\.branch_id/);
+  assert.doesNotMatch(status,/loadBusinessConnection/);
+});
+
+test('disconnect deletes one exact branch connection and never unsubscribes a shared WABA',()=>{
+  assert.match(disconnect,/loadBusinessBranchConnection/);
+  assert.match(disconnect,/loadPrimaryBusinessConnection/);
+  assert.match(disconnect,/deleteExactBusinessConnection/);
+  assert.match(disconnect,/BRANCH_SAFE_LOCAL_DISCONNECT/);
+  assert.doesNotMatch(disconnect,/removeBusinessConnection/);
+  assert.doesNotMatch(disconnect,/unsubscribeWaba/);
+});
+
+test('Embedded Signup keeps Meta flow unchanged while a one-time server branch intent controls storage',()=>{
+  assert.match(intentMigration,/create table if not exists public\.dabbir_whatsapp_branch_intents/);
+  assert.match(intentMigration,/force row level security/);
+  assert.match(intentMigration,/dabbir_private\.branch_access_allowed/);
+  assert.match(intentMigration,/select i\.branch_id into v_branch_id/);
+  assert.match(intentMigration,/delete from public\.dabbir_whatsapp_branch_intents/);
+  assert.match(intentApi,/ownerContext/);
+  assert.match(intentApi,/resolution=merge-duplicates,return=representation/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-embedded-complete/);
+  assert.match(branchUi,/\/api\/whatsapp-branch-intent/);
+  assert.match(branchUi,/persistWhatsAppIntent/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-status/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-disconnect/);
 });

--- a/test/dabbir-whatsapp-branch-routing.test.mjs
+++ b/test/dabbir-whatsapp-branch-routing.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read=path=>fs.readFileSync(new URL('../'+path,import.meta.url),'utf8');
+const branchMigration=read('supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql');
+const inboundFix=read('supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql');
+const outboundMigration=read('supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql');
+const exactConnection=read('api/_whatsapp-branch-connection.js');
+const reply=read('api/dabbir-whatsapp-reply.js');
+
+test('WhatsApp connections are branch-owned with business/branch integrity',()=>{
+  assert.match(branchMigration,/add column if not exists branch_id uuid/);
+  assert.match(branchMigration,/alter column branch_id set not null/);
+  assert.match(branchMigration,/foreign key \(branch_id,business_id\)/);
+  assert.match(branchMigration,/unique \(business_id,branch_id\)/);
+  assert.match(branchMigration,/dabbir_whatsapp_connection_branch_guard/);
+  assert.match(branchMigration,/dabbir_whatsapp_upsert_branch_connection/);
+});
+
+test('inbound routing derives conversation branch from the receiving connection',()=>{
+  assert.match(inboundFix,/c\.branch_id=v_connection\.branch_id/);
+  assert.match(inboundFix,/insert into public\.dabbir_conversations\(business_id,branch_id/);
+  assert.match(inboundFix,/v_connection\.business_id,v_connection\.branch_id,v_customer_id/);
+  assert.match(inboundFix,/#variable_conflict use_column/);
+  assert.match(inboundFix,/grant execute on function public\.dabbir_whatsapp_persist_inbound[\s\S]*to service_role/);
+});
+
+test('outbound reservation resolves conversation before selecting its branch connection',()=>{
+  const conversationIndex=outboundMigration.indexOf('select * into v_conversation');
+  const connectionIndex=outboundMigration.indexOf('c.branch_id=v_conversation.branch_id');
+  assert.ok(conversationIndex>=0&&connectionIndex>conversationIndex);
+  assert.match(outboundMigration,/WHATSAPP_BRANCH_CONNECTION_NOT_FOUND/);
+  assert.doesNotMatch(outboundMigration,/where c\.business_id=p_business_id and c\.status='connected' limit 1;[\s\S]*select \* into v_conversation/);
+});
+
+test('exact connection authority scopes reads and token rotation to one connection id',()=>{
+  assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(connection\)\}&business_id=eq/);
+  assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(row\.id\)\}&business_id=eq/);
+  assert.match(exactConnection,/WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH/);
+  assert.doesNotMatch(exactConnection,/dabbir_whatsapp_connections\?business_id=eq\.\$\{encodeURIComponent\(String\(row\.business_id\)\)\}/);
+});
+
+test('reply reserves the branch connection before loading and sending through that exact connection',()=>{
+  assert.match(reply,/loadExactBusinessConnection/);
+  const reserveIndex=reply.indexOf('reservation = await reserveOutboundReply');
+  const loadIndex=reply.indexOf('const connection = await loadExactBusinessConnection');
+  const sendIndex=reply.indexOf('sent = await sendMetaText');
+  assert.ok(reserveIndex>=0&&loadIndex>reserveIndex&&sendIndex>loadIndex);
+  assert.match(reply,/reservation\.connectionId/);
+  assert.match(reply,/WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION/);
+  assert.doesNotMatch(reply,/loadBusinessConnection\(/);
+});

--- a/test/dabbir-whatsapp-disconnect-truth.test.mjs
+++ b/test/dabbir-whatsapp-disconnect-truth.test.mjs
@@ -4,12 +4,24 @@ import { verifiedDeletion } from '../api/dabbir-whatsapp-disconnect.js';
 
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
 const OTHER_BUSINESS_ID = '00000000-0000-4000-8000-000000000222';
+const CONNECTION_ID = '00000000-0000-4000-8000-000000000333';
+const OTHER_CONNECTION_ID = '00000000-0000-4000-8000-000000000444';
 
-test('WhatsApp disconnect success requires exactly one matching deleted tenant row', () => {
+test('WhatsApp disconnect success requires one exact business and connection deletion', () => {
+  assert.equal(verifiedDeletion([{ id: CONNECTION_ID, business_id: BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), true);
+  assert.equal(verifiedDeletion({ id: CONNECTION_ID, business_id: BUSINESS_ID }, BUSINESS_ID, CONNECTION_ID), true);
+  assert.equal(verifiedDeletion([], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([{ id: CONNECTION_ID, business_id: OTHER_BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([{ id: OTHER_CONNECTION_ID, business_id: BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([
+    { id: CONNECTION_ID, business_id: BUSINESS_ID },
+    { id: OTHER_CONNECTION_ID, business_id: BUSINESS_ID },
+  ], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([null], BUSINESS_ID, CONNECTION_ID), false);
+});
+
+test('legacy verification without connection id still requires one matching business row', () => {
   assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }], BUSINESS_ID), true);
-  assert.equal(verifiedDeletion([], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion({ business_id: BUSINESS_ID }, BUSINESS_ID), true);
   assert.equal(verifiedDeletion([{ business_id: OTHER_BUSINESS_ID }], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }, { business_id: BUSINESS_ID }], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion([null], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion({ business_id: BUSINESS_ID }, BUSINESS_ID), false);
 });

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -182,16 +182,19 @@ test('WhatsApp connection storage is tenant-scoped and RLS protected', async () 
   assert.doesNotMatch(migration, /grant .* to anon/i);
 });
 
-test('WhatsApp connection persistence uses the tenant-checked database RPC', async () => {
+test('WhatsApp connection persistence keeps the legacy tenant-checked RPC while branch routing supersedes business-only storage', async () => {
   const core = await read('api/_whatsapp-embedded-core.js');
-  const migration = await read('supabase/migrations/20260831032000_dabbir_whatsapp_connection_upsert_rpc_v1.sql');
+  const legacyMigration = await read('supabase/migrations/20260831032000_dabbir_whatsapp_connection_upsert_rpc_v1.sql');
+  const branchMigration = await read('supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql');
   assert.match(core, /supabaseRpc\('dabbir_whatsapp_upsert_connection'/);
   assert.doesNotMatch(core, /supabaseRest\('dabbir_whatsapp_connections\?on_conflict=business_id'/);
-  assert.match(migration, /create or replace function public\.dabbir_whatsapp_upsert_connection/);
-  assert.match(migration, /dabbir_private\.is_active_member\(p_business_id\)/);
-  assert.match(migration, /WHATSAPP_PHONE_ALREADY_CONNECTED/);
-  assert.match(migration, /on conflict \(business_id\) do update/);
-  assert.match(migration, /grant execute on function public\.dabbir_whatsapp_upsert_connection/);
+  assert.match(legacyMigration, /create or replace function public\.dabbir_whatsapp_upsert_connection/);
+  assert.match(legacyMigration, /dabbir_private\.is_active_member\(p_business_id\)/);
+  assert.match(legacyMigration, /WHATSAPP_PHONE_ALREADY_CONNECTED/);
+  assert.match(branchMigration, /select i\.branch_id into v_branch_id/);
+  assert.match(branchMigration, /on conflict \(business_id,branch_id\) do update/);
+  assert.match(branchMigration, /delete from public\.dabbir_whatsapp_branch_intents/);
+  assert.match(branchMigration, /grant execute on function public\.dabbir_whatsapp_upsert_connection/);
 });
 
 test('production shell mounts Embedded Signup and CSP permits only required Meta browser origins', async () => {
@@ -203,13 +206,16 @@ test('production shell mounts Embedded Signup and CSP permits only required Meta
   assert.match(vercel, /connect-src 'self' https:\/\/graph\.facebook\.com/);
 });
 
-test('status endpoint prefers business-scoped Embedded Signup when business_id is supplied', async () => {
+test('status endpoint is tenant-scoped and branch-aware when business_id is supplied', async () => {
   const status = await read('api/dabbir-whatsapp-status.js');
   assert.match(status, /embeddedStatus/);
   assert.match(status, /source:\s*'embedded_signup'/);
   assert.match(status, /singleQueryValue\(req, 'business_id'\)/);
+  assert.match(status, /singleQueryValue\(req,'branch_id'\)/);
   assert.doesNotMatch(status, /req\.query/);
-  assert.match(status, /loadBusinessConnection/);
+  assert.match(status, /loadBusinessBranchConnection/);
+  assert.match(status, /loadPrimaryBusinessConnection/);
+  assert.doesNotMatch(status, /loadBusinessConnection/);
 });
 
 test('Meta App ID can be discovered server-side from the existing WhatsApp authorization', async () => {

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -7,37 +7,51 @@ const statusPath='api/dabbir-whatsapp-status.js';
 const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
 const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
-const raceMigrationPath='supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql';
+const raceMigrationPath='supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql';
 const hardeningPath='supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql';
+const branchEvidencePath='supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql';
 const status=fs.readFileSync(statusPath,'utf8');
 const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
 const migration=fs.readFileSync(migrationPath,'utf8');
 const raceMigration=fs.readFileSync(raceMigrationPath,'utf8');
 const hardening=fs.readFileSync(hardeningPath,'utf8');
+const branchEvidence=fs.readFileSync(branchEvidencePath,'utf8');
 
-test('WhatsApp operational evidence is tenant-scoped, non-demo, provider-backed, and server-only',()=>{
+test('WhatsApp operational evidence is tenant-and-branch scoped, non-demo, provider-backed, and server-only',()=>{
   assert.match(status,/serviceRpc/);
   assert.doesNotMatch(status,/supabaseRpc/);
-  assert.match(status,/dabbir_whatsapp_operational_evidence/);
-  assert.match(status,/\{ p_business_id: businessId \}/);
+  assert.match(status,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(status,/p_business_id: businessId/);
+  assert.match(status,/p_branch_id: branchId/);
+  assert.match(status,/loadOperationalEvidence\(businessId,row\.branch_id\)/);
+
+  // Preserve the original service-only evidence authority while requiring the
+  // branch-scoped successor for tenant UI truth.
   assert.match(migration,/function public\.dabbir_whatsapp_operational_evidence\(p_business_id uuid\)/);
-  assert.match(migration,/c\.business_id=p_business_id and c\.channel_type='whatsapp' and c\.demo_mode=false/);
-  assert.match(migration,/e\.business_id=p_business_id and e\.direction='inbound' and e\.event_type='message' and e\.message_id is not null/);
-  assert.match(migration,/r\.business_id=p_business_id and r\.message_id is not null and r\.provider_message_id is not null/);
-  assert.match(migration,/r\.business_id=p_business_id and r\.provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
   assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) from public,anon,authenticated/i);
   assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to service_role/i);
   assert.doesNotMatch(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
+
+  assert.match(branchEvidence,/function public\.dabbir_whatsapp_branch_operational_evidence\(p_business_id uuid,p_branch_id uuid\)/);
+  assert.match(branchEvidence,/c\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/join public\.dabbir_conversations c on c\.id=e\.conversation_id and c\.business_id=e\.business_id/);
+  assert.match(branchEvidence,/e\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/join public\.dabbir_conversations c on c\.id=r\.conversation_id and c\.business_id=r\.business_id/);
+  assert.match(branchEvidence,/r\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/security invoker/i);
+  assert.match(branchEvidence,/from public,anon,authenticated/i);
+  assert.match(branchEvidence,/to service_role/i);
 });
 
-test('distinct inbound messages from one new sender serialize conversation ownership',()=>{
-  assert.match(raceMigration,/hashtextextended\(v_connection\.business_id::text \|\| ':wa-sender:' \|\| v_sender, 0\)/);
+test('distinct inbound messages serialize ownership per tenant branch and sender',()=>{
+  assert.match(raceMigration,/v_connection\.business_id::text\|\|':'\|\|v_connection\.branch_id::text\|\|':wa-sender:'\|\|v_sender/);
   const senderLock=raceMigration.indexOf("':wa-sender:'");
   const customerUpsert=raceMigration.indexOf('insert into public.dabbir_customers');
   const conversationLookup=raceMigration.indexOf('select c.id into v_conversation_id');
   assert.ok(senderLock>0&&senderLock<customerUpsert&&customerUpsert<conversationLookup);
   assert.match(raceMigration,/on conflict \(business_id,channel_handle\) where channel_handle is not null/);
+  assert.match(raceMigration,/c\.branch_id=v_connection\.branch_id/);
 });
 
 test('WhatsApp becomes operational only through the explicit evidence state machine',()=>{
@@ -84,7 +98,7 @@ test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
 });
 
 test('operational truth files parse as Node modules',()=>{
-  for(const path of [statusPath,machinePath,activationPath,'api/_whatsapp-live-core.js','api/dabbir-whatsapp-reply.js','api/dabbir-whatsapp-webhook.js']){
+  for(const path of [statusPath,machinePath,activationPath,'api/_whatsapp-live-core.js','api/_whatsapp-branch-connection.js','api/dabbir-whatsapp-reply.js','api/dabbir-whatsapp-webhook.js','api/dabbir-whatsapp-disconnect.js','api/whatsapp-branch-intent.js']){
     const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
     assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
   }

--- a/test/dabbir-whatsapp-rpc-security.test.mjs
+++ b/test/dabbir-whatsapp-rpc-security.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 
 const status=fs.readFileSync('api/dabbir-whatsapp-status.js','utf8');
 const hardening=fs.readFileSync('supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql','utf8');
+const branchEvidence=fs.readFileSync('supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql','utf8');
 
 const serverOnlyFunctions=[
   'dabbir_whatsapp_persist_inbound',
@@ -14,20 +15,31 @@ const serverOnlyFunctions=[
   'dabbir_whatsapp_operational_evidence',
 ];
 
-test('WhatsApp operational evidence is fetched server-side rather than with the user token',()=>{
+test('WhatsApp operational evidence is fetched server-side and scoped to the selected branch',()=>{
   assert.match(status,/import \{ serviceRpc, whatsappLiveServerCapability \} from '.\/_whatsapp-live-core\.js'/);
-  assert.match(status,/serviceRpc\('dabbir_whatsapp_operational_evidence', \{ p_business_id: businessId \}\)/);
+  assert.match(status,/serviceRpc\('dabbir_whatsapp_branch_operational_evidence', \{/);
+  assert.match(status,/p_business_id: businessId/);
+  assert.match(status,/p_branch_id: branchId/);
   assert.doesNotMatch(status,/supabaseRpc/);
   assert.match(status,/await ownerContext\(req, businessId\)/);
 });
 
-test('all live WhatsApp RPCs are service-role only and do not retain SECURITY DEFINER',()=>{
+test('legacy live WhatsApp RPCs remain service-role only and SECURITY INVOKER',()=>{
   for(const fn of serverOnlyFunctions){
     assert.match(hardening,new RegExp(`(?:alter function public\\.${fn}\\([^;]+\\) security invoker|create or replace function public\\.${fn}\\([\\s\\S]*?security invoker)`,'i'),`${fn} must be SECURITY INVOKER`);
     assert.match(hardening,new RegExp(`revoke all on function public\\.${fn}\\([^;]+\\) from public,anon,authenticated`,'i'),`${fn} client execute must be revoked`);
     assert.match(hardening,new RegExp(`grant execute on function public\\.${fn}\\([^;]+\\) to service_role`,'i'),`${fn} must be service-role executable`);
   }
   assert.doesNotMatch(hardening,/grant execute on function public\.dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
+});
+
+test('branch operational evidence is SECURITY INVOKER and service-role only',()=>{
+  assert.match(branchEvidence,/create or replace function public\.dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(branchEvidence,/security invoker/i);
+  assert.match(branchEvidence,/revoke all on function public\.dabbir_whatsapp_branch_operational_evidence\(uuid,uuid\) from public,anon,authenticated/i);
+  assert.match(branchEvidence,/grant execute on function public\.dabbir_whatsapp_branch_operational_evidence\(uuid,uuid\) to service_role/i);
+  assert.doesNotMatch(branchEvidence,/security definer/i);
+  assert.doesNotMatch(branchEvidence,/auth\.uid\(\)/i);
 });
 
 test('server-only operational evidence does not depend on auth.uid or client permission bypass',()=>{


### PR DESCRIPTION
Closes the first executable P1 slice from #405 under ACTION → ARTIFACT → TEST → EVIDENCE.

## ACTION
- Sync Owner Broker to the live v6 contract and pin OTP/session authority to active `ROOT_OWNER` only.
- Add source-controlled owner-authority consolidation so a rebuild cannot regress to legacy `platform_owner/support_admin` semantics.
- Build the branch data model: explicit member↔branch assignments, branch service/product/worker availability, branch inventory, and branch IDs on operational transactions.
- Add fail-closed branch guards and RESTRICTIVE RLS for bookings/orders.
- Add cross-branch resource validation for booking staff/services and order products.
- Add exact-order covering indexes for new composite FKs and remove duplicate permissive SELECT policy evaluation.

## LIVE ARTIFACTS ALREADY APPLIED
- Owner session/root-authority hardening migrations in DABBIR Mumbai.
- `dabbir-owner-broker` v6 ACTIVE; SHA-256 `d8490c99988699f858a0b6c5f3039cd3dfdfc70b8700aadf264440483777fcbe`.
- `dabbir_branch_scope_foundation_v1` applied successfully.
- `dabbir_branch_scope_perf_hardening_v1` applied successfully.
- `dabbir_owner_authority_source_sync_v1` applied successfully.

## TEST / EVIDENCE
- Existing data: 0 appointments/orders/inventory movements without required branch IDs; 0 branch/business mismatches; 0 unseeded services/workers.
- Red-team transaction: worker/service/product from primary branch rejected in temporary secondary branch; product path succeeds in primary branch; transaction rolled back.
- Employee isolation transaction: assigned primary branch => `primary_allowed=true`, unassigned secondary => `secondary_allowed=false`, secondary appointments visible = 0; transaction rolled back.
- Owner transaction: owner can see secondary branch as intended.
- Owner session: active `OWNER_DELEGATE` rejected by owner session issuer; existing ROOT_OWNER session remains valid.
- Supabase performance advisor after hardening: 0 `unindexed_foreign_keys`, 0 `multiple_permissive_policies`; remaining items are unused-index telemetry / Auth connection strategy INFO.
- Regression contract added in `test/dabbir-branch-scope-foundation.test.mjs`.

## REMAINS OPEN
- Branch-aware UI/API selection and All Branches view.
- WhatsApp connection → branch routing.
- GCC currency-neutral transaction model (`*_aed` legacy columns remain).
- Public anon SECURITY DEFINER order-status RPC security contract.

This PR does not claim DABBIR release-ready; it makes the first P1 security/branch foundation reproducible from source.