### PR TITLE
Harden GCC monetary precision and immutable currency truth

### DIFF
--- a/supabase/migrations/20260903192233_dabbir_gcc_money_precision_v2.sql
+++ b/supabase/migrations/20260903192233_dabbir_gcc_money_precision_v2.sql
@@ -1,0 +1,73 @@
+-- Live Production migration 20260903192233.
+-- GCC monetary precision foundation: business money supports 3-decimal currencies
+-- (BHD/KWD/OMR) without breaking legacy *_aed write names.
+
+drop trigger if exists dabbir_operational_payment_status_sync on public.dabbir_operational_payments;
+drop trigger if exists zz_dabbir_deposit_auto_confirm on public.dabbir_operational_payments;
+
+alter table public.dabbir_appointment_services
+  alter column unit_price_aed type numeric(14,3) using unit_price_aed::numeric(14,3),
+  alter column discount_aed type numeric(14,3) using discount_aed::numeric(14,3);
+
+alter table public.dabbir_appointments
+  alter column quoted_price_aed type numeric(14,3) using quoted_price_aed::numeric(14,3),
+  alter column discount_aed type numeric(14,3) using discount_aed::numeric(14,3),
+  alter column visit_fee_aed type numeric(14,3) using visit_fee_aed::numeric(14,3);
+
+alter table public.dabbir_car_wash_booking_requests
+  alter column quoted_price_aed type numeric(14,3) using quoted_price_aed::numeric(14,3);
+
+alter table public.dabbir_car_wash_offers
+  alter column saloon_price_aed type numeric(14,3) using saloon_price_aed::numeric(14,3),
+  alter column station_price_aed type numeric(14,3) using station_price_aed::numeric(14,3);
+
+alter table public.dabbir_cash_guardian_settings
+  alter column buffer_threshold_aed type numeric(14,3) using buffer_threshold_aed::numeric(14,3);
+
+alter table public.dabbir_clinic_packages
+  alter column price_aed type numeric(14,3) using price_aed::numeric(14,3);
+
+alter table public.dabbir_commissions
+  alter column revenue_aed type numeric(14,3) using revenue_aed::numeric(14,3),
+  alter column commission_aed type numeric(14,3) using commission_aed::numeric(14,3),
+  alter column salon_gross_aed type numeric(14,3) using salon_gross_aed::numeric(14,3);
+
+alter table public.dabbir_expenses
+  alter column amount_aed type numeric(14,3) using amount_aed::numeric(14,3);
+
+alter table public.dabbir_financial_evidence
+  alter column amount_aed type numeric(14,3) using amount_aed::numeric(14,3);
+
+alter table public.dabbir_home_service_settings
+  alter column default_visit_fee_aed type numeric(14,3) using default_visit_fee_aed::numeric(14,3);
+
+alter table public.dabbir_operational_payments
+  alter column amount_aed type numeric(14,3) using amount_aed::numeric(14,3);
+
+alter table public.dabbir_order_items
+  alter column unit_price_aed type numeric(14,3) using unit_price_aed::numeric(14,3),
+  alter column line_total_aed type numeric(14,3) using line_total_aed::numeric(14,3);
+
+alter table public.dabbir_order_returns
+  alter column refund_aed type numeric(14,3) using refund_aed::numeric(14,3);
+
+alter table public.dabbir_orders
+  alter column total_aed type numeric(14,3) using total_aed::numeric(14,3),
+  alter column paid_aed type numeric(14,3) using paid_aed::numeric(14,3);
+
+alter table public.dabbir_products
+  alter column price_aed type numeric(14,3) using price_aed::numeric(14,3);
+
+alter table public.dabbir_services
+  alter column price_aed type numeric(14,3) using price_aed::numeric(14,3);
+
+alter table public.dabbir_worker_services
+  alter column price_aed type numeric(14,3) using price_aed::numeric(14,3);
+
+create trigger dabbir_operational_payment_status_sync
+after insert or update of status, amount_aed on public.dabbir_operational_payments
+for each row execute function dabbir_private.sync_appointment_payment_status();
+
+create trigger zz_dabbir_deposit_auto_confirm
+after insert or update of status, amount_aed on public.dabbir_operational_payments
+for each row execute function dabbir_private.auto_confirm_paid_deposit();

--- a/supabase/migrations/20260903192355_dabbir_gcc_commission_rounding_v1.sql
+++ b/supabase/migrations/20260903192355_dabbir_gcc_commission_rounding_v1.sql
@@ -1,0 +1,51 @@
+-- Live Production migration 20260903192355.
+-- Commission rounding follows the business market minor units instead of forcing 2 decimals.
+
+create or replace function dabbir_private.business_currency_minor_units(p_business_id uuid)
+returns integer
+language sql
+stable
+set search_path = ''
+as $$
+  select m.currency_minor_units::integer
+  from public.dabbir_businesses b
+  join public.dabbir_markets m
+    on m.country_code=b.country_code
+   and m.currency_code=b.currency_code
+   and m.is_active=true
+  where b.id=p_business_id
+$$;
+
+revoke all on function dabbir_private.business_currency_minor_units(uuid) from public, anon, authenticated;
+
+do $$
+declare
+  v_def text;
+  v_count integer;
+begin
+  select pg_get_functiondef(p.oid)
+    into v_def
+  from pg_proc p
+  join pg_namespace n on n.oid=p.pronamespace
+  where n.nspname='dabbir_private'
+    and p.proname='capture_appointment_workflow'
+    and p.prokind='f'
+  limit 1;
+
+  if v_def is null then
+    raise exception 'CAPTURE_APPOINTMENT_WORKFLOW_NOT_FOUND';
+  end if;
+
+  v_count := (length(v_def)-length(replace(v_def,'end,2)','')))/length('end,2)');
+  if v_count <> 2 then
+    raise exception 'COMMISSION_ROUNDING_SOURCE_DRIFT:%',v_count;
+  end if;
+
+  v_def := replace(
+    v_def,
+    'end,2)',
+    'end,dabbir_private.business_currency_minor_units(new.business_id))'
+  );
+  execute v_def;
+end
+$$;

--- a/supabase/migrations/20260903192500_dabbir_gcc_currency_snapshot_v1.sql
+++ b/supabase/migrations/20260903192500_dabbir_gcc_currency_snapshot_v1.sql
@@ -1,0 +1,146 @@
+-- Live Production migration 20260903192500.
+-- Currency snapshots are immutable financial truth. Neutral generated aliases let
+-- runtime reads migrate away from legacy *_aed names without breaking old writers.
+
+create or replace function dabbir_private.enforce_business_currency_snapshot()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_currency text;
+begin
+  if tg_op='UPDATE' then
+    if new.business_id is distinct from old.business_id then raise exception 'MONEY_SNAPSHOT_BUSINESS_IMMUTABLE'; end if;
+    if new.currency_code is distinct from old.currency_code then raise exception 'MONEY_SNAPSHOT_CURRENCY_IMMUTABLE'; end if;
+    return new;
+  end if;
+  select b.currency_code into v_currency from public.dabbir_businesses b where b.id=new.business_id;
+  if v_currency is null then raise exception 'BUSINESS_CURRENCY_NOT_CONFIGURED'; end if;
+  if new.currency_code is null then new.currency_code:=v_currency;
+  elsif new.currency_code<>v_currency then raise exception 'BUSINESS_CURRENCY_MISMATCH'; end if;
+  return new;
+end
+$$;
+
+create or replace function dabbir_private.enforce_appointment_currency_snapshot()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_currency text;
+begin
+  if tg_op='UPDATE' then
+    if new.business_id is distinct from old.business_id or new.appointment_id is distinct from old.appointment_id then raise exception 'APPOINTMENT_MONEY_IDENTITY_IMMUTABLE'; end if;
+    if new.currency_code is distinct from old.currency_code then raise exception 'MONEY_SNAPSHOT_CURRENCY_IMMUTABLE'; end if;
+    return new;
+  end if;
+  select a.deposit_currency_code into v_currency from public.dabbir_appointments a where a.business_id=new.business_id and a.id=new.appointment_id;
+  if v_currency is null then raise exception 'APPOINTMENT_CURRENCY_NOT_CONFIGURED'; end if;
+  if new.currency_code is null then new.currency_code:=v_currency;
+  elsif new.currency_code<>v_currency then raise exception 'APPOINTMENT_CURRENCY_MISMATCH'; end if;
+  return new;
+end
+$$;
+
+create or replace function dabbir_private.enforce_order_currency_snapshot()
+returns trigger
+language plpgsql
+security definer
+set search_path=''
+as $$
+declare v_currency text;
+begin
+  if tg_op='UPDATE' then
+    if new.business_id is distinct from old.business_id or new.order_id is distinct from old.order_id then raise exception 'ORDER_MONEY_IDENTITY_IMMUTABLE'; end if;
+    if new.currency_code is distinct from old.currency_code then raise exception 'MONEY_SNAPSHOT_CURRENCY_IMMUTABLE'; end if;
+    return new;
+  end if;
+  select o.currency_code into v_currency from public.dabbir_orders o where o.business_id=new.business_id and o.id=new.order_id;
+  if v_currency is null then raise exception 'ORDER_CURRENCY_NOT_CONFIGURED'; end if;
+  if new.currency_code is null then new.currency_code:=v_currency;
+  elsif new.currency_code<>v_currency then raise exception 'ORDER_CURRENCY_MISMATCH'; end if;
+  return new;
+end
+$$;
+
+revoke all on function dabbir_private.enforce_business_currency_snapshot() from public,anon,authenticated;
+revoke all on function dabbir_private.enforce_appointment_currency_snapshot() from public,anon,authenticated;
+revoke all on function dabbir_private.enforce_order_currency_snapshot() from public,anon,authenticated;
+
+alter table public.dabbir_orders add column if not exists currency_code text;
+alter table public.dabbir_operational_payments add column if not exists currency_code text;
+alter table public.dabbir_expenses add column if not exists currency_code text;
+alter table public.dabbir_financial_evidence add column if not exists currency_code text;
+alter table public.dabbir_commissions add column if not exists currency_code text;
+alter table public.dabbir_car_wash_booking_requests add column if not exists currency_code text;
+alter table public.dabbir_order_returns add column if not exists currency_code text;
+
+update public.dabbir_orders o set currency_code=b.currency_code from public.dabbir_businesses b where b.id=o.business_id and o.currency_code is null;
+update public.dabbir_operational_payments p set currency_code=a.deposit_currency_code from public.dabbir_appointments a where a.business_id=p.business_id and a.id=p.appointment_id and p.currency_code is null;
+update public.dabbir_expenses e set currency_code=b.currency_code from public.dabbir_businesses b where b.id=e.business_id and e.currency_code is null;
+update public.dabbir_financial_evidence e set currency_code=b.currency_code from public.dabbir_businesses b where b.id=e.business_id and e.currency_code is null;
+update public.dabbir_commissions c set currency_code=a.deposit_currency_code from public.dabbir_appointments a where a.business_id=c.business_id and a.id=c.appointment_id and c.currency_code is null;
+update public.dabbir_car_wash_booking_requests r set currency_code=b.currency_code from public.dabbir_businesses b where b.id=r.business_id and r.currency_code is null;
+update public.dabbir_order_returns r set currency_code=o.currency_code from public.dabbir_orders o where o.business_id=r.business_id and o.id=r.order_id and r.currency_code is null;
+
+alter table public.dabbir_orders alter column currency_code set not null;
+alter table public.dabbir_operational_payments alter column currency_code set not null;
+alter table public.dabbir_expenses alter column currency_code set not null;
+alter table public.dabbir_financial_evidence alter column currency_code set not null;
+alter table public.dabbir_commissions alter column currency_code set not null;
+alter table public.dabbir_car_wash_booking_requests alter column currency_code set not null;
+alter table public.dabbir_order_returns alter column currency_code set not null;
+
+alter table public.dabbir_orders add constraint dabbir_orders_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_operational_payments add constraint dabbir_operational_payments_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_expenses add constraint dabbir_expenses_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_financial_evidence add constraint dabbir_financial_evidence_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_commissions add constraint dabbir_commissions_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_car_wash_booking_requests add constraint dabbir_car_wash_booking_requests_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+alter table public.dabbir_order_returns add constraint dabbir_order_returns_currency_code_check check (currency_code ~ '^[A-Z]{3}$');
+
+drop trigger if exists dabbir_orders_currency_snapshot on public.dabbir_orders;
+create trigger dabbir_orders_currency_snapshot before insert or update on public.dabbir_orders for each row execute function dabbir_private.enforce_business_currency_snapshot();
+drop trigger if exists dabbir_expenses_currency_snapshot on public.dabbir_expenses;
+create trigger dabbir_expenses_currency_snapshot before insert or update on public.dabbir_expenses for each row execute function dabbir_private.enforce_business_currency_snapshot();
+drop trigger if exists dabbir_financial_evidence_currency_snapshot on public.dabbir_financial_evidence;
+create trigger dabbir_financial_evidence_currency_snapshot before insert or update on public.dabbir_financial_evidence for each row execute function dabbir_private.enforce_business_currency_snapshot();
+drop trigger if exists dabbir_car_wash_booking_currency_snapshot on public.dabbir_car_wash_booking_requests;
+create trigger dabbir_car_wash_booking_currency_snapshot before insert or update on public.dabbir_car_wash_booking_requests for each row execute function dabbir_private.enforce_business_currency_snapshot();
+
+drop trigger if exists dabbir_operational_payments_currency_snapshot on public.dabbir_operational_payments;
+create trigger dabbir_operational_payments_currency_snapshot before insert or update on public.dabbir_operational_payments for each row execute function dabbir_private.enforce_appointment_currency_snapshot();
+drop trigger if exists dabbir_commissions_currency_snapshot on public.dabbir_commissions;
+create trigger dabbir_commissions_currency_snapshot before insert or update on public.dabbir_commissions for each row execute function dabbir_private.enforce_appointment_currency_snapshot();
+
+drop trigger if exists dabbir_order_returns_currency_snapshot on public.dabbir_order_returns;
+create trigger dabbir_order_returns_currency_snapshot before insert or update on public.dabbir_order_returns for each row execute function dabbir_private.enforce_order_currency_snapshot();
+
+alter table public.dabbir_products add column if not exists price_amount numeric(14,3) generated always as (price_aed) stored;
+alter table public.dabbir_services add column if not exists price_amount numeric(14,3) generated always as (price_aed) stored;
+alter table public.dabbir_worker_services add column if not exists price_amount numeric(14,3) generated always as (price_aed) stored;
+alter table public.dabbir_appointments add column if not exists quoted_price_amount numeric(14,3) generated always as (quoted_price_aed) stored;
+alter table public.dabbir_appointments add column if not exists discount_amount numeric(14,3) generated always as (discount_aed) stored;
+alter table public.dabbir_appointments add column if not exists visit_fee_amount numeric(14,3) generated always as (visit_fee_aed) stored;
+alter table public.dabbir_appointments add column if not exists currency_code text generated always as (deposit_currency_code) stored;
+alter table public.dabbir_appointment_services add column if not exists unit_price_amount numeric(14,3) generated always as (unit_price_aed) stored;
+alter table public.dabbir_appointment_services add column if not exists discount_amount numeric(14,3) generated always as (discount_aed) stored;
+alter table public.dabbir_orders add column if not exists total_amount numeric(14,3) generated always as (total_aed) stored;
+alter table public.dabbir_orders add column if not exists paid_amount numeric(14,3) generated always as (paid_aed) stored;
+alter table public.dabbir_order_items add column if not exists unit_price_amount numeric(14,3) generated always as (unit_price_aed) stored;
+alter table public.dabbir_order_items add column if not exists line_total_amount numeric(14,3) generated always as (line_total_aed) stored;
+alter table public.dabbir_order_returns add column if not exists refund_amount numeric(14,3) generated always as (refund_aed) stored;
+alter table public.dabbir_operational_payments add column if not exists amount numeric(14,3) generated always as (amount_aed) stored;
+alter table public.dabbir_expenses add column if not exists amount numeric(14,3) generated always as (amount_aed) stored;
+alter table public.dabbir_financial_evidence add column if not exists amount numeric(14,3) generated always as (amount_aed) stored;
+alter table public.dabbir_commissions add column if not exists revenue_amount numeric(14,3) generated always as (revenue_aed) stored;
+alter table public.dabbir_commissions add column if not exists commission_amount numeric(14,3) generated always as (commission_aed) stored;
+alter table public.dabbir_commissions add column if not exists salon_gross_amount numeric(14,3) generated always as (salon_gross_aed) stored;
+alter table public.dabbir_home_service_settings add column if not exists default_visit_fee_amount numeric(14,3) generated always as (default_visit_fee_aed) stored;
+alter table public.dabbir_car_wash_offers add column if not exists saloon_price_amount numeric(14,3) generated always as (saloon_price_aed) stored;
+alter table public.dabbir_car_wash_offers add column if not exists station_price_amount numeric(14,3) generated always as (station_price_aed) stored;
+alter table public.dabbir_car_wash_booking_requests add column if not exists quoted_price_amount numeric(14,3) generated always as (quoted_price_aed) stored;
+alter table public.dabbir_clinic_packages add column if not exists price_amount numeric(14,3) generated always as (price_aed) stored;
+alter table public.dabbir_cash_guardian_settings add column if not exists buffer_threshold_amount numeric(14,3) generated always as (buffer_threshold_aed) stored;

--- a/test/dabbir-gcc-money-core.test.mjs
+++ b/test/dabbir-gcc-money-core.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const precision=fs.readFileSync('supabase/migrations/20260903192233_dabbir_gcc_money_precision_v2.sql','utf8');
+const rounding=fs.readFileSync('supabase/migrations/20260903192355_dabbir_gcc_commission_rounding_v1.sql','utf8');
+const snapshot=fs.readFileSync('supabase/migrations/20260903192500_dabbir_gcc_currency_snapshot_v1.sql','utf8');
+
+test('GCC money core preserves three-decimal currencies without breaking legacy writers',()=>{
+  for(const column of ['unit_price_aed','quoted_price_aed','visit_fee_aed','amount_aed','total_aed','paid_aed','refund_aed','price_aed']){
+    assert.match(precision,new RegExp(`alter column ${column} type numeric\\(14,3\\)`,'i'));
+  }
+  assert.doesNotMatch(precision,/type numeric\(14,2\)/i);
+  const drop=precision.indexOf('drop trigger if exists dabbir_operational_payment_status_sync');
+  const alter=precision.indexOf('alter table public.dabbir_operational_payments');
+  const recreate=precision.lastIndexOf('create trigger dabbir_operational_payment_status_sync');
+  assert.ok(drop>=0&&drop<alter&&alter<recreate,'amount trigger must be dropped only around the compatible type change');
+});
+
+test('commission rounding follows market minor units and fails closed on source drift',()=>{
+  assert.match(rounding,/business_currency_minor_units\(p_business_id uuid\)/);
+  assert.match(rounding,/m\.currency_minor_units::integer/);
+  assert.match(rounding,/m\.currency_code=b\.currency_code/);
+  assert.match(rounding,/if v_count <> 2 then/);
+  assert.match(rounding,/COMMISSION_ROUNDING_SOURCE_DRIFT/);
+  assert.match(rounding,/business_currency_minor_units\(new\.business_id\)/);
+  assert.doesNotMatch(rounding,/end,2\).*execute v_def/is);
+});
+
+test('financial records freeze ISO currency and expose neutral amount aliases',()=>{
+  for(const table of ['dabbir_orders','dabbir_operational_payments','dabbir_expenses','dabbir_financial_evidence','dabbir_commissions','dabbir_car_wash_booking_requests','dabbir_order_returns']){
+    assert.match(snapshot,new RegExp(`alter table public\\.${table} add column if not exists currency_code text`));
+    assert.match(snapshot,new RegExp(`alter table public\\.${table} alter column currency_code set not null`));
+  }
+  assert.match(snapshot,/MONEY_SNAPSHOT_CURRENCY_IMMUTABLE/);
+  assert.match(snapshot,/BUSINESS_CURRENCY_MISMATCH/);
+  assert.match(snapshot,/APPOINTMENT_CURRENCY_MISMATCH/);
+  assert.match(snapshot,/ORDER_CURRENCY_MISMATCH/);
+  for(const alias of ['price_amount','quoted_price_amount','total_amount','paid_amount','refund_amount','revenue_amount','commission_amount','salon_gross_amount','default_visit_fee_amount','quoted_price_amount','buffer_threshold_amount']){
+    assert.match(snapshot,new RegExp(`add column if not exists ${alias} numeric\\(14,3\\) generated always as`,'i'));
+  }
+  assert.match(snapshot,/dabbir_appointments add column if not exists currency_code text generated always as \(deposit_currency_code\) stored/);
+  assert.doesNotMatch(snapshot,/currency_code\s+text\s+not null\s+default\s+'AED'/i);
+});

--- a/test/dabbir-gcc-money-core.test.mjs
+++ b/test/dabbir-gcc-money-core.test.mjs
@@ -24,7 +24,10 @@ test('commission rounding follows market minor units and fails closed on source 
   assert.match(rounding,/if v_count <> 2 then/);
   assert.match(rounding,/COMMISSION_ROUNDING_SOURCE_DRIFT/);
   assert.match(rounding,/business_currency_minor_units\(new\.business_id\)/);
-  assert.doesNotMatch(rounding,/end,2\).*execute v_def/is);
+  const legacyToken=rounding.indexOf("'end,2)'");
+  const dynamicToken=rounding.indexOf("'end,dabbir_private.business_currency_minor_units(new.business_id))'");
+  const execute=rounding.indexOf('execute v_def;');
+  assert.ok(legacyToken>=0&&dynamicToken>legacyToken&&execute>dynamicToken,'legacy two-decimal source tokens must be replaced with market precision before the function definition is executed');
 });
 
 test('financial records freeze ISO currency and expose neutral amount aliases',()=>{


### PR DESCRIPTION
ACTION → ARTIFACT → TEST → EVIDENCE

## Root cause
DABBIR market registry correctly supports BHD/KWD/OMR at 3 minor units, but legacy business monetary columns were still numeric(...,2) and runtime/schema names remained *_aed. That could silently truncate GCC monetary values and let historical transactions inherit the wrong currency if a business profile changed later.

## Live artifacts already applied to DABBIR Mumbai
- `20260903192233_dabbir_gcc_money_precision_v2`
- `20260903192355_dabbir_gcc_commission_rounding_v1`
- `20260903192500_dabbir_gcc_currency_snapshot_v1`

## Changes
- Widen business monetary storage to numeric(14,3) while retaining legacy *_aed write compatibility.
- Preserve/recreate operational payment triggers around the type change.
- Commission rounding now derives market `currency_minor_units` instead of forcing 2 decimals and fails closed if source text drifts.
- Freeze immutable ISO currency snapshots on orders, operational payments, expenses, financial evidence, commissions, car-wash booking requests, and returns.
- Add neutral generated read aliases such as `price_amount`, `total_amount`, `paid_amount`, `refund_amount`, `commission_amount` and appointment `currency_code`.
- Add static regression contract.

## Live verification
- Existing financial currency mismatches/nulls: 0.
- Transactional KWD red-team: temporary KWD business created order with `currency_code=KWD`, `total_amount=12.345`, `paid_amount=1.234`, both scale=3, then full rollback.
- Attempt to mutate an existing payment currency was rejected with `MONEY_SNAPSHOT_CURRENCY_IMMUTABLE`.
- Service storage accepted `12.345` at scale=3 inside a rollback transaction.

This PR source-aligns already-applied Production migrations. It must pass GitHub CI and Vercel fail-closed validation before merge.