### PR TITLE
fix(dabbir): deploy exact SHA for iPad WebKit release gate

### DIFF
--- a/test/vercel-ignore-ipad-exact-sha.test.mjs
+++ b/test/vercel-ignore-ipad-exact-sha.test.mjs
@@ -1,0 +1,64 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const sourceScript = path.resolve('vercel-ignore-if-unaffected.sh');
+
+function git(cwd, ...args) {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' }).trim();
+}
+
+function setupRepo() {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'dabbir-ipad-vercel-ignore-'));
+  git(dir, 'init', '-q');
+  git(dir, 'config', 'user.email', 'dabbir-ci@example.invalid');
+  git(dir, 'config', 'user.name', 'DABBIR CI');
+  fs.copyFileSync(sourceScript, path.join(dir, 'vercel-ignore-if-unaffected.sh'));
+  fs.writeFileSync(path.join(dir, 'README.md'), 'base\n');
+  git(dir, 'add', '.');
+  git(dir, 'commit', '-qm', 'base');
+  return dir;
+}
+
+function commitPath(dir, relativePath, content) {
+  const target = path.join(dir, relativePath);
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+  git(dir, 'add', '.');
+  git(dir, 'commit', '-qm', `change ${relativePath}`);
+  return git(dir, 'rev-parse', 'HEAD');
+}
+
+function runGuard(dir, head, baseline) {
+  return spawnSync('bash', ['vercel-ignore-if-unaffected.sh'], {
+    cwd: dir,
+    env: {
+      ...process.env,
+      VERCEL_GIT_COMMIT_SHA: head,
+      VERCEL_GIT_PREVIOUS_SHA: baseline,
+      VERCEL_GIT_COMMIT_REF: 'main',
+    },
+    encoding: 'utf8',
+  });
+}
+
+test('every iPad exact-Production QA contract path forces Vercel deployment on main', () => {
+  const contractPaths = [
+    '.github/workflows/dabbir-ipad-webkit-production.yml',
+    'test/run-ai-full-customer-journey-ipad.mjs',
+    'test/dabbir-ipad-webkit-production-contract.test.mjs',
+  ];
+
+  for (const relativePath of contractPaths) {
+    const dir = setupRepo();
+    const baseline = git(dir, 'rev-parse', 'HEAD');
+    const content = relativePath.endsWith('.yml') ? 'name: ipad exact production\n' : 'export {};\n';
+    const head = commitPath(dir, relativePath, content);
+    const result = runGuard(dir, head, baseline);
+    assert.equal(result.status, 1, `${relativePath}: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout, /Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence/);
+  }
+});

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -70,10 +70,13 @@ while IFS= read -r path; do
     test/dabbir-protected-live-smoke.mjs|\
     .github/workflows/dabbir-protected-live-smoke.yml|\
     .github/workflows/dabbir-ai-customer-journey.yml|\
+    .github/workflows/dabbir-ipad-webkit-production.yml|\
     .github/workflows/dabbir-bar12-readiness.yml|\
     .github/scripts/dabbir-bar12-*|\
     scripts/dabbir-readiness-gate.mjs|\
     test/ai-full-customer-journey-v2.mjs|\
+    test/run-ai-full-customer-journey-ipad.mjs|\
+    test/dabbir-ipad-webkit-production-contract.test.mjs|\
     test/dabbir-protected-full-journey-preload.mjs|\
     test/dabbir-protected-journey-access.test.mjs|\
     test/dabbir-authorized-journey-workflow.test.mjs|\


### PR DESCRIPTION
Superseded by #428. The source classification and dynamic regression from this PR are preserved there, with two additional requirements needed to complete the loop: the iPad Production workflow itself tracks `vercel-ignore-if-unaffected.sh`, and the iPad contract test locks that dependency. Closing this duplicate prevents concurrent merges of the same release-policy repair.