### PR TITLE
Fix iPhone owner UI authority first-paint race

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -4,6 +4,8 @@ const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;
+const OWNER_FIRST_SCRIPT_RE = /<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g;
+const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -18,6 +20,22 @@ function stripLegacyNavigationOverrides(body) {
   return body
     .split(LEGACY_STORE_SLOT_HIDE).join('')
     .split(LEGACY_STORE_APPOINTMENT_REDIRECT).join('');
+}
+
+function orderOwnerFirstBeforeAuthBoot(body) {
+  if (typeof body !== 'string') return body;
+  const ownerScripts = body.match(OWNER_FIRST_SCRIPT_RE) || [];
+  if (ownerScripts.length !== 1) throw new Error(`DABBIR_OWNER_FIRST_SCRIPT_COUNT_${ownerScripts.length}`);
+  const firstBoot = body.indexOf(AUTH_BOOT_ANCHOR);
+  const secondBoot = firstBoot < 0 ? -1 : body.indexOf(AUTH_BOOT_ANCHOR, firstBoot + AUTH_BOOT_ANCHOR.length);
+  if (firstBoot < 0 || secondBoot >= 0) throw new Error(`DABBIR_AUTH_BOOT_ANCHOR_COUNT_${firstBoot < 0 ? 0 : 2}`);
+
+  const ownerScript = ownerScripts[0];
+  const withoutLateOwner = body.replace(ownerScript, '');
+  return withoutLateOwner.replace(
+    AUTH_BOOT_ANCHOR,
+    `</script>\n${ownerScript}\n<script>\napplyLang();boot();\n</script>`,
+  );
 }
 
 function injectSafariAuthFailOpen(body) {
@@ -44,10 +62,12 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
+      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-before-auth-boot-v1');
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);
-      return res.end(injectSafariAuthFailOpen(canonical));
+      const ordered = orderOwnerFirstBeforeAuthBoot(canonical);
+      return res.end(injectSafariAuthFailOpen(ordered));
     },
   };
 

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -1,11 +1,28 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import appSafariRecoveryHandler from '../api/app-safari-recovery.js';
 
 const recovery = fs.readFileSync(new URL('../api/app-safari-recovery.js', import.meta.url), 'utf8');
 const app = fs.readFileSync(new URL('../api/app.js', import.meta.url), 'utf8');
 const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui.js', import.meta.url), 'utf8');
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
+
+function renderCanonicalRoot(){
+  const headers=new Map();
+  let body='';
+  const res={
+    _status:200,
+    setHeader(name,value){headers.set(String(name).toLowerCase(),String(value));return this},
+    getHeader(name){return headers.get(String(name).toLowerCase())},
+    removeHeader(name){headers.delete(String(name).toLowerCase())},
+    end(value=''){body=String(value);return this},
+    set statusCode(value){this._status=Number(value)},
+    get statusCode(){return this._status},
+  };
+  appSafariRecoveryHandler({method:'GET',headers:{}},res);
+  return {body,headers,status:res.statusCode};
+}
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
   assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
@@ -13,6 +30,21 @@ test('root shell bypasses stale Safari UI bundle versions', () => {
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
+});
+
+test('owner-first authority executes after base render definitions but before auth boot can expose first paint', () => {
+  assert.match(recovery,/orderOwnerFirstBeforeAuthBoot/);
+  assert.match(recovery,/DABBIR_OWNER_FIRST_SCRIPT_COUNT_/);
+  assert.match(recovery,/DABBIR_AUTH_BOOT_ANCHOR_COUNT_/);
+  const {body,headers,status}=renderCanonicalRoot();
+  assert.equal(status,200);
+  const ownerTags=body.match(/<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g)||[];
+  assert.equal(ownerTags.length,1);
+  const renderIndex=body.indexOf('function renderAll()');
+  const ownerIndex=body.indexOf(ownerTags[0]);
+  const bootIndex=body.indexOf('applyLang();boot();');
+  assert.ok(renderIndex>=0 && ownerIndex>renderIndex && bootIndex>ownerIndex,`render=${renderIndex} owner=${ownerIndex} boot=${bootIndex}`);
+  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-before-auth-boot-v1');
 });
 
 test('root shell injects an independent Safari auth fail-open watchdog', () => {


### PR DESCRIPTION
Root-cause fix for the exact Production Protected Live Smoke failure `UI_AUTHORITY_INVALID_null` on WebKit/iPhone-size login.

- Production already serves the owner-first script correctly, but base `boot()` can receive unauthenticated 401 and expose `#authGate` before the parser reaches the late owner-first script.
- Canonical Safari root now moves the single owner-first script after base render/function definitions but before `applyLang();boot()`.
- Transformation fails closed if there is not exactly one owner-first script or exactly one auth-boot anchor.
- Adds rendered-HTML regression proof that render definitions < owner-first authority < auth boot.
- Does not weaken the Protected Live Smoke with waits and does not touch Supabase, owner authority, or WhatsApp routing.

Merge only after GitHub CI and Vercel Preview prove the fix; then exact Production Protected Live Smoke must pass before closing the incident.