### PR TITLE
fix(dabbir): verify real responsive navigation on iPad WebKit

### DIFF
--- a/test/dabbir-ipad-webkit-production-contract.test.mjs
+++ b/test/dabbir-ipad-webkit-production-contract.test.mjs
@@ -24,6 +24,27 @@ test('iPad WebKit journey runs inside the already-authorized canonical customer 
   assert.match(wrapper,/IPAD_WEBKIT_JOURNEY_PASS/);
 });
 
+test('iPad journey adapts to the real visible responsive navigation instead of forcing phone-only controls',()=>{
+  assert.match(wrapper,/#nav \[data-screen=\"conversations\"\]:visible, #bottomNav \[data-screen=\"conversations\"\]:visible/);
+  assert.match(wrapper,/#nav \[data-screen=\"operations\"\]:visible, #bottomNav \[data-screen=\"operations\"\]:visible/);
+  assert.match(wrapper,/BROWSER_VISIBLE_CONVERSATIONS_NAV_COUNT_/);
+  assert.match(wrapper,/BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_/);
+  assert.match(wrapper,/DABBIR_RESPONSIVE_OPERATIONS_NAV_STATE/);
+  assert.match(wrapper,/centre_hits_target/);
+  assert.match(wrapper,/pointer_events/);
+  assert.match(wrapper,/visible-responsive-nav/);
+  assert.doesNotMatch(wrapper,/style\.display\s*=\s*['\"](?:flex|block|grid)['\"]/);
+});
+
+test('iPad responsive source transformation fails closed if the canonical navigation contract moves',()=>{
+  assert.match(wrapper,/replaceSingleExact/);
+  assert.match(wrapper,/replaceSingleRange/);
+  assert.match(wrapper,/IPAD_WEBKIT_CONVERSATIONS_NAV_CONTRACT_CHANGED/);
+  assert.match(wrapper,/IPAD_WEBKIT_OPERATIONS_NAV_CONTRACT_CHANGED/);
+  assert.match(wrapper,/IPAD_WEBKIT_RESPONSIVE_NAV_REWRITE_FAILED/);
+  assert.match(wrapper,/IPAD_WEBKIT_EVIDENCE_DETAIL_CONTRACT_CHANGED/);
+});
+
 test('canonical iPad journey remains fail closed and persists its PASS summary into uploaded canonical evidence',()=>{
   assert.match(wrapper,/\$\{label\}_REPORT_MISSING/);
   assert.match(wrapper,/\$\{label\}_JOURNEY_NOT_PASS/);

--- a/test/run-ai-full-customer-journey-en.mjs
+++ b/test/run-ai-full-customer-journey-en.mjs
@@ -7,8 +7,74 @@ const source = fs.readFileSync(sourceUrl, 'utf8');
 const arabicLocale = "locale: 'ar-AE',";
 const iphoneViewport = "viewport: { width: 390, height: 844 },";
 const ipadViewport = "viewport: { width: 820, height: 1180 },";
+const iphoneJourneyDetail = 'WebKit iPhone-size journey completed password + TOTP MFA, then rendered owner workspace, conversation, product, and approved DABBIR identity.';
+const ipadJourneyDetail = 'WebKit iPad-size journey completed password + TOTP MFA, then used the visible responsive navigation and rendered owner workspace, conversation, product, and approved DABBIR identity.';
+const phoneConversationNavigation = `  await page.locator('#bottomNav [data-screen="conversations"]').click();`;
+const tabletConversationNavigation = `  const visibleConversationsNav = page.locator('#nav [data-screen="conversations"]:visible, #bottomNav [data-screen="conversations"]:visible');
+  const visibleConversationsCount = await visibleConversationsNav.count();
+  assert(visibleConversationsCount === 1, \`BROWSER_VISIBLE_CONVERSATIONS_NAV_COUNT_\${visibleConversationsCount}\`);
+  await visibleConversationsNav.click();`;
+const phoneNavigationStart = `  const mobileMenuState = await page.locator('#menuBtn').evaluate(element => {`;
+const phoneNavigationEnd = `  assert(operationsTransition.target_found && operationsTransition.active && !operationsTransition.side_open, \`BROWSER_OPERATIONS_TRANSITION_FAILED_\${JSON.stringify(operationsTransition)}\`);`;
+const tabletOperationsNavigation = `  const visibleOperationsNav = page.locator('#nav [data-screen="operations"]:visible, #bottomNav [data-screen="operations"]:visible');
+  const visibleOperationsCount = await visibleOperationsNav.count();
+  assert(visibleOperationsCount === 1, \`BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_\${visibleOperationsCount}\`);
+  const operationsNavState = await visibleOperationsNav.evaluate(element => {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    const centerX = rect.left + (rect.width / 2);
+    const centerY = rect.top + (rect.height / 2);
+    const hit = document.elementFromPoint(centerX, centerY);
+    return {
+      display: style.display,
+      visibility: style.visibility,
+      pointer_events: style.pointerEvents,
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+      left: Math.round(rect.left),
+      top: Math.round(rect.top),
+      viewport_width: window.innerWidth,
+      viewport_height: window.innerHeight,
+      centre_hits_target: hit === element || element.contains(hit),
+    };
+  });
+  console.log(\`DABBIR_RESPONSIVE_OPERATIONS_NAV_STATE=\${JSON.stringify(operationsNavState)}\`);
+  assert(
+    operationsNavState.display !== 'none'
+      && operationsNavState.visibility !== 'hidden'
+      && operationsNavState.pointer_events !== 'none'
+      && operationsNavState.width >= 40
+      && operationsNavState.height >= 40
+      && operationsNavState.centre_hits_target,
+    \`BROWSER_OPERATIONS_NAV_NOT_ACTIONABLE_\${JSON.stringify(operationsNavState)}\`,
+  );
+  await visibleOperationsNav.click();
+  await page.locator('#screen-operations.active').waitFor({ state: 'visible', timeout: 10_000 });
+  const operationsTransition = await page.evaluate(() => ({
+    active: document.querySelector('#screen-operations')?.classList.contains('active') === true,
+    sidebar_open: document.querySelector('#side')?.classList.contains('open') === true,
+  }));
+  console.log(\`DABBIR_RESPONSIVE_OPERATIONS_TRANSITION=\${JSON.stringify(operationsTransition)}\`);
+  assert(operationsTransition.active, \`BROWSER_OPERATIONS_TRANSITION_FAILED_\${JSON.stringify(operationsTransition)}\`);`;
 const englishReportPath = 'dabbir-ai-customer-journey-report-en.json';
 const ipadReportPath = 'dabbir-ai-customer-journey-report-ipad.json';
+
+function countExact(haystack, needle) {
+  return haystack.split(needle).length - 1;
+}
+
+function replaceSingleExact(haystack, needle, replacement, errorCode) {
+  if (countExact(haystack, needle) !== 1) throw new Error(errorCode);
+  return haystack.replace(needle, replacement);
+}
+
+function replaceSingleRange(haystack, startNeedle, endNeedle, replacement, errorCode) {
+  if (countExact(haystack, startNeedle) !== 1 || countExact(haystack, endNeedle) !== 1) throw new Error(errorCode);
+  const start = haystack.indexOf(startNeedle);
+  const end = haystack.indexOf(endNeedle, start);
+  if (start < 0 || end < start) throw new Error(errorCode);
+  return `${haystack.slice(0, start)}${replacement}${haystack.slice(end + endNeedle.length)}`;
+}
 
 if ((source.match(/locale:\s*'ar-AE',/g) || []).length !== 1) {
   throw new Error('ENGLISH_WEBKIT_SOURCE_LOCALE_CONTRACT_CHANGED');
@@ -25,9 +91,14 @@ if (!englishSource.includes("locale: 'en-US',")) {
   throw new Error('ENGLISH_WEBKIT_LOCALE_REWRITE_FAILED');
 }
 
-const ipadSource = source.replace(iphoneViewport, ipadViewport);
-if (!ipadSource.includes(ipadViewport)) {
-  throw new Error('IPAD_WEBKIT_VIEWPORT_REWRITE_FAILED');
+let ipadSource = replaceSingleExact(source, iphoneViewport, ipadViewport, 'IPAD_WEBKIT_SOURCE_VIEWPORT_CONTRACT_CHANGED');
+ipadSource = replaceSingleExact(ipadSource, phoneConversationNavigation, tabletConversationNavigation, 'IPAD_WEBKIT_CONVERSATIONS_NAV_CONTRACT_CHANGED');
+ipadSource = replaceSingleRange(ipadSource, phoneNavigationStart, phoneNavigationEnd, tabletOperationsNavigation, 'IPAD_WEBKIT_OPERATIONS_NAV_CONTRACT_CHANGED');
+ipadSource = replaceSingleExact(ipadSource, iphoneJourneyDetail, ipadJourneyDetail, 'IPAD_WEBKIT_EVIDENCE_DETAIL_CONTRACT_CHANGED');
+if (!ipadSource.includes(ipadViewport)
+  || !ipadSource.includes('#nav [data-screen="conversations"]:visible')
+  || !ipadSource.includes('#nav [data-screen="operations"]:visible')) {
+  throw new Error('IPAD_WEBKIT_RESPONSIVE_NAV_REWRITE_FAILED');
 }
 
 function readPassingJourneyReport(reportPath, label) {
@@ -76,6 +147,7 @@ try {
     required_failures: Number(ipad.report.required_failures || 0),
     mobile_step_status: ipad.mobileStep.status,
     viewport: { width: 820, height: 1180 },
+    navigation_contract: 'visible-responsive-nav',
     report_path: ipadReportPath,
   };
   fs.writeFileSync(englishReportPath, `${JSON.stringify(english.report, null, 2)}\n`, 'utf8');


### PR DESCRIPTION
ACTION → ARTIFACT → TEST → EVIDENCE

## Root cause proved on merged Production SHA 7d82d74648d5c6e23d8198e7081de1a8c8278245
Canonical run 521 locked exact Production deployment dpl_4u4ymijsijXrxwe5dQYFpMu3CHrn and kept it stable. Arabic full journey and English iPhone WebKit passed. iPad WebKit failed because the 820x1180 responsive layout correctly hides `#bottomNav`, while the inherited phone journey hardcoded `#bottomNav [data-screen="conversations"]` and later assumed the mobile menu path.

## Repair
- keep the canonical phone/English journey unchanged;
- adapt only the generated iPad source to use whichever real navigation control is visible: `#nav` or `#bottomNav`;
- require exactly one visible conversation and operations destination;
- require operations target to be visible, pointer-enabled, >=40px and hit-testable;
- do not inject CSS or force hidden phone controls visible;
- fail closed if canonical source anchors move;
- label iPad evidence truthfully and persist `navigation_contract=visible-responsive-nav`.

## Acceptance
1. exact PR-head DABBIR CI success;
2. exact PR-head Vercel READY with zero test failures;
3. protected merge only;
4. merged exact Production SHA READY;
5. canonical Production journey must show Arabic PASS, English iPhone PASS, `IPAD_WEBKIT_JOURNEY_PASS`, cross-tenant/WhatsApp isolation PASS, final journey PASS, and stable exact Production SHA.