### PR TITLE
diagnostic(dabbir): expose WebKit owner authority execution state

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,3 +1,4 @@
+import { Script } from 'node:vm';
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
@@ -56,11 +57,10 @@ function ownerFirstInlineScript() {
     throw new Error(`DABBIR_OWNER_FIRST_INLINE_CONTENT_TYPE_${contentType || 'missing'}`);
   }
   try {
-    // Compile the exact browser payload. api/dabbir-owner-first-ui.js itself can be
-    // syntactically valid while the JavaScript stored inside its String.raw payload is not.
-    new Function(payload);
+    new Script(payload, { filename: 'dabbir-owner-first-inline.js' });
   } catch (error) {
-    throw new Error(`DABBIR_OWNER_FIRST_INLINE_PARSE_${String(error?.message || error).slice(0, 180)}`);
+    const detail = String(error?.stack || error?.message || error).replace(/\s*\n\s*/g, ' | ').slice(0, 700);
+    throw new Error(`DABBIR_OWNER_FIRST_INLINE_PARSE_${detail}`);
   }
   const probe = '<script data-dabbir-owner-first-probe="owner-first-probe-v1">window.__dabbirOwnerFirstBootstrapProbe={version:"owner-first-probe-v1",reached:true};</script>';
   const owner = `<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>`;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -55,7 +55,16 @@ function ownerFirstInlineScript() {
   if (!contentType.toLowerCase().includes('application/javascript')) {
     throw new Error(`DABBIR_OWNER_FIRST_INLINE_CONTENT_TYPE_${contentType || 'missing'}`);
   }
-  return `<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>`;
+  try {
+    // Compile the exact browser payload. api/dabbir-owner-first-ui.js itself can be
+    // syntactically valid while the JavaScript stored inside its String.raw payload is not.
+    new Function(payload);
+  } catch (error) {
+    throw new Error(`DABBIR_OWNER_FIRST_INLINE_PARSE_${String(error?.message || error).slice(0, 180)}`);
+  }
+  const probe = '<script data-dabbir-owner-first-probe="owner-first-probe-v1">window.__dabbirOwnerFirstBootstrapProbe={version:"owner-first-probe-v1",reached:true};</script>';
+  const owner = `<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>`;
+  return `${probe}\n${owner}`;
 }
 
 function orderOwnerFirstBeforeAuthBoot(body) {
@@ -98,7 +107,7 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
-      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v2');
+      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v3');
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -8,6 +8,8 @@ const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appoint
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;
 const OWNER_FIRST_SCRIPT_RE = /<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g;
 const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
+const OWNER_FIRST_BROKEN_PREFIX = "const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':';";
+const OWNER_FIRST_FIXED_PREFIX = "const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':'';";
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -22,6 +24,12 @@ function stripLegacyNavigationOverrides(body) {
   return body
     .split(LEGACY_STORE_SLOT_HIDE).join('')
     .split(LEGACY_STORE_APPOINTMENT_REDIRECT).join('');
+}
+
+function reconcileOwnerFirstPayload(payload) {
+  const pieces = String(payload).split(OWNER_FIRST_BROKEN_PREFIX);
+  if (pieces.length !== 2) throw new Error(`DABBIR_OWNER_FIRST_PREFIX_RECONCILIATION_COUNT_${pieces.length - 1}`);
+  return pieces.join(OWNER_FIRST_FIXED_PREFIX);
 }
 
 function ownerFirstInlineScript() {
@@ -56,6 +64,7 @@ function ownerFirstInlineScript() {
   if (!contentType.toLowerCase().includes('application/javascript')) {
     throw new Error(`DABBIR_OWNER_FIRST_INLINE_CONTENT_TYPE_${contentType || 'missing'}`);
   }
+  payload = reconcileOwnerFirstPayload(payload);
   try {
     new Script(payload, { filename: 'dabbir-owner-first-inline.js' });
   } catch (error) {
@@ -107,7 +116,7 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
-      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v3');
+      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-compiled-reconciled-before-auth-boot-v4');
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -48,7 +48,7 @@ async function step(name, fn) {
   } catch (error) {
     row.status = 'FAIL';
     row.duration_ms = Date.now() - started;
-    row.detail = String(error?.stack || error?.message || error).slice(0, 1200);
+    row.detail = String(error?.stack || error?.message || error).slice(0, 2000);
     console.error(`FAIL ${name} (${row.duration_ms}ms) — ${row.detail}`);
     throw error;
   }
@@ -148,8 +148,34 @@ try {
     await page.locator('#authPassword').waitFor({ state: 'visible', timeout: 10_000 });
     await page.locator('#authSubmit').waitFor({ state: 'visible', timeout: 10_000 });
 
-    const authority = await page.evaluate(() => window.__dabbirUiAuthority || null);
-    assert(authority?.version === 'owner-first-v4', `UI_AUTHORITY_INVALID_${JSON.stringify(authority)}`);
+    const browserHeaders = await response.allHeaders();
+    const authorityDebug = await page.evaluate(() => {
+      const inline = document.querySelector('script[data-dabbir-owner-first-inline="owner-first-v4"]');
+      const probeTag = document.querySelector('script[data-dabbir-owner-first-probe="owner-first-probe-v1"]');
+      return {
+        authority: window.__dabbirUiAuthority || null,
+        ownerFlag: window.__dabbirOwnerFirstUiV4 === true,
+        probe: window.__dabbirOwnerFirstBootstrapProbe || null,
+        inlineCount: document.querySelectorAll('script[data-dabbir-owner-first-inline="owner-first-v4"]').length,
+        probeCount: document.querySelectorAll('script[data-dabbir-owner-first-probe="owner-first-probe-v1"]').length,
+        inlineTextLength: inline?.textContent?.length || 0,
+        probeTextLength: probeTag?.textContent?.length || 0,
+        bodyAuthority: document.body?.getAttribute('data-dabbir-ui') || null,
+      };
+    });
+    const diagnostic = {
+      ...authorityDebug,
+      firstPaintHeader: browserHeaders['x-dabbir-first-paint-authority'] || null,
+      csp: browserHeaders['content-security-policy'] || null,
+      pageErrors: pageErrors.slice(0, 8),
+      consoleErrors: consoleErrors.slice(0, 8),
+    };
+    report.artifacts.webkit_owner_authority_diagnostic = diagnostic;
+    console.log(`WEBKIT_OWNER_AUTHORITY_DIAGNOSTIC=${JSON.stringify(diagnostic)}`);
+    assert(
+      authorityDebug.authority?.version === 'owner-first-v4',
+      `UI_AUTHORITY_INVALID_${JSON.stringify(diagnostic)}`,
+    );
 
     await page.screenshot({ path: 'dabbir-protected-live-smoke.png', fullPage: true });
     report.artifacts.screenshot = 'dabbir-protected-live-smoke.png';
@@ -169,7 +195,7 @@ try {
   report.verdict = 'PASS';
 } catch (error) {
   report.verdict = 'FAIL';
-  report.error = String(error?.stack || error?.message || error).slice(0, 1600);
+  report.error = String(error?.stack || error?.message || error).slice(0, 2400);
   process.exitCode = 1;
 } finally {
   if (browser) await browser.close().catch(() => {});

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -32,8 +32,12 @@ test('root shell bypasses stale Safari UI bundle versions', () => {
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
 });
 
-test('owner-first authority is parsed, probed, server-inlined, and executed before auth boot first paint', () => {
+test('owner-first authority reconciles one known malformed token, parses, probes, and executes before auth boot first paint', () => {
   assert.match(recovery,/ownerFirstInlineScript/);
+  assert.match(recovery,/reconcileOwnerFirstPayload/);
+  assert.match(recovery,/OWNER_FIRST_BROKEN_PREFIX/);
+  assert.match(recovery,/OWNER_FIRST_FIXED_PREFIX/);
+  assert.match(recovery,/DABBIR_OWNER_FIRST_PREFIX_RECONCILIATION_COUNT_/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_STATUS_/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_AUTHORITY_MISSING/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_UNSAFE_SCRIPT_CLOSE/);
@@ -50,13 +54,15 @@ test('owner-first authority is parsed, probed, server-inlined, and executed befo
   assert.equal(externalOwnerTags.length,0,'first paint must not depend on an owner-first subresource request');
   assert.equal(probeTags.length,1,'exactly one first-paint execution probe must exist');
   assert.equal(inlineOwnerTags.length,1,'exactly one owner-first inline authority must execute');
+  assert.doesNotMatch(body,/const prefix=raw\.includes\('•'\).*\+' ':';/,'malformed owner-first prefix must not reach final HTML');
+  assert.match(body,/const prefix=raw\.includes\('•'\).*\+' ':'';/,'reconciled owner-first prefix must reach final HTML');
   const renderIndex=body.indexOf('function renderAll()');
   const probeIndex=body.indexOf(probeTags[0]);
   const ownerIndex=body.indexOf(inlineOwnerTags[0]);
   const authorityIndex=body.indexOf("window.__dabbirUiAuthority={version:'owner-first-v4'",ownerIndex);
   const bootIndex=body.indexOf('applyLang();boot();');
   assert.ok(renderIndex>=0 && probeIndex>renderIndex && ownerIndex>probeIndex && authorityIndex>ownerIndex && bootIndex>authorityIndex,`render=${renderIndex} probe=${probeIndex} owner=${ownerIndex} authority=${authorityIndex} boot=${bootIndex}`);
-  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-before-auth-boot-v3');
+  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-compiled-reconciled-before-auth-boot-v4');
 });
 
 test('root shell injects an independent Safari auth fail-open watchdog', () => {

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -38,7 +38,7 @@ test('owner-first authority is parsed, probed, server-inlined, and executed befo
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_AUTHORITY_MISSING/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_UNSAFE_SCRIPT_CLOSE/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_PARSE_/);
-  assert.match(recovery,/new Function\(payload\)/);
+  assert.match(recovery,/new Script\(payload/);
   assert.match(recovery,/dabbir-owner-first-probe/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_SCRIPT_COUNT_/);
   assert.match(recovery,/DABBIR_AUTH_BOOT_ANCHOR_COUNT_/);

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -32,25 +32,31 @@ test('root shell bypasses stale Safari UI bundle versions', () => {
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
 });
 
-test('owner-first authority is server-inlined after base render definitions and before auth boot first paint', () => {
+test('owner-first authority is parsed, probed, server-inlined, and executed before auth boot first paint', () => {
   assert.match(recovery,/ownerFirstInlineScript/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_STATUS_/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_AUTHORITY_MISSING/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_UNSAFE_SCRIPT_CLOSE/);
+  assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_PARSE_/);
+  assert.match(recovery,/new Function\(payload\)/);
+  assert.match(recovery,/dabbir-owner-first-probe/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_SCRIPT_COUNT_/);
   assert.match(recovery,/DABBIR_AUTH_BOOT_ANCHOR_COUNT_/);
   const {body,headers,status}=renderCanonicalRoot();
   assert.equal(status,200);
   const externalOwnerTags=body.match(/<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g)||[];
   const inlineOwnerTags=body.match(/<script data-dabbir-owner-first-inline="owner-first-v4">/g)||[];
+  const probeTags=body.match(/<script data-dabbir-owner-first-probe="owner-first-probe-v1">/g)||[];
   assert.equal(externalOwnerTags.length,0,'first paint must not depend on an owner-first subresource request');
+  assert.equal(probeTags.length,1,'exactly one first-paint execution probe must exist');
   assert.equal(inlineOwnerTags.length,1,'exactly one owner-first inline authority must execute');
   const renderIndex=body.indexOf('function renderAll()');
+  const probeIndex=body.indexOf(probeTags[0]);
   const ownerIndex=body.indexOf(inlineOwnerTags[0]);
   const authorityIndex=body.indexOf("window.__dabbirUiAuthority={version:'owner-first-v4'",ownerIndex);
   const bootIndex=body.indexOf('applyLang();boot();');
-  assert.ok(renderIndex>=0 && ownerIndex>renderIndex && authorityIndex>ownerIndex && bootIndex>authorityIndex,`render=${renderIndex} owner=${ownerIndex} authority=${authorityIndex} boot=${bootIndex}`);
-  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-before-auth-boot-v2');
+  assert.ok(renderIndex>=0 && probeIndex>renderIndex && ownerIndex>probeIndex && authorityIndex>ownerIndex && bootIndex>authorityIndex,`render=${renderIndex} probe=${probeIndex} owner=${ownerIndex} authority=${authorityIndex} boot=${bootIndex}`);
+  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-before-auth-boot-v3');
 });
 
 test('root shell injects an independent Safari auth fail-open watchdog', () => {


### PR DESCRIPTION
Superseded by #423 after the fail-closed parser identified the exact malformed owner-first payload token at browser payload line 177. #423 contains the root repair plus the mobile menu target fix on the latest main.