### PR TITLE
fix(dabbir): keep release guardian inside protected-branch policy

### DIFF
--- a/.github/workflows/dabbir-release-guardian.yml
+++ b/.github/workflows/dabbir-release-guardian.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: dabbir-release-guardian-main
@@ -30,12 +31,14 @@ jobs:
       FAILED_SHA: ${{ github.event.workflow_run.head_sha }}
       FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}
       FAILED_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
         with:
           ref: main
           fetch-depth: 20
-      - name: Fail closed by reverting the failing head if it is still current
+
+      - name: Fail closed with a governed revert PR if the failing head is still current
         shell: bash
         run: |
           set -euo pipefail
@@ -52,8 +55,16 @@ jobs:
             exit 1
           fi
 
+          short_sha="${FAILED_SHA:0:12}"
+          branch="guardian/revert-${short_sha}"
+          if git ls-remote --exit-code --heads origin "$branch" >/dev/null 2>&1; then
+            echo "Governed revert branch $branch already exists; duplicate rollback suppressed."
+            exit 0
+          fi
+
           git config user.name 'dabbir-release-guardian'
           git config user.email 'dabbir-release-guardian@users.noreply.github.com'
+          git switch -c "$branch"
 
           parent_count="$(git rev-list --parents -n 1 "$FAILED_SHA" | awk '{print NF-1}')"
           if [ "$parent_count" -gt 1 ]; then
@@ -63,5 +74,32 @@ jobs:
           fi
 
           git commit --amend -m "revert(guardian): ${FAILED_WORKFLOW} ${FAILED_CONCLUSION} on ${FAILED_SHA}"
-          git push origin HEAD:main
-          echo "Fail-closed rollback pushed for $FAILED_SHA after ${FAILED_WORKFLOW}=${FAILED_CONCLUSION}."
+          git push origin HEAD:"$branch"
+
+          body=$(cat <<EOF
+          DABBIR Release Guardian detected a protected-main validation failure and prepared a governed rollback candidate.
+
+          Failed workflow: ${FAILED_WORKFLOW}
+          Failed conclusion: ${FAILED_CONCLUSION}
+          Failed SHA: ${FAILED_SHA}
+          Rollback branch: ${branch}
+
+          Safety contract:
+          - direct main push: forbidden
+          - branch protection: preserved
+          - required checks: must pass
+          - rollback merge: only through pull request
+          - re-revert loop: blocked
+          EOF
+          )
+
+          pr_url=$(gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "revert(guardian): ${FAILED_WORKFLOW} failure on ${short_sha}" \
+            --body "$body")
+          echo "Governed rollback PR created: $pr_url"
+
+          # Enable auto-merge only if repository policy supports it. This never bypasses
+          # required reviews/checks; otherwise the PR remains open and fail-closed.
+          gh pr merge "$pr_url" --auto --squash || echo "Auto-merge unavailable; rollback PR remains governed and open."

--- a/test/dabbir-release-guardian.test.mjs
+++ b/test/dabbir-release-guardian.test.mjs
@@ -14,7 +14,7 @@ test('Vercel build gate fails closed on syntax, dependency audit, and full tests
   assert.match(buildGate,/process\.exit\(exitCode\)/);
 });
 
-test('release guardian auto-reverts failed main heads without stale rollback or loops',()=>{
+test('release guardian creates a governed rollback PR without bypassing protected main',()=>{
   for(const workflow of [
     'DABBIR CI',
     'DABBIR Mobile CI',
@@ -24,12 +24,22 @@ test('release guardian auto-reverts failed main heads without stale rollback or 
     'DABBIR Main Lineage Guard',
   ]) assert.ok(guardian.includes(`- ${workflow}`));
 
-  assert.match(guardian,/permissions:[\s\S]*contents: write/);
+  assert.match(guardian,/permissions:[\s\S]*contents: write[\s\S]*pull-requests: write/);
   assert.match(guardian,/current_sha=.*origin\/main/);
   assert.match(guardian,/current_sha.*FAILED_SHA/);
   assert.match(guardian,/revert\\\(guardian\\\):/);
+  assert.match(guardian,/branch="guardian\/revert-\$\{short_sha\}"/);
+  assert.match(guardian,/git ls-remote --exit-code --heads origin "\$branch"/);
+  assert.match(guardian,/duplicate rollback suppressed/);
   assert.match(guardian,/git revert/);
-  assert.match(guardian,/git push origin HEAD:main/);
+  assert.match(guardian,/git push origin HEAD:"\$branch"/);
+  assert.match(guardian,/gh pr create/);
+  assert.match(guardian,/--base main/);
+  assert.match(guardian,/--head "\$branch"/);
+  assert.match(guardian,/Governed rollback PR created/);
+  assert.match(guardian,/gh pr merge "\$pr_url" --auto --squash/);
+  assert.match(guardian,/Auto-merge unavailable; rollback PR remains governed and open/);
+  assert.doesNotMatch(guardian,/git push origin HEAD:main/);
 });
 
 test('main lineage guard requires a merged PR and only exempts Guardian rollback commits',()=>{

--- a/test/dabbir-worst-case-resilience-gate.test.mjs
+++ b/test/dabbir-worst-case-resilience-gate.test.mjs
@@ -57,10 +57,14 @@ test('worst-case gate: stale and expired customer messages fail closed',()=>{
   assert.match(resilience,/a\.starts_at<=now\(\)/);
 });
 
-test('worst-case gate: failed main releases still have automatic rollback protection',()=>{
+test('worst-case gate: failed main releases retain automatic rollback through protected PR governance',()=>{
   assert.match(guardian,/DABBIR CI/);
   assert.match(guardian,/DABBIR Protected Live Smoke/);
   assert.match(guardian,/DABBIR AI Full Customer Journey/);
   assert.match(guardian,/git revert/);
-  assert.match(guardian,/Fail-closed rollback pushed/);
+  assert.match(guardian,/guardian\/revert-/);
+  assert.match(guardian,/git push origin HEAD:"\$branch"/);
+  assert.match(guardian,/gh pr create/);
+  assert.match(guardian,/Governed rollback PR created/);
+  assert.doesNotMatch(guardian,/git push origin HEAD:main/);
 });


### PR DESCRIPTION
## Failure observed
DABBIR Release Guardian run 33794548324 attempted to revert failing main SHA `fb9636c8c756becc20a5d8fce14c438d3436b374` by pushing directly to `main`. GitHub correctly rejected it because branch protection requires pull requests and the `test` status check.

## Repair
- Preserve branch protection; never push rollback commits directly to main.
- Create one deterministic `guardian/revert-<sha>` rollback branch.
- Suppress duplicate rollback branches for repeated failed workflows on the same SHA.
- Open a governed revert PR.
- Attempt auto-merge only through GitHub's protected PR path; if unavailable, leave the rollback PR open and fail-closed.
- Keep the existing guard against re-reverting a guardian revert.

## Acceptance
The workflow must pass repository CI. A future failed main validation must create a rollback PR instead of producing GH006 from a direct main push.