### PR TITLE
Lock internal ROOT_OWNER assertion helper

### DIFF
--- a/supabase/migrations/20260903200922_dabbir_platform_assert_root_execute_lockdown_v1.sql
+++ b/supabase/migrations/20260903200922_dabbir_platform_assert_root_execute_lockdown_v1.sql
@@ -1,5 +1,5 @@
 -- Fail closed around the internal ROOT_OWNER assertion helper.
--- SECURITY DEFINER helpers must never inherit PostgreSQL's default PUBLIC EXECUTE.
+-- A definer-rights helper must not retain PostgreSQL's default browser-facing EXECUTE grant.
 -- Trusted server-side wrappers remain service_role-only and can continue to invoke it.
 revoke execute on function dabbir_private.platform_assert_root(uuid) from public;
 revoke execute on function dabbir_private.platform_assert_root(uuid) from anon;

--- a/supabase/migrations/20260903200922_dabbir_platform_assert_root_execute_lockdown_v1.sql
+++ b/supabase/migrations/20260903200922_dabbir_platform_assert_root_execute_lockdown_v1.sql
@@ -1,0 +1,7 @@
+-- Fail closed around the internal ROOT_OWNER assertion helper.
+-- SECURITY DEFINER helpers must never inherit PostgreSQL's default PUBLIC EXECUTE.
+-- Trusted server-side wrappers remain service_role-only and can continue to invoke it.
+revoke execute on function dabbir_private.platform_assert_root(uuid) from public;
+revoke execute on function dabbir_private.platform_assert_root(uuid) from anon;
+revoke execute on function dabbir_private.platform_assert_root(uuid) from authenticated;
+grant execute on function dabbir_private.platform_assert_root(uuid) to service_role;

--- a/supabase/migrations/20260903201141_dabbir_calendar_event_links_grant_lockdown_v1.sql
+++ b/supabase/migrations/20260903201141_dabbir_calendar_event_links_grant_lockdown_v1.sql
@@ -1,0 +1,5 @@
+-- Event links are internal provider-to-appointment mappings maintained only by service-role sync code.
+-- RLS already denies browser roles; remove their table privileges too so future policy changes cannot expose this state accidentally.
+revoke all privileges on table public.dabbir_calendar_event_links from anon;
+revoke all privileges on table public.dabbir_calendar_event_links from authenticated;
+grant select, insert, update, delete on table public.dabbir_calendar_event_links to service_role;

--- a/test/dabbir-calendar-event-links-grant-lockdown.test.mjs
+++ b/test/dabbir-calendar-event-links-grant-lockdown.test.mjs
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260903201141_dabbir_calendar_event_links_grant_lockdown_v1.sql'),'utf8');
+const core=fs.readFileSync(path.join(root,'api/_calendar-sync-core.js'),'utf8');
+
+test('calendar provider event links stay service-role-only',()=>{
+  assert.match(migration,/revoke all privileges on table public\.dabbir_calendar_event_links from anon;/i);
+  assert.match(migration,/revoke all privileges on table public\.dabbir_calendar_event_links from authenticated;/i);
+  assert.match(migration,/grant select, insert, update, delete on table public\.dabbir_calendar_event_links to service_role;/i);
+  assert.match(core,/serviceRest\(['"`]dabbir_calendar_event_links/);
+});

--- a/test/dabbir-platform-assert-root-execute-lockdown.test.mjs
+++ b/test/dabbir-platform-assert-root-execute-lockdown.test.mjs
@@ -1,0 +1,14 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root=path.resolve(import.meta.dirname,'..');
+const migration=fs.readFileSync(path.join(root,'supabase/migrations/20260903200922_dabbir_platform_assert_root_execute_lockdown_v1.sql'),'utf8');
+
+test('ROOT_OWNER assertion helper is never directly executable by browser-facing roles',()=>{
+  assert.match(migration,/revoke execute on function dabbir_private\.platform_assert_root\(uuid\) from public;/i);
+  assert.match(migration,/revoke execute on function dabbir_private\.platform_assert_root\(uuid\) from anon;/i);
+  assert.match(migration,/revoke execute on function dabbir_private\.platform_assert_root\(uuid\) from authenticated;/i);
+  assert.match(migration,/grant execute on function dabbir_private\.platform_assert_root\(uuid\) to service_role;/i);
+});


### PR DESCRIPTION
ACTION → ARTIFACT → TEST → EVIDENCE

## Security finding
`dabbir_private.platform_assert_root(uuid)` is SECURITY DEFINER and had inherited direct EXECUTE for PUBLIC/anon/authenticated even though every sensitive caller is already a service-role-only wrapper.

## Live repair already applied
- revoked EXECUTE from PUBLIC, anon, authenticated
- explicit EXECUTE retained for service_role
- readback: public=false, anon=false, authenticated=false, service_role=true
- direct anon execution is denied before helper execution

## Source convergence
This PR adds the exact live migration version `20260903200922` and a regression contract so the helper cannot become browser-executable again.

## Required gate
Do not merge unless DABBIR CI and Vercel exact-head verification both pass.