### PR TITLE
Use WHATWG query parsing for public order tracking

### DIFF
--- a/api/public-order-status.js
+++ b/api/public-order-status.js
@@ -1,4 +1,5 @@
 import { json } from './_auth-core.js';
+import { singleQueryValue } from './_request-query.js';
 import { supabaseKeyHeaders } from './_supabase-key-auth.js';
 
 const SUPABASE_URL=String(process.env.SUPABASE_URL||'').replace(/\/$/,'');
@@ -25,7 +26,7 @@ export default async function handler(req,res){
   res.setHeader('x-content-type-options','nosniff');
   if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
   if(!SUPABASE_URL||!SERVICE_KEY)return json(res,503,{ok:false,error:'ORDER_STATUS_UNAVAILABLE'});
-  const token=String(req.query?.token||'').trim();
+  const token=String(singleQueryValue(req,'token')||'').trim();
   if(!UUID_RE.test(token))return json(res,404,{ok:false,error:'ORDER_NOT_FOUND'});
   try{
     const row=await readStatus(token);

--- a/test/dabbir-owner-broker-v9-contract.test.mjs
+++ b/test/dabbir-owner-broker-v9-contract.test.mjs
@@ -41,10 +41,12 @@ test('full executive view and owner decisions remain root-only',()=>{
   assert.match(broker,/if\(action==='decision_resolve'\).*requireRoot\(session\)/s);
 });
 
-test('public order tracking uses the server secret only on the server',()=>{
+test('public order tracking uses the server secret only on the server and WHATWG parsing',()=>{
   assert.match(tracking,/SUPABASE_SERVICE_ROLE_KEY/);
   assert.match(tracking,/dabbir_public_order_status/);
   assert.match(tracking,/UUID_RE/);
+  assert.match(tracking,/singleQueryValue\(req,'token'\)/);
+  assert.doesNotMatch(tracking,/req\.query/);
   assert.match(tracking,/cache-control','no-store/);
 });
 


### PR DESCRIPTION
Production runtime closeout follow-up.

- replaces `req.query` access on the new public order capability endpoint with the repository's canonical WHATWG `singleQueryValue` parser
- adds a regression assertion preventing `req.query` from returning
- no database/schema change

Observed production signal: Node DEP0169 warning on `/api/public-order-status` after security hardening. Merge only after required checks and Preview pass.