### PR TITLE
fix(dabbir): open the real iPad sidebar before WebKit navigation

### DIFF
--- a/test/dabbir-ipad-webkit-production-contract.test.mjs
+++ b/test/dabbir-ipad-webkit-production-contract.test.mjs
@@ -9,6 +9,7 @@ const wrapper=read('test/run-ai-full-customer-journey-en.mjs');
 const canonicalWorkflow=read('.github/workflows/dabbir-ai-customer-journey.yml');
 const broker=read('supabase/functions/barman-qa-suite-runner/index.ts');
 const deploymentClassifier=read('vercel-ignore-if-unaffected.sh');
+const shell=read('index.html');
 
 test('iPad WebKit journey runs inside the already-authorized canonical customer journey identity',()=>{
   assert.equal(fs.existsSync(pathUrl('.github/workflows/dabbir-ipad-webkit-production.yml')),false,'standalone privileged iPad workflow must be retired');
@@ -24,16 +25,37 @@ test('iPad WebKit journey runs inside the already-authorized canonical customer 
   assert.match(wrapper,/IPAD_WEBKIT_JOURNEY_PASS/);
 });
 
-test('iPad journey adapts to the real visible responsive navigation instead of forcing phone-only controls',()=>{
-  assert.match(wrapper,/#nav \[data-screen=\"conversations\"\]:visible, #bottomNav \[data-screen=\"conversations\"\]:visible/);
-  assert.match(wrapper,/#nav \[data-screen=\"operations\"\]:visible, #bottomNav \[data-screen=\"operations\"\]:visible/);
-  assert.match(wrapper,/BROWSER_VISIBLE_CONVERSATIONS_NAV_COUNT_/);
-  assert.match(wrapper,/BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_/);
-  assert.match(wrapper,/DABBIR_RESPONSIVE_OPERATIONS_NAV_STATE/);
+test('iPad test follows the real 701-920px shell contract: menu button opens transformed sidebar before navigation',()=>{
+  assert.match(shell,/@media\(max-width:920px\)\{[^}]*\.shell\{grid-template-columns:1fr\}\.side\{position:fixed;/);
+  assert.match(shell,/\.side\.open\{transform:translateX\(0\)!important\}/);
+  assert.match(shell,/\.mobileMenu\{display:block;/);
+  assert.match(shell,/@media\(max-width:700px\)[\s\S]*?\.bottomNav\{position:fixed;display:grid;/);
+  assert.match(wrapper,/#menuBtn:visible/);
+  assert.match(wrapper,/#side\.open #nav \[data-screen=\"conversations\"\]:visible/);
+  assert.match(wrapper,/#side\.open #nav \[data-screen=\"operations\"\]:visible/);
+  assert.match(wrapper,/BROWSER_IPAD_MENU_FOR_CONVERSATIONS_MISSING/);
+  assert.match(wrapper,/BROWSER_IPAD_MENU_FOR_OPERATIONS_MISSING/);
+});
+
+test('iPad sidebar targets must be truly inside the viewport and pointer-hit-testable before Playwright clicks',()=>{
+  assert.match(wrapper,/DABBIR_IPAD_CONVERSATIONS_NAV_STATE/);
+  assert.match(wrapper,/DABBIR_IPAD_OPERATIONS_NAV_STATE/);
+  assert.match(wrapper,/inside_viewport:/);
   assert.match(wrapper,/centre_hits_target/);
   assert.match(wrapper,/pointer_events/);
-  assert.match(wrapper,/visible-responsive-nav/);
+  assert.match(wrapper,/width >= 40/);
+  assert.match(wrapper,/height >= 40/);
+  assert.match(wrapper,/rect\.left < window\.innerWidth && rect\.right > 0/);
   assert.doesNotMatch(wrapper,/style\.display\s*=\s*['\"](?:flex|block|grid)['\"]/);
+  assert.doesNotMatch(wrapper,/dispatchEvent\(/);
+});
+
+test('each iPad sidebar navigation proves the responsive shell closes after a successful destination change',()=>{
+  assert.match(wrapper,/DABBIR_IPAD_CONVERSATIONS_TRANSITION/);
+  assert.match(wrapper,/conversationsTransition\.active && !conversationsTransition\.sidebar_open/);
+  assert.match(wrapper,/DABBIR_IPAD_OPERATIONS_TRANSITION/);
+  assert.match(wrapper,/operationsTransition\.active && !operationsTransition\.sidebar_open/);
+  assert.match(wrapper,/menu-opened-responsive-sidebar/);
 });
 
 test('iPad responsive source transformation fails closed if the canonical navigation contract moves',()=>{

--- a/test/run-ai-full-customer-journey-en.mjs
+++ b/test/run-ai-full-customer-journey-en.mjs
@@ -8,15 +8,73 @@ const arabicLocale = "locale: 'ar-AE',";
 const iphoneViewport = "viewport: { width: 390, height: 844 },";
 const ipadViewport = "viewport: { width: 820, height: 1180 },";
 const iphoneJourneyDetail = 'WebKit iPhone-size journey completed password + TOTP MFA, then rendered owner workspace, conversation, product, and approved DABBIR identity.';
-const ipadJourneyDetail = 'WebKit iPad-size journey completed password + TOTP MFA, then used the visible responsive navigation and rendered owner workspace, conversation, product, and approved DABBIR identity.';
+const ipadJourneyDetail = 'WebKit iPad-size journey completed password + TOTP MFA, then opened the real responsive sidebar and rendered owner workspace, conversation, product, and approved DABBIR identity.';
 const phoneConversationNavigation = `  await page.locator('#bottomNav [data-screen="conversations"]').click();`;
-const tabletConversationNavigation = `  const visibleConversationsNav = page.locator('#nav [data-screen="conversations"]:visible, #bottomNav [data-screen="conversations"]:visible');
+const tabletConversationNavigation = `  const ipadMenuForConversations = page.locator('#menuBtn:visible');
+  assert(await ipadMenuForConversations.count() === 1, 'BROWSER_IPAD_MENU_FOR_CONVERSATIONS_MISSING');
+  await ipadMenuForConversations.click();
+  await page.waitForFunction(() => {
+    const side = document.querySelector('#side');
+    if (!side || !side.classList.contains('open')) return false;
+    const rect = side.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }, null, { timeout: 10_000 });
+  const visibleConversationsNav = page.locator('#side.open #nav [data-screen="conversations"]:visible');
   const visibleConversationsCount = await visibleConversationsNav.count();
   assert(visibleConversationsCount === 1, \`BROWSER_VISIBLE_CONVERSATIONS_NAV_COUNT_\${visibleConversationsCount}\`);
-  await visibleConversationsNav.click();`;
+  const conversationsNavState = await visibleConversationsNav.evaluate(element => {
+    const style = getComputedStyle(element);
+    const rect = element.getBoundingClientRect();
+    const centerX = rect.left + (rect.width / 2);
+    const centerY = rect.top + (rect.height / 2);
+    const hit = document.elementFromPoint(centerX, centerY);
+    return {
+      display: style.display,
+      visibility: style.visibility,
+      pointer_events: style.pointerEvents,
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+      left: Math.round(rect.left),
+      right: Math.round(rect.right),
+      top: Math.round(rect.top),
+      bottom: Math.round(rect.bottom),
+      viewport_width: window.innerWidth,
+      viewport_height: window.innerHeight,
+      inside_viewport: centerX >= 0 && centerX <= window.innerWidth && centerY >= 0 && centerY <= window.innerHeight,
+      centre_hits_target: hit === element || element.contains(hit),
+    };
+  });
+  console.log(\`DABBIR_IPAD_CONVERSATIONS_NAV_STATE=\${JSON.stringify(conversationsNavState)}\`);
+  assert(
+    conversationsNavState.display !== 'none'
+      && conversationsNavState.visibility !== 'hidden'
+      && conversationsNavState.pointer_events !== 'none'
+      && conversationsNavState.width >= 40
+      && conversationsNavState.height >= 40
+      && conversationsNavState.inside_viewport
+      && conversationsNavState.centre_hits_target,
+    \`BROWSER_CONVERSATIONS_NAV_NOT_ACTIONABLE_\${JSON.stringify(conversationsNavState)}\`,
+  );
+  await visibleConversationsNav.click();
+  await page.locator('#screen-conversations.active').waitFor({ state: 'visible', timeout: 10_000 });
+  const conversationsTransition = await page.evaluate(() => ({
+    active: document.querySelector('#screen-conversations')?.classList.contains('active') === true,
+    sidebar_open: document.querySelector('#side')?.classList.contains('open') === true,
+  }));
+  console.log(\`DABBIR_IPAD_CONVERSATIONS_TRANSITION=\${JSON.stringify(conversationsTransition)}\`);
+  assert(conversationsTransition.active && !conversationsTransition.sidebar_open, \`BROWSER_CONVERSATIONS_TRANSITION_FAILED_\${JSON.stringify(conversationsTransition)}\`);`;
 const phoneNavigationStart = `  const mobileMenuState = await page.locator('#menuBtn').evaluate(element => {`;
 const phoneNavigationEnd = `  assert(operationsTransition.target_found && operationsTransition.active && !operationsTransition.side_open, \`BROWSER_OPERATIONS_TRANSITION_FAILED_\${JSON.stringify(operationsTransition)}\`);`;
-const tabletOperationsNavigation = `  const visibleOperationsNav = page.locator('#nav [data-screen="operations"]:visible, #bottomNav [data-screen="operations"]:visible');
+const tabletOperationsNavigation = `  const ipadMenuForOperations = page.locator('#menuBtn:visible');
+  assert(await ipadMenuForOperations.count() === 1, 'BROWSER_IPAD_MENU_FOR_OPERATIONS_MISSING');
+  await ipadMenuForOperations.click();
+  await page.waitForFunction(() => {
+    const side = document.querySelector('#side');
+    if (!side || !side.classList.contains('open')) return false;
+    const rect = side.getBoundingClientRect();
+    return rect.width > 0 && rect.height > 0 && rect.left < window.innerWidth && rect.right > 0;
+  }, null, { timeout: 10_000 });
+  const visibleOperationsNav = page.locator('#side.open #nav [data-screen="operations"]:visible');
   const visibleOperationsCount = await visibleOperationsNav.count();
   assert(visibleOperationsCount === 1, \`BROWSER_VISIBLE_OPERATIONS_NAV_COUNT_\${visibleOperationsCount}\`);
   const operationsNavState = await visibleOperationsNav.evaluate(element => {
@@ -32,19 +90,23 @@ const tabletOperationsNavigation = `  const visibleOperationsNav = page.locator(
       width: Math.round(rect.width),
       height: Math.round(rect.height),
       left: Math.round(rect.left),
+      right: Math.round(rect.right),
       top: Math.round(rect.top),
+      bottom: Math.round(rect.bottom),
       viewport_width: window.innerWidth,
       viewport_height: window.innerHeight,
+      inside_viewport: centerX >= 0 && centerX <= window.innerWidth && centerY >= 0 && centerY <= window.innerHeight,
       centre_hits_target: hit === element || element.contains(hit),
     };
   });
-  console.log(\`DABBIR_RESPONSIVE_OPERATIONS_NAV_STATE=\${JSON.stringify(operationsNavState)}\`);
+  console.log(\`DABBIR_IPAD_OPERATIONS_NAV_STATE=\${JSON.stringify(operationsNavState)}\`);
   assert(
     operationsNavState.display !== 'none'
       && operationsNavState.visibility !== 'hidden'
       && operationsNavState.pointer_events !== 'none'
       && operationsNavState.width >= 40
       && operationsNavState.height >= 40
+      && operationsNavState.inside_viewport
       && operationsNavState.centre_hits_target,
     \`BROWSER_OPERATIONS_NAV_NOT_ACTIONABLE_\${JSON.stringify(operationsNavState)}\`,
   );
@@ -54,8 +116,8 @@ const tabletOperationsNavigation = `  const visibleOperationsNav = page.locator(
     active: document.querySelector('#screen-operations')?.classList.contains('active') === true,
     sidebar_open: document.querySelector('#side')?.classList.contains('open') === true,
   }));
-  console.log(\`DABBIR_RESPONSIVE_OPERATIONS_TRANSITION=\${JSON.stringify(operationsTransition)}\`);
-  assert(operationsTransition.active, \`BROWSER_OPERATIONS_TRANSITION_FAILED_\${JSON.stringify(operationsTransition)}\`);`;
+  console.log(\`DABBIR_IPAD_OPERATIONS_TRANSITION=\${JSON.stringify(operationsTransition)}\`);
+  assert(operationsTransition.active && !operationsTransition.sidebar_open, \`BROWSER_OPERATIONS_TRANSITION_FAILED_\${JSON.stringify(operationsTransition)}\`);`;
 const englishReportPath = 'dabbir-ai-customer-journey-report-en.json';
 const ipadReportPath = 'dabbir-ai-customer-journey-report-ipad.json';
 
@@ -96,8 +158,10 @@ ipadSource = replaceSingleExact(ipadSource, phoneConversationNavigation, tabletC
 ipadSource = replaceSingleRange(ipadSource, phoneNavigationStart, phoneNavigationEnd, tabletOperationsNavigation, 'IPAD_WEBKIT_OPERATIONS_NAV_CONTRACT_CHANGED');
 ipadSource = replaceSingleExact(ipadSource, iphoneJourneyDetail, ipadJourneyDetail, 'IPAD_WEBKIT_EVIDENCE_DETAIL_CONTRACT_CHANGED');
 if (!ipadSource.includes(ipadViewport)
-  || !ipadSource.includes('#nav [data-screen="conversations"]:visible')
-  || !ipadSource.includes('#nav [data-screen="operations"]:visible')) {
+  || !ipadSource.includes('#side.open #nav [data-screen="conversations"]:visible')
+  || !ipadSource.includes('#side.open #nav [data-screen="operations"]:visible')
+  || !ipadSource.includes('BROWSER_IPAD_MENU_FOR_CONVERSATIONS_MISSING')
+  || !ipadSource.includes('BROWSER_IPAD_MENU_FOR_OPERATIONS_MISSING')) {
   throw new Error('IPAD_WEBKIT_RESPONSIVE_NAV_REWRITE_FAILED');
 }
 
@@ -147,7 +211,7 @@ try {
     required_failures: Number(ipad.report.required_failures || 0),
     mobile_step_status: ipad.mobileStep.status,
     viewport: { width: 820, height: 1180 },
-    navigation_contract: 'visible-responsive-nav',
+    navigation_contract: 'menu-opened-responsive-sidebar',
     report_path: ipadReportPath,
   };
   fs.writeFileSync(englishReportPath, `${JSON.stringify(english.report, null, 2)}\n`, 'utf8');


### PR DESCRIPTION
ACTION → ARTIFACT → TEST → EVIDENCE

## Production root cause
Run 522 on exact Production SHA `1f0853a17b889593a837e69e5839c7b098a95a1c` proved Arabic full journey PASS and English iPhone PASS, with stable release `dpl_6jbEQRWqePboUAtRYZ5masfYdNXU`. iPad still failed because the 820px shell is in the `max-width:920px` breakpoint: `#side` is a transformed off-canvas sidebar until `#menuBtn` opens it. CSS visibility alone made Playwright resolve the nav button even though its geometry was outside the viewport.

## Repair
- use the real visible `#menuBtn` before iPad Conversations and Operations navigation;
- wait fail-closed until `#side.open` geometry intersects the viewport;
- target only `#side.open #nav` at the 820px breakpoint;
- require each target to be visible, pointer-enabled, >=40px, center-inside-viewport and hit-testable;
- click through Playwright normally;
- require destination active and sidebar closed after navigation;
- preserve English iPhone journey unchanged;
- no CSS override, no DOM click bypass, no event injection, no Supabase authority expansion.

## Acceptance
Exact PR head: required GitHub `test` SUCCESS + Vercel full gate 0 failures. Then protected merge. On merged exact Production SHA, canonical journey must show Arabic PASS, English iPhone PASS, `IPAD_WEBKIT_JOURNEY_PASS`, cross-tenant/WhatsApp isolation PASS, final full journey PASS, and stable exact Production SHA.