### PR TITLE
Add exact-Production iPad WebKit full journey gate

### DIFF
--- a/.github/workflows/dabbir-ipad-webkit-production.yml
+++ b/.github/workflows/dabbir-ipad-webkit-production.yml
@@ -1,0 +1,123 @@
+name: DABBIR iPad WebKit Production
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'test/ai-full-customer-journey-v2.mjs'
+      - 'test/run-ai-full-customer-journey-ipad.mjs'
+      - 'test/dabbir-ipad-webkit-production-contract.test.mjs'
+      - '.github/workflows/dabbir-ipad-webkit-production.yml'
+      - 'api/**'
+      - 'index.html'
+      - 'supabase/migrations/*dabbir*'
+      - 'supabase/functions/barman-qa-suite-runner/**'
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: dabbir-ipad-webkit-production
+  cancel-in-progress: false
+
+jobs:
+  ipad-webkit-production:
+    name: Exact Production iPad WebKit full journey
+    runs-on: ubuntu-latest
+    timeout-minutes: 22
+    env:
+      PRODUCTION_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
+      JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report-ipad.json
+      EXPECTED_VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
+      EXPECTED_GIT_REPOSITORY: barman-systems/pilot
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      - name: Require authoritative main identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = 'refs/heads/main'
+          test "$GITHUB_REPOSITORY" = "$EXPECTED_GIT_REPOSITORY"
+          [[ "$GITHUB_SHA" =~ ^[0-9a-f]{40}$ ]]
+          echo "AUTHORIZED_IPAD_QA_SHA=$GITHUB_SHA"
+
+      - name: Prepare trusted Vercel OIDC access
+        shell: bash
+        run: |
+          set -euo pipefail
+          request_url="${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          request_token="${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          test -n "$request_url"
+          test -n "$request_token"
+          response="$(curl --fail-with-body --silent --show-error -H "Authorization: Bearer ${request_token}" "$request_url")"
+          token="$(printf '%s' "$response" | jq -r '.value // empty')"
+          test -n "$token"
+          echo "::add-mask::$token"
+          echo "VERCEL_TRUSTED_OIDC_TOKEN=$token" >> "$GITHUB_ENV"
+
+      - name: Lock exact Production release
+        id: release-before
+        shell: bash
+        run: |
+          set -euo pipefail
+          body=''; observed=''; deployment=''
+          for attempt in $(seq 1 60); do
+            body="$(curl --silent --show-error -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" -H 'accept: application/json' "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)" || true)"
+            observed="$(printf '%s' "$body" | jq -r '.commit_sha // empty' 2>/dev/null || true)"
+            deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty' 2>/dev/null || true)"
+            project_id="$(printf '%s' "$body" | jq -r '.project_id // empty' 2>/dev/null || true)"
+            repository="$(printf '%s' "$body" | jq -r '.repository // empty' 2>/dev/null || true)"
+            environment="$(printf '%s' "$body" | jq -r '.environment // empty' 2>/dev/null || true)"
+            if [ "$observed" = "$GITHUB_SHA" ] && [[ "$deployment" == dpl_* ]] && [ "$project_id" = "$EXPECTED_VERCEL_PROJECT_ID" ] && [ "$repository" = "$EXPECTED_GIT_REPOSITORY" ] && [ "$environment" = 'production' ]; then
+              break
+            fi
+            observed=''; deployment=''; sleep 5
+          done
+          test -n "$observed"
+          echo "sha=$observed" >> "$GITHUB_OUTPUT"
+          echo "deployment=$deployment" >> "$GITHUB_OUTPUT"
+          echo "LOCKED_IPAD_PRODUCTION_SHA=$observed deployment=$deployment"
+
+      - name: Install WebKit
+        run: |
+          npm install --no-save playwright@1.62.1
+          npx playwright install --with-deps webkit
+
+      - name: Run iPad WebKit full customer journey
+        shell: bash
+        run: |
+          set -euo pipefail
+          node --import ./test/dabbir-protected-full-journey-preload.mjs test/run-ai-full-customer-journey-ipad.mjs
+          test -s "$JOURNEY_REPORT_PATH"
+          jq -e '.verdict == "PASS" and .required_failures == 0 and any(.steps[]; .name == "25_mobile_webkit_owner_journey" and .status == "PASS")' "$JOURNEY_REPORT_PATH" >/dev/null
+          echo "IPAD_WEBKIT_FULL_JOURNEY_PASS steps=$(jq -r '.steps | length' "$JOURNEY_REPORT_PATH")"
+
+      - name: Prove Production release remained exact
+        shell: bash
+        run: |
+          set -euo pipefail
+          body="$(curl --fail-with-body --silent --show-error -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" -H 'accept: application/json' "${PRODUCTION_ORIGIN}/api/release-evidence?t=$(date +%s%N)")"
+          observed="$(printf '%s' "$body" | jq -r '.commit_sha // empty')"
+          deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty')"
+          test "$observed" = "$GITHUB_SHA"
+          test "$observed" = "${{ steps.release-before.outputs.sha }}"
+          test "$deployment" = "${{ steps.release-before.outputs.deployment }}"
+          echo "STABLE_IPAD_PRODUCTION_SHA=$observed deployment=$deployment"
+
+      - name: Upload iPad journey evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-ipad-webkit-production-evidence
+          path: |
+            dabbir-ai-customer-journey-report-ipad.json
+            dabbir-ai-customer-journey-screenshot.png
+          if-no-files-found: warn
+          retention-days: 14

--- a/test/dabbir-ipad-webkit-production-contract.test.mjs
+++ b/test/dabbir-ipad-webkit-production-contract.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root=new URL('../',import.meta.url);
+const read=path=>fs.readFileSync(new URL(path,root),'utf8');
+const runner=read('test/run-ai-full-customer-journey-ipad.mjs');
+const workflow=read('.github/workflows/dabbir-ipad-webkit-production.yml');
+
+test('iPad runner reuses the canonical full journey and changes only the touch viewport',()=>{
+  assert.match(runner,/ai-full-customer-journey-v2\.mjs/);
+  assert.match(runner,/viewport:\s*\{\s*width:\s*390,\s*height:\s*844\s*\}/);
+  assert.match(runner,/viewport: \{ width: 820, height: 1180 \}/);
+  assert.match(runner,/isMobile:\\s\*true/);
+  assert.match(runner,/hasTouch:\\s\*true/);
+  assert.match(runner,/dabbir-ai-customer-journey-report-ipad\.json/);
+});
+
+test('iPad Production workflow is exact-SHA, OIDC protected, and fail closed on the real WebKit journey',()=>{
+  assert.match(workflow,/name: DABBIR iPad WebKit Production/);
+  assert.match(workflow,/refs\/heads\/main/);
+  assert.match(workflow,/id-token: write/);
+  assert.match(workflow,/VERCEL_TRUSTED_OIDC_TOKEN/);
+  assert.match(workflow,/\/api\/release-evidence/);
+  assert.match(workflow,/observed.*GITHUB_SHA/);
+  assert.match(workflow,/run-ai-full-customer-journey-ipad\.mjs/);
+  assert.match(workflow,/25_mobile_webkit_owner_journey/);
+  assert.match(workflow,/IPAD_WEBKIT_FULL_JOURNEY_PASS/);
+  assert.match(workflow,/STABLE_IPAD_PRODUCTION_SHA/);
+  assert.doesNotMatch(workflow,/continue-on-error:\s*true/);
+});

--- a/test/run-ai-full-customer-journey-ipad.mjs
+++ b/test/run-ai-full-customer-journey-ipad.mjs
@@ -1,0 +1,26 @@
+import fs from 'node:fs';
+
+const sourceUrl = new URL('./ai-full-customer-journey-v2.mjs', import.meta.url);
+const generatedUrl = new URL('./.dabbir-ai-full-customer-journey-ipad.generated.mjs', import.meta.url);
+const source = fs.readFileSync(sourceUrl, 'utf8');
+const iphoneViewport = "viewport: { width: 390, height: 844 },";
+const ipadViewport = "viewport: { width: 820, height: 1180 },";
+
+if ((source.match(/viewport:\s*\{\s*width:\s*390,\s*height:\s*844\s*\},/g) || []).length !== 1) {
+  throw new Error('IPAD_WEBKIT_SOURCE_VIEWPORT_CONTRACT_CHANGED');
+}
+if ((source.match(/isMobile:\s*true,/g) || []).length !== 1 || (source.match(/hasTouch:\s*true,/g) || []).length !== 1) {
+  throw new Error('IPAD_WEBKIT_TOUCH_CONTRACT_CHANGED');
+}
+
+const ipadSource = source.replace(iphoneViewport, ipadViewport);
+if (!ipadSource.includes(ipadViewport)) throw new Error('IPAD_WEBKIT_VIEWPORT_REWRITE_FAILED');
+
+process.env.JOURNEY_REPORT_PATH = process.env.JOURNEY_REPORT_PATH || 'dabbir-ai-customer-journey-report-ipad.json';
+fs.writeFileSync(generatedUrl, ipadSource, 'utf8');
+
+try {
+  await import(`${generatedUrl.href}?run=${Date.now()}`);
+} finally {
+  fs.rmSync(generatedUrl, { force: true });
+}


### PR DESCRIPTION
ACTION → ARTIFACT → TEST → EVIDENCE

## Why
The root audit requires real iPhone and iPad Safari/WebKit QA. Production iPhone/WebKit is now verified green after #424, but there was no persistent iPad Production gate.

## Artifact
- `test/run-ai-full-customer-journey-ipad.mjs` reuses the canonical full customer journey and changes only the WebKit touch viewport from iPhone 390×844 to iPad portrait 820×1180.
- `.github/workflows/dabbir-ipad-webkit-production.yml` runs on main/runtime changes, obtains trusted Vercel OIDC, locks exact Production SHA/deployment, executes the full real journey against protected Production, requires the WebKit owner step to PASS, verifies the release did not move, and uploads evidence.
- regression contract prevents the exact-SHA/OIDC/fail-closed behavior from weakening.

## Acceptance
1. DABBIR CI succeeds on exact PR head.
2. Vercel Preview full build gate succeeds on exact PR head.
3. Merge through protected PR flow only.
4. Post-merge `DABBIR iPad WebKit Production` must PASS on the exact merged Production SHA with zero required journey failures.

No iPad readiness claim until the post-merge real Production run passes.