### PR TITLE
Reconcile branch runtime and WhatsApp routing onto current main

### DIFF
--- a/api/_branch-scope.js
+++ b/api/_branch-scope.js
@@ -1,0 +1,90 @@
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const ALL_BRANCHES='all';
+
+export function branchId(value){
+  const raw=String(value??'').trim();
+  return UUID_RE.test(raw)?raw:null;
+}
+
+function permissionsOf(membership){
+  return Array.isArray(membership?.permissions)?membership.permissions.map(String):[];
+}
+
+export function canUseAllBranches(membership){
+  const role=String(membership?.role||'').toLowerCase();
+  if(role==='owner'||role==='admin')return true;
+  const permissions=permissionsOf(membership);
+  return permissions.includes('manage_business')||permissions.includes('manage_team');
+}
+
+/**
+ * Resolve branch scope on the server using RLS-scoped branch and assignment rows.
+ * Owners/admins may use all branches or any active branch. Restricted staff may
+ * only use branches explicitly assigned to their own membership.
+ */
+export async function resolveBranchScope({businessId,membership,userId,requestedBranch,fetchRows}){
+  if(!branchId(businessId)||!membership||membership.business_id!==businessId){
+    throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+  }
+  const requested=String(requestedBranch??'').trim().toLowerCase();
+  const allAllowed=canUseAllBranches(membership);
+
+  const branches=await fetchRows(
+    `dabbir_business_branches?select=id,business_id,name,status,is_primary,timezone&business_id=eq.${encodeURIComponent(businessId)}&status=eq.active&order=is_primary.desc,created_at.asc`,
+    'BRANCH_LOOKUP_FAILED',
+  );
+  const active=(Array.isArray(branches)?branches:[]).filter(row=>row?.business_id===businessId&&branchId(row?.id));
+  if(!active.length)throw Object.assign(new Error('ACTIVE_BRANCH_REQUIRED'),{status:409});
+
+  if(requested===ALL_BRANCHES){
+    if(!allAllowed)throw Object.assign(new Error('ALL_BRANCHES_ACCESS_DENIED'),{status:403});
+    return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+  }
+
+  const requestedId=branchId(requestedBranch);
+  if(requestedBranch!=null&&String(requestedBranch).trim()&&!requestedId){
+    throw Object.assign(new Error('INVALID_BRANCH_ID'),{status:400});
+  }
+
+  if(allAllowed){
+    if(!requestedId)return {mode:'all',branch_id:null,branch_ids:active.map(row=>row.id),branch:null,all_allowed:true};
+    const selected=active.find(row=>row.id===requestedId);
+    if(!selected)throw Object.assign(new Error('BRANCH_NOT_FOUND'),{status:404});
+    return {mode:'selected',branch_id:selected.id,branch_ids:[selected.id],branch:selected,all_allowed:true};
+  }
+
+  const assignments=await fetchRows(
+    `dabbir_membership_branches?select=business_id,user_id,branch_id&business_id=eq.${encodeURIComponent(businessId)}&user_id=eq.${encodeURIComponent(userId)}&order=created_at.asc`,
+    'BRANCH_ASSIGNMENTS_LOOKUP_FAILED',
+  );
+  const assignedIds=new Set((Array.isArray(assignments)?assignments:[]).filter(row=>row?.business_id===businessId&&row?.user_id===userId).map(row=>row.branch_id));
+  const allowed=active.filter(row=>assignedIds.has(row.id));
+  if(!allowed.length)throw Object.assign(new Error('BRANCH_ASSIGNMENT_REQUIRED'),{status:403});
+
+  if(requestedId){
+    const selected=active.find(row=>row.id===requestedId);
+    if(!selected)throw Object.assign(new Error('BRANCH_NOT_FOUND'),{status:404});
+    if(!assignedIds.has(requestedId))throw Object.assign(new Error('BRANCH_ACCESS_DENIED'),{status:403});
+    return {mode:'selected',branch_id:selected.id,branch_ids:[selected.id],branch:selected,all_allowed:false};
+  }
+
+  if(allowed.length!==1){
+    throw Object.assign(new Error('BRANCH_SELECTION_REQUIRED'),{status:409,branches:allowed.map(row=>row.id)});
+  }
+  return {mode:'selected',branch_id:allowed[0].id,branch_ids:[allowed[0].id],branch:allowed[0],all_allowed:false};
+}
+
+export function branchFilter(scope,column='branch_id'){
+  if(!scope||scope.mode==='all')return '';
+  const id=branchId(scope.branch_id);
+  if(!id)throw Object.assign(new Error('BRANCH_SCOPE_INVALID'),{status:500});
+  return `&${encodeURIComponent(column)}=eq.${encodeURIComponent(id)}`;
+}
+
+export function branchWrite(scope){
+  if(!scope||scope.mode!=='selected'||!branchId(scope.branch_id)){
+    throw Object.assign(new Error('SELECTED_BRANCH_REQUIRED'),{status:409});
+  }
+  return scope.branch_id;
+}

--- a/api/_whatsapp-branch-connection.js
+++ b/api/_whatsapp-branch-connection.js
@@ -1,0 +1,118 @@
+import { supabaseRest } from './_auth-core.js';
+import { withServerReadTimeout } from './_server-read-timeout.js';
+import {
+  embeddedPlatformConfig,
+  openAccessToken,
+  sealAccessToken,
+  tokenNeedsRotation,
+} from './_whatsapp-embedded-core.js';
+
+const READ_TIMEOUT_MS=10_000;
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const SELECT='id,business_id,branch_id,status,meta_app_id,waba_id,phone_number_id,display_phone_number,verified_name,access_token_ciphertext,access_token_iv,access_token_tag,token_key_version,token_expires_at,connected_at,last_verified_at,last_provider_status,last_error';
+
+async function readRows(response,code,{max=1}={}){
+  const text=await response.text();
+  let rows=null;
+  try{rows=text?JSON.parse(text):null}catch{rows=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||502)});
+  if(!Array.isArray(rows)||rows.length>max)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_RESPONSE_MALFORMED'),{status:502});
+  return rows;
+}
+
+async function rotateExact(accessToken,row,config,options={}){
+  if(!row||!tokenNeedsRotation(row,config)||!config.rotationReady)return row;
+  const plaintext=openAccessToken(row,config,row.business_id);
+  const sealed=sealAccessToken(plaintext,config,row.business_id);
+  return withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?id=eq.${encodeURIComponent(row.id)}&business_id=eq.${encodeURIComponent(row.business_id)}&select=${SELECT}`;
+    const response=await supabaseRest(path,accessToken,{
+      method:'PATCH',
+      headers:{prefer:'return=representation'},
+      body:JSON.stringify(sealed),
+      signal,
+    });
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_ROTATION_FAILED');
+    const rotated=rows[0]||null;
+    if(!rotated||rotated.id!==row.id||rotated.business_id!==row.business_id){
+      throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ROTATION_UNVERIFIED'),{status:502});
+    }
+    return rotated;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_ROTATION',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_ROTATION_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+}
+
+async function loadConnection(accessToken,business,filter,options={}){
+  let row=await withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?select=${SELECT}&business_id=eq.${encodeURIComponent(business)}&${filter}&limit=1`;
+    const response=await supabaseRest(path,accessToken,{signal});
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_READ_FAILED');
+    return rows[0]||null;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_READ',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_READ_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+  if(!row)return null;
+  if(row.business_id!==business||!safeId(row.id)||!safeId(row.branch_id)){
+    throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  }
+  row=await rotateExact(accessToken,row,embeddedPlatformConfig(),options);
+  return row;
+}
+
+export async function loadExactBusinessConnection(accessToken,businessId,connectionId,options={}){
+  const business=safeId(businessId),connection=safeId(connectionId);
+  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+  const row=await loadConnection(accessToken,business,`id=eq.${encodeURIComponent(connection)}`,options);
+  if(row&&row.id!==connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  return row;
+}
+
+export async function loadBusinessBranchConnection(accessToken,businessId,branchId,options={}){
+  const business=safeId(businessId),branch=safeId(branchId);
+  if(!business||!branch)throw Object.assign(new Error('WHATSAPP_BRANCH_CONNECTION_ID_REQUIRED'),{status:400});
+  const row=await loadConnection(accessToken,business,`branch_id=eq.${encodeURIComponent(branch)}`,options);
+  if(row&&row.branch_id!==branch)throw Object.assign(new Error('WHATSAPP_BRANCH_CONNECTION_SCOPE_MISMATCH'),{status:502});
+  return row;
+}
+
+export async function loadPrimaryBusinessConnection(accessToken,businessId,options={}){
+  const business=safeId(businessId);
+  if(!business)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const branch=await withServerReadTimeout(async signal=>{
+    const path=`dabbir_business_branches?select=id,business_id,status,is_primary&business_id=eq.${encodeURIComponent(business)}&status=eq.active&is_primary=eq.true&limit=1`;
+    const response=await supabaseRest(path,accessToken,{signal});
+    const rows=await readRows(response,'WHATSAPP_PRIMARY_BRANCH_READ_FAILED');
+    return rows[0]||null;
+  },{
+    label:'WHATSAPP_PRIMARY_BRANCH_READ',
+    errorCode:'WHATSAPP_PRIMARY_BRANCH_READ_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+  if(!branch?.id||branch.business_id!==business)throw Object.assign(new Error('WHATSAPP_PRIMARY_BRANCH_REQUIRED'),{status:409});
+  return loadBusinessBranchConnection(accessToken,business,branch.id,options);
+}
+
+export async function deleteExactBusinessConnection(accessToken,businessId,connectionId,options={}){
+  const business=safeId(businessId),connection=safeId(connectionId);
+  if(!business||!connection)throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_ID_REQUIRED'),{status:400});
+  return withServerReadTimeout(async signal=>{
+    const path=`dabbir_whatsapp_connections?id=eq.${encodeURIComponent(connection)}&business_id=eq.${encodeURIComponent(business)}&select=id,business_id,branch_id,waba_id,phone_number_id`;
+    const response=await supabaseRest(path,accessToken,{method:'DELETE',headers:{prefer:'return=representation'},signal});
+    const rows=await readRows(response,'WHATSAPP_EXACT_CONNECTION_DELETE_FAILED');
+    const deleted=rows[0]||null;
+    if(!deleted||deleted.id!==connection||deleted.business_id!==business){
+      throw Object.assign(new Error('WHATSAPP_EXACT_CONNECTION_DELETE_UNVERIFIED'),{status:502});
+    }
+    return deleted;
+  },{
+    label:'WHATSAPP_EXACT_CONNECTION_DELETE',
+    errorCode:'WHATSAPP_EXACT_CONNECTION_DELETE_TIMEOUT',
+    timeoutMs:options.timeoutMs??READ_TIMEOUT_MS,
+  });
+}

--- a/api/branch-context-ui.js
+++ b/api/branch-context-ui.js
@@ -1,0 +1,203 @@
+const css=String.raw`
+.dbBranchScope{margin-top:8px}.dbBranchScope label{display:block;color:#8f969e;font-size:8px;margin:0 0 4px}.dbBranchScope select{width:100%;min-height:40px;border:1px solid #30363d;background:#15181b;color:#fff;border-radius:10px;padding:7px 9px;font-size:10px}.dbBranchScope small{display:block;margin-top:4px;color:#767d85;font-size:7px}.dbBranchScope[data-state="error"] small{color:#ffb4ba}
+@media(max-width:700px){.dbBranchScope select{min-height:44px;font-size:12px}}
+`;
+
+const script=String.raw`(()=>{
+  if(window.__dabbirBranchContextUi)return;
+  window.__dabbirBranchContextUi='v3-server-scoped-whatsapp';
+  const PREFIX='dabbir_active_branch_scope:';
+  let activeBusiness=null,context=null,loading=null,apiPatched=false,fetchPatched=false;
+  const style=document.createElement('style');style.textContent=${JSON.stringify(css)};style.dataset.dabbirBranchContext='v3';document.head.append(style);
+
+  function businessId(){try{return String(workspace?.business?.id||'').trim()}catch{return''}}
+  function key(id){return PREFIX+String(id||'')}
+  function stored(id){try{return localStorage.getItem(key(id))||''}catch{return''}}
+  function save(id,value){try{localStorage.setItem(key(id),String(value||''))}catch{}}
+  function isAr(){return document.documentElement.lang!=='en'}
+  function copy(){return isAr()?{label:'نطاق الفرع',all:'كل الفروع',hint:'ما يظهر هنا يحدد بيانات التشغيل المعروضة.',error:'تعذر تحميل صلاحيات الفروع'}:{label:'Branch scope',all:'All branches',hint:'This controls which operational data is loaded.',error:'Could not load branch permissions'}}
+  function parseBody(options){try{return options?.body?JSON.parse(options.body):null}catch{return null}}
+
+  function currentScope(id){
+    const value=stored(id);
+    if(value)return value;
+    if(context?.business_id===id&&context.default_scope)return String(context.default_scope);
+    return 'all';
+  }
+
+  function routedApi(original,url,options){
+    const raw=String(url||'');
+    if(!raw.startsWith('/api/dabbir-runtime'))return original(url,options);
+    let parsed;
+    try{parsed=new URL(raw,location.origin)}catch{return original(url,options)}
+    const body=parseBody(options);
+    const method=String(options?.method||'GET').toUpperCase();
+    const bid=String(parsed.searchParams.get('business_id')||body?.business_id||businessId()||'').trim();
+    if(!bid)return original(url,options);
+    const scope=currentScope(bid);
+    if(!scope||scope==='all')return original(url,options);
+
+    if(method==='GET'){
+      const target=new URL('/api/branch-workspace',location.origin);
+      target.searchParams.set('business_id',bid);
+      target.searchParams.set('branch_id',scope);
+      const cid=parsed.searchParams.get('conversation_id');if(cid)target.searchParams.set('conversation_id',cid);
+      return original(target.pathname+target.search,options);
+    }
+
+    if(method==='POST'&&body&&['start_conversation','create_appointment'].includes(String(body.action||''))){
+      const next=Object.assign({},body,{business_id:bid,branch_id:scope});
+      return original('/api/branch-operations',Object.assign({},options,{body:JSON.stringify(next)}));
+    }
+    return original(url,options);
+  }
+
+  function patchApi(){
+    if(apiPatched)return true;
+    if(typeof window.api!=='function')return false;
+    const original=window.api.bind(window);
+    window.api=function(url,options){return routedApi(original,url,options)};
+    window.api.__dabbirBranchScoped=true;
+    apiPatched=true;
+    return true;
+  }
+
+  async function persistWhatsAppIntent(original,bid,scope){
+    const response=await original('/api/whatsapp-branch-intent',{
+      method:'POST',cache:'no-store',
+      headers:{'content-type':'application/json','accept':'application/json','x-dabbir-client':'web'},
+      body:JSON.stringify({business_id:bid,branch_id:scope&&scope!=='all'?scope:null}),
+    });
+    const payload=await response.clone().json().catch(()=>({}));
+    if(!response.ok||!payload.ok)throw new Error(payload.error||'WHATSAPP_BRANCH_INTENT_REQUIRED');
+    return payload;
+  }
+
+  function patchFetch(){
+    if(fetchPatched)return true;
+    if(typeof window.fetch!=='function')return false;
+    const original=window.fetch.bind(window);
+    window.fetch=async function(input,options){
+      const raw=typeof input==='string'?input:String(input?.url||'');
+      let parsed;try{parsed=new URL(raw,location.origin)}catch{return original(input,options)}
+      const path=parsed.pathname;
+      if(!['/api/dabbir-whatsapp-embedded-complete','/api/dabbir-whatsapp-embedded-config','/api/dabbir-whatsapp-status','/api/dabbir-whatsapp-disconnect'].includes(path)){
+        return original(input,options);
+      }
+      const body=parseBody(options);
+      const method=String(options?.method||'GET').toUpperCase();
+      const bid=String(parsed.searchParams.get('business_id')||body?.business_id||businessId()||'').trim();
+      if(!bid)return original(input,options);
+      const scope=currentScope(bid);
+
+      if(path==='/api/dabbir-whatsapp-embedded-complete'&&method==='POST'){
+        try{await persistWhatsAppIntent(original,bid,scope)}catch(error){
+          return new Response(JSON.stringify({ok:false,error:String(error?.message||'WHATSAPP_BRANCH_INTENT_REQUIRED')}),{
+            status:409,headers:{'content-type':'application/json'}
+          });
+        }
+        return original(input,options);
+      }
+
+      if(scope&&scope!=='all'&&['/api/dabbir-whatsapp-embedded-config','/api/dabbir-whatsapp-status'].includes(path)&&method==='GET'){
+        parsed.searchParams.set('business_id',bid);parsed.searchParams.set('branch_id',scope);
+        return original(parsed.pathname+parsed.search,options);
+      }
+
+      if(scope&&scope!=='all'&&path==='/api/dabbir-whatsapp-disconnect'&&method==='POST'&&body){
+        const next=Object.assign({},body,{business_id:bid,branch_id:scope});
+        return original(input,Object.assign({},options,{body:JSON.stringify(next)}));
+      }
+      return original(input,options);
+    };
+    window.fetch.__dabbirWhatsAppBranchScoped=true;
+    fetchPatched=true;
+    return true;
+  }
+
+  async function loadContext(id){
+    if(!id)return null;
+    if(loading)return loading;
+    loading=(async()=>{
+      const response=await fetch('/api/branch-context?business_id='+encodeURIComponent(id),{cache:'no-store',headers:{accept:'application/json','x-dabbir-client':'web'}});
+      const payload=await response.json().catch(()=>({}));
+      if(!response.ok||!payload.ok)throw new Error(payload.error||'BRANCH_CONTEXT_FAILED');
+      context=payload;
+      const valid=new Set((payload.branches||[]).map(row=>String(row.id)));
+      let value=stored(id);
+      if(value==='all'&&!payload.all_allowed)value='';
+      if(value!=='all'&&value&&!valid.has(value))value='';
+      if(!value)value=String(payload.default_scope||payload.branches?.[0]?.id||'');
+      if(value)save(id,value);
+      document.documentElement.dataset.dabbirBranchScope=value||'unselected';
+      return payload;
+    })().finally(()=>{loading=null});
+    return loading;
+  }
+
+  function ensureUi(){
+    const host=document.querySelector('.side .workspace');
+    if(!host)return null;
+    let box=host.querySelector('#dbBranchScope');
+    if(!box){
+      box=document.createElement('div');box.id='dbBranchScope';box.className='dbBranchScope';
+      box.innerHTML='<label></label><select aria-label="Branch scope"></select><small></small>';
+      host.append(box);
+      box.querySelector('select').addEventListener('change',async event=>{
+        const id=businessId();if(!id)return;
+        const value=String(event.target.value||'');if(!value)return;
+        save(id,value);document.documentElement.dataset.dabbirBranchScope=value;
+        window.dispatchEvent(new CustomEvent('dabbir:branch-scope-changed',{detail:{business_id:id,branch_id:value==='all'?null:value,mode:value==='all'?'all':'selected'}}));
+        try{if(typeof window.loadRuntime==='function')await window.loadRuntime(id)}catch{}
+      });
+    }
+    return box;
+  }
+
+  function render(){
+    const box=ensureUi();if(!box)return;
+    const t=copy();box.querySelector('label').textContent=t.label;box.querySelector('small').textContent=t.hint;
+    const select=box.querySelector('select');
+    const id=businessId();
+    if(!context||context.business_id!==id){select.innerHTML='';select.disabled=true;return}
+    const options=[];
+    if(context.all_allowed)options.push('<option value="all">'+t.all+'</option>');
+    for(const branch of context.branches||[])options.push('<option value="'+String(branch.id).replace(/"/g,'')+'">'+String(branch.name||'Branch').replace(/[&<>]/g,ch=>({'&':'&amp;','<':'&lt;','>':'&gt;'}[ch]))+'</option>');
+    select.innerHTML=options.join('');select.disabled=false;
+    const value=currentScope(id);if([...select.options].some(o=>o.value===value))select.value=value;
+    box.dataset.state='ready';
+  }
+
+  async function sync(){
+    patchFetch();patchApi();
+    const id=businessId();
+    if(!id){activeBusiness=null;context=null;render();return}
+    if(id!==activeBusiness){
+      activeBusiness=id;context=null;render();
+      try{await loadContext(id);render()}catch{const box=ensureUi();if(box){box.dataset.state='error';box.querySelector('small').textContent=copy().error}}
+    }else render();
+  }
+
+  window.dabbirBranchContext={
+    scope:()=>{const id=businessId();const value=currentScope(id);return {business_id:id,mode:value==='all'?'all':'selected',branch_id:value==='all'?null:value}},
+    query(url){const id=businessId(),value=currentScope(id);if(!id||!value||value==='all')return url;const u=new URL(url,location.origin);u.searchParams.set('branch_id',value);return u.pathname+u.search},
+    refresh:sync,
+  };
+
+  let ticks=0;const timer=setInterval(()=>{sync();ticks++;if(ticks>120&&apiPatched&&fetchPatched&&businessId())clearInterval(timer)},250);
+  document.addEventListener('click',()=>setTimeout(sync,0),true);
+  window.addEventListener('dabbir:language-changed',render);
+  sync();
+})();`;
+
+export default async function handler(req,res){
+  if(req.method!=='GET'){
+    res.statusCode=405;res.setHeader('allow','GET');return res.end('Method Not Allowed');
+  }
+  res.statusCode=200;
+  res.setHeader('content-type','application/javascript; charset=utf-8');
+  res.setHeader('cache-control','no-store');
+  res.setHeader('x-content-type-options','nosniff');
+  res.setHeader('x-dabbir-branch-context','server-scoped-v3-whatsapp');
+  return res.end(script);
+}

--- a/api/branch-context.js
+++ b/api/branch-context.js
@@ -1,0 +1,67 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  supabaseRest,
+} from './_auth-core.js';
+import { canUseAllBranches } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const enc=value=>encodeURIComponent(String(value));
+
+async function readData(response,code){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||500)});
+  return Array.isArray(payload)?payload:[];
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const token=accessTokenFromRequest(req);
+  if(!token)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  try{
+    const businessId=safeId(singleQueryValue(req,'business_id'));
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_ID_REQUIRED'});
+    const membership=(Array.isArray(memberships)?memberships:[]).find(row=>row.business_id===businessId&&row.status==='active');
+    if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+
+    const allAllowed=canUseAllBranches(membership);
+    const branches=await readData(await supabaseRest(
+      `dabbir_business_branches?select=id,business_id,name,status,is_primary,timezone,address_text&business_id=eq.${enc(businessId)}&status=eq.active&order=is_primary.desc,created_at.asc`,
+      token,
+    ),'BRANCH_LOOKUP_FAILED');
+    let allowed=branches;
+    if(!allAllowed){
+      const assignments=await readData(await supabaseRest(
+        `dabbir_membership_branches?select=business_id,user_id,branch_id&business_id=eq.${enc(businessId)}&user_id=eq.${enc(user.id)}`,
+        token,
+      ),'BRANCH_ASSIGNMENTS_LOOKUP_FAILED');
+      const ids=new Set(assignments.filter(row=>row.business_id===businessId&&row.user_id===user.id).map(row=>row.branch_id));
+      allowed=branches.filter(row=>ids.has(row.id));
+    }
+    if(!allowed.length)return json(res,403,{ok:false,error:'BRANCH_ASSIGNMENT_REQUIRED'});
+    return json(res,200,{
+      ok:true,
+      business_id:businessId,
+      role:membership.role,
+      all_allowed:allAllowed,
+      branches:allowed,
+      default_scope:allAllowed?'all':allowed.length===1?allowed[0].id:null,
+      selection_required:!allAllowed&&allowed.length>1,
+      truth:{state:'VERIFIED',source:'SERVER_RLS_BRANCH_ASSIGNMENTS'},
+    });
+  }catch(error){
+    const status=Number(error?.status||500);
+    return json(res,[400,401,403,404,409,502,503].includes(status)?status:500,{ok:false,error:String(error?.message||'BRANCH_CONTEXT_FAILED')});
+  }
+}

--- a/api/branch-operations.js
+++ b/api/branch-operations.js
@@ -1,0 +1,167 @@
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  readJsonBody,
+  requireSameOrigin,
+  supabaseRest,
+} from './_auth-core.js';
+import { branchWrite, resolveBranchScope } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const clean=(value,max=500)=>String(value??'').trim().slice(0,max);
+
+async function readData(response,fallback='DATA_REQUEST_FAILED'){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=Number(response.status||500);
+    error.detail=payload?.code||payload?.message||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=async(token,path,options={},fallback)=>readData(await supabaseRest(path,token,options),fallback);
+
+async function context(req){
+  const token=accessTokenFromRequest(req);
+  if(!token)return null;
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return null;
+  return {token,user,memberships:Array.isArray(memberships)?memberships:[]};
+}
+
+function membershipFor(ctx,businessId){
+  return ctx.memberships.find(row=>row.business_id===businessId&&row.status==='active')||null;
+}
+
+function persisted(rows,code){
+  const row=Array.isArray(rows)?rows[0]:null;
+  if(!row?.id)throw Object.assign(new Error(code),{status:502});
+  return row;
+}
+
+async function selectedScope(ctx,body){
+  const businessId=safeId(body?.business_id);
+  if(!businessId)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const membership=membershipFor(ctx,businessId);
+  if(!membership)throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+  const scope=await resolveBranchScope({
+    businessId,
+    membership,
+    userId:ctx.user.id,
+    requestedBranch:body?.branch_id,
+    fetchRows:(path,code)=>rest(ctx.token,path,{},code),
+  });
+  return {businessId,branchId:branchWrite(scope),scope};
+}
+
+async function createCustomer(ctx,businessId,name,source){
+  const rows=await rest(ctx.token,'dabbir_customers?select=id,display_name,lead_status,created_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      display_name:clean(name||'Customer',120)||'Customer',
+      lead_status:'new',
+      metadata:{source},
+    }),
+  },'CUSTOMER_CREATE_FAILED');
+  return persisted(rows,'CUSTOMER_CREATE_UNVERIFIED');
+}
+
+async function startConversation(ctx,body){
+  const {businessId,branchId}=await selectedScope(ctx,body);
+  const customer=await createCustomer(ctx,businessId,body?.display_name||'Web Customer','dabbir_branch_web_runtime');
+  const rows=await rest(ctx.token,'dabbir_conversations?select=id,business_id,branch_id,customer_id,channel_type,state,demo_mode,created_at,updated_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      branch_id:branchId,
+      customer_id:customer.id,
+      channel_type:'web',
+      state:'ai_active',
+      demo_mode:false,
+    }),
+  },'CONVERSATION_CREATE_FAILED');
+  const conversation=persisted(rows,'CONVERSATION_CREATE_UNVERIFIED');
+  if(conversation.branch_id!==branchId)throw Object.assign(new Error('CONVERSATION_BRANCH_UNVERIFIED'),{status:502});
+  return {
+    ok:true,
+    action:'start_conversation',
+    state:'VERIFIED_PERSISTED',
+    customer,
+    conversation,
+    channel:'web',
+    branch_id:branchId,
+    verified_persisted:true,
+    truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',branch_id:branchId,entity_id:conversation.id,verified_at:new Date().toISOString()},
+    external_side_effects:false,
+  };
+}
+
+async function createAppointment(ctx,body){
+  const {businessId,branchId}=await selectedScope(ctx,body);
+  let customerId=safeId(body?.customer_id);
+  const startsAt=new Date(String(body?.starts_at||''));
+  if(Number.isNaN(startsAt.getTime()))throw Object.assign(new Error('VALID_START_TIME_REQUIRED'),{status:400});
+  if(!customerId){
+    const customer=await createCustomer(ctx,businessId,body?.customer_name||'Customer','dabbir_branch_appointment_runtime');
+    customerId=customer.id;
+  }
+  const rows=await rest(ctx.token,'dabbir_appointments?select=id,business_id,branch_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,created_at,updated_at',{
+    method:'POST',
+    headers:{prefer:'return=representation'},
+    body:JSON.stringify({
+      business_id:businessId,
+      branch_id:branchId,
+      customer_id:customerId,
+      service_id:safeId(body?.service_id),
+      starts_at:startsAt.toISOString(),
+      status:'requested',
+      simulated:false,
+    }),
+  },'APPOINTMENT_CREATE_FAILED');
+  const appointment=persisted(rows,'APPOINTMENT_PERSISTENCE_UNVERIFIED');
+  if(appointment.branch_id!==branchId)throw Object.assign(new Error('APPOINTMENT_BRANCH_UNVERIFIED'),{status:502});
+  return {
+    ok:true,
+    action:'create_appointment',
+    state:'VERIFIED_PERSISTED',
+    appointment,
+    branch_id:branchId,
+    verified_persisted:true,
+    truth:{state:'VERIFIED',source:'SUPABASE_RETURN_REPRESENTATION',branch_id:branchId,entity_id:appointment.id,verified_at:new Date().toISOString()},
+    external_side_effects:false,
+  };
+}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
+  const ctx=await context(req);
+  if(!ctx)return json(res,401,{ok:false,error:'AUTH_REQUIRED'});
+  try{
+    const body=await readJsonBody(req);
+    const action=clean(body?.action,60);
+    let result;
+    if(action==='start_conversation')result=await startConversation(ctx,body);
+    else if(action==='create_appointment')result=await createAppointment(ctx,body);
+    else return json(res,400,{ok:false,error:'UNSUPPORTED_BRANCH_ACTION'});
+    res.setHeader('x-dabbir-branch-write','verified');
+    return json(res,200,result);
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,413,429,502,503].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'BRANCH_OPERATION_FAILED'),detail:error?.detail||null});
+  }
+}

--- a/api/branch-workspace.js
+++ b/api/branch-workspace.js
@@ -1,0 +1,142 @@
+import { singleQueryValue } from './_request-query.js';
+import {
+  accessTokenFromRequest,
+  getBusinessMemberships,
+  getVerifiedUser,
+  json,
+  supabaseRest,
+} from './_auth-core.js';
+import { getDABBIRAiConfig } from './_ai-core.js';
+import { branchFilter, resolveBranchScope } from './_branch-scope.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+const enc=value=>encodeURIComponent(String(value));
+
+async function readData(response,fallback='DATA_REQUEST_FAILED'){
+  const text=await response.text();
+  let payload=null;
+  try{payload=text?JSON.parse(text):null}catch{payload=null}
+  if(!response.ok){
+    const error=new Error(fallback);
+    error.status=Number(response.status||500);
+    error.detail=payload?.code||payload?.message||null;
+    throw error;
+  }
+  return payload;
+}
+
+const rest=async(token,path,fallback)=>readData(await supabaseRest(path,token),fallback);
+
+async function identity(req){
+  const token=accessTokenFromRequest(req);
+  if(!token)return null;
+  const [user,memberships]=await Promise.all([
+    getVerifiedUser(token).catch(()=>null),
+    getBusinessMemberships(token).catch(()=>[]),
+  ]);
+  if(!user)return null;
+  return {token,user,memberships:Array.isArray(memberships)?memberships:[]};
+}
+
+function membershipFor(memberships,businessId){
+  return memberships.find(row=>row.business_id===businessId&&row.status==='active')||null;
+}
+
+function idsFilter(ids){
+  const clean=[...new Set(ids.map(safeId).filter(Boolean))];
+  return clean.length?`(${clean.map(enc).join(',')})`:null;
+}
+
+async function workspace(req,ctx){
+  const businessId=safeId(singleQueryValue(req,'business_id'));
+  if(!businessId)throw Object.assign(new Error('BUSINESS_ID_REQUIRED'),{status:400});
+  const membership=membershipFor(ctx.memberships,businessId);
+  if(!membership)throw Object.assign(new Error('BUSINESS_ACCESS_DENIED'),{status:403});
+
+  const requestedBranch=singleQueryValue(req,'branch_id');
+  const fetchRows=(path,code)=>rest(ctx.token,path,code);
+  const scope=await resolveBranchScope({
+    businessId,
+    membership,
+    userId:ctx.user.id,
+    requestedBranch,
+    fetchRows,
+  });
+  const suffix=branchFilter(scope);
+
+  const [businessRows,conversations,appointments]=await Promise.all([
+    rest(ctx.token,`dabbir_businesses?select=id,slug,name,business_type,locale,demo_mode,country_code,currency_code,timezone,phone_country_prefix,created_at,updated_at&id=eq.${enc(businessId)}&limit=1`,'BUSINESS_LOOKUP_FAILED'),
+    rest(ctx.token,`dabbir_conversations?select=id,branch_id,customer_id,channel_type,state,demo_mode,created_at,updated_at&business_id=eq.${enc(businessId)}${suffix}&channel_type=eq.web&order=updated_at.desc&limit=50`,'CONVERSATIONS_LOOKUP_FAILED'),
+    rest(ctx.token,`dabbir_appointments?select=id,branch_id,customer_id,service_id,worker_id,starts_at,ends_at,status,simulated,created_at,updated_at&business_id=eq.${enc(businessId)}${suffix}&order=starts_at.desc&limit=100`,'APPOINTMENTS_LOOKUP_FAILED'),
+  ]);
+  const business=businessRows?.[0]||null;
+  if(!business)throw Object.assign(new Error('BUSINESS_NOT_FOUND'),{status:404});
+
+  const conversationIds=idsFilter((conversations||[]).map(row=>row.id));
+  const customerIds=idsFilter([
+    ...(conversations||[]).map(row=>row.customer_id),
+    ...(appointments||[]).map(row=>row.customer_id),
+  ]);
+  const requestedConversation=safeId(singleQueryValue(req,'conversation_id'));
+  let selectedConversationId=requestedConversation&&conversations?.some(row=>row.id===requestedConversation)?requestedConversation:null;
+  if(!selectedConversationId)selectedConversationId=conversations?.[0]?.id||null;
+
+  const [customers,handoffs,followups,messages]=await Promise.all([
+    customerIds?rest(ctx.token,`dabbir_customers?select=id,display_name,phone_e164,lead_status,metadata,created_at,updated_at&business_id=eq.${enc(businessId)}&id=in.${customerIds}&order=updated_at.desc&limit=200`,'CUSTOMERS_LOOKUP_FAILED'):[],
+    conversationIds?rest(ctx.token,`dabbir_handoffs?select=id,conversation_id,customer_id,route_class,reason,state,priority,summary,created_at,updated_at&business_id=eq.${enc(businessId)}&conversation_id=in.${conversationIds}&order=updated_at.desc&limit=100`,'HANDOFFS_LOOKUP_FAILED'):[],
+    conversationIds?rest(ctx.token,`dabbir_followups?select=id,conversation_id,customer_id,channel_type,reason,status,due_at,recommended_message,blocked_reason,created_at,updated_at&business_id=eq.${enc(businessId)}&conversation_id=in.${conversationIds}&order=updated_at.desc&limit=100`,'FOLLOWUPS_LOOKUP_FAILED'):[],
+    selectedConversationId?rest(ctx.token,`dabbir_messages?select=id,conversation_id,sender_type,body,intent,simulated,created_at&business_id=eq.${enc(businessId)}&conversation_id=eq.${enc(selectedConversationId)}&order=created_at.asc&limit=100`,'MESSAGES_LOOKUP_FAILED'):[],
+  ]);
+
+  const ai=getDABBIRAiConfig();
+  return {
+    ok:true,
+    authenticated:true,
+    user:ctx.user,
+    needs_onboarding:false,
+    operational_mode:'AUTHENTICATED_BRANCH_RUNTIME',
+    truth_mode:'FAIL_CLOSED_BRANCH_SCOPED_READS',
+    membership,
+    memberships:ctx.memberships,
+    business,
+    branch_scope:{
+      mode:scope.mode,
+      branch_id:scope.branch_id,
+      branch_ids:scope.branch_ids,
+      branch:scope.branch,
+      all_allowed:scope.all_allowed,
+      source:'SERVER_RLS_BRANCH_SCOPE',
+    },
+    conversations:Array.isArray(conversations)?conversations:[],
+    selected_conversation_id:selectedConversationId,
+    messages:Array.isArray(messages)?messages:[],
+    customers:Array.isArray(customers)?customers:[],
+    appointments:Array.isArray(appointments)?appointments:[],
+    handoffs:Array.isArray(handoffs)?handoffs:[],
+    followups:Array.isArray(followups)?followups:[],
+    ai:{
+      provider:ai.provider,
+      model:ai.model,
+      configured:ai.configured,
+      cost_mode:ai.cost_mode,
+      state:ai.configured?'OPERATIONAL_PROVIDER_READY':'UNCONFIGURED',
+    },
+    whatsapp:{state:'NOT_OPERATIONAL',blocker:'META_AUTHORIZATION_NOT_COMPLETED'},
+  };
+}
+
+export default async function handler(req,res){
+  if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
+  const ctx=await identity(req);
+  if(!ctx)return json(res,401,{ok:false,authenticated:false,error:'AUTH_REQUIRED'});
+  try{
+    const payload=await workspace(req,ctx);
+    res.setHeader('x-dabbir-branch-scope',payload.branch_scope?.mode||'unknown');
+    return json(res,200,payload);
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,429,502,503].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'BRANCH_WORKSPACE_FAILED'),detail:error?.detail||null});
+  }
+}

--- a/api/dabbir-whatsapp-disconnect.js
+++ b/api/dabbir-whatsapp-disconnect.js
@@ -1,21 +1,24 @@
 import { json, readJsonBody, requireSameOrigin } from './_auth-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
 import {
-  embeddedPlatformConfig,
-  loadBusinessConnection,
-  openAccessToken,
-  ownerContext,
-  removeBusinessConnection,
-  unsubscribeWaba,
-} from './_whatsapp-embedded-core.js';
+  deleteExactBusinessConnection,
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
 
-export function verifiedDeletion(rows, businessId) {
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+
+export function verifiedDeletion(value, businessId, connectionId = null) {
+  const rows=Array.isArray(value)?value:[value].filter(Boolean);
+  if(rows.length!==1)return false;
+  const row=rows[0];
   return Boolean(
-    Array.isArray(rows)
-    && rows.length === 1
-    && rows[0]
-    && typeof rows[0] === 'object'
-    && !Array.isArray(rows[0])
-    && String(rows[0].business_id || '') === String(businessId)
+    row
+    && typeof row==='object'
+    && !Array.isArray(row)
+    && String(row.business_id||'')===String(businessId)
+    && (!connectionId||String(row.id||'')===String(connectionId))
   );
 }
 
@@ -25,32 +28,33 @@ export default async function handler(req, res) {
 
   try {
     const body = await readJsonBody(req, 4096);
-    const businessId = String(body?.business_id || '').trim();
+    const businessId = safeId(body?.business_id);
+    const branchRaw=String(body?.branch_id||'').trim();
+    const branchId=branchRaw?safeId(branchRaw):null;
     if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+    if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
 
     const owner = await ownerContext(req, businessId);
-    const row = await loadBusinessConnection(owner.accessToken, businessId);
-    if (!row) return json(res, 200, { ok: true, connected: false, already_disconnected: true });
+    // Backward-compatible callers without branch_id operate on the primary branch only.
+    // A branch disconnect must never delete all connections for the business.
+    const row = branchId
+      ? await loadBusinessBranchConnection(owner.accessToken,businessId,branchId)
+      : await loadPrimaryBusinessConnection(owner.accessToken,businessId);
+    if (!row) return json(res, 200, { ok: true, connected: false, already_disconnected: true, branch_id: branchId });
 
-    const platform = embeddedPlatformConfig();
-    let remoteUnsubscribed = false;
-    if (platform.appSecret && platform.encryptionSecret) {
-      try {
-        const token = openAccessToken(row, platform, businessId);
-        remoteUnsubscribed = await unsubscribeWaba(platform, token, row.waba_id);
-      } catch {
-        remoteUnsubscribed = false;
-      }
-    }
-
-    const deleted = await removeBusinessConnection(owner.accessToken, businessId);
-    if (!verifiedDeletion(deleted, businessId)) {
+    const deleted = await deleteExactBusinessConnection(owner.accessToken,businessId,row.id);
+    if (!verifiedDeletion(deleted, businessId, row.id)) {
       throw Object.assign(new Error('WHATSAPP_CONNECTION_DELETE_UNVERIFIED'), { status: 502 });
     }
+
     return json(res, 200, {
       ok: true,
       connected: false,
-      remote_unsubscribed: remoteUnsubscribed,
+      branch_id: row.branch_id,
+      connection_id: row.id,
+      phone_number_id: row.phone_number_id,
+      remote_unsubscribed: false,
+      remote_unsubscribe_skipped_reason: 'BRANCH_SAFE_LOCAL_DISCONNECT',
       secrets_exposed: false,
     });
   } catch (error) {

--- a/api/dabbir-whatsapp-embedded-config.js
+++ b/api/dabbir-whatsapp-embedded-config.js
@@ -1,7 +1,14 @@
 import { singleQueryValue } from './_request-query.js';
 import { accessTokenFromRequest, getVerifiedUser, json } from './_auth-core.js';
 import { applyDabbirMetaPublicIdentifiers } from './_dabbir-meta-public-config.js';
-import { loadBusinessConnection, ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
+import { ownerContext, resolveEmbeddedPlatformConfig } from './_whatsapp-embedded-core.js';
+import {
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
 function readiness(platform) {
   return {
@@ -35,11 +42,16 @@ export default async function handler(req, res) {
   }
 
   const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
+  const branchRaw=String(singleQueryValue(req,'branch_id')||'').trim();
+  const branchId=branchRaw?safeId(branchRaw):null;
   if (!businessId) return json(res, 400, { ok: false, error: 'BUSINESS_REQUIRED' });
+  if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
 
   try {
     await ownerContext(req, businessId);
-    const connection = await loadBusinessConnection(accessToken, businessId);
+    const connection = branchId
+      ? await loadBusinessBranchConnection(accessToken,businessId,branchId)
+      : await loadPrimaryBusinessConnection(accessToken,businessId);
     return json(res, 200, {
       ok: true,
       auth_required: false,
@@ -49,8 +61,12 @@ export default async function handler(req, res) {
       config_id: platform.ready ? platform.configId : null,
       graph_version: platform.graphVersion,
       sdk_locale: 'en_US',
+      branch_id: connection?.branch_id || branchId || null,
+      connection_id: connection?.id || null,
       connected: Boolean(connection && connection.status !== 'disconnected'),
       connection: connection ? {
+        id: connection.id,
+        branch_id: connection.branch_id,
         status: connection.status,
         waba_id: connection.waba_id,
         phone_number_id: connection.phone_number_id,

--- a/api/dabbir-whatsapp-reply.js
+++ b/api/dabbir-whatsapp-reply.js
@@ -1,6 +1,7 @@
 import crypto from 'node:crypto';
 import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
-import { loadBusinessConnection, ownerContext } from './_whatsapp-embedded-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
+import { loadExactBusinessConnection } from './_whatsapp-branch-connection.js';
 import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   finalizeOutboundReply,
@@ -101,9 +102,9 @@ export default async function handler(req, res) {
     }
 
     const owner = await ownerContext(req, businessId);
-    const connection = await loadBusinessConnection(owner.accessToken, businessId);
-    if (!connection || connection.status !== 'connected') return json(res, 409, { ok: false, error: 'WHATSAPP_TENANT_NOT_LINKED' });
 
+    // The database resolves conversation.branch_id first and reserves the exact
+    // WhatsApp connection for that branch. Never choose a connection by business alone.
     reservation = await reserveOutboundReply({
       businessId,
       conversationId,
@@ -144,6 +145,16 @@ export default async function handler(req, res) {
         retry_requires_new_operation: true,
         automatic_resend_blocked: true,
       });
+    }
+
+    const connection = await loadExactBusinessConnection(
+      owner.accessToken,
+      businessId,
+      reservation.connectionId,
+    );
+    if (!connection || connection.status !== 'connected') {
+      await markOutboundResult(reservation.reservationId, 'FAILED', 'WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION');
+      return json(res, 409, { ok: false, state: 'FAILED', error: 'WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION' });
     }
 
     if (String(connection.id) !== String(reservation.connectionId)
@@ -200,7 +211,7 @@ export default async function handler(req, res) {
       message: persisted,
       truth: {
         state: 'VERIFIED_PERSISTED_PROVIDER_ACCEPTED',
-        source: 'RESERVATION_META_SEND_FINALIZE_READBACK',
+        source: 'BRANCH_RESERVATION_EXACT_CONNECTION_META_SEND_FINALIZE_READBACK',
         verified_at: new Date().toISOString(),
       },
       automatic_resend_blocked: true,

--- a/api/dabbir-whatsapp-status.js
+++ b/api/dabbir-whatsapp-status.js
@@ -5,12 +5,17 @@ import { serviceRpc, whatsappLiveServerCapability } from './_whatsapp-live-core.
 import { withServerReadTimeout } from './_server-read-timeout.js';
 import {
   embeddedPlatformConfig,
-  loadBusinessConnection,
   ownerContext,
   verifyStoredConnection,
 } from './_whatsapp-embedded-core.js';
+import {
+  loadBusinessBranchConnection,
+  loadPrimaryBusinessConnection,
+} from './_whatsapp-branch-connection.js';
 
 const WHATSAPP_STATUS_TIMEOUT_MS = 10_000;
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 
 function firstEnv(...names) {
   for (const name of names) {
@@ -59,9 +64,13 @@ function emptyOperationalEvidence(available = true) {
   };
 }
 
-export async function loadOperationalEvidence(businessId) {
+export async function loadOperationalEvidence(businessId,branchId) {
+  if(!safeId(businessId)||!safeId(branchId))return emptyOperationalEvidence(false);
   try {
-    const rows = await serviceRpc('dabbir_whatsapp_operational_evidence', { p_business_id: businessId });
+    const rows = await serviceRpc('dabbir_whatsapp_branch_operational_evidence', {
+      p_business_id: businessId,
+      p_branch_id: branchId,
+    });
     const row = Array.isArray(rows) ? rows[0] : rows;
     if (!row) return emptyOperationalEvidence(false);
     return {
@@ -76,12 +85,13 @@ export async function loadOperationalEvidence(businessId) {
   }
 }
 
-export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED') {
+export function tenantUnconfiguredStatus(reason = 'TENANT_WHATSAPP_NOT_LINKED',branchId=null) {
   const machine = deriveWhatsAppOperationalState({ hasConnection: false });
   return {
     ok: true,
     channel: 'whatsapp',
     source: 'embedded_signup',
+    branch_id: branchId,
     configured: false,
     connected: false,
     webhook_configured: false,
@@ -130,15 +140,17 @@ export async function verifyMetaAuthorization(config = getWhatsAppConfig()) {
   }
 }
 
-async function embeddedStatus(req, accessToken, businessId) {
+async function embeddedStatus(req, accessToken, businessId, branchId=null) {
   await ownerContext(req, businessId);
-  const row = await loadBusinessConnection(accessToken, businessId);
+  const row = branchId
+    ? await loadBusinessBranchConnection(accessToken,businessId,branchId)
+    : await loadPrimaryBusinessConnection(accessToken,businessId);
   if (!row) return null;
   const platform = embeddedPlatformConfig();
   try {
     const [verified, evidence] = await Promise.all([
       verifyStoredConnection(platform, row),
-      loadOperationalEvidence(businessId),
+      loadOperationalEvidence(businessId,row.branch_id),
     ]);
     const machine = deriveWhatsAppOperationalState({
       hasConnection: true,
@@ -149,6 +161,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       ok: true,
       channel: 'whatsapp',
       source: 'embedded_signup',
+      branch_id: row.branch_id,
+      connection_id: row.id,
       configured: true,
       connected: Boolean(verified.authorized),
       webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
@@ -186,6 +200,8 @@ async function embeddedStatus(req, accessToken, businessId) {
       ok: true,
       channel: 'whatsapp',
       source: 'embedded_signup',
+      branch_id: row.branch_id,
+      connection_id: row.id,
       configured: true,
       connected: false,
       webhook_configured: Boolean(firstEnv('DABBIR_WHATSAPP_VERIFY_TOKEN', 'PILOT_WHATSAPP_VERIFY_TOKEN') && platform.appSecret),
@@ -211,9 +227,9 @@ async function embeddedStatus(req, accessToken, businessId) {
   }
 }
 
-async function tenantStatus(req, accessToken, businessId) {
-  const tenant = await embeddedStatus(req, accessToken, businessId);
-  return tenant || tenantUnconfiguredStatus();
+async function tenantStatus(req, accessToken, businessId, branchId=null) {
+  const tenant = await embeddedStatus(req, accessToken, businessId,branchId);
+  return tenant || tenantUnconfiguredStatus('TENANT_WHATSAPP_NOT_LINKED',branchId);
 }
 
 export default async function handler(req, res) {
@@ -233,9 +249,12 @@ export default async function handler(req, res) {
   if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
   const businessId = String(singleQueryValue(req, 'business_id') || '').trim();
+  const branchRaw=String(singleQueryValue(req,'branch_id')||'').trim();
+  const branchId=branchRaw?safeId(branchRaw):null;
+  if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
   if (businessId) {
     try {
-      return json(res, 200, await tenantStatus(req, accessToken, businessId));
+      return json(res, 200, await tenantStatus(req, accessToken, businessId,branchId));
     } catch (error) {
       return json(res, Number(error?.status || error?.code || 500), { ok: false, error: error?.safeCode || error?.message || 'REQUEST_FAILED' });
     }
@@ -243,7 +262,7 @@ export default async function handler(req, res) {
 
   // The authenticated DABBIR UI must never inherit a global/server WhatsApp
   // identity. Platform-level credentials remain webhook/runtime infrastructure
-  // only; tenant display state always resolves from the tenant connection row.
+  // only; tenant display state always resolves from a tenant branch connection row.
   try {
     const memberships = await withServerReadTimeout(
       signal => getBusinessMemberships(accessToken, { signal }),
@@ -253,7 +272,7 @@ export default async function handler(req, res) {
       .map(item => String(item?.business_id || '').trim())
       .filter(Boolean))];
     if (businessIds.length === 1) {
-      return json(res, 200, await tenantStatus(req, accessToken, businessIds[0]));
+      return json(res, 200, await tenantStatus(req, accessToken, businessIds[0],null));
     }
     return json(res, 200, tenantUnconfiguredStatus(businessIds.length > 1 ? 'BUSINESS_CONTEXT_REQUIRED' : 'TENANT_WHATSAPP_NOT_LINKED'));
   } catch (error) {

--- a/api/whatsapp-branch-intent.js
+++ b/api/whatsapp-branch-intent.js
@@ -1,0 +1,68 @@
+import { json, readJsonBody, requireSameOrigin, supabaseRest } from './_auth-core.js';
+import { ownerContext } from './_whatsapp-embedded-core.js';
+
+const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
+
+async function readRows(response,code){
+  const text=await response.text();
+  let rows=null;
+  try{rows=text?JSON.parse(text):null}catch{rows=null}
+  if(!response.ok)throw Object.assign(new Error(code),{status:Number(response.status||502)});
+  return Array.isArray(rows)?rows:[];
+}
+
+export default async function handler(req,res){
+  if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
+  if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'SAME_ORIGIN_REQUIRED'});
+  try{
+    const body=await readJsonBody(req,4096);
+    const businessId=safeId(body?.business_id);
+    const branchRaw=String(body?.branch_id||'').trim();
+    const branchId=branchRaw?safeId(branchRaw):null;
+    if(!businessId)return json(res,400,{ok:false,error:'BUSINESS_REQUIRED'});
+    if(branchRaw&&!branchId)return json(res,400,{ok:false,error:'VALID_BRANCH_REQUIRED'});
+    const owner=await ownerContext(req,businessId);
+
+    if(!branchId){
+      const response=await supabaseRest(
+        `dabbir_whatsapp_branch_intents?business_id=eq.${encodeURIComponent(businessId)}&user_id=eq.${encodeURIComponent(owner.user.id)}`,
+        owner.accessToken,{method:'DELETE',headers:{prefer:'return=minimal'}},
+      );
+      if(!response.ok)throw Object.assign(new Error('WHATSAPP_BRANCH_INTENT_CLEAR_FAILED'),{status:Number(response.status||502)});
+      return json(res,200,{ok:true,cleared:true,business_id:businessId,branch_id:null});
+    }
+
+    const branches=await readRows(await supabaseRest(
+      `dabbir_business_branches?select=id,business_id,status&id=eq.${encodeURIComponent(branchId)}&business_id=eq.${encodeURIComponent(businessId)}&status=eq.active&limit=1`,
+      owner.accessToken,
+    ),'WHATSAPP_BRANCH_INTENT_BRANCH_LOOKUP_FAILED');
+    if(!branches[0]?.id)return json(res,404,{ok:false,error:'ACTIVE_BRANCH_NOT_FOUND'});
+
+    const expiresAt=new Date(Date.now()+10*60*1000).toISOString();
+    const response=await supabaseRest(
+      'dabbir_whatsapp_branch_intents?on_conflict=business_id,user_id&select=business_id,user_id,branch_id,expires_at,updated_at',
+      owner.accessToken,{
+        method:'POST',
+        headers:{prefer:'resolution=merge-duplicates,return=representation'},
+        body:JSON.stringify({
+          business_id:businessId,
+          user_id:owner.user.id,
+          branch_id:branchId,
+          expires_at:expiresAt,
+          updated_at:new Date().toISOString(),
+        }),
+      },
+    );
+    const rows=await readRows(response,'WHATSAPP_BRANCH_INTENT_STORE_FAILED');
+    const stored=rows[0]||null;
+    if(!stored||stored.business_id!==businessId||stored.branch_id!==branchId||stored.user_id!==owner.user.id){
+      throw Object.assign(new Error('WHATSAPP_BRANCH_INTENT_STORE_UNVERIFIED'),{status:502});
+    }
+    return json(res,200,{ok:true,business_id:businessId,branch_id:branchId,expires_at:stored.expires_at,truth:{state:'VERIFIED_PERSISTED',source:'SUPABASE_RLS_RETURN_REPRESENTATION'}});
+  }catch(error){
+    const status=Number(error?.status||500);
+    const safe=[400,401,403,404,409,413,429,502,503,504].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:String(error?.message||'WHATSAPP_BRANCH_INTENT_FAILED').slice(0,180)});
+  }
+}

--- a/config/dabbir-ui-bundles.json
+++ b/config/dabbir-ui-bundles.json
@@ -6,6 +6,7 @@
     "/api/auth-session-stability-ui"
   ],
   "deferred": [
+    "/api/branch-context-ui",
     "/api/dabbir-whatsapp-embedded-ui",
     "/api/dabbir-whatsapp-connect-guard-ui",
     "/api/timezone-ui",
@@ -25,7 +26,6 @@
     "/api/platform-recovery-reconciliation-ui",
     "/api/verified-metrics-ui",
     "/api/customer-activation-ui",
-    "/api/owner-copilot-ui",
     "/api/dabbir-contextual-navigation-ui",
     "/api/dabbir-navigation-event-bridge-ui",
     "/api/car-wash-loader-ui"

--- a/test/dabbir-branch-runtime-integration.test.mjs
+++ b/test/dabbir-branch-runtime-integration.test.mjs
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read=path=>fs.readFileSync(new URL('../'+path,import.meta.url),'utf8');
+const workspace=read('api/branch-workspace.js');
+const operations=read('api/branch-operations.js');
+const context=read('api/branch-context.js');
+const ui=read('api/branch-context-ui.js');
+const bundles=JSON.parse(read('config/dabbir-ui-bundles.json'));
+
+test('branch workspace filters branch-owned operational reads on the server',()=>{
+  assert.match(workspace,/resolveBranchScope/);
+  assert.match(workspace,/const suffix=branchFilter\(scope\)/);
+  assert.match(workspace,/dabbir_conversations\?[\s\S]*\$\{suffix\}/);
+  assert.match(workspace,/dabbir_appointments\?[\s\S]*\$\{suffix\}/);
+  assert.match(workspace,/truth_mode:'FAIL_CLOSED_BRANCH_SCOPED_READS'/);
+});
+
+test('branch workspace derives dependent rows from scoped conversation ids',()=>{
+  assert.match(workspace,/conversationIds=idsFilter/);
+  assert.match(workspace,/dabbir_handoffs\?[\s\S]*conversation_id=in\.\$\{conversationIds\}/);
+  assert.match(workspace,/dabbir_followups\?[\s\S]*conversation_id=in\.\$\{conversationIds\}/);
+  assert.match(workspace,/dabbir_messages\?[\s\S]*conversation_id=eq\.\$\{enc\(selectedConversationId\)\}/);
+});
+
+test('branch writes require an explicit selected scope and verify persisted branch id',()=>{
+  assert.match(operations,/branchWrite\(scope\)/);
+  assert.match(operations,/branch_id:branchId/);
+  assert.match(operations,/conversation\.branch_id!==branchId/);
+  assert.match(operations,/appointment\.branch_id!==branchId/);
+});
+
+test('authorized branch options are server-derived, not guessed from the business branch registry',()=>{
+  assert.match(context,/dabbir_membership_branches/);
+  assert.match(context,/all_allowed:allAllowed/);
+  assert.match(context,/SERVER_RLS_BRANCH_ASSIGNMENTS/);
+});
+
+test('branch UI reuses the bounded shell by replacing the duplicate owner-copilot presentation slot',()=>{
+  assert.ok(bundles.deferred.includes('/api/branch-context-ui'));
+  assert.ok(!bundles.deferred.includes('/api/owner-copilot-ui'));
+  assert.equal(bundles.critical.length+bundles.deferred.length,26);
+  assert.equal(bundles.critical.at(-1),'/api/auth-session-stability-ui');
+  assert.match(ui,/\/api\/branch-workspace/);
+  assert.match(ui,/\/api\/branch-operations/);
+  assert.match(ui,/\['start_conversation','create_appointment'\]/);
+  assert.match(ui,/dabbir_active_branch_scope:/);
+  assert.match(ui,/dabbir:branch-scope-changed/);
+});

--- a/test/dabbir-branch-scope-contract.test.mjs
+++ b/test/dabbir-branch-scope-contract.test.mjs
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolveBranchScope,branchFilter,branchWrite } from '../api/_branch-scope.js';
+
+const businessId='11111111-1111-4111-8111-111111111111';
+const branchA='aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const branchB='bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const userId='22222222-2222-4222-8222-222222222222';
+const activeBranches=[
+  {id:branchA,business_id:businessId,name:'A',status:'active',is_primary:true},
+  {id:branchB,business_id:businessId,name:'B',status:'active',is_primary:false},
+];
+
+function fetcher(assignments=[]){
+  return async path=>path.startsWith('dabbir_business_branches?')?activeBranches:assignments;
+}
+
+test('owner defaults to all branches and may select a branch',async()=>{
+  const membership={business_id:businessId,role:'owner',permissions:[]};
+  const all=await resolveBranchScope({businessId,membership,userId,fetchRows:fetcher()});
+  assert.equal(all.mode,'all');
+  assert.deepEqual(all.branch_ids,[branchA,branchB]);
+  const selected=await resolveBranchScope({businessId,membership,userId,requestedBranch:branchB,fetchRows:fetcher()});
+  assert.equal(selected.mode,'selected');
+  assert.equal(selected.branch_id,branchB);
+  assert.equal(branchFilter(selected),'&branch_id=eq.bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb');
+  assert.equal(branchWrite(selected),branchB);
+});
+
+test('restricted employee defaults to sole assigned branch',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[{business_id:businessId,user_id:userId,branch_id:branchA}];
+  const scope=await resolveBranchScope({businessId,membership,userId,fetchRows:fetcher(assignments)});
+  assert.equal(scope.mode,'selected');
+  assert.equal(scope.branch_id,branchA);
+});
+
+test('restricted employee cannot request all branches or an unassigned branch',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[{business_id:businessId,user_id:userId,branch_id:branchA}];
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,requestedBranch:'all',fetchRows:fetcher(assignments)}),
+    error=>error.message==='ALL_BRANCHES_ACCESS_DENIED'&&error.status===403,
+  );
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,requestedBranch:branchB,fetchRows:fetcher(assignments)}),
+    error=>error.message==='BRANCH_ACCESS_DENIED'&&error.status===403,
+  );
+});
+
+test('multi-assigned restricted employee must choose a branch explicitly',async()=>{
+  const membership={business_id:businessId,role:'employee',permissions:[]};
+  const assignments=[
+    {business_id:businessId,user_id:userId,branch_id:branchA},
+    {business_id:businessId,user_id:userId,branch_id:branchB},
+  ];
+  await assert.rejects(
+    resolveBranchScope({businessId,membership,userId,fetchRows:fetcher(assignments)}),
+    error=>error.message==='BRANCH_SELECTION_REQUIRED'&&error.status===409,
+  );
+});
+
+test('selected write is mandatory for branch-owned operational records',()=>{
+  assert.throws(()=>branchWrite({mode:'all',branch_id:null}),/SELECTED_BRANCH_REQUIRED/);
+});

--- a/test/dabbir-whatsapp-branch-routing.test.mjs
+++ b/test/dabbir-whatsapp-branch-routing.test.mjs
@@ -1,0 +1,95 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read=path=>fs.readFileSync(new URL('../'+path,import.meta.url),'utf8');
+const branchMigration=read('supabase/migrations/20260903155503_dabbir_whatsapp_branch_routing_v1.sql');
+const inboundFix=read('supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql');
+const outboundMigration=read('supabase/migrations/20260903155919_dabbir_whatsapp_outbound_branch_routing_v1.sql');
+const evidenceMigration=read('supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql');
+const intentMigration=read('supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql');
+const exactConnection=read('api/_whatsapp-branch-connection.js');
+const reply=read('api/dabbir-whatsapp-reply.js');
+const status=read('api/dabbir-whatsapp-status.js');
+const disconnect=read('api/dabbir-whatsapp-disconnect.js');
+const branchUi=read('api/branch-context-ui.js');
+const intentApi=read('api/whatsapp-branch-intent.js');
+
+test('WhatsApp connections are branch-owned with business/branch integrity',()=>{
+  assert.match(branchMigration,/add column if not exists branch_id uuid/);
+  assert.match(branchMigration,/alter column branch_id set not null/);
+  assert.match(branchMigration,/foreign key \(branch_id,business_id\)/);
+  assert.match(branchMigration,/unique \(business_id,branch_id\)/);
+  assert.match(branchMigration,/dabbir_whatsapp_connection_branch_guard/);
+  assert.match(branchMigration,/dabbir_whatsapp_upsert_branch_connection/);
+});
+
+test('inbound routing derives conversation branch from the receiving connection',()=>{
+  assert.match(inboundFix,/c\.branch_id=v_connection\.branch_id/);
+  assert.match(inboundFix,/insert into public\.dabbir_conversations\(business_id,branch_id/);
+  assert.match(inboundFix,/v_connection\.business_id,v_connection\.branch_id,v_customer_id/);
+  assert.match(inboundFix,/#variable_conflict use_column/);
+  assert.match(inboundFix,/grant execute on function public\.dabbir_whatsapp_persist_inbound[\s\S]*to service_role/);
+});
+
+test('outbound reservation resolves conversation before selecting its branch connection',()=>{
+  const conversationIndex=outboundMigration.indexOf('select * into v_conversation');
+  const connectionIndex=outboundMigration.indexOf('c.branch_id=v_conversation.branch_id');
+  assert.ok(conversationIndex>=0&&connectionIndex>conversationIndex);
+  assert.match(outboundMigration,/WHATSAPP_BRANCH_CONNECTION_NOT_FOUND/);
+  assert.doesNotMatch(outboundMigration,/where c\.business_id=p_business_id and c\.status='connected' limit 1;[\s\S]*select \* into v_conversation/);
+});
+
+test('exact connection authority scopes reads rotation and deletion to one connection id',()=>{
+  assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(connection\)\}&business_id=eq/);
+  assert.match(exactConnection,/id=eq\.\$\{encodeURIComponent\(row\.id\)\}&business_id=eq/);
+  assert.match(exactConnection,/deleteExactBusinessConnection/);
+  assert.match(exactConnection,/WHATSAPP_EXACT_CONNECTION_SCOPE_MISMATCH/);
+  assert.doesNotMatch(exactConnection,/dabbir_whatsapp_connections\?business_id=eq\.\$\{encodeURIComponent\(String\(row\.business_id\)\)\}/);
+});
+
+test('reply reserves the branch connection before loading and sending through that exact connection',()=>{
+  assert.match(reply,/loadExactBusinessConnection/);
+  const reserveIndex=reply.indexOf('reservation = await reserveOutboundReply');
+  const loadIndex=reply.indexOf('const connection = await loadExactBusinessConnection');
+  const sendIndex=reply.indexOf('sent = await sendMetaText');
+  assert.ok(reserveIndex>=0&&loadIndex>reserveIndex&&sendIndex>loadIndex);
+  assert.match(reply,/reservation\.connectionId/);
+  assert.match(reply,/WHATSAPP_BRANCH_CONNECTION_UNAVAILABLE_AFTER_RESERVATION/);
+  assert.doesNotMatch(reply,/loadBusinessConnection\(/);
+});
+
+test('branch status uses branch-specific connection and branch-specific operational evidence',()=>{
+  assert.match(evidenceMigration,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(evidenceMigration,/c\.branch_id=p_branch_id/);
+  assert.match(status,/loadBusinessBranchConnection/);
+  assert.match(status,/loadPrimaryBusinessConnection/);
+  assert.match(status,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(status,/p_branch_id: branchId/);
+  assert.match(status,/branch_id: row\.branch_id/);
+  assert.doesNotMatch(status,/loadBusinessConnection/);
+});
+
+test('disconnect deletes one exact branch connection and never unsubscribes a shared WABA',()=>{
+  assert.match(disconnect,/loadBusinessBranchConnection/);
+  assert.match(disconnect,/loadPrimaryBusinessConnection/);
+  assert.match(disconnect,/deleteExactBusinessConnection/);
+  assert.match(disconnect,/BRANCH_SAFE_LOCAL_DISCONNECT/);
+  assert.doesNotMatch(disconnect,/removeBusinessConnection/);
+  assert.doesNotMatch(disconnect,/unsubscribeWaba/);
+});
+
+test('Embedded Signup keeps Meta flow unchanged while a one-time server branch intent controls storage',()=>{
+  assert.match(intentMigration,/create table if not exists public\.dabbir_whatsapp_branch_intents/);
+  assert.match(intentMigration,/force row level security/);
+  assert.match(intentMigration,/dabbir_private\.branch_access_allowed/);
+  assert.match(intentMigration,/select i\.branch_id into v_branch_id/);
+  assert.match(intentMigration,/delete from public\.dabbir_whatsapp_branch_intents/);
+  assert.match(intentApi,/ownerContext/);
+  assert.match(intentApi,/resolution=merge-duplicates,return=representation/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-embedded-complete/);
+  assert.match(branchUi,/\/api\/whatsapp-branch-intent/);
+  assert.match(branchUi,/persistWhatsAppIntent/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-status/);
+  assert.match(branchUi,/\/api\/dabbir-whatsapp-disconnect/);
+});

--- a/test/dabbir-whatsapp-disconnect-truth.test.mjs
+++ b/test/dabbir-whatsapp-disconnect-truth.test.mjs
@@ -4,12 +4,24 @@ import { verifiedDeletion } from '../api/dabbir-whatsapp-disconnect.js';
 
 const BUSINESS_ID = '00000000-0000-4000-8000-000000000111';
 const OTHER_BUSINESS_ID = '00000000-0000-4000-8000-000000000222';
+const CONNECTION_ID = '00000000-0000-4000-8000-000000000333';
+const OTHER_CONNECTION_ID = '00000000-0000-4000-8000-000000000444';
 
-test('WhatsApp disconnect success requires exactly one matching deleted tenant row', () => {
+test('WhatsApp disconnect success requires one exact business and connection deletion', () => {
+  assert.equal(verifiedDeletion([{ id: CONNECTION_ID, business_id: BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), true);
+  assert.equal(verifiedDeletion({ id: CONNECTION_ID, business_id: BUSINESS_ID }, BUSINESS_ID, CONNECTION_ID), true);
+  assert.equal(verifiedDeletion([], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([{ id: CONNECTION_ID, business_id: OTHER_BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([{ id: OTHER_CONNECTION_ID, business_id: BUSINESS_ID }], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([
+    { id: CONNECTION_ID, business_id: BUSINESS_ID },
+    { id: OTHER_CONNECTION_ID, business_id: BUSINESS_ID },
+  ], BUSINESS_ID, CONNECTION_ID), false);
+  assert.equal(verifiedDeletion([null], BUSINESS_ID, CONNECTION_ID), false);
+});
+
+test('legacy verification without connection id still requires one matching business row', () => {
   assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }], BUSINESS_ID), true);
-  assert.equal(verifiedDeletion([], BUSINESS_ID), false);
+  assert.equal(verifiedDeletion({ business_id: BUSINESS_ID }, BUSINESS_ID), true);
   assert.equal(verifiedDeletion([{ business_id: OTHER_BUSINESS_ID }], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion([{ business_id: BUSINESS_ID }, { business_id: BUSINESS_ID }], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion([null], BUSINESS_ID), false);
-  assert.equal(verifiedDeletion({ business_id: BUSINESS_ID }, BUSINESS_ID), false);
 });

--- a/test/dabbir-whatsapp-embedded-signup.test.mjs
+++ b/test/dabbir-whatsapp-embedded-signup.test.mjs
@@ -182,16 +182,19 @@ test('WhatsApp connection storage is tenant-scoped and RLS protected', async () 
   assert.doesNotMatch(migration, /grant .* to anon/i);
 });
 
-test('WhatsApp connection persistence uses the tenant-checked database RPC', async () => {
+test('WhatsApp connection persistence keeps the legacy tenant-checked RPC while branch routing supersedes business-only storage', async () => {
   const core = await read('api/_whatsapp-embedded-core.js');
-  const migration = await read('supabase/migrations/20260831032000_dabbir_whatsapp_connection_upsert_rpc_v1.sql');
+  const legacyMigration = await read('supabase/migrations/20260831032000_dabbir_whatsapp_connection_upsert_rpc_v1.sql');
+  const branchMigration = await read('supabase/migrations/20260903160747_dabbir_whatsapp_branch_intent_v1.sql');
   assert.match(core, /supabaseRpc\('dabbir_whatsapp_upsert_connection'/);
   assert.doesNotMatch(core, /supabaseRest\('dabbir_whatsapp_connections\?on_conflict=business_id'/);
-  assert.match(migration, /create or replace function public\.dabbir_whatsapp_upsert_connection/);
-  assert.match(migration, /dabbir_private\.is_active_member\(p_business_id\)/);
-  assert.match(migration, /WHATSAPP_PHONE_ALREADY_CONNECTED/);
-  assert.match(migration, /on conflict \(business_id\) do update/);
-  assert.match(migration, /grant execute on function public\.dabbir_whatsapp_upsert_connection/);
+  assert.match(legacyMigration, /create or replace function public\.dabbir_whatsapp_upsert_connection/);
+  assert.match(legacyMigration, /dabbir_private\.is_active_member\(p_business_id\)/);
+  assert.match(legacyMigration, /WHATSAPP_PHONE_ALREADY_CONNECTED/);
+  assert.match(branchMigration, /select i\.branch_id into v_branch_id/);
+  assert.match(branchMigration, /on conflict \(business_id,branch_id\) do update/);
+  assert.match(branchMigration, /delete from public\.dabbir_whatsapp_branch_intents/);
+  assert.match(branchMigration, /grant execute on function public\.dabbir_whatsapp_upsert_connection/);
 });
 
 test('production shell mounts Embedded Signup and CSP permits only required Meta browser origins', async () => {
@@ -203,13 +206,16 @@ test('production shell mounts Embedded Signup and CSP permits only required Meta
   assert.match(vercel, /connect-src 'self' https:\/\/graph\.facebook\.com/);
 });
 
-test('status endpoint prefers business-scoped Embedded Signup when business_id is supplied', async () => {
+test('status endpoint is tenant-scoped and branch-aware when business_id is supplied', async () => {
   const status = await read('api/dabbir-whatsapp-status.js');
   assert.match(status, /embeddedStatus/);
   assert.match(status, /source:\s*'embedded_signup'/);
   assert.match(status, /singleQueryValue\(req, 'business_id'\)/);
+  assert.match(status, /singleQueryValue\(req,'branch_id'\)/);
   assert.doesNotMatch(status, /req\.query/);
-  assert.match(status, /loadBusinessConnection/);
+  assert.match(status, /loadBusinessBranchConnection/);
+  assert.match(status, /loadPrimaryBusinessConnection/);
+  assert.doesNotMatch(status, /loadBusinessConnection/);
 });
 
 test('Meta App ID can be discovered server-side from the existing WhatsApp authorization', async () => {

--- a/test/dabbir-whatsapp-operational-truth.test.mjs
+++ b/test/dabbir-whatsapp-operational-truth.test.mjs
@@ -7,37 +7,51 @@ const statusPath='api/dabbir-whatsapp-status.js';
 const machinePath='api/_dabbir-whatsapp-state-machine.js';
 const activationPath='api/customer-activation-ui.js';
 const migrationPath='supabase/migrations/20260828044500_dabbir_whatsapp_live_message_path_v2.sql';
-const raceMigrationPath='supabase/migrations/20260828045000_dabbir_whatsapp_inbound_sender_race_hardening_v1.sql';
+const raceMigrationPath='supabase/migrations/20260903155620_dabbir_whatsapp_inbound_variable_conflict_fix_v1.sql';
 const hardeningPath='supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql';
+const branchEvidencePath='supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql';
 const status=fs.readFileSync(statusPath,'utf8');
 const machine=fs.readFileSync(machinePath,'utf8');
 const activation=fs.readFileSync(activationPath,'utf8');
 const migration=fs.readFileSync(migrationPath,'utf8');
 const raceMigration=fs.readFileSync(raceMigrationPath,'utf8');
 const hardening=fs.readFileSync(hardeningPath,'utf8');
+const branchEvidence=fs.readFileSync(branchEvidencePath,'utf8');
 
-test('WhatsApp operational evidence is tenant-scoped, non-demo, provider-backed, and server-only',()=>{
+test('WhatsApp operational evidence is tenant-and-branch scoped, non-demo, provider-backed, and server-only',()=>{
   assert.match(status,/serviceRpc/);
   assert.doesNotMatch(status,/supabaseRpc/);
-  assert.match(status,/dabbir_whatsapp_operational_evidence/);
-  assert.match(status,/\{ p_business_id: businessId \}/);
+  assert.match(status,/dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(status,/p_business_id: businessId/);
+  assert.match(status,/p_branch_id: branchId/);
+  assert.match(status,/loadOperationalEvidence\(businessId,row\.branch_id\)/);
+
+  // Preserve the original service-only evidence authority while requiring the
+  // branch-scoped successor for tenant UI truth.
   assert.match(migration,/function public\.dabbir_whatsapp_operational_evidence\(p_business_id uuid\)/);
-  assert.match(migration,/c\.business_id=p_business_id and c\.channel_type='whatsapp' and c\.demo_mode=false/);
-  assert.match(migration,/e\.business_id=p_business_id and e\.direction='inbound' and e\.event_type='message' and e\.message_id is not null/);
-  assert.match(migration,/r\.business_id=p_business_id and r\.message_id is not null and r\.provider_message_id is not null/);
-  assert.match(migration,/r\.business_id=p_business_id and r\.provider_verified=true and r\.state in \('DELIVERED','READ'\)/);
   assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) from public,anon,authenticated/i);
   assert.match(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to service_role/i);
   assert.doesNotMatch(hardening,/dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
+
+  assert.match(branchEvidence,/function public\.dabbir_whatsapp_branch_operational_evidence\(p_business_id uuid,p_branch_id uuid\)/);
+  assert.match(branchEvidence,/c\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/join public\.dabbir_conversations c on c\.id=e\.conversation_id and c\.business_id=e\.business_id/);
+  assert.match(branchEvidence,/e\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/join public\.dabbir_conversations c on c\.id=r\.conversation_id and c\.business_id=r\.business_id/);
+  assert.match(branchEvidence,/r\.business_id=p_business_id and c\.branch_id=p_branch_id/);
+  assert.match(branchEvidence,/security invoker/i);
+  assert.match(branchEvidence,/from public,anon,authenticated/i);
+  assert.match(branchEvidence,/to service_role/i);
 });
 
-test('distinct inbound messages from one new sender serialize conversation ownership',()=>{
-  assert.match(raceMigration,/hashtextextended\(v_connection\.business_id::text \|\| ':wa-sender:' \|\| v_sender, 0\)/);
+test('distinct inbound messages serialize ownership per tenant branch and sender',()=>{
+  assert.match(raceMigration,/v_connection\.business_id::text\|\|':'\|\|v_connection\.branch_id::text\|\|':wa-sender:'\|\|v_sender/);
   const senderLock=raceMigration.indexOf("':wa-sender:'");
   const customerUpsert=raceMigration.indexOf('insert into public.dabbir_customers');
   const conversationLookup=raceMigration.indexOf('select c.id into v_conversation_id');
   assert.ok(senderLock>0&&senderLock<customerUpsert&&customerUpsert<conversationLookup);
   assert.match(raceMigration,/on conflict \(business_id,channel_handle\) where channel_handle is not null/);
+  assert.match(raceMigration,/c\.branch_id=v_connection\.branch_id/);
 });
 
 test('WhatsApp becomes operational only through the explicit evidence state machine',()=>{
@@ -84,7 +98,7 @@ test('activation distinguishes Meta-linked from operational WhatsApp',()=>{
 });
 
 test('operational truth files parse as Node modules',()=>{
-  for(const path of [statusPath,machinePath,activationPath,'api/_whatsapp-live-core.js','api/dabbir-whatsapp-reply.js','api/dabbir-whatsapp-webhook.js']){
+  for(const path of [statusPath,machinePath,activationPath,'api/_whatsapp-live-core.js','api/_whatsapp-branch-connection.js','api/dabbir-whatsapp-reply.js','api/dabbir-whatsapp-webhook.js','api/dabbir-whatsapp-disconnect.js','api/whatsapp-branch-intent.js']){
     const result=spawnSync(process.execPath,['--check',path],{encoding:'utf8'});
     assert.equal(result.status,0,`${path}: ${result.stderr||result.stdout}`);
   }

--- a/test/dabbir-whatsapp-rpc-security.test.mjs
+++ b/test/dabbir-whatsapp-rpc-security.test.mjs
@@ -4,6 +4,7 @@ import fs from 'node:fs';
 
 const status=fs.readFileSync('api/dabbir-whatsapp-status.js','utf8');
 const hardening=fs.readFileSync('supabase/migrations/20260828045200_dabbir_whatsapp_rpc_security_invoker_v1.sql','utf8');
+const branchEvidence=fs.readFileSync('supabase/migrations/20260903160359_dabbir_whatsapp_branch_operational_evidence_v1.sql','utf8');
 
 const serverOnlyFunctions=[
   'dabbir_whatsapp_persist_inbound',
@@ -14,20 +15,31 @@ const serverOnlyFunctions=[
   'dabbir_whatsapp_operational_evidence',
 ];
 
-test('WhatsApp operational evidence is fetched server-side rather than with the user token',()=>{
+test('WhatsApp operational evidence is fetched server-side and scoped to the selected branch',()=>{
   assert.match(status,/import \{ serviceRpc, whatsappLiveServerCapability \} from '.\/_whatsapp-live-core\.js'/);
-  assert.match(status,/serviceRpc\('dabbir_whatsapp_operational_evidence', \{ p_business_id: businessId \}\)/);
+  assert.match(status,/serviceRpc\('dabbir_whatsapp_branch_operational_evidence', \{/);
+  assert.match(status,/p_business_id: businessId/);
+  assert.match(status,/p_branch_id: branchId/);
   assert.doesNotMatch(status,/supabaseRpc/);
   assert.match(status,/await ownerContext\(req, businessId\)/);
 });
 
-test('all live WhatsApp RPCs are service-role only and do not retain SECURITY DEFINER',()=>{
+test('legacy live WhatsApp RPCs remain service-role only and SECURITY INVOKER',()=>{
   for(const fn of serverOnlyFunctions){
     assert.match(hardening,new RegExp(`(?:alter function public\\.${fn}\\([^;]+\\) security invoker|create or replace function public\\.${fn}\\([\\s\\S]*?security invoker)`,'i'),`${fn} must be SECURITY INVOKER`);
     assert.match(hardening,new RegExp(`revoke all on function public\\.${fn}\\([^;]+\\) from public,anon,authenticated`,'i'),`${fn} client execute must be revoked`);
     assert.match(hardening,new RegExp(`grant execute on function public\\.${fn}\\([^;]+\\) to service_role`,'i'),`${fn} must be service-role executable`);
   }
   assert.doesNotMatch(hardening,/grant execute on function public\.dabbir_whatsapp_operational_evidence\(uuid\) to authenticated/i);
+});
+
+test('branch operational evidence is SECURITY INVOKER and service-role only',()=>{
+  assert.match(branchEvidence,/create or replace function public\.dabbir_whatsapp_branch_operational_evidence/);
+  assert.match(branchEvidence,/security invoker/i);
+  assert.match(branchEvidence,/revoke all on function public\.dabbir_whatsapp_branch_operational_evidence\(uuid,uuid\) from public,anon,authenticated/i);
+  assert.match(branchEvidence,/grant execute on function public\.dabbir_whatsapp_branch_operational_evidence\(uuid,uuid\) to service_role/i);
+  assert.doesNotMatch(branchEvidence,/security definer/i);
+  assert.doesNotMatch(branchEvidence,/auth\.uid\(\)/i);
 });
 
 test('server-only operational evidence does not depend on auth.uid or client permission bypass',()=>{


### PR DESCRIPTION
Continuation of #406 after main advanced through #407-#411.

ACTION → ARTIFACT → TEST → EVIDENCE

## Reconciliation strategy
- Base is exact current main `fb9636c8c756becc20a5d8fce14c438d3436b374`.
- Preserve owner/delegate authority already merged via #407/#409/#410.
- Preserve Production migration source reconciliation already merged via #411.
- Do NOT reintroduce the stale branch-foundation migration filenames or older owner broker snapshots from #406.
- Carry only the unique branch Runtime/API layer, branch-aware WhatsApp Runtime, UI branch selector, and behavior regressions previously verified on #406.

## Runtime authority added
- Server-derived branch scope and branch workspace/operations APIs.
- Branch context UI and selected-branch routing.
- WhatsApp config/status/reply/disconnect authority scoped to the exact branch connection.
- Server-side WhatsApp branch intent for Embedded Signup.
- Regression tests for branch reads/writes, branch selection, inbound/outbound WhatsApp routing, operational evidence, exact disconnect, and RPC security.

## Prior evidence
- The same Runtime blobs were verified on #406 at SHA `831f322041c7b2a41e05990b3c33eb2de9c32457` with Vercel fail-closed gate: 1030/1030 tests passed, 0 failed.
- This PR must pass CI and a fresh Vercel Preview again on the reconciled SHA before merge.

No Production claim until exact-SHA CI/Preview and mergeability are green.