### PR TITLE
Reconcile Production branch and WhatsApp migration source

### DIFF
--- a/supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql
+++ b/supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql
@@ -1,0 +1,293 @@
+alter table public.dabbir_whatsapp_connections
+  add column if not exists branch_id uuid;
+
+update public.dabbir_whatsapp_connections c
+set branch_id=dabbir_private.primary_branch_for_business(c.business_id)
+where c.branch_id is null;
+
+alter table public.dabbir_whatsapp_connections
+  alter column branch_id set not null;
+
+alter table public.dabbir_whatsapp_connections
+  drop constraint if exists dabbir_whatsapp_connections_business_id_key;
+
+alter table public.dabbir_whatsapp_connections
+  drop constraint if exists dabbir_whatsapp_connections_branch_business_fkey;
+
+alter table public.dabbir_whatsapp_connections
+  add constraint dabbir_whatsapp_connections_branch_business_fkey
+  foreign key (branch_id,business_id)
+  references public.dabbir_business_branches(id,business_id)
+  on delete restrict;
+
+alter table public.dabbir_whatsapp_connections
+  add constraint dabbir_whatsapp_connections_business_branch_key
+  unique (business_id,branch_id);
+
+create index if not exists dabbir_whatsapp_connections_branch_idx
+  on public.dabbir_whatsapp_connections(branch_id);
+
+drop trigger if exists dabbir_whatsapp_connection_branch_guard on public.dabbir_whatsapp_connections;
+create trigger dabbir_whatsapp_connection_branch_guard
+before insert or update of business_id,branch_id on public.dabbir_whatsapp_connections
+for each row execute function dabbir_private.ensure_operational_branch();
+
+create or replace function public.dabbir_whatsapp_upsert_connection(
+  p_business_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+  v_branch_id uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+
+  v_branch_id:=dabbir_private.primary_branch_for_business(p_business_id);
+  if v_branch_id is null then raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=v_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,v_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;
+
+create or replace function public.dabbir_whatsapp_upsert_branch_connection(
+  p_business_id uuid,p_branch_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or p_branch_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+  if not exists (
+    select 1 from public.dabbir_business_branches b
+    where b.id=p_branch_id and b.business_id=p_business_id and b.status='active'
+  ) then raise exception 'WHATSAPP_BRANCH_ACCESS_REQUIRED' using errcode='42501'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=p_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,p_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_branch_connection(uuid,uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_branch_connection(uuid,uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;
+
+create or replace function public.dabbir_whatsapp_ai_connection(p_business_id uuid,p_connection_id uuid)
+returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare v_connection public.dabbir_whatsapp_connections%rowtype;
+begin
+  if coalesce((select auth.role()),'')<>'service_role' then raise exception 'SERVICE_ROLE_REQUIRED'; end if;
+  select * into v_connection from public.dabbir_whatsapp_connections
+  where id=p_connection_id and business_id=p_business_id and status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+  return jsonb_build_object(
+    'id',v_connection.id,'business_id',v_connection.business_id,'branch_id',v_connection.branch_id,
+    'status',v_connection.status,'phone_number_id',v_connection.phone_number_id,'waba_id',v_connection.waba_id,
+    'access_token_ciphertext',v_connection.access_token_ciphertext,'access_token_iv',v_connection.access_token_iv,
+    'access_token_tag',v_connection.access_token_tag,'token_key_version',v_connection.token_key_version,
+    'token_expires_at',v_connection.token_expires_at
+  );
+end;
+$$;
+revoke all on function public.dabbir_whatsapp_ai_connection(uuid,uuid) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_ai_connection(uuid,uuid) to service_role;
+
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,p_provider_message_id text,p_sender_handle text,p_display_name text,
+  p_body text,p_intent text,p_occurred_at timestamptz default now()
+)
+returns table(business_id uuid,connection_id uuid,customer_id uuid,conversation_id uuid,message_id uuid,duplicate boolean)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+  v_sender text:=trim(coalesce(p_sender_handle,''));
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id)>320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(v_sender,'') is null or length(v_sender)>160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id) and c.status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key:='inbound:'||trim(p_provider_message_id);
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_event_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_connection.branch_id::text||':wa-sender:'||v_sender,0));
+
+  v_name:=left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,v_sender,'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb)||jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id and c.branch_id=v_connection.branch_id
+    and c.customer_id=v_customer_id and c.channel_type='whatsapp' and c.demo_mode=false and c.state<>'closed'
+  order by c.updated_at desc limit 1 for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,branch_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_connection.branch_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations set state=case when state='waiting_customer' then 'ai_active' else state end,updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id and branch_id=v_connection.branch_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true,'branch_id',v_connection.branch_id)
+  );
+
+  update public.dabbir_whatsapp_connections set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;

--- a/supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql
+++ b/supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql
@@ -1,0 +1,99 @@
+create or replace function public.dabbir_whatsapp_persist_inbound(
+  p_phone_number_id text,
+  p_provider_message_id text,
+  p_sender_handle text,
+  p_display_name text,
+  p_body text,
+  p_intent text,
+  p_occurred_at timestamptz default now()
+)
+returns table(
+  business_id uuid,
+  connection_id uuid,
+  customer_id uuid,
+  conversation_id uuid,
+  message_id uuid,
+  duplicate boolean
+)
+language plpgsql
+security definer
+set search_path = ''
+as $$
+#variable_conflict use_column
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_customer_id uuid;
+  v_conversation_id uuid;
+  v_message_id uuid;
+  v_existing public.dabbir_whatsapp_event_ledger%rowtype;
+  v_event_key text;
+  v_name text;
+  v_sender text:=trim(coalesce(p_sender_handle,''));
+begin
+  if nullif(trim(p_phone_number_id),'') is null then raise exception 'WHATSAPP_PHONE_NUMBER_ID_REQUIRED'; end if;
+  if nullif(trim(p_provider_message_id),'') is null or length(p_provider_message_id)>320 then raise exception 'WHATSAPP_PROVIDER_MESSAGE_ID_REQUIRED'; end if;
+  if nullif(v_sender,'') is null or length(v_sender)>160 then raise exception 'WHATSAPP_SENDER_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id) and c.status='connected' limit 1;
+  if not found then raise exception 'WHATSAPP_TENANT_CONNECTION_NOT_FOUND'; end if;
+
+  v_event_key:='inbound:'||trim(p_provider_message_id);
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_event_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_event_ledger e
+  where e.business_id=v_connection.business_id and e.event_key=v_event_key limit 1;
+  if found then
+    return query select v_existing.business_id,v_existing.connection_id,
+      (select c.customer_id from public.dabbir_conversations c where c.id=v_existing.conversation_id),
+      v_existing.conversation_id,v_existing.message_id,true;
+    return;
+  end if;
+
+  perform pg_catalog.pg_advisory_xact_lock(pg_catalog.hashtextextended(v_connection.business_id::text||':'||v_connection.branch_id::text||':wa-sender:'||v_sender,0));
+
+  v_name:=left(coalesce(nullif(trim(p_display_name),''),'WhatsApp Customer'),120);
+  insert into public.dabbir_customers(business_id,display_name,channel_handle,lead_status,metadata)
+  values(v_connection.business_id,v_name,v_sender,'new',jsonb_build_object('source','whatsapp','provider','meta'))
+  on conflict (business_id,channel_handle) where channel_handle is not null
+  do update set display_name=case when excluded.display_name<>'WhatsApp Customer' then excluded.display_name else public.dabbir_customers.display_name end,
+    metadata=coalesce(public.dabbir_customers.metadata,'{}'::jsonb)||jsonb_build_object('source','whatsapp','provider','meta')
+  returning id into v_customer_id;
+
+  select c.id into v_conversation_id from public.dabbir_conversations c
+  where c.business_id=v_connection.business_id and c.branch_id=v_connection.branch_id
+    and c.customer_id=v_customer_id and c.channel_type='whatsapp' and c.demo_mode=false and c.state<>'closed'
+  order by c.updated_at desc limit 1 for update;
+
+  if v_conversation_id is null then
+    insert into public.dabbir_conversations(business_id,branch_id,customer_id,channel_type,state,demo_mode)
+    values(v_connection.business_id,v_connection.branch_id,v_customer_id,'whatsapp','ai_active',false)
+    returning id into v_conversation_id;
+  else
+    update public.dabbir_conversations set state=case when state='waiting_customer' then 'ai_active' else state end,updated_at=now()
+    where id=v_conversation_id and business_id=v_connection.business_id and branch_id=v_connection.branch_id;
+  end if;
+
+  insert into public.dabbir_messages(business_id,conversation_id,sender_type,body,intent,simulated)
+  values(v_connection.business_id,v_conversation_id,'customer',left(trim(p_body),4000),nullif(left(trim(coalesce(p_intent,'')),120),''),false)
+  returning id into v_message_id;
+
+  insert into public.dabbir_whatsapp_event_ledger(
+    business_id,connection_id,event_key,direction,event_type,provider_message_id,
+    conversation_id,message_id,provider_status,provider_verified,occurred_at,verified_at,evidence
+  ) values (
+    v_connection.business_id,v_connection.id,v_event_key,'inbound','message',trim(p_provider_message_id),
+    v_conversation_id,v_message_id,'received',true,coalesce(p_occurred_at,now()),now(),
+    jsonb_build_object('source','meta_signed_webhook','signature_verified',true,'branch_id',v_connection.branch_id)
+  );
+
+  update public.dabbir_whatsapp_connections set last_verified_at=now(),last_provider_status=200,last_error=null,updated_at=now()
+  where id=v_connection.id;
+
+  return query select v_connection.business_id,v_connection.id,v_customer_id,v_conversation_id,v_message_id,false;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_persist_inbound(text,text,text,text,text,text,timestamptz) to service_role;

--- a/supabase/migrations/20260903155707_dabbir_whatsapp_branch_fk_index_v1.sql
+++ b/supabase/migrations/20260903155707_dabbir_whatsapp_branch_fk_index_v1.sql
@@ -1,0 +1,3 @@
+drop index if exists public.dabbir_whatsapp_connections_branch_idx;
+create index if not exists dabbir_whatsapp_connections_branch_business_fk_idx
+  on public.dabbir_whatsapp_connections(branch_id,business_id);

--- a/supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql
+++ b/supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql
@@ -1,0 +1,97 @@
+create or replace function public.dabbir_whatsapp_reserve_outbound(
+  p_business_id uuid,
+  p_conversation_id uuid,
+  p_sender_user_id uuid,
+  p_idempotency_key text,
+  p_payload_hash text,
+  p_body text
+)
+returns table(
+  reservation_id uuid,
+  should_send boolean,
+  reservation_state text,
+  connection_id uuid,
+  phone_number_id text,
+  recipient_handle text,
+  provider_message_id text,
+  message_id uuid
+)
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_connection public.dabbir_whatsapp_connections%rowtype;
+  v_conversation public.dabbir_conversations%rowtype;
+  v_existing public.dabbir_whatsapp_outbound_reservations%rowtype;
+  v_recipient text;
+  v_key text:=trim(coalesce(p_idempotency_key,''));
+  v_hash text:=lower(trim(coalesce(p_payload_hash,'')));
+begin
+  if p_business_id is null or p_conversation_id is null or p_sender_user_id is null then raise exception 'WHATSAPP_OUTBOUND_CONTEXT_REQUIRED'; end if;
+  if length(v_key) not between 16 and 160 then raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REQUIRED'; end if;
+  if v_hash !~ '^[0-9a-f]{64}$' then raise exception 'WHATSAPP_PAYLOAD_HASH_REQUIRED'; end if;
+  if nullif(trim(p_body),'') is null or length(p_body)>4000 then raise exception 'WHATSAPP_MESSAGE_BODY_REQUIRED'; end if;
+
+  if exists(select 1 from public.account_access_state s where s.user_id=p_sender_user_id and s.status='suspended') then
+    raise exception 'WHATSAPP_REPLY_ACCOUNT_SUSPENDED';
+  end if;
+  if not exists(
+    select 1 from auth.users u where u.id=p_sender_user_id and u.deleted_at is null and (u.banned_until is null or u.banned_until<=now())
+  ) then raise exception 'WHATSAPP_REPLY_USER_INACTIVE'; end if;
+  if not exists(
+    select 1 from public.dabbir_memberships m
+    where m.business_id=p_business_id and m.user_id=p_sender_user_id and m.status='active'
+      and m.suspended_at is null and m.removed_at is null and m.role in ('owner','admin')
+  ) then raise exception 'WHATSAPP_REPLY_APPROVER_REQUIRED'; end if;
+
+  select * into v_conversation from public.dabbir_conversations c
+  where c.business_id=p_business_id and c.id=p_conversation_id and c.channel_type='whatsapp' and c.demo_mode=false
+  limit 1;
+  if not found or v_conversation.customer_id is null or v_conversation.branch_id is null then raise exception 'WHATSAPP_CONVERSATION_NOT_FOUND'; end if;
+
+  select nullif(trim(c.channel_handle),'') into v_recipient
+  from public.dabbir_customers c
+  where c.business_id=p_business_id and c.id=v_conversation.customer_id
+  limit 1;
+  if v_recipient is null then raise exception 'WHATSAPP_CUSTOMER_HANDLE_REQUIRED'; end if;
+
+  perform pg_advisory_xact_lock(hashtextextended(p_business_id::text || ':wa-out:' || v_key,0));
+
+  select * into v_existing from public.dabbir_whatsapp_outbound_reservations r
+  where r.business_id=p_business_id and r.idempotency_key=v_key
+  limit 1;
+  if found then
+    if v_existing.conversation_id<>p_conversation_id
+      or v_existing.sender_user_id<>p_sender_user_id
+      or v_existing.payload_hash<>v_hash then
+      raise exception 'WHATSAPP_IDEMPOTENCY_KEY_REUSED_DIFFERENT_REQUEST';
+    end if;
+    select * into v_connection from public.dabbir_whatsapp_connections c
+    where c.id=v_existing.connection_id and c.business_id=p_business_id limit 1;
+    if not found then raise exception 'WHATSAPP_RESERVED_CONNECTION_NOT_FOUND'; end if;
+    return query select v_existing.id,false,v_existing.state,v_existing.connection_id,
+      v_connection.phone_number_id,v_existing.recipient_handle,v_existing.provider_message_id,v_existing.message_id;
+    return;
+  end if;
+
+  select * into v_connection from public.dabbir_whatsapp_connections c
+  where c.business_id=p_business_id and c.branch_id=v_conversation.branch_id and c.status='connected'
+  limit 1;
+  if not found then raise exception 'WHATSAPP_BRANCH_CONNECTION_NOT_FOUND'; end if;
+
+  insert into public.dabbir_whatsapp_outbound_reservations(
+    business_id,connection_id,conversation_id,sender_user_id,idempotency_key,payload_hash,
+    recipient_handle,body,state,external_attempt_started_at
+  ) values (
+    p_business_id,v_connection.id,p_conversation_id,p_sender_user_id,v_key,v_hash,
+    v_recipient,left(trim(p_body),4000),'SENDING',now()
+  ) returning * into v_existing;
+
+  return query select v_existing.id,true,v_existing.state,v_existing.connection_id,
+    v_connection.phone_number_id,v_existing.recipient_handle,null::text,null::uuid;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_reserve_outbound(uuid,uuid,uuid,text,text,text) to service_role;

--- a/supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql
+++ b/supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql
@@ -1,0 +1,45 @@
+create or replace function public.dabbir_whatsapp_branch_operational_evidence(p_business_id uuid,p_branch_id uuid)
+returns table(
+  available boolean,
+  real_whatsapp_conversation boolean,
+  real_inbound_message boolean,
+  real_outbound_reply boolean,
+  verified_external_result boolean
+)
+language sql
+stable
+security invoker
+set search_path = pg_catalog, public
+as $$
+  select true,
+    exists(
+      select 1 from public.dabbir_conversations c
+      where c.business_id=p_business_id and c.branch_id=p_branch_id
+        and c.channel_type='whatsapp' and c.demo_mode=false
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_event_ledger e
+      join public.dabbir_conversations c on c.id=e.conversation_id and c.business_id=e.business_id
+      where e.business_id=p_business_id and c.branch_id=p_branch_id
+        and e.direction='inbound' and e.event_type='message' and e.message_id is not null
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_outbound_reservations r
+      join public.dabbir_conversations c on c.id=r.conversation_id and c.business_id=r.business_id
+      where r.business_id=p_business_id and c.branch_id=p_branch_id
+        and r.message_id is not null and r.provider_message_id is not null
+        and r.state in ('PROVIDER_ACCEPTED','SENT','DELIVERED','READ')
+    ),
+    exists(
+      select 1
+      from public.dabbir_whatsapp_outbound_reservations r
+      join public.dabbir_conversations c on c.id=r.conversation_id and c.business_id=r.business_id
+      where r.business_id=p_business_id and c.branch_id=p_branch_id
+        and r.provider_verified=true and r.state in ('DELIVERED','READ')
+    );
+$$;
+
+revoke all on function public.dabbir_whatsapp_branch_operational_evidence(uuid,uuid) from public,anon,authenticated;
+grant execute on function public.dabbir_whatsapp_branch_operational_evidence(uuid,uuid) to service_role;

--- a/supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql
+++ b/supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql
@@ -1,0 +1,154 @@
+create table if not exists public.dabbir_whatsapp_branch_intents(
+  business_id uuid not null references public.dabbir_businesses(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade default auth.uid(),
+  branch_id uuid not null,
+  expires_at timestamptz not null default (now()+interval '10 minutes'),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key(business_id,user_id),
+  constraint dabbir_whatsapp_branch_intents_branch_business_fkey
+    foreign key(branch_id,business_id)
+    references public.dabbir_business_branches(id,business_id)
+    on delete cascade
+);
+
+create index if not exists dabbir_whatsapp_branch_intents_expiry_idx
+  on public.dabbir_whatsapp_branch_intents(expires_at);
+create index if not exists dabbir_whatsapp_branch_intents_branch_business_fk_idx
+  on public.dabbir_whatsapp_branch_intents(branch_id,business_id);
+
+alter table public.dabbir_whatsapp_branch_intents enable row level security;
+alter table public.dabbir_whatsapp_branch_intents force row level security;
+revoke all on public.dabbir_whatsapp_branch_intents from public,anon;
+grant select,insert,update,delete on public.dabbir_whatsapp_branch_intents to authenticated;
+
+drop policy if exists dabbir_whatsapp_branch_intents_select on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_select on public.dabbir_whatsapp_branch_intents
+for select to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_insert on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_insert on public.dabbir_whatsapp_branch_intents
+for insert to authenticated
+with check (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+  and expires_at>now()
+  and expires_at<=now()+interval '15 minutes'
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_update on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_update on public.dabbir_whatsapp_branch_intents
+for update to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+)
+with check (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+  and dabbir_private.branch_access_allowed(business_id,branch_id)
+  and expires_at>now()
+  and expires_at<=now()+interval '15 minutes'
+);
+
+drop policy if exists dabbir_whatsapp_branch_intents_delete on public.dabbir_whatsapp_branch_intents;
+create policy dabbir_whatsapp_branch_intents_delete on public.dabbir_whatsapp_branch_intents
+for delete to authenticated
+using (
+  user_id=(select auth.uid())
+  and dabbir_private.has_permission(business_id,'manage_business')
+);
+
+create or replace function public.dabbir_whatsapp_upsert_connection(
+  p_business_id uuid,p_provider text,p_status text,p_meta_app_id text,p_waba_id text,
+  p_phone_number_id text,p_display_phone_number text,p_verified_name text,
+  p_access_token_ciphertext text,p_access_token_iv text,p_access_token_tag text,
+  p_token_expires_at timestamptz,p_token_key_version text,p_connected_by uuid,
+  p_connected_at timestamptz,p_last_verified_at timestamptz,p_last_provider_status integer,p_last_error text
+)
+returns setof public.dabbir_whatsapp_connections
+language plpgsql
+security invoker
+set search_path = pg_catalog, public, dabbir_private, auth
+as $$
+declare
+  v_row public.dabbir_whatsapp_connections%rowtype;
+  v_uid uuid := (select auth.uid());
+  v_phone_owner uuid;
+  v_branch_id uuid;
+begin
+  if v_uid is null then raise exception 'WHATSAPP_CONNECTION_AUTH_REQUIRED' using errcode='42501'; end if;
+  if p_business_id is null or nullif(trim(p_waba_id),'') is null or nullif(trim(p_phone_number_id),'') is null then
+    raise exception 'WHATSAPP_CONNECTION_REQUIRED_FIELDS' using errcode='22023';
+  end if;
+  if p_connected_by is distinct from v_uid then raise exception 'WHATSAPP_CONNECTION_ACTOR_MISMATCH' using errcode='42501'; end if;
+  if not dabbir_private.is_active_member(p_business_id)
+     or not exists (
+       select 1 from public.dabbir_memberships m
+       where m.business_id=p_business_id and m.user_id=v_uid and m.status='active'
+         and m.suspended_at is null and m.removed_at is null
+         and m.role=any(array['owner'::text,'admin'::text])
+     ) then raise exception 'WHATSAPP_CONNECTION_OWNER_REQUIRED' using errcode='42501'; end if;
+
+  select i.branch_id into v_branch_id
+  from public.dabbir_whatsapp_branch_intents i
+  where i.business_id=p_business_id and i.user_id=v_uid and i.expires_at>now()
+    and exists(
+      select 1 from public.dabbir_business_branches b
+      where b.id=i.branch_id and b.business_id=i.business_id and b.status='active'
+    )
+  order by i.updated_at desc limit 1;
+
+  if v_branch_id is null then v_branch_id:=dabbir_private.primary_branch_for_business(p_business_id); end if;
+  if v_branch_id is null then raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED'; end if;
+
+  select c.business_id into v_phone_owner
+  from public.dabbir_whatsapp_connections c
+  where c.phone_number_id=trim(p_phone_number_id)
+    and not (c.business_id=p_business_id and c.branch_id=v_branch_id)
+  limit 1;
+  if v_phone_owner is not null then raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505'; end if;
+
+  begin
+    insert into public.dabbir_whatsapp_connections(
+      business_id,branch_id,provider,status,meta_app_id,waba_id,phone_number_id,
+      display_phone_number,verified_name,access_token_ciphertext,access_token_iv,
+      access_token_tag,token_expires_at,token_key_version,connected_by,connected_at,
+      last_verified_at,last_provider_status,last_error,updated_at
+    ) values (
+      p_business_id,v_branch_id,coalesce(nullif(trim(p_provider),''),'meta'),
+      coalesce(nullif(trim(p_status),''),'connected'),nullif(trim(p_meta_app_id),''),
+      trim(p_waba_id),trim(p_phone_number_id),nullif(trim(p_display_phone_number),''),
+      nullif(trim(p_verified_name),''),p_access_token_ciphertext,p_access_token_iv,
+      p_access_token_tag,p_token_expires_at,coalesce(nullif(trim(p_token_key_version),''),'whatsapp_v1'),
+      p_connected_by,coalesce(p_connected_at,now()),p_last_verified_at,p_last_provider_status,p_last_error,now()
+    )
+    on conflict (business_id,branch_id) do update set
+      provider=excluded.provider,status=excluded.status,meta_app_id=excluded.meta_app_id,
+      waba_id=excluded.waba_id,phone_number_id=excluded.phone_number_id,
+      display_phone_number=excluded.display_phone_number,verified_name=excluded.verified_name,
+      access_token_ciphertext=excluded.access_token_ciphertext,access_token_iv=excluded.access_token_iv,
+      access_token_tag=excluded.access_token_tag,token_expires_at=excluded.token_expires_at,
+      token_key_version=excluded.token_key_version,connected_by=excluded.connected_by,
+      connected_at=excluded.connected_at,last_verified_at=excluded.last_verified_at,
+      last_provider_status=excluded.last_provider_status,last_error=excluded.last_error,updated_at=now()
+    returning * into v_row;
+  exception when unique_violation then
+    raise exception 'WHATSAPP_PHONE_ALREADY_CONNECTED' using errcode='23505';
+  end;
+
+  delete from public.dabbir_whatsapp_branch_intents i
+  where i.business_id=p_business_id and i.user_id=v_uid;
+
+  return next v_row;
+end;
+$$;
+
+revoke all on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) from public,anon;
+grant execute on function public.dabbir_whatsapp_upsert_connection(uuid,text,text,text,text,text,text,text,text,text,text,timestamptz,text,uuid,timestamptz,timestamptz,integer,text) to authenticated,service_role;

--- a/supabase/migrations/20260903161347_dabbir_whatsapp_branch_intent_user_index_v1.sql
+++ b/supabase/migrations/20260903161347_dabbir_whatsapp_branch_intent_user_index_v1.sql
@@ -1,0 +1,2 @@
+create index if not exists dabbir_whatsapp_branch_intents_user_idx
+  on public.dabbir_whatsapp_branch_intents(user_id);

--- a/supabase/migrations/20260903210000_dabbir_branch_scope_source_reconciliation_v1.sql
+++ b/supabase/migrations/20260903210000_dabbir_branch_scope_source_reconciliation_v1.sql
@@ -1,0 +1,365 @@
+-- DABBIR branch-scope source reconciliation.
+-- Production already carries this contract from the 2026-09-03 emergency cutover.
+-- This migration is intentionally idempotent so current Production converges without
+-- destructive rewrites while fresh environments reproduce the same fail-closed model.
+
+create table if not exists public.dabbir_membership_branches (
+  business_id uuid not null,
+  user_id uuid not null,
+  branch_id uuid not null,
+  created_at timestamptz not null default now(),
+  created_by uuid default auth.uid(),
+  primary key (business_id,user_id,branch_id),
+  foreign key (business_id,user_id) references public.dabbir_memberships(business_id,user_id) on delete cascade,
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade
+);
+alter table public.dabbir_membership_branches enable row level security;
+
+create or replace function dabbir_private.branch_access_allowed(p_business_id uuid,p_branch_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+  select dabbir_private.account_active()
+    and p_branch_id is not null
+    and exists(
+      select 1
+      from public.dabbir_memberships m
+      where m.business_id=p_business_id
+        and m.user_id=(select auth.uid())
+        and m.status='active'
+        and (
+          m.role in ('owner','admin')
+          or exists(
+            select 1 from public.dabbir_membership_branches mb
+            where mb.business_id=p_business_id
+              and mb.user_id=m.user_id
+              and mb.branch_id=p_branch_id
+          )
+        )
+    );
+$$;
+revoke all on function dabbir_private.branch_access_allowed(uuid,uuid) from public,anon;
+grant execute on function dabbir_private.branch_access_allowed(uuid,uuid) to authenticated,service_role;
+
+drop policy if exists dabbir_membership_branches_select on public.dabbir_membership_branches;
+create policy dabbir_membership_branches_select
+on public.dabbir_membership_branches for select to authenticated
+using (user_id=(select auth.uid()) or dabbir_private.has_permission(business_id,'manage_team'));
+
+create unique index if not exists dabbir_services_business_id_id_uq on public.dabbir_services(business_id,id);
+create unique index if not exists dabbir_products_business_id_id_uq on public.dabbir_products(business_id,id);
+
+create table if not exists public.dabbir_branch_services (
+  business_id uuid not null,
+  branch_id uuid not null,
+  service_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,service_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,service_id) references public.dabbir_services(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_services enable row level security;
+drop policy if exists dabbir_branch_services_select on public.dabbir_branch_services;
+create policy dabbir_branch_services_select on public.dabbir_branch_services for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'view_services'));
+
+create table if not exists public.dabbir_branch_products (
+  business_id uuid not null,
+  branch_id uuid not null,
+  product_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,product_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,product_id) references public.dabbir_products(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_products enable row level security;
+drop policy if exists dabbir_branch_products_select on public.dabbir_branch_products;
+create policy dabbir_branch_products_select on public.dabbir_branch_products for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+create table if not exists public.dabbir_worker_branches (
+  business_id uuid not null,
+  branch_id uuid not null,
+  worker_id uuid not null,
+  active boolean not null default true,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,worker_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,worker_id) references public.dabbir_workers(business_id,id) on delete cascade
+);
+alter table public.dabbir_worker_branches enable row level security;
+drop policy if exists dabbir_worker_branches_select on public.dabbir_worker_branches;
+create policy dabbir_worker_branches_select on public.dabbir_worker_branches for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+create table if not exists public.dabbir_branch_inventory (
+  business_id uuid not null,
+  branch_id uuid not null,
+  product_id uuid not null,
+  quantity integer not null default 0 check(quantity>=0),
+  reserved integer not null default 0 check(reserved>=0 and reserved<=quantity),
+  updated_at timestamptz not null default now(),
+  primary key (business_id,branch_id,product_id),
+  foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete cascade,
+  foreign key (business_id,product_id) references public.dabbir_products(business_id,id) on delete cascade
+);
+alter table public.dabbir_branch_inventory enable row level security;
+drop policy if exists dabbir_branch_inventory_select on public.dabbir_branch_inventory;
+create policy dabbir_branch_inventory_select on public.dabbir_branch_inventory for select to authenticated
+using (dabbir_private.branch_access_allowed(business_id,branch_id));
+
+create or replace function dabbir_private.primary_branch_for_business(p_business_id uuid)
+returns uuid
+language sql
+stable
+security definer
+set search_path='pg_catalog','public'
+as $$
+  select id
+  from public.dabbir_business_branches
+  where business_id=p_business_id and is_primary=true and status='active'
+  order by created_at,id
+  limit 1
+$$;
+revoke all on function dabbir_private.primary_branch_for_business(uuid) from public,anon,authenticated;
+grant execute on function dabbir_private.primary_branch_for_business(uuid) to service_role;
+
+insert into public.dabbir_branch_services(business_id,branch_id,service_id,active)
+select s.business_id,dabbir_private.primary_branch_for_business(s.business_id),s.id,s.active
+from public.dabbir_services s
+where dabbir_private.primary_branch_for_business(s.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_branch_products(business_id,branch_id,product_id,active)
+select p.business_id,dabbir_private.primary_branch_for_business(p.business_id),p.id,p.active
+from public.dabbir_products p
+where dabbir_private.primary_branch_for_business(p.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_worker_branches(business_id,branch_id,worker_id,active)
+select w.business_id,dabbir_private.primary_branch_for_business(w.business_id),w.id,(w.status='active')
+from public.dabbir_workers w
+where dabbir_private.primary_branch_for_business(w.business_id) is not null
+on conflict do nothing;
+
+insert into public.dabbir_branch_inventory(business_id,branch_id,product_id,quantity,reserved,updated_at)
+select i.business_id,dabbir_private.primary_branch_for_business(i.business_id),i.product_id,i.quantity,i.reserved,i.updated_at
+from public.dabbir_inventory i
+where dabbir_private.primary_branch_for_business(i.business_id) is not null
+on conflict (business_id,branch_id,product_id) do nothing;
+
+alter table public.dabbir_appointments add column if not exists branch_id uuid;
+alter table public.dabbir_orders add column if not exists branch_id uuid;
+alter table public.dabbir_inventory_movements add column if not exists branch_id uuid;
+alter table public.dabbir_conversations add column if not exists branch_id uuid;
+
+update public.dabbir_appointments set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+update public.dabbir_orders set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+update public.dabbir_inventory_movements set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+update public.dabbir_conversations set branch_id=dabbir_private.primary_branch_for_business(business_id) where branch_id is null;
+
+do $$
+begin
+  if exists(select 1 from public.dabbir_appointments where branch_id is null)
+     or exists(select 1 from public.dabbir_orders where branch_id is null)
+     or exists(select 1 from public.dabbir_inventory_movements where branch_id is null)
+     or exists(select 1 from public.dabbir_conversations where branch_id is null) then
+    raise exception 'DABBIR_BRANCH_BACKFILL_INCOMPLETE';
+  end if;
+end
+$$;
+
+alter table public.dabbir_appointments alter column branch_id set not null;
+alter table public.dabbir_orders alter column branch_id set not null;
+alter table public.dabbir_inventory_movements alter column branch_id set not null;
+alter table public.dabbir_conversations alter column branch_id set not null;
+
+do $$
+begin
+  if not exists(select 1 from pg_constraint where conrelid='public.dabbir_appointments'::regclass and conname='dabbir_appointments_branch_business_fk') then
+    alter table public.dabbir_appointments add constraint dabbir_appointments_branch_business_fk foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+  end if;
+  if not exists(select 1 from pg_constraint where conrelid='public.dabbir_orders'::regclass and conname='dabbir_orders_branch_business_fk') then
+    alter table public.dabbir_orders add constraint dabbir_orders_branch_business_fk foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+  end if;
+  if not exists(select 1 from pg_constraint where conrelid='public.dabbir_inventory_movements'::regclass and conname='dabbir_inventory_movements_branch_business_fk') then
+    alter table public.dabbir_inventory_movements add constraint dabbir_inventory_movements_branch_business_fk foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+  end if;
+  if not exists(select 1 from pg_constraint where conrelid='public.dabbir_conversations'::regclass and conname='dabbir_conversations_branch_business_fk') then
+    alter table public.dabbir_conversations add constraint dabbir_conversations_branch_business_fk foreign key (branch_id,business_id) references public.dabbir_business_branches(id,business_id) on delete restrict;
+  end if;
+end
+$$;
+
+create index if not exists dabbir_appointments_business_branch_start_idx on public.dabbir_appointments(business_id,branch_id,starts_at);
+create index if not exists dabbir_orders_business_branch_created_idx on public.dabbir_orders(business_id,branch_id,created_at desc);
+create index if not exists dabbir_inventory_movements_business_branch_product_idx on public.dabbir_inventory_movements(business_id,branch_id,product_id,created_at desc);
+create index if not exists dabbir_conversations_business_branch_updated_idx on public.dabbir_conversations(business_id,branch_id,updated_at desc);
+create index if not exists dabbir_appointments_branch_business_fk_idx on public.dabbir_appointments(branch_id,business_id);
+create index if not exists dabbir_orders_branch_business_fk_idx on public.dabbir_orders(branch_id,business_id);
+create index if not exists dabbir_inventory_movements_branch_business_fk_idx on public.dabbir_inventory_movements(branch_id,business_id);
+create index if not exists dabbir_conversations_branch_business_fk_idx on public.dabbir_conversations(branch_id,business_id);
+create index if not exists dabbir_membership_branches_branch_business_idx on public.dabbir_membership_branches(branch_id,business_id);
+create index if not exists dabbir_branch_services_branch_business_idx on public.dabbir_branch_services(branch_id,business_id);
+create index if not exists dabbir_branch_services_business_service_idx on public.dabbir_branch_services(business_id,service_id);
+create index if not exists dabbir_branch_products_branch_business_idx on public.dabbir_branch_products(branch_id,business_id);
+create index if not exists dabbir_branch_products_business_product_idx on public.dabbir_branch_products(business_id,product_id);
+create index if not exists dabbir_worker_branches_branch_business_idx on public.dabbir_worker_branches(branch_id,business_id);
+create index if not exists dabbir_worker_branches_business_worker_idx on public.dabbir_worker_branches(business_id,worker_id);
+create index if not exists dabbir_branch_inventory_branch_business_idx on public.dabbir_branch_inventory(branch_id,business_id);
+create index if not exists dabbir_branch_inventory_business_product_idx on public.dabbir_branch_inventory(business_id,product_id);
+
+create or replace function dabbir_private.ensure_operational_branch()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+begin
+  if tg_op='INSERT' or new.business_id is distinct from old.business_id or new.branch_id is distinct from old.branch_id then
+    if new.branch_id is null then new.branch_id:=dabbir_private.primary_branch_for_business(new.business_id); end if;
+    if new.branch_id is null or not exists(
+      select 1 from public.dabbir_business_branches b
+      where b.id=new.branch_id and b.business_id=new.business_id and b.status='active'
+    ) then raise exception 'DABBIR_ACTIVE_BRANCH_REQUIRED'; end if;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.ensure_operational_branch() from public,anon,authenticated;
+
+drop trigger if exists dabbir_appointments_branch_guard on public.dabbir_appointments;
+create trigger dabbir_appointments_branch_guard before insert or update of business_id,branch_id on public.dabbir_appointments for each row execute function dabbir_private.ensure_operational_branch();
+drop trigger if exists dabbir_orders_branch_guard on public.dabbir_orders;
+create trigger dabbir_orders_branch_guard before insert or update of business_id,branch_id on public.dabbir_orders for each row execute function dabbir_private.ensure_operational_branch();
+drop trigger if exists dabbir_inventory_movements_branch_guard on public.dabbir_inventory_movements;
+create trigger dabbir_inventory_movements_branch_guard before insert or update of business_id,branch_id on public.dabbir_inventory_movements for each row execute function dabbir_private.ensure_operational_branch();
+drop trigger if exists dabbir_conversations_branch_guard on public.dabbir_conversations;
+create trigger dabbir_conversations_branch_guard before insert or update of business_id,branch_id on public.dabbir_conversations for each row execute function dabbir_private.ensure_operational_branch();
+
+create or replace function dabbir_private.validate_appointment_branch_resources()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public'
+as $$
+begin
+  if new.service_id is not null and not exists(
+    select 1 from public.dabbir_branch_services x where x.business_id=new.business_id and x.branch_id=new.branch_id and x.service_id=new.service_id and x.active=true
+  ) then raise exception 'DABBIR_SERVICE_NOT_AVAILABLE_IN_BRANCH'; end if;
+  if new.worker_id is not null and not exists(
+    select 1 from public.dabbir_worker_branches x where x.business_id=new.business_id and x.branch_id=new.branch_id and x.worker_id=new.worker_id and x.active=true
+  ) then raise exception 'DABBIR_WORKER_NOT_ASSIGNED_TO_BRANCH'; end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.validate_appointment_branch_resources() from public,anon,authenticated;
+drop trigger if exists dabbir_appointments_branch_resource_guard on public.dabbir_appointments;
+create trigger dabbir_appointments_branch_resource_guard before insert or update of business_id,branch_id,service_id,worker_id on public.dabbir_appointments for each row execute function dabbir_private.validate_appointment_branch_resources();
+
+create or replace function dabbir_private.validate_order_item_branch_product()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public'
+as $$
+declare v_branch uuid; v_business uuid;
+begin
+  select business_id,branch_id into v_business,v_branch from public.dabbir_orders where id=new.order_id;
+  if v_business is null or v_business<>new.business_id then raise exception 'DABBIR_ORDER_BUSINESS_MISMATCH'; end if;
+  if not exists(
+    select 1 from public.dabbir_branch_products x where x.business_id=new.business_id and x.branch_id=v_branch and x.product_id=new.product_id and x.active=true
+  ) then raise exception 'DABBIR_PRODUCT_NOT_AVAILABLE_IN_BRANCH'; end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.validate_order_item_branch_product() from public,anon,authenticated;
+drop trigger if exists dabbir_order_items_branch_product_guard on public.dabbir_order_items;
+create trigger dabbir_order_items_branch_product_guard before insert or update of business_id,order_id,product_id on public.dabbir_order_items for each row execute function dabbir_private.validate_order_item_branch_product();
+
+create or replace function dabbir_private.seed_primary_branch_resource()
+returns trigger
+language plpgsql
+security definer
+set search_path='pg_catalog','public','dabbir_private'
+as $$
+declare v_branch uuid;
+begin
+  v_branch:=dabbir_private.primary_branch_for_business(new.business_id);
+  if v_branch is null then return new; end if;
+  if tg_table_name='dabbir_services' then
+    insert into public.dabbir_branch_services(business_id,branch_id,service_id,active) values(new.business_id,v_branch,new.id,new.active) on conflict do nothing;
+  elsif tg_table_name='dabbir_products' then
+    insert into public.dabbir_branch_products(business_id,branch_id,product_id,active) values(new.business_id,v_branch,new.id,new.active) on conflict do nothing;
+  elsif tg_table_name='dabbir_workers' then
+    insert into public.dabbir_worker_branches(business_id,branch_id,worker_id,active) values(new.business_id,v_branch,new.id,new.status='active') on conflict do nothing;
+  end if;
+  return new;
+end;
+$$;
+revoke all on function dabbir_private.seed_primary_branch_resource() from public,anon,authenticated;
+drop trigger if exists dabbir_services_primary_branch_seed on public.dabbir_services;
+create trigger dabbir_services_primary_branch_seed after insert on public.dabbir_services for each row execute function dabbir_private.seed_primary_branch_resource();
+drop trigger if exists dabbir_products_primary_branch_seed on public.dabbir_products;
+create trigger dabbir_products_primary_branch_seed after insert on public.dabbir_products for each row execute function dabbir_private.seed_primary_branch_resource();
+drop trigger if exists dabbir_workers_primary_branch_seed on public.dabbir_workers;
+create trigger dabbir_workers_primary_branch_seed after insert on public.dabbir_workers for each row execute function dabbir_private.seed_primary_branch_resource();
+
+-- Replace broad mutation policies with operation-specific policies so SELECT has one permissive path.
+drop policy if exists dabbir_membership_branches_manage on public.dabbir_membership_branches;
+drop policy if exists dabbir_membership_branches_insert on public.dabbir_membership_branches;
+drop policy if exists dabbir_membership_branches_update on public.dabbir_membership_branches;
+drop policy if exists dabbir_membership_branches_delete on public.dabbir_membership_branches;
+create policy dabbir_membership_branches_insert on public.dabbir_membership_branches for insert to authenticated with check (dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_membership_branches_update on public.dabbir_membership_branches for update to authenticated using (dabbir_private.has_permission(business_id,'manage_team')) with check (dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_membership_branches_delete on public.dabbir_membership_branches for delete to authenticated using (dabbir_private.has_permission(business_id,'manage_team'));
+
+drop policy if exists dabbir_branch_services_manage on public.dabbir_branch_services;
+drop policy if exists dabbir_branch_services_insert on public.dabbir_branch_services;
+drop policy if exists dabbir_branch_services_update on public.dabbir_branch_services;
+drop policy if exists dabbir_branch_services_delete on public.dabbir_branch_services;
+create policy dabbir_branch_services_insert on public.dabbir_branch_services for insert to authenticated with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+create policy dabbir_branch_services_update on public.dabbir_branch_services for update to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services')) with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+create policy dabbir_branch_services_delete on public.dabbir_branch_services for delete to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_services'));
+
+drop policy if exists dabbir_branch_products_manage on public.dabbir_branch_products;
+drop policy if exists dabbir_branch_products_insert on public.dabbir_branch_products;
+drop policy if exists dabbir_branch_products_update on public.dabbir_branch_products;
+drop policy if exists dabbir_branch_products_delete on public.dabbir_branch_products;
+create policy dabbir_branch_products_insert on public.dabbir_branch_products for insert to authenticated with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_products_update on public.dabbir_branch_products for update to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations')) with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_products_delete on public.dabbir_branch_products for delete to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+drop policy if exists dabbir_worker_branches_manage on public.dabbir_worker_branches;
+drop policy if exists dabbir_worker_branches_insert on public.dabbir_worker_branches;
+drop policy if exists dabbir_worker_branches_update on public.dabbir_worker_branches;
+drop policy if exists dabbir_worker_branches_delete on public.dabbir_worker_branches;
+create policy dabbir_worker_branches_insert on public.dabbir_worker_branches for insert to authenticated with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_worker_branches_update on public.dabbir_worker_branches for update to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team')) with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+create policy dabbir_worker_branches_delete on public.dabbir_worker_branches for delete to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_team'));
+
+drop policy if exists dabbir_branch_inventory_manage on public.dabbir_branch_inventory;
+drop policy if exists dabbir_branch_inventory_insert on public.dabbir_branch_inventory;
+drop policy if exists dabbir_branch_inventory_update on public.dabbir_branch_inventory;
+drop policy if exists dabbir_branch_inventory_delete on public.dabbir_branch_inventory;
+create policy dabbir_branch_inventory_insert on public.dabbir_branch_inventory for insert to authenticated with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_inventory_update on public.dabbir_branch_inventory for update to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations')) with check (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+create policy dabbir_branch_inventory_delete on public.dabbir_branch_inventory for delete to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id) and dabbir_private.has_permission(business_id,'manage_store_operations'));
+
+-- RESTRICTIVE policies AND with existing business-level permission policies.
+drop policy if exists dabbir_appointments_branch_restrict on public.dabbir_appointments;
+create policy dabbir_appointments_branch_restrict on public.dabbir_appointments as restrictive for all to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id)) with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+drop policy if exists dabbir_orders_branch_restrict on public.dabbir_orders;
+create policy dabbir_orders_branch_restrict on public.dabbir_orders as restrictive for all to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id)) with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+drop policy if exists dabbir_conversations_branch_restrict on public.dabbir_conversations;
+create policy dabbir_conversations_branch_restrict on public.dabbir_conversations as restrictive for all to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id)) with check (dabbir_private.branch_access_allowed(business_id,branch_id));
+drop policy if exists dabbir_inventory_movements_branch_restrict on public.dabbir_inventory_movements;
+create policy dabbir_inventory_movements_branch_restrict on public.dabbir_inventory_movements as restrictive for all to authenticated using (dabbir_private.branch_access_allowed(business_id,branch_id)) with check (dabbir_private.branch_access_allowed(business_id,branch_id));

--- a/supabase/migrations/20260903210100_dabbir_branch_scope_live_parity_v1.sql
+++ b/supabase/migrations/20260903210100_dabbir_branch_scope_live_parity_v1.sql
@@ -1,0 +1,23 @@
+-- Preserve exact live semantics after source reconciliation.
+create or replace function dabbir_private.primary_branch_for_business(p_business_id uuid)
+returns uuid
+language sql
+stable
+security definer
+set search_path='pg_catalog','public'
+as $$
+  select id
+  from public.dabbir_business_branches
+  where business_id=p_business_id and is_primary=true
+  order by created_at,id
+  limit 1
+$$;
+revoke all on function dabbir_private.primary_branch_for_business(uuid) from public,anon,authenticated;
+grant execute on function dabbir_private.primary_branch_for_business(uuid) to service_role;
+
+insert into public.dabbir_branch_inventory(business_id,branch_id,product_id,quantity,reserved,updated_at)
+select i.business_id,dabbir_private.primary_branch_for_business(i.business_id),i.product_id,i.quantity,i.reserved,i.updated_at
+from public.dabbir_inventory i
+where dabbir_private.primary_branch_for_business(i.business_id) is not null
+on conflict (business_id,branch_id,product_id) do update
+set quantity=excluded.quantity,reserved=excluded.reserved,updated_at=excluded.updated_at;

--- a/test/dabbir-branch-whatsapp-source-reconciliation.test.mjs
+++ b/test/dabbir-branch-whatsapp-source-reconciliation.test.mjs
@@ -28,7 +28,7 @@ test('Production WhatsApp branch migration history is immutable in source',()=>{
 
 test('source reconciliation rebuilds the missing branch-scope contract without owner-authority rollback',()=>{
   const reconcile=text('supabase/migrations/20260903210000_dabbir_branch_scope_source_reconciliation_v1.sql');
-  const parity=text('supabase/migrations/20260903210100_dabbir_branch_scope_production_parity_v1.sql');
+  const parity=text('supabase/migrations/20260903210100_dabbir_branch_scope_live_parity_v1.sql');
   for(const token of [
     'dabbir_membership_branches','dabbir_branch_services','dabbir_branch_products',
     'dabbir_worker_branches','dabbir_branch_inventory','branch_access_allowed',

--- a/test/dabbir-branch-whatsapp-source-reconciliation.test.mjs
+++ b/test/dabbir-branch-whatsapp-source-reconciliation.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+
+const ROOT=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,ROOT));
+const text=path=>read(path).toString('utf8');
+const gitBlobSha=path=>{
+  const body=read(path);
+  const header=Buffer.from(`blob ${body.length}\0`,'utf8');
+  return crypto.createHash('sha1').update(header).update(body).digest('hex');
+};
+
+const productionHistory={
+  'supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql':'74b0921a9ce94750d105f0ec636b1cf83153b602',
+  'supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql':'ff8c85bb45d2ba4aa5d37925060c239a0942ed2c',
+  'supabase/migrations/20260903155707_dabbir_whatsapp_branch_fk_index_v1.sql':'0bfd04ed1f3d052733770dc68366ca2484f5d202',
+  'supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql':'4700d7135c05493c6e2d2199786b6175395549b2',
+  'supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql':'9908a7e5cd38c468bccfa140771e24f4226077ec',
+  'supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql':'fa6f5b5f429ab3da0e81f5b76bea3675a6aa7a0e',
+  'supabase/migrations/20260903161347_dabbir_whatsapp_branch_intent_user_index_v1.sql':'099bd3781206885c0a465e9741476c8453e60dd3',
+};
+
+test('Production WhatsApp branch migration history is immutable in source',()=>{
+  for(const [path,sha] of Object.entries(productionHistory)) assert.equal(gitBlobSha(path),sha,path);
+});
+
+test('source reconciliation rebuilds the missing branch-scope contract without owner-authority rollback',()=>{
+  const reconcile=text('supabase/migrations/20260903210000_dabbir_branch_scope_source_reconciliation_v1.sql');
+  const parity=text('supabase/migrations/20260903210100_dabbir_branch_scope_production_parity_v1.sql');
+  for(const token of [
+    'dabbir_membership_branches','dabbir_branch_services','dabbir_branch_products',
+    'dabbir_worker_branches','dabbir_branch_inventory','branch_access_allowed',
+    'ensure_operational_branch','dabbir_appointments_branch_restrict','dabbir_orders_branch_restrict',
+    'dabbir_conversations_branch_restrict','dabbir_inventory_movements_branch_restrict'
+  ]) assert.match(reconcile,new RegExp(token));
+  assert.match(parity,/primary_branch_for_business/);
+  assert.match(parity,/where business_id=p_business_id and is_primary=true/);
+  assert.doesNotMatch(reconcile,/dabbir-owner-broker|ROOT_OWNER|OWNER_DELEGATE|platform_owner|support_admin/i);
+  assert.doesNotMatch(parity,/dabbir-owner-broker|ROOT_OWNER|OWNER_DELEGATE|platform_owner|support_admin/i);
+});
+
+test('WhatsApp branch routing remains fail-closed and branch-owned',()=>{
+  const inbound=text('supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql');
+  const outbound=text('supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql');
+  const intent=text('supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql');
+  assert.match(inbound,/branch_id=v_connection\.branch_id/);
+  assert.match(outbound,/branch_id=v_conversation\.branch_id/);
+  assert.match(outbound,/WHATSAPP_BRANCH_CONNECTION_NOT_FOUND/);
+  assert.match(intent,/force row level security/);
+  assert.match(intent,/dabbir_private\.branch_access_allowed/);
+});


### PR DESCRIPTION
Source-of-truth repair for Production drift discovered after #410.

- restores the seven WhatsApp branch-routing migrations with the exact historical Git blob SHAs that were already applied and recorded in Production
- adds an idempotent branch-scope reconciliation migration for membership/resource/transaction branch isolation missing from main
- adds a parity migration that preserves the current Production primary-branch semantics instead of changing behavior during source sync
- pins historical migration blobs in CI so applied migrations cannot be silently rewritten later
- explicitly excludes owner broker / ROOT_OWNER / OWNER_DELEGATE authority changes from this PR

No Production database write is performed by this PR itself before merge. Merge only after GitHub CI and Vercel Preview pass.