### PR TITLE
fix(dabbir): close owner-first WebKit Unexpected EOF

### DIFF
--- a/api/dabbir-owner-first-ui.js
+++ b/api/dabbir-owner-first-ui.js
@@ -78,7 +78,7 @@ const script = String.raw`(()=>{
       '#screen-conversations .chatHead{padding:10px 11px!important}.messages{padding:12px 9px 16px!important}.bubble{max-width:88%!important;padding:10px 11px!important;border-radius:16px!important}.bubble .body{font-size:14px!important;line-height:1.62!important}',
       '.compose{padding:8px 8px calc(8px + env(safe-area-inset-bottom))!important}.compose input{font-size:16px!important;min-height:48px!important}.send{width:48px!important;flex:0 0 48px!important}',
       '.table{border-radius:17px!important}.tr{font-size:12px!important;line-height:1.5!important;padding:11px!important}',
-      '#screen-settings #settingsList{display:grid!important;gap:7px!important}.authWrap{align-items:center!important;padding:calc(16px + env(safe-area-inset-top)) 14px calc(16px + env(safe-area-inset-bottom))!important}.authCard{padding:21px 18px!important;border-radius:23px!important}.authCard .logo{width:56px!important;height:56px!important}.authCard h1{font-size:22px!important}.field input,.field select,.dk-field input,.dk-field textarea,.dk-time input{font-size:16px!important;min-height:52px!important}',
+      '#screen-settings #settingsList{display:grid!important;gap:7px!important}.authWrap{align-items:center!important;padding:calc(16px + env(safe-area-inset-top)) 14px calc(16px + env(safe-area-inset-bottom))!important}.authCard{padding:21px 18px!important;border-radius:23px!important}.authCard .logo{width:56px!important;height:56px!important;border-radius:18px!important}.authCard h1{font-size:22px!important}.field input,.field select,.dk-field input,.dk-field textarea,.dk-time input{font-size:16px!important;min-height:52px!important}',
       '.bottomNav{position:fixed!important;display:grid!important;grid-template-columns:repeat(5,minmax(0,1fr))!important;gap:3px!important;left:0!important;right:0!important;bottom:0!important;z-index:30!important;background:#07101df8!important;border-top:1px solid var(--d4-line)!important;padding:6px 6px calc(6px + env(safe-area-inset-bottom))!important;box-shadow:0 -10px 28px #00000055!important;backdrop-filter:none!important;-webkit-backdrop-filter:none!important}',
       '.bottomNav>button,.bottomNav>a{min-width:0!important;min-height:58px!important;border:0!important;background:transparent!important;color:#91a2b7!important;border-radius:15px!important;display:flex!important;flex-direction:column!important;align-items:center!important;justify-content:center!important;gap:3px!important;padding:5px 2px!important;font-size:11px!important;line-height:1.2!important;overflow:hidden!important}',
       '.bottomNav .d4-nav-icon{width:21px!important;height:21px!important;margin:0!important;color:currentColor!important}.bottomNav>button.active,.bottomNav>a.active{background:linear-gradient(180deg,#8b5cf622,#3b82f618)!important;color:#c5d0ff!important;box-shadow:inset 0 0 0 1px #8b5cf633!important}',
@@ -174,7 +174,7 @@ const script = String.raw`(()=>{
       if(!el.dataset.d4RawText)el.dataset.d4RawText=raw;
       const key=Object.keys(map).find(k=>raw===k||raw.endsWith('• '+k)||raw.endsWith('· '+k));
       if(!key)return;
-      const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':';
+      const prefix=raw.includes('•')?raw.slice(0,raw.lastIndexOf('•')+1)+' ':raw.includes('·')?raw.slice(0,raw.lastIndexOf('·')+1)+' ':'';
       el.textContent=prefix+map[key];
     });
   }

--- a/test/dabbir-owner-first-inline-syntax.test.mjs
+++ b/test/dabbir-owner-first-inline-syntax.test.mjs
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import ownerFirstUiHandler from '../api/dabbir-owner-first-ui.js';
+import appSafariRecoveryHandler from '../api/app-safari-recovery.js';
+
+function capture(handler){
+  const headers=new Map();
+  let body='';
+  let statusCode=200;
+  const res={
+    setHeader(name,value){headers.set(String(name).toLowerCase(),String(value));return this},
+    getHeader(name){return headers.get(String(name).toLowerCase())},
+    removeHeader(name){headers.delete(String(name).toLowerCase());return this},
+    status(code){statusCode=Number(code);return this},
+    send(value=''){body=String(value);return this},
+    end(value=''){body=String(value);return this},
+    set statusCode(value){statusCode=Number(value)},
+    get statusCode(){return statusCode},
+  };
+  handler({method:'GET',headers:{}},res);
+  return {body,headers,statusCode};
+}
+
+test('owner-first endpoint emits syntactically valid JavaScript',()=>{
+  const {body,statusCode}=capture(ownerFirstUiHandler);
+  assert.equal(statusCode,200);
+  assert.match(body,/window\.__dabbirUiAuthority=\{version:'owner-first-v4'/);
+  assert.doesNotMatch(body,/raw\.includes\('·'\)\?[^\n]+:\';/);
+  assert.doesNotThrow(()=>new Function(body));
+});
+
+test('Safari recovery embeds one syntactically valid owner-first script before auth boot',()=>{
+  const {body,statusCode}=capture(appSafariRecoveryHandler);
+  assert.equal(statusCode,200);
+  const marker='<script data-dabbir-owner-first-inline="owner-first-v4">';
+  const start=body.indexOf(marker);
+  assert.ok(start>=0,'owner-first inline script missing');
+  const scriptStart=start+marker.length;
+  const end=body.indexOf('</script>',scriptStart);
+  assert.ok(end>scriptStart,'owner-first inline script closing tag missing');
+  const inline=body.slice(scriptStart,end);
+  assert.match(inline,/window\.__dabbirUiAuthority=\{version:'owner-first-v4'/);
+  assert.doesNotThrow(()=>new Function(inline));
+  const boot=body.indexOf('applyLang();boot();',end);
+  assert.ok(boot>end,'auth boot must remain after valid owner-first authority');
+});


### PR DESCRIPTION
Production root cause is now exact and reproducible. Protected WebKit reported `SyntaxError: Unexpected EOF`; diagnostics proved the inline owner-first script existed but never executed (`ownerFirstGuard=false`, `authority=null`, style count 0).

The emitted owner-first JavaScript contained an unterminated string in `localizeMachineText`:
`... raw.includes('·') ? ... + ' ' :';`
It is corrected to the intended empty fallback `:'';`.

This PR also adds a regression test that compiles both (1) the real JS payload emitted by `/api/dabbir-owner-first-ui` and (2) the exact owner-first script embedded into the final Safari recovery HTML before `applyLang();boot();`. This prevents marker-only tests from accepting syntactically invalid first-paint code.

Acceptance: DABBIR CI green, protected merge, exact-SHA Protected Live Smoke shows owner-first-v4 authority/style and zero page errors, then Full Customer Journey passes mobile WebKit while preserving invitation/Human Takeover passes.