### PR TITLE
Fix WebKit owner bootstrap diagnostics and mobile menu target

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,12 +1,13 @@
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
-const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
+const UI_CACHE_BUST = '20260903-webkit-owner-diagnostics-v4';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;
 const OWNER_FIRST_SCRIPT_RE = /<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g;
 const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
+const MOBILE_MENU_TOUCH_TARGET = `<style data-dabbir-mobile-menu-touch-target="v1">@media(max-width:700px){html body #appShell #menuBtn{min-width:44px!important;min-height:44px!important;flex-shrink:0!important;box-sizing:border-box!important}}</style>`;
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -21,6 +22,37 @@ function stripLegacyNavigationOverrides(body) {
   return body
     .split(LEGACY_STORE_SLOT_HIDE).join('')
     .split(LEGACY_STORE_APPOINTMENT_REDIRECT).join('');
+}
+
+function ownerFirstProbeScript() {
+  return `<script data-dabbir-owner-first-probe="v1">
+(()=>{
+  const safeError=value=>{try{return String(value&&((value.stack)||(value.message))||value||'UNKNOWN_OWNER_FIRST_ERROR').slice(0,1200)}catch{return 'UNKNOWN_OWNER_FIRST_ERROR'}};
+  window.__dabbirOwnerFirstInitError=null;
+  window.__dabbirOwnerFirstInlineState={stage:'before_owner_first',error:null};
+  window.addEventListener('error',event=>{
+    if(window.__dabbirUiAuthority)return;
+    const detail=safeError(event&&event.error?event.error:(event&&event.message?event.message:'OWNER_FIRST_WINDOW_ERROR'));
+    window.__dabbirOwnerFirstInitError=detail;
+    window.__dabbirOwnerFirstInlineState={stage:'window_error',error:detail};
+  });
+  window.addEventListener('unhandledrejection',event=>{
+    if(window.__dabbirUiAuthority)return;
+    const detail=safeError(event&&event.reason?event.reason:'OWNER_FIRST_UNHANDLED_REJECTION');
+    window.__dabbirOwnerFirstInitError=detail;
+    window.__dabbirOwnerFirstInlineState={stage:'unhandled_rejection',error:detail};
+  });
+})();
+</script>`;
+}
+
+function ownerFirstPostScript() {
+  return `<script data-dabbir-owner-first-post="v1">
+window.__dabbirOwnerFirstInlineState={
+  stage:(window.__dabbirUiAuthority&&window.__dabbirUiAuthority.version==='owner-first-v4')?'ready':'missing_authority',
+  error:window.__dabbirOwnerFirstInitError||null
+};
+</script>`;
 }
 
 function ownerFirstInlineScript() {
@@ -55,7 +87,7 @@ function ownerFirstInlineScript() {
   if (!contentType.toLowerCase().includes('application/javascript')) {
     throw new Error(`DABBIR_OWNER_FIRST_INLINE_CONTENT_TYPE_${contentType || 'missing'}`);
   }
-  return `<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>`;
+  return `${ownerFirstProbeScript()}\n<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>\n${ownerFirstPostScript()}`;
 }
 
 function orderOwnerFirstBeforeAuthBoot(body) {
@@ -72,6 +104,11 @@ function orderOwnerFirstBeforeAuthBoot(body) {
     AUTH_BOOT_ANCHOR,
     `</script>\n${inlineOwner}\n<script>\napplyLang();boot();\n</script>`,
   );
+}
+
+function injectMobileMenuTouchTarget(body) {
+  if (typeof body !== 'string' || body.includes('data-dabbir-mobile-menu-touch-target')) return body;
+  return body.replace('</head>', `${MOBILE_MENU_TOUCH_TARGET}\n</head>`);
 }
 
 function injectSafariAuthFailOpen(body) {
@@ -98,12 +135,13 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
-      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v2');
+      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-diagnostic-before-auth-boot-v3');
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);
       const ordered = orderOwnerFirstBeforeAuthBoot(canonical);
-      return res.end(injectSafariAuthFailOpen(ordered));
+      const touchSafe = injectMobileMenuTouchTarget(ordered);
+      return res.end(injectSafariAuthFailOpen(touchSafe));
     },
   };
 

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,7 +1,7 @@
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
-const UI_CACHE_BUST = '20260903-webkit-owner-diagnostics-v4';
+const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/test/dabbir-protected-live-smoke.mjs
+++ b/test/dabbir-protected-live-smoke.mjs
@@ -132,7 +132,7 @@ try {
     const page = await context.newPage();
     const pageErrors = [];
     const consoleErrors = [];
-    page.on('pageerror', error => pageErrors.push(String(error?.message || error)));
+    page.on('pageerror', error => pageErrors.push(String(error?.stack || error?.message || error)));
     page.on('console', message => {
       if (message.type() !== 'error') return;
       const text = message.text();
@@ -148,11 +148,19 @@ try {
     await page.locator('#authPassword').waitFor({ state: 'visible', timeout: 10_000 });
     await page.locator('#authSubmit').waitFor({ state: 'visible', timeout: 10_000 });
 
-    const authority = await page.evaluate(() => window.__dabbirUiAuthority || null);
-    assert(authority?.version === 'owner-first-v4', `UI_AUTHORITY_INVALID_${JSON.stringify(authority)}`);
-
     await page.screenshot({ path: 'dabbir-protected-live-smoke.png', fullPage: true });
     report.artifacts.screenshot = 'dabbir-protected-live-smoke.png';
+
+    const diagnostics = await page.evaluate(() => ({
+      authority: window.__dabbirUiAuthority || null,
+      inline_state: window.__dabbirOwnerFirstInlineState || null,
+      init_error: window.__dabbirOwnerFirstInitError || null,
+      owner_flag: window.__dabbirOwnerFirstUiV4 || null,
+    }));
+    if (diagnostics?.authority?.version !== 'owner-first-v4') {
+      throw new Error(`UI_AUTHORITY_INVALID_${JSON.stringify(diagnostics)}_PAGE_ERRORS_${JSON.stringify(pageErrors.slice(0,8))}_CONSOLE_ERRORS_${JSON.stringify(consoleErrors.slice(0,8))}`);
+    }
+    assert(diagnostics?.inline_state?.stage === 'ready', `UI_INLINE_STATE_INVALID_${JSON.stringify(diagnostics)}`);
 
     const logo = authGate.locator('.authCard .brand .logo');
     assert(await logo.count() === 1, `AUTH_APPROVED_LOGO_COUNT_${await logo.count()}`);

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -25,15 +25,20 @@ function renderCanonicalRoot(){
 }
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-webkit-owner-diagnostics-v4'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
 });
 
-test('owner-first authority is server-inlined after base render definitions and before auth boot first paint', () => {
+test('owner-first authority is server-inlined with a truthful diagnostic probe before auth boot first paint', () => {
   assert.match(recovery,/ownerFirstInlineScript/);
+  assert.match(recovery,/ownerFirstProbeScript/);
+  assert.match(recovery,/ownerFirstPostScript/);
+  assert.match(recovery,/__dabbirOwnerFirstInitError/);
+  assert.match(recovery,/before_owner_first/);
+  assert.match(recovery,/missing_authority/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_STATUS_/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_AUTHORITY_MISSING/);
   assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_UNSAFE_SCRIPT_CLOSE/);
@@ -42,15 +47,32 @@ test('owner-first authority is server-inlined after base render definitions and 
   const {body,headers,status}=renderCanonicalRoot();
   assert.equal(status,200);
   const externalOwnerTags=body.match(/<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g)||[];
+  const probeTags=body.match(/<script data-dabbir-owner-first-probe="v1">/g)||[];
   const inlineOwnerTags=body.match(/<script data-dabbir-owner-first-inline="owner-first-v4">/g)||[];
+  const postTags=body.match(/<script data-dabbir-owner-first-post="v1">/g)||[];
   assert.equal(externalOwnerTags.length,0,'first paint must not depend on an owner-first subresource request');
+  assert.equal(probeTags.length,1,'exactly one pre-owner diagnostic probe must execute');
   assert.equal(inlineOwnerTags.length,1,'exactly one owner-first inline authority must execute');
+  assert.equal(postTags.length,1,'exactly one post-owner diagnostic probe must execute');
   const renderIndex=body.indexOf('function renderAll()');
+  const probeIndex=body.indexOf(probeTags[0]);
   const ownerIndex=body.indexOf(inlineOwnerTags[0]);
   const authorityIndex=body.indexOf("window.__dabbirUiAuthority={version:'owner-first-v4'",ownerIndex);
+  const postIndex=body.indexOf(postTags[0]);
   const bootIndex=body.indexOf('applyLang();boot();');
-  assert.ok(renderIndex>=0 && ownerIndex>renderIndex && authorityIndex>ownerIndex && bootIndex>authorityIndex,`render=${renderIndex} owner=${ownerIndex} authority=${authorityIndex} boot=${bootIndex}`);
-  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-before-auth-boot-v2');
+  assert.ok(renderIndex>=0 && probeIndex>renderIndex && ownerIndex>probeIndex && authorityIndex>ownerIndex && postIndex>authorityIndex && bootIndex>postIndex,`render=${renderIndex} probe=${probeIndex} owner=${ownerIndex} authority=${authorityIndex} post=${postIndex} boot=${bootIndex}`);
+  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-diagnostic-before-auth-boot-v3');
+});
+
+test('iPhone root shell enforces an accessible mobile menu touch target', () => {
+  const {body,status}=renderCanonicalRoot();
+  assert.equal(status,200);
+  const tags=body.match(/<style data-dabbir-mobile-menu-touch-target="v1">[\s\S]*?<\/style>/g)||[];
+  assert.equal(tags.length,1,'exactly one mobile menu touch-target authority must be served');
+  assert.match(tags[0],/#appShell #menuBtn/);
+  assert.match(tags[0],/min-width:44px!important/);
+  assert.match(tags[0],/min-height:44px!important/);
+  assert.match(tags[0],/flex-shrink:0!important/);
 });
 
 test('root shell injects an independent Safari auth fail-open watchdog', () => {

--- a/test/dabbir-webkit-owner-diagnostics-contract.test.mjs
+++ b/test/dabbir-webkit-owner-diagnostics-contract.test.mjs
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const shell=fs.readFileSync(new URL('../api/app-safari-recovery.js',import.meta.url),'utf8');
+const smoke=fs.readFileSync(new URL('./dabbir-protected-live-smoke.mjs',import.meta.url),'utf8');
+
+test('owner-first diagnostics expose failure without promoting failed initialization to ready',()=>{
+  assert.match(shell,/__dabbirOwnerFirstInitError=null/);
+  assert.match(shell,/stage:'before_owner_first'/);
+  assert.match(shell,/stage:'window_error'/);
+  assert.match(shell,/stage:'unhandled_rejection'/);
+  assert.match(shell,/stage:\(window\.__dabbirUiAuthority&&window\.__dabbirUiAuthority\.version==='owner-first-v4'\)\?'ready':'missing_authority'/);
+  assert.doesNotMatch(shell,/__dabbirUiAuthority=\{version:'owner-first-v4'.*before_owner_first/s);
+});
+
+test('protected WebKit smoke reports diagnostics but still requires the real authority',()=>{
+  assert.match(smoke,/inline_state: window\.__dabbirOwnerFirstInlineState \|\| null/);
+  assert.match(smoke,/init_error: window\.__dabbirOwnerFirstInitError \|\| null/);
+  assert.match(smoke,/authority: window\.__dabbirUiAuthority \|\| null/);
+  assert.match(smoke,/diagnostics\?\.authority\?\.version !== 'owner-first-v4'/);
+  assert.match(smoke,/diagnostics\?\.inline_state\?\.stage === 'ready'/);
+});
+
+test('mobile menu target cannot regress below 44px on the canonical root',()=>{
+  assert.match(shell,/#appShell #menuBtn\{min-width:44px!important;min-height:44px!important/);
+  assert.match(shell,/flex-shrink:0!important/);
+});


### PR DESCRIPTION
Superseded by #423. #422 added useful diagnostics and a 44×44 menu target, but did not repair the malformed owner-first JavaScript payload proved by the parser. #423 carries the root syntax reconciliation, compile gate, retained #421 diagnostics, and the menu target on current main.