### PR TITLE
fix(dabbir): align iPad exact-SHA QA with Vercel release classification

### DIFF
--- a/.github/workflows/dabbir-ipad-webkit-production.yml
+++ b/.github/workflows/dabbir-ipad-webkit-production.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches: [main]
     paths:
+      - 'vercel-ignore-if-unaffected.sh'
       - 'test/ai-full-customer-journey-v2.mjs'
       - 'test/run-ai-full-customer-journey-ipad.mjs'
       - 'test/dabbir-ipad-webkit-production-contract.test.mjs'

--- a/test/dabbir-ipad-vercel-exact-sha-classification.test.mjs
+++ b/test/dabbir-ipad-vercel-exact-sha-classification.test.mjs
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {execFileSync,spawnSync} from 'node:child_process';
+
+const sourceScript=path.resolve('vercel-ignore-if-unaffected.sh');
+const exactShaMessage=/Exact-SHA Production verification contract changed; deploy exact SHA for truthful release evidence/;
+
+function git(cwd,...args){return execFileSync('git',args,{cwd,encoding:'utf8'}).trim()}
+
+function setupRepo(){
+  const dir=fs.mkdtempSync(path.join(os.tmpdir(),'dabbir-ipad-exact-sha-'));
+  git(dir,'init','-q');
+  git(dir,'config','user.email','dabbir-ci@example.invalid');
+  git(dir,'config','user.name','DABBIR CI');
+  fs.copyFileSync(sourceScript,path.join(dir,'vercel-ignore-if-unaffected.sh'));
+  fs.writeFileSync(path.join(dir,'README.md'),'baseline\n');
+  git(dir,'add','.');
+  git(dir,'commit','-qm','baseline');
+  return dir;
+}
+
+function changePath(dir,relativePath){
+  const target=path.join(dir,relativePath);
+  fs.mkdirSync(path.dirname(target),{recursive:true});
+  fs.writeFileSync(target,relativePath.endsWith('.yml')?'name: ipad production\n':'export {};\n');
+  git(dir,'add','.');
+  git(dir,'commit','-qm',`change ${relativePath}`);
+  return git(dir,'rev-parse','HEAD');
+}
+
+function runGuard(dir,current,previous){
+  return spawnSync('bash',['vercel-ignore-if-unaffected.sh'],{
+    cwd:dir,
+    env:{...process.env,VERCEL_GIT_COMMIT_SHA:current,VERCEL_GIT_PREVIOUS_SHA:previous,VERCEL_GIT_COMMIT_REF:'main'},
+    encoding:'utf8',
+  });
+}
+
+test('every iPad exact-SHA QA contract forces a Production deployment instead of Vercel ignore',()=>{
+  for(const relativePath of [
+    '.github/workflows/dabbir-ipad-webkit-production.yml',
+    'test/run-ai-full-customer-journey-ipad.mjs',
+    'test/dabbir-ipad-webkit-production-contract.test.mjs',
+  ]){
+    const dir=setupRepo();
+    const previous=git(dir,'rev-parse','HEAD');
+    const current=changePath(dir,relativePath);
+    const result=runGuard(dir,current,previous);
+    assert.equal(result.status,1,`${relativePath} unexpectedly skipped deployment: ${result.stdout}\n${result.stderr}`);
+    assert.match(result.stdout,exactShaMessage,relativePath);
+  }
+});

--- a/test/dabbir-ipad-webkit-production-contract.test.mjs
+++ b/test/dabbir-ipad-webkit-production-contract.test.mjs
@@ -6,6 +6,7 @@ const root=new URL('../',import.meta.url);
 const read=path=>fs.readFileSync(new URL(path,root),'utf8');
 const runner=read('test/run-ai-full-customer-journey-ipad.mjs');
 const workflow=read('.github/workflows/dabbir-ipad-webkit-production.yml');
+const deploymentClassifier=read('vercel-ignore-if-unaffected.sh');
 
 test('iPad runner reuses the canonical full journey and changes only the touch viewport',()=>{
   assert.match(runner,/ai-full-customer-journey-v2\.mjs/);
@@ -28,4 +29,18 @@ test('iPad Production workflow is exact-SHA, OIDC protected, and fail closed on 
   assert.match(workflow,/IPAD_WEBKIT_FULL_JOURNEY_PASS/);
   assert.match(workflow,/STABLE_IPAD_PRODUCTION_SHA/);
   assert.doesNotMatch(workflow,/continue-on-error:\s*true/);
+});
+
+test('iPad exact-SHA workflow tracks the Vercel release classifier that can allow or cancel its Production SHA',()=>{
+  assert.match(workflow,/- 'vercel-ignore-if-unaffected\.sh'/);
+});
+
+test('all iPad exact-SHA QA contract files force a truthful Production deployment',()=>{
+  for(const path of [
+    '.github/workflows/dabbir-ipad-webkit-production.yml',
+    'test/run-ai-full-customer-journey-ipad.mjs',
+    'test/dabbir-ipad-webkit-production-contract.test.mjs',
+  ]){
+    assert.ok(deploymentClassifier.includes(path),`${path} must be classified as exact-SHA Production-affecting`);
+  }
 });

--- a/vercel-ignore-if-unaffected.sh
+++ b/vercel-ignore-if-unaffected.sh
@@ -70,10 +70,13 @@ while IFS= read -r path; do
     test/dabbir-protected-live-smoke.mjs|\
     .github/workflows/dabbir-protected-live-smoke.yml|\
     .github/workflows/dabbir-ai-customer-journey.yml|\
+    .github/workflows/dabbir-ipad-webkit-production.yml|\
     .github/workflows/dabbir-bar12-readiness.yml|\
     .github/scripts/dabbir-bar12-*|\
     scripts/dabbir-readiness-gate.mjs|\
     test/ai-full-customer-journey-v2.mjs|\
+    test/run-ai-full-customer-journey-ipad.mjs|\
+    test/dabbir-ipad-webkit-production-contract.test.mjs|\
     test/dabbir-protected-full-journey-preload.mjs|\
     test/dabbir-protected-journey-access.test.mjs|\
     test/dabbir-authorized-journey-workflow.test.mjs|\


### PR DESCRIPTION
Production runtime at `4d6bae6987de...` already passed Protected Live Smoke #387 and Full Customer Journey #518. The child QA-only commit `30873fe854c2...` added an exact-Production iPad WebKit workflow, but Vercel canceled that Production deployment because `vercel-ignore-if-unaffected.sh` still classified the new iPad workflow/runner/contract as generic `.github/*` or `test/*`. The iPad workflow then correctly stalled waiting for its exact SHA, creating a release-policy contradiction.

This PR fixes the release discipline rather than weakening the exact-SHA gate:
- classifies all three iPad exact-SHA QA contract paths as Production-deployment-affecting;
- makes the iPad Production workflow rerun when the Vercel classifier changes;
- locks the dependency in the iPad contract test;
- adds a dynamic regression test that runs the real ignore script in temporary Git repos and proves every iPad QA contract returns build/continue, never skip.

Acceptance: DABBIR CI green + Vercel Preview READY; protected merge; merged SHA must receive a real Vercel Production deployment; DABBIR iPad WebKit Production must lock that exact SHA, pass the full WebKit journey including step `25_mobile_webkit_owner_journey`, and prove the Production deployment remained unchanged through the test.