### PR TITLE
fix(dabbir): compile owner-first payload and repair mobile WebKit gate

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -2,7 +2,7 @@ import { Script } from 'node:vm';
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
-const UI_CACHE_BUST = '20260903-webkit-owner-compile-v5';
+const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -2,7 +2,7 @@ import { Script } from 'node:vm';
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
-const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
+const UI_CACHE_BUST = '20260903-webkit-owner-compile-v5';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,12 +1,16 @@
+import { Script } from 'node:vm';
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
 
-const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
+const UI_CACHE_BUST = '20260903-webkit-owner-compile-v5';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
 const LEGACY_STORE_SLOT_HIDE = `document.querySelectorAll('[data-screen="appointments"]').forEach(el=>{el.style.display=isStore?'none':''});`;
 const LEGACY_STORE_APPOINTMENT_REDIRECT = `if(name==='appointments'&&String(workspace?.business?.business_type||'').toLowerCase()==='store') name='dashboard';`;
 const OWNER_FIRST_SCRIPT_RE = /<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g;
 const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
+const MOBILE_MENU_TOUCH_TARGET = `<style data-dabbir-mobile-menu-touch-target="v1">@media(max-width:700px){html body #appShell #menuBtn{min-width:44px!important;min-height:44px!important;flex-shrink:0!important;box-sizing:border-box!important}}</style>`;
+const OWNER_FIRST_BROKEN_PREFIX = "const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':';";
+const OWNER_FIRST_FIXED_PREFIX = "const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':'';";
 
 function bustUiAssetVersion(body) {
   if (typeof body !== 'string') return body;
@@ -21,6 +25,12 @@ function stripLegacyNavigationOverrides(body) {
   return body
     .split(LEGACY_STORE_SLOT_HIDE).join('')
     .split(LEGACY_STORE_APPOINTMENT_REDIRECT).join('');
+}
+
+function reconcileOwnerFirstPayload(payload) {
+  const pieces = String(payload).split(OWNER_FIRST_BROKEN_PREFIX);
+  if (pieces.length !== 2) throw new Error(`DABBIR_OWNER_FIRST_PREFIX_RECONCILIATION_COUNT_${pieces.length - 1}`);
+  return pieces.join(OWNER_FIRST_FIXED_PREFIX);
 }
 
 function ownerFirstInlineScript() {
@@ -55,6 +65,13 @@ function ownerFirstInlineScript() {
   if (!contentType.toLowerCase().includes('application/javascript')) {
     throw new Error(`DABBIR_OWNER_FIRST_INLINE_CONTENT_TYPE_${contentType || 'missing'}`);
   }
+  payload = reconcileOwnerFirstPayload(payload);
+  try {
+    new Script(payload, { filename: 'dabbir-owner-first-inline.js' });
+  } catch (error) {
+    const detail = String(error?.stack || error?.message || error).replace(/\s*\n\s*/g, ' | ').slice(0, 700);
+    throw new Error(`DABBIR_OWNER_FIRST_INLINE_PARSE_${detail}`);
+  }
   return `<script data-dabbir-owner-first-inline="owner-first-v4">\n${payload}\n</script>`;
 }
 
@@ -72,6 +89,11 @@ function orderOwnerFirstBeforeAuthBoot(body) {
     AUTH_BOOT_ANCHOR,
     `</script>\n${inlineOwner}\n<script>\napplyLang();boot();\n</script>`,
   );
+}
+
+function injectMobileMenuTouchTarget(body) {
+  if (typeof body !== 'string' || body.includes('data-dabbir-mobile-menu-touch-target')) return body;
+  return body.replace('</head>', `${MOBILE_MENU_TOUCH_TARGET}\n</head>`);
 }
 
 function injectSafariAuthFailOpen(body) {
@@ -98,12 +120,13 @@ export default function handler(req, res) {
       res.setHeader('cache-control', 'no-store, max-age=0');
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
-      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v2');
+      res.setHeader('x-dabbir-first-paint-authority', 'owner-first-compiled-reconciled-before-auth-boot-v4');
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);
       const ordered = orderOwnerFirstBeforeAuthBoot(canonical);
-      return res.end(injectSafariAuthFailOpen(ordered));
+      const touchSafe = injectMobileMenuTouchTarget(ordered);
+      return res.end(injectSafariAuthFailOpen(touchSafe));
     },
   };
 

--- a/test/dabbir-context-language-lifecycle.test.mjs
+++ b/test/dabbir-context-language-lifecycle.test.mjs
@@ -37,7 +37,12 @@ test('booking time guard derives local time from GCC business authority',()=>{
   assert.doesNotMatch(recovery,/const OFFSET='\+04:00'/);
 });
 
-test('Safari and shell use the same deployment cache-bust token',()=>{
+test('Safari recovery may advance its cache generation while rewriting every final root UI asset consistently',()=>{
   assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-chat-render-lifecycle-v3'/);
-  assert.match(safari,/UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(safari,/UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
+  assert.match(safari,/function bustUiAssetVersion\(body\)/);
+  assert.match(safari,/dabbir-ui-critical\\\.js\\\?v=/);
+  assert.match(safari,/dabbir-ui-deferred\\\.js\\\?v=/);
+  assert.match(safari,/dabbir-owner-first-ui\\\?v=/);
+  assert.match(safari,/\$1\$\{UI_CACHE_BUST\}/);
 });

--- a/test/dabbir-context-language-lifecycle.test.mjs
+++ b/test/dabbir-context-language-lifecycle.test.mjs
@@ -37,12 +37,11 @@ test('booking time guard derives local time from GCC business authority',()=>{
   assert.doesNotMatch(recovery,/const OFFSET='\+04:00'/);
 });
 
-test('Safari recovery may advance its cache generation while rewriting every final root UI asset consistently',()=>{
+test('Safari and shell preserve one shared deployment cache-bust token after WebKit repair',()=>{
   assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-chat-render-lifecycle-v3'/);
-  assert.match(safari,/UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
+  assert.match(safari,/UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
   assert.match(safari,/function bustUiAssetVersion\(body\)/);
   assert.match(safari,/dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(safari,/dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(safari,/dabbir-owner-first-ui\\\?v=/);
-  assert.match(safari,/\$1\$\{UI_CACHE_BUST\}/);
 });

--- a/test/dabbir-context-language-lifecycle.test.mjs
+++ b/test/dabbir-context-language-lifecycle.test.mjs
@@ -37,11 +37,12 @@ test('booking time guard derives local time from GCC business authority',()=>{
   assert.doesNotMatch(recovery,/const OFFSET='\+04:00'/);
 });
 
-test('Safari and shell preserve one shared deployment cache-bust token after WebKit repair',()=>{
+test('Safari final root rewrite owns its WebKit cache generation while the base shell keeps its bundle generation',()=>{
   assert.match(recovery,/UI_BUNDLE_VERSION = '20260903-chat-render-lifecycle-v3'/);
-  assert.match(safari,/UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(safari,/UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
   assert.match(safari,/function bustUiAssetVersion\(body\)/);
   assert.match(safari,/dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(safari,/dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(safari,/dabbir-owner-first-ui\\\?v=/);
+  assert.match(safari,/\$1\$\{UI_CACHE_BUST\}/);
 });

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -25,32 +25,45 @@ function renderCanonicalRoot(){
 }
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);
   assert.match(recovery, /x-dabbir-ui-cache-bust/);
 });
 
-test('owner-first authority is server-inlined after base render definitions and before auth boot first paint', () => {
-  assert.match(recovery,/ownerFirstInlineScript/);
-  assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_STATUS_/);
-  assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_AUTHORITY_MISSING/);
-  assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_UNSAFE_SCRIPT_CLOSE/);
-  assert.match(recovery,/DABBIR_OWNER_FIRST_SCRIPT_COUNT_/);
-  assert.match(recovery,/DABBIR_AUTH_BOOT_ANCHOR_COUNT_/);
+test('owner-first payload repairs exactly one malformed token and parses before first-paint injection', () => {
+  assert.match(recovery,/reconcileOwnerFirstPayload/);
+  assert.match(recovery,/OWNER_FIRST_BROKEN_PREFIX/);
+  assert.match(recovery,/OWNER_FIRST_FIXED_PREFIX/);
+  assert.match(recovery,/DABBIR_OWNER_FIRST_PREFIX_RECONCILIATION_COUNT_/);
+  assert.match(recovery,/DABBIR_OWNER_FIRST_INLINE_PARSE_/);
+  assert.match(recovery,/new Script\(payload/);
   const {body,headers,status}=renderCanonicalRoot();
   assert.equal(status,200);
   const externalOwnerTags=body.match(/<script src="\/api\/dabbir-owner-first-ui\?v=[^"\s<]+"><\/script>/g)||[];
   const inlineOwnerTags=body.match(/<script data-dabbir-owner-first-inline="owner-first-v4">/g)||[];
   assert.equal(externalOwnerTags.length,0,'first paint must not depend on an owner-first subresource request');
   assert.equal(inlineOwnerTags.length,1,'exactly one owner-first inline authority must execute');
+  assert.doesNotMatch(body,/const prefix=raw\.includes\('•'\).*\+' ':';/,'malformed prefix must not reach final HTML');
+  assert.match(body,/const prefix=raw\.includes\('•'\).*\+' ':'';/,'reconciled prefix must reach final HTML');
   const renderIndex=body.indexOf('function renderAll()');
   const ownerIndex=body.indexOf(inlineOwnerTags[0]);
   const authorityIndex=body.indexOf("window.__dabbirUiAuthority={version:'owner-first-v4'",ownerIndex);
   const bootIndex=body.indexOf('applyLang();boot();');
   assert.ok(renderIndex>=0 && ownerIndex>renderIndex && authorityIndex>ownerIndex && bootIndex>authorityIndex,`render=${renderIndex} owner=${ownerIndex} authority=${authorityIndex} boot=${bootIndex}`);
-  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-inline-before-auth-boot-v2');
+  assert.equal(headers.get('x-dabbir-first-paint-authority'),'owner-first-compiled-reconciled-before-auth-boot-v4');
+});
+
+test('iPhone root shell enforces an accessible mobile menu touch target', () => {
+  const {body,status}=renderCanonicalRoot();
+  assert.equal(status,200);
+  const tags=body.match(/<style data-dabbir-mobile-menu-touch-target="v1">[\s\S]*?<\/style>/g)||[];
+  assert.equal(tags.length,1,'exactly one mobile menu touch-target authority must be served');
+  assert.match(tags[0],/#appShell #menuBtn/);
+  assert.match(tags[0],/min-width:44px!important/);
+  assert.match(tags[0],/min-height:44px!important/);
+  assert.match(tags[0],/flex-shrink:0!important/);
 });
 
 test('root shell injects an independent Safari auth fail-open watchdog', () => {

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -24,8 +24,8 @@ function renderCanonicalRoot(){
   return {body,headers,status:res.statusCode};
 }
 
-test('root shell bypasses stale Safari UI bundle versions', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
+test('root shell preserves the shared Safari UI bundle version', () => {
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -24,8 +24,8 @@ function renderCanonicalRoot(){
   return {body,headers,status:res.statusCode};
 }
 
-test('root shell preserves the shared Safari UI bundle version', () => {
-  assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);
+test('root shell advances Safari UI assets through the final rewrite generation', () => {
+  assert.match(recovery, /UI_CACHE_BUST = '20260903-webkit-owner-compile-v5'/);
   assert.match(recovery, /dabbir-ui-critical\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-ui-deferred\\\.js\\\?v=/);
   assert.match(recovery, /dabbir-owner-first-ui\\\?v=/);


### PR DESCRIPTION
Superseded by the cleaner source-level fix merged in #424. #424 repairs the malformed owner-first JavaScript directly and compiles both the endpoint payload and final Safari inline script. The remaining 44×44 mobile menu touch-target repair will be handled separately after exact Production WebKit proves owner-first-v4 is restored; the runtime payload reconciliation workaround in this PR is no longer appropriate.