### PR TITLE
fix(barman): repair legacy truth state and retire obsolete runtime

### DIFF
--- a/.github/workflows/barman-independent-verifier.yml
+++ b/.github/workflows/barman-independent-verifier.yml
@@ -1,6 +1,9 @@
 name: BARMAN Independent Verifier
 
 on:
+  push:
+    branches:
+      - main
   schedule:
     - cron: '*/5 * * * *'
   workflow_dispatch:
@@ -19,7 +22,7 @@ jobs:
   verify:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
         with:
@@ -29,6 +32,11 @@ jobs:
         with:
           node-version: 22
           cache: npm
+      - name: Wait for exact Production verifier on push wake-up
+        if: github.event_name == 'push'
+        env:
+          BARMAN_EXPECTED_SHA: ${{ github.sha }}
+        run: node scripts/wait-dabbir-production-sha.mjs
       - name: Verify BARMAN executor evidence independently
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/barman-tool-agent.yml
+++ b/.github/workflows/barman-tool-agent.yml
@@ -1,6 +1,9 @@
 name: BARMAN Persistent Tool Agent
 
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
     - cron: '*/5 * * * *'
@@ -18,6 +21,7 @@ concurrency:
 
 jobs:
   execute:
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     timeout-minutes: 50
     steps:
@@ -28,6 +32,11 @@ jobs:
         with:
           node-version-file: package.json
           package-manager-cache: false
+      - name: Wait for exact Production broker on push wake-up
+        if: github.event_name == 'push'
+        env:
+          BARMAN_EXPECTED_SHA: ${{ github.sha }}
+        run: node scripts/wait-dabbir-production-sha.mjs
       - name: Execute one BARMAN tool-agent command
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/api/barman-independent-verifier.js
+++ b/api/barman-independent-verifier.js
@@ -20,7 +20,7 @@ function claimAllowed(payload,now=Math.floor(Date.now()/1000)){
     &&payload?.repository===EXPECTED_REPO
     &&payload?.ref===EXPECTED_REF
     &&payload?.workflow_ref===EXPECTED_WORKFLOW
-    &&['schedule','workflow_dispatch'].includes(String(payload?.event_name||''))
+    &&['schedule','workflow_dispatch','push'].includes(String(payload?.event_name||''))
     &&Number(payload?.exp||0)>now-5
     &&Number(payload?.nbf||0)<=now+30;
 }

--- a/api/barman-tool-agent-broker.js
+++ b/api/barman-tool-agent-broker.js
@@ -23,7 +23,7 @@ function claimAllowed(payload,now=Math.floor(Date.now()/1000)){
     &&payload?.repository===EXPECTED_REPO
     &&payload?.ref===EXPECTED_REF
     &&payload?.workflow_ref===EXPECTED_WORKFLOW
-    &&['schedule','workflow_dispatch'].includes(String(payload?.event_name||''))
+    &&['schedule','workflow_dispatch','push'].includes(String(payload?.event_name||''))
     &&Number(payload?.exp||0)>now-5
     &&Number(payload?.nbf||0)<=now+30;
 }

--- a/scripts/wait-dabbir-production-sha.mjs
+++ b/scripts/wait-dabbir-production-sha.mjs
@@ -1,0 +1,31 @@
+const expected=String(process.env.BARMAN_EXPECTED_SHA||process.env.GITHUB_SHA||'').trim().toLowerCase();
+const origin='https://dabbir.bmalman.com';
+const started=Date.now();
+const timeoutMs=10*60*1000;
+const sleep=ms=>new Promise(resolve=>setTimeout(resolve,ms));
+
+if(!/^[0-9a-f]{40}$/.test(expected)){
+  console.error('BARMAN_EXPECTED_SHA_INVALID');
+  process.exit(1);
+}
+
+let last='none';
+while(Date.now()-started<timeoutMs){
+  try{
+    const response=await fetch(`${origin}/api/release-evidence?t=${Date.now()}`,{
+      headers:{accept:'application/json'},cache:'no-store',signal:AbortSignal.timeout(15000),
+    });
+    const payload=await response.json().catch(()=>null);
+    last=String(payload?.commit_sha||'none').toLowerCase();
+    if(response.ok&&payload?.ok===true&&String(payload?.environment||'').toLowerCase()==='production'&&last===expected){
+      console.log(`BARMAN_PRODUCTION_SHA_READY ${expected}`);
+      process.exit(0);
+    }
+  }catch(error){
+    last=String(error?.message||error||'fetch-error').slice(0,160);
+  }
+  await sleep(10000);
+}
+
+console.error(`BARMAN_PRODUCTION_SHA_TIMEOUT expected=${expected} last=${last}`);
+process.exit(1);

--- a/supabase/migrations/20260903212500_barman_truth_repair_v8.sql
+++ b/supabase/migrations/20260903212500_barman_truth_repair_v8.sql
@@ -1,0 +1,184 @@
+-- BARMAN Executive OS truth repair v8.
+-- Preserve historical records, but remove trust from legacy self-asserted evidence
+-- and normalize legacy task/integration state so health cannot look better than reality.
+
+alter table dabbir_private.executive_integrations
+  drop constraint if exists executive_integrations_status_check;
+
+alter table dabbir_private.executive_integrations
+  add constraint executive_integrations_status_check
+  check (status = any (array['CONNECTED'::text,'PARTIAL'::text,'BROKEN'::text,'MISSING'::text,'UNAUTHORIZED'::text,'RETIRED'::text]));
+
+update dabbir_private.executive_integrations
+set status='RETIRED',
+    can_read=false,
+    can_analyze=false,
+    can_execute=false,
+    can_verify=false,
+    last_checked_at=now(),
+    metadata=coalesce(metadata,'{}'::jsonb) || jsonb_build_object(
+      'retired_at',now(),
+      'retirement_reason','REPLACED_BY_DABBIR_CANONICAL_RUNTIME',
+      'replacement_vercel_project_id','prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq',
+      'replacement_supabase_project_ref','fphpoysqdsceniwduxjq'
+    ),
+    evidence=coalesce(evidence,'[]'::jsonb) || jsonb_build_array(jsonb_build_object(
+      'type','decision',
+      'reference','BARMAN_TRUTH_REPAIR_V8',
+      'verified',true,
+      'details',jsonb_build_object('decision','RETIRED_LEGACY_RUNTIME','replacement','DABBIR canonical runtime')
+    ))
+where integration_key='vercel_barman_live_ceo';
+
+insert into dabbir_private.executive_audit_logs(
+  command_id,actor,action,project_key,reason,result,metadata
+)
+select c.id,
+       'BARMAN Truth Repair v8',
+       'LEGACY_STATE_NORMALIZE',
+       'DABBIR',
+       'PRE_HARDENING_STATE_WAS_NOT_INDEPENDENTLY_VERIFIED',
+       'NORMALIZING',
+       jsonb_build_object(
+         'previous_status',c.status,
+         'previous_orchestration_state',c.orchestration_state,
+         'previous_verification_status',c.verification_status,
+         'created_at',c.created_at
+       )
+from dabbir_private.dabbir_ceo_commands c
+where (c.status='DONE' and c.verification_status='PENDING')
+   or (c.status='BLOCKED' and (c.orchestration_state<>'BLOCKED' or c.verification_status='PENDING'))
+   or (c.status='CANCELLED' and (c.orchestration_state<>'CANCELLED' or c.verification_status<>'NOT_APPLICABLE'));
+
+update dabbir_private.executive_evidence
+set details=coalesce(details,'{}'::jsonb) || jsonb_build_object(
+      'truth_repair_v8',jsonb_strip_nulls(jsonb_build_object(
+        'original_verified',true,
+        'original_verified_by',verified_by,
+        'original_verified_at',verified_at,
+        'original_verification_method',verification_method,
+        'repaired_at',now(),
+        'reason','LEGACY_SELF_ASSERTED_EVIDENCE_CANNOT_SUPPORT_VERIFIED_STATE'
+      ))
+    ),
+    verified=false,
+    verified_by=null,
+    verified_at=null
+where verified=true
+  and coalesce(verification_method,'') in ('LEGACY_SELF_ASSERTED','SELF_ASSERTED');
+
+update dabbir_private.dabbir_ceo_commands
+set status='BLOCKED',
+    orchestration_state='BLOCKED',
+    verification_status='FAILED',
+    blocked_reason=coalesce(nullif(blocked_reason,''),'LEGACY_PRE_HARDENING_RESULT_HAS_NO_INDEPENDENT_VERIFICATION'),
+    updated_at=now()
+where status='DONE'
+  and verification_status='PENDING';
+
+update dabbir_private.dabbir_ceo_commands
+set orchestration_state='BLOCKED',
+    verification_status='FAILED',
+    blocked_reason=coalesce(nullif(blocked_reason,''),'BLOCKED_COMMAND_NORMALIZED_BY_TRUTH_REPAIR'),
+    updated_at=now()
+where status='BLOCKED'
+  and (orchestration_state<>'BLOCKED' or verification_status='PENDING');
+
+update dabbir_private.dabbir_ceo_commands
+set orchestration_state='CANCELLED',
+    verification_status='NOT_APPLICABLE',
+    updated_at=now()
+where status='CANCELLED'
+  and (orchestration_state<>'CANCELLED' or verification_status<>'NOT_APPLICABLE');
+
+create or replace function public.barman_executive_self_diagnostic_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, pg_temp
+as $$
+declare
+  v_broken integer;
+  v_partial integer;
+  v_retired integer;
+  v_stale integer;
+  v_queue integer;
+  v_weak integer;
+  v_legacy_untrusted integer;
+  v_pending_verify integer;
+  v_cron integer;
+  v_status text;
+begin
+  select count(*) into v_broken
+  from dabbir_private.executive_integrations
+  where status in ('BROKEN','MISSING','UNAUTHORIZED');
+
+  select count(*) into v_partial
+  from dabbir_private.executive_integrations
+  where status='PARTIAL';
+
+  select count(*) into v_retired
+  from dabbir_private.executive_integrations
+  where status='RETIRED';
+
+  select count(*) into v_stale
+  from dabbir_private.dabbir_ceo_commands
+  where status='IN_PROGRESS'
+    and coalesce(lease_until,now()-interval '1 second')<now();
+
+  select count(*) into v_queue
+  from dabbir_private.dabbir_ceo_commands
+  where status='QUEUED';
+
+  select count(*) into v_pending_verify
+  from dabbir_private.dabbir_ceo_commands
+  where status='DONE' and verification_status='INDEPENDENT_REQUIRED';
+
+  select count(*) into v_weak
+  from dabbir_private.executive_evidence
+  where verified=true
+    and coalesce(verification_method,'') in ('','LEGACY_SELF_ASSERTED','SELF_ASSERTED');
+
+  select count(*) into v_legacy_untrusted
+  from dabbir_private.executive_evidence
+  where verified=false
+    and coalesce(verification_method,'') in ('LEGACY_SELF_ASSERTED','SELF_ASSERTED');
+
+  select count(*) into v_cron
+  from cron.job
+  where active=true
+    and jobname in ('barman-executive-rollup','barman-executive-heartbeat');
+
+  v_status:=case
+    when v_broken>0 then 'PARTIAL'
+    when v_stale>0 or v_cron<2 or v_pending_verify>0 or v_weak>0 or v_partial>0 then 'DEGRADED'
+    else 'HEALTHY'
+  end;
+
+  return jsonb_build_object(
+    'ok',true,
+    'service','BARMAN Executive OS',
+    'status',v_status,
+    'autonomy_level','A3',
+    'canonical_database','fphpoysqdsceniwduxjq',
+    'metrics',jsonb_build_object(
+      'broken_integrations',v_broken,
+      'partial_integrations',v_partial,
+      'retired_integrations',v_retired,
+      'queued_commands',v_queue,
+      'stale_in_progress',v_stale,
+      'commands_waiting_independent_verification',v_pending_verify,
+      'weak_verified_evidence',v_weak,
+      'legacy_untrusted_evidence',v_legacy_untrusted,
+      'active_core_cron_jobs',v_cron
+    ),
+    'checked_at',now()
+  );
+end;
+$$;
+
+revoke all on function public.barman_executive_self_diagnostic_v1() from public, anon, authenticated;
+grant execute on function public.barman_executive_self_diagnostic_v1() to service_role;
+
+comment on function public.barman_executive_self_diagnostic_v1() is
+  'Truthful BARMAN health diagnostic. Partial integrations, stale tasks, weak trusted evidence, missing cron, or pending independent verification prevent HEALTHY.';

--- a/supabase/migrations/20260903214000_barman_github_dispatch_fallback_v9.sql
+++ b/supabase/migrations/20260903214000_barman_github_dispatch_fallback_v9.sql
@@ -1,0 +1,177 @@
+-- BARMAN Executive OS GitHub dispatch fallback v9.
+-- GitHub scheduled workflows have shown long trigger gaps. Supabase pg_cron becomes
+-- the independent wake source once a fine-grained Actions-write token is stored
+-- in Vault as `barman_github_actions_token`. The secret is never returned/logged.
+
+create table if not exists dabbir_private.executive_scheduler_state (
+  scheduler_key text primary key,
+  last_attempt_at timestamptz,
+  last_request_id bigint,
+  last_reason text,
+  metadata jsonb not null default '{}'::jsonb,
+  updated_at timestamptz not null default now()
+);
+
+revoke all on table dabbir_private.executive_scheduler_state from public, anon, authenticated;
+
+insert into dabbir_private.executive_integrations(
+  integration_key,provider,project_key,status,can_read,can_analyze,can_execute,can_verify,
+  last_checked_at,last_success_at,last_failure_at,evidence,metadata
+) values (
+  'github_actions_dispatch_fallback','GitHub Actions','DABBIR','MISSING',true,true,false,false,
+  now(),null,null,'[]'::jsonb,
+  jsonb_build_object(
+    'required_vault_secret','barman_github_actions_token',
+    'required_permission','Actions: write',
+    'purpose','Supabase pg_cron wake-up fallback for BARMAN tool-agent and independent verifier'
+  )
+)
+on conflict (integration_key) do update
+set provider=excluded.provider,
+    project_key=excluded.project_key,
+    last_checked_at=now(),
+    metadata=coalesce(dabbir_private.executive_integrations.metadata,'{}'::jsonb) || excluded.metadata;
+
+create or replace function public.barman_github_dispatch_tick_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, vault, net, pg_temp
+as $$
+declare
+  v_token text;
+  v_tool_pending integer:=0;
+  v_verify_pending integer:=0;
+  v_tool_request bigint;
+  v_verify_request bigint;
+  v_tool_last timestamptz;
+  v_verify_last timestamptz;
+  v_now timestamptz:=now();
+begin
+  select decrypted_secret into v_token
+  from vault.decrypted_secrets
+  where name='barman_github_actions_token'
+  order by created_at desc
+  limit 1;
+
+  select count(*) into v_tool_pending
+  from dabbir_private.dabbir_ceo_commands c
+  where c.status in ('QUEUED','ACCEPTED')
+     or (c.status='IN_PROGRESS' and coalesce(c.lease_until,v_now-interval '1 second')<v_now);
+
+  select count(*) into v_verify_pending
+  from dabbir_private.dabbir_ceo_commands c
+  where c.status='DONE'
+    and c.verification_status='INDEPENDENT_REQUIRED'
+    and c.orchestration_state='VERIFYING';
+
+  update dabbir_private.executive_integrations
+  set last_checked_at=v_now,
+      status=case when nullif(v_token,'') is null then 'MISSING' else 'PARTIAL' end,
+      can_execute=(nullif(v_token,'') is not null),
+      can_verify=(nullif(v_token,'') is not null),
+      metadata=coalesce(metadata,'{}'::jsonb) || jsonb_build_object(
+        'credential_present',nullif(v_token,'') is not null,
+        'tool_pending',v_tool_pending,
+        'verify_pending',v_verify_pending,
+        'last_tick_at',v_now
+      )
+  where integration_key='github_actions_dispatch_fallback';
+
+  if nullif(v_token,'') is null then
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_reason,metadata,updated_at)
+    values('github_actions_dispatch_fallback',v_now,'CREDENTIAL_MISSING',jsonb_build_object('tool_pending',v_tool_pending,'verify_pending',v_verify_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,
+          last_reason=excluded.last_reason,
+          metadata=excluded.metadata,
+          updated_at=excluded.updated_at;
+    return jsonb_build_object(
+      'ok',false,
+      'status','CREDENTIAL_MISSING',
+      'required_vault_secret','barman_github_actions_token',
+      'tool_pending',v_tool_pending,
+      'verify_pending',v_verify_pending
+    );
+  end if;
+
+  select last_attempt_at into v_tool_last
+  from dabbir_private.executive_scheduler_state
+  where scheduler_key='github_tool_agent_dispatch';
+
+  if v_tool_pending>0 and (v_tool_last is null or v_tool_last<v_now-interval '4 minutes') then
+    v_tool_request:=net.http_post(
+      url:='https://api.github.com/repos/barman-systems/pilot/actions/workflows/barman-tool-agent.yml/dispatches',
+      body:=jsonb_build_object('ref','main'),
+      params:='{}'::jsonb,
+      headers:=jsonb_build_object(
+        'Authorization','Bearer '||v_token,
+        'Accept','application/vnd.github+json',
+        'X-GitHub-Api-Version','2022-11-28',
+        'User-Agent','BARMAN-Executive-OS'
+      ),
+      timeout_milliseconds:=10000
+    );
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_request_id,last_reason,metadata,updated_at)
+    values('github_tool_agent_dispatch',v_now,v_tool_request,'WORK_PENDING',jsonb_build_object('pending',v_tool_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,last_request_id=excluded.last_request_id,last_reason=excluded.last_reason,metadata=excluded.metadata,updated_at=excluded.updated_at;
+  end if;
+
+  select last_attempt_at into v_verify_last
+  from dabbir_private.executive_scheduler_state
+  where scheduler_key='github_independent_verifier_dispatch';
+
+  if v_verify_pending>0 and (v_verify_last is null or v_verify_last<v_now-interval '4 minutes') then
+    v_verify_request:=net.http_post(
+      url:='https://api.github.com/repos/barman-systems/pilot/actions/workflows/barman-independent-verifier.yml/dispatches',
+      body:=jsonb_build_object('ref','main'),
+      params:='{}'::jsonb,
+      headers:=jsonb_build_object(
+        'Authorization','Bearer '||v_token,
+        'Accept','application/vnd.github+json',
+        'X-GitHub-Api-Version','2022-11-28',
+        'User-Agent','BARMAN-Executive-OS'
+      ),
+      timeout_milliseconds:=10000
+    );
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_request_id,last_reason,metadata,updated_at)
+    values('github_independent_verifier_dispatch',v_now,v_verify_request,'VERIFICATION_PENDING',jsonb_build_object('pending',v_verify_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,last_request_id=excluded.last_request_id,last_reason=excluded.last_reason,metadata=excluded.metadata,updated_at=excluded.updated_at;
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,
+    'status','DISPATCH_QUEUED',
+    'tool_pending',v_tool_pending,
+    'verify_pending',v_verify_pending,
+    'tool_request_id',v_tool_request,
+    'verify_request_id',v_verify_request
+  );
+exception when others then
+  update dabbir_private.executive_integrations
+  set status='BROKEN',
+      can_execute=false,
+      can_verify=false,
+      last_checked_at=now(),
+      last_failure_at=now(),
+      metadata=coalesce(metadata,'{}'::jsonb) || jsonb_build_object('last_dispatch_error_sqlstate',sqlstate,'last_dispatch_error_at',now())
+  where integration_key='github_actions_dispatch_fallback';
+  return jsonb_build_object('ok',false,'status','DISPATCH_ERROR','sqlstate',sqlstate);
+end;
+$$;
+
+revoke all on function public.barman_github_dispatch_tick_v1() from public, anon, authenticated;
+grant execute on function public.barman_github_dispatch_tick_v1() to service_role;
+
+select cron.unschedule('barman-github-dispatch-fallback')
+where exists(select 1 from cron.job where jobname='barman-github-dispatch-fallback');
+select cron.schedule(
+  'barman-github-dispatch-fallback',
+  '*/5 * * * *',
+  'select public.barman_github_dispatch_tick_v1();'
+);
+
+comment on function public.barman_github_dispatch_tick_v1() is
+  'Fail-closed Supabase pg_cron fallback that wakes BARMAN GitHub workers when work is pending. Requires Vault secret barman_github_actions_token with Actions:write; never returns the secret.';

--- a/test/barman-github-dispatch-fallback-v9.test.mjs
+++ b/test/barman-github-dispatch-fallback-v9.test.mjs
@@ -9,7 +9,9 @@ test('scheduler never exposes the GitHub wake credential',()=>{
   assert.match(sql,/vault\.decrypted_secrets/);
   assert.match(sql,/CREDENTIAL_MISSING/);
   assert.doesNotMatch(sql,/return\s+v_token/i);
-  assert.doesNotMatch(sql,/jsonb_build_object\([^;]*v_token/si);
+  assert.doesNotMatch(sql,/'(?:token|credential|secret)'\s*,\s*v_token/i);
+  assert.doesNotMatch(sql,/raise\s+(?:notice|warning|exception)[^;]*v_token/i);
+  assert.match(sql,/'Authorization','Bearer '\|\|v_token/);
 });
 
 test('scheduler dispatches only canonical BARMAN workflows on main',()=>{

--- a/test/barman-github-dispatch-fallback-v9.test.mjs
+++ b/test/barman-github-dispatch-fallback-v9.test.mjs
@@ -1,0 +1,37 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const sql=fs.readFileSync(new URL('../supabase/migrations/20260903214000_barman_github_dispatch_fallback_v9.sql',import.meta.url),'utf8');
+
+test('scheduler never exposes the GitHub wake credential',()=>{
+  assert.match(sql,/barman_github_actions_token/);
+  assert.match(sql,/vault\.decrypted_secrets/);
+  assert.match(sql,/CREDENTIAL_MISSING/);
+  assert.doesNotMatch(sql,/return\s+v_token/i);
+  assert.doesNotMatch(sql,/jsonb_build_object\([^;]*v_token/si);
+});
+
+test('scheduler dispatches only canonical BARMAN workflows on main',()=>{
+  assert.match(sql,/barman-tool-agent\.yml\/dispatches/);
+  assert.match(sql,/barman-independent-verifier\.yml\/dispatches/);
+  assert.match(sql,/jsonb_build_object\('ref','main'\)/);
+  assert.match(sql,/X-GitHub-Api-Version/);
+  assert.match(sql,/BARMAN-Executive-OS/);
+});
+
+test('scheduler is bounded, idempotent and service-role only',()=>{
+  assert.match(sql,/last_attempt_at/);
+  assert.match(sql,/interval '4 minutes'/);
+  assert.match(sql,/on conflict \(scheduler_key\) do update/i);
+  assert.match(sql,/revoke all on function public\.barman_github_dispatch_tick_v1\(\) from public, anon, authenticated/i);
+  assert.match(sql,/grant execute on function public\.barman_github_dispatch_tick_v1\(\) to service_role/i);
+  assert.match(sql,/cron\.schedule\(\s*'barman-github-dispatch-fallback'/s);
+});
+
+test('missing credential is visible as a real integration failure instead of fake readiness',()=>{
+  assert.match(sql,/github_actions_dispatch_fallback/);
+  assert.match(sql,/'MISSING'/);
+  assert.match(sql,/required_permission','Actions: write'/);
+  assert.match(sql,/status=case when nullif\(v_token,''\) is null then 'MISSING' else 'PARTIAL' end/);
+});

--- a/test/barman-independent-verifier.test.mjs
+++ b/test/barman-independent-verifier.test.mjs
@@ -5,14 +5,19 @@ import assert from 'node:assert/strict';
 const broker=fs.readFileSync(new URL('../api/barman-independent-verifier.js',import.meta.url),'utf8');
 const worker=fs.readFileSync(new URL('../scripts/barman-independent-verifier.mjs',import.meta.url),'utf8');
 const workflow=fs.readFileSync(new URL('../.github/workflows/barman-independent-verifier.yml',import.meta.url),'utf8');
+const waitProduction=fs.readFileSync(new URL('../scripts/wait-dabbir-production-sha.mjs',import.meta.url),'utf8');
 const migration=fs.readFileSync(new URL('../supabase/migrations/20260903211000_barman_independent_verifier_v7.sql',import.meta.url),'utf8');
 
 test('independent verifier has a distinct GitHub OIDC identity',()=>{
   assert.match(broker,/AUDIENCE='barman-executive-independent-verifier'/);
   assert.match(broker,/barman-independent-verifier\.yml@\$\{EXPECTED_REF\}/);
   assert.match(broker,/payload\?\.ref===EXPECTED_REF/);
-  assert.match(broker,/\['schedule','workflow_dispatch'\]/);
+  assert.match(broker,/\['schedule','workflow_dispatch','push'\]/);
   assert.doesNotMatch(broker,/barman-executive-tool-agent/);
+  assert.match(workflow,/push:\s*\n\s*branches:\s*\n\s*- main/);
+  assert.match(workflow,/github\.event_name == 'push'/);
+  assert.match(workflow,/wait-dabbir-production-sha\.mjs/);
+  assert.match(waitProduction,/release-evidence/);
   assert.match(workflow,/id-token: write/);
   assert.match(workflow,/contents: read/);
   assert.match(workflow,/actions: read/);

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -6,6 +6,7 @@ import { routeToolAgentCommand, validateToolAgentClaims } from '../api/barman-to
 const workflow=fs.readFileSync(new URL('../.github/workflows/barman-tool-agent.yml',import.meta.url),'utf8');
 const worker=fs.readFileSync(new URL('../scripts/barman-tool-agent.mjs',import.meta.url),'utf8');
 const broker=fs.readFileSync(new URL('../api/barman-tool-agent-broker.js',import.meta.url),'utf8');
+const waitProduction=fs.readFileSync(new URL('../scripts/wait-dabbir-production-sha.mjs',import.meta.url),'utf8');
 const ci=fs.readFileSync(new URL('../.github/workflows/ci.yml',import.meta.url),'utf8');
 
 const baseClaims={
@@ -21,6 +22,8 @@ const baseClaims={
 
 test('tool-agent OIDC is locked to the canonical main workflow',()=>{
   assert.equal(validateToolAgentClaims(baseClaims,1000),true);
+  assert.equal(validateToolAgentClaims({...baseClaims,event_name:'workflow_dispatch'},1000),true);
+  assert.equal(validateToolAgentClaims({...baseClaims,event_name:'push'},1000),true);
   assert.equal(validateToolAgentClaims({...baseClaims,workflow_ref:'barman-systems/pilot/.github/workflows/evil.yml@refs/heads/main'},1000),false);
   assert.equal(validateToolAgentClaims({...baseClaims,ref:'refs/heads/dev'},1000),false);
   assert.equal(validateToolAgentClaims({...baseClaims,event_name:'pull_request'},1000),false);
@@ -37,11 +40,16 @@ test('tool-agent routes non-code commands fail-closed before patch generation',(
   assert.match(worker,/routing\.route!==['"]REPO_CHANGE['"]/);
 });
 
-test('persistent worker is event-looped and cannot bypass governance files',()=>{
+test('persistent worker has schedule plus protected-main push wake-up',()=>{
   assert.match(workflow,/cron:\s*'\*\/5 \* \* \* \*'/);
+  assert.match(workflow,/push:\s*\n\s*branches:\s*\n\s*- main/);
+  assert.match(workflow,/github\.event_name == 'push'/);
+  assert.match(workflow,/wait-dabbir-production-sha\.mjs/);
   for(const token of ['id-token: write','contents: write','pull-requests: write','actions: write','cancel-in-progress: false'])assert.match(workflow,new RegExp(token.replace(/[.*+?^${}()|[\]\\]/g,'\\$&')));
+  assert.match(waitProduction,/release-evidence/);
+  assert.match(waitProduction,/commit_sha/);
+  assert.match(waitProduction,/environment/);
   assert.match(worker,/phase:'claim'/);
-  assert.match(worker,/p_lane:'tool_agent'|phase:'claim'/);
   assert.match(worker,/spawnSync\('git',\['apply','--check'/);
   assert.match(worker,/PATCH_TOUCHED_GOVERNANCE_FILE/);
   assert.match(worker,/path\.startsWith\('\.github\/'\)/);

--- a/test/barman-truth-repair-v8.test.mjs
+++ b/test/barman-truth-repair-v8.test.mjs
@@ -1,0 +1,42 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const sql=fs.readFileSync(new URL('../supabase/migrations/20260903212500_barman_truth_repair_v8.sql',import.meta.url),'utf8');
+
+test('legacy self-asserted evidence is preserved but demoted from trust',()=>{
+  assert.match(sql,/LEGACY_SELF_ASSERTED_EVIDENCE_CANNOT_SUPPORT_VERIFIED_STATE/);
+  assert.match(sql,/original_verified/);
+  assert.match(sql,/verified=false/);
+  assert.match(sql,/verified_by=null/);
+  assert.match(sql,/verified_at=null/);
+  assert.doesNotMatch(sql,/delete\s+from\s+dabbir_private\.executive_evidence/i);
+});
+
+test('legacy task states cannot remain done pending queued',()=>{
+  assert.match(sql,/where status='DONE'\s+and verification_status='PENDING'/i);
+  assert.match(sql,/status='BLOCKED'/);
+  assert.match(sql,/orchestration_state='BLOCKED'/);
+  assert.match(sql,/verification_status='FAILED'/);
+  assert.match(sql,/LEGACY_PRE_HARDENING_RESULT_HAS_NO_INDEPENDENT_VERIFICATION/);
+  assert.match(sql,/status='CANCELLED'/);
+  assert.match(sql,/verification_status='NOT_APPLICABLE'/);
+});
+
+test('retired legacy Vercel runtime no longer counts as broken',()=>{
+  assert.match(sql,/'RETIRED'::text/);
+  assert.match(sql,/integration_key='vercel_barman_live_ceo'/);
+  assert.match(sql,/REPLACED_BY_DABBIR_CANONICAL_RUNTIME/);
+  assert.match(sql,/replacement_vercel_project_id/);
+  assert.match(sql,/replacement_supabase_project_ref/);
+});
+
+test('health cannot report healthy while partial integrations or weak truth remain',()=>{
+  assert.match(sql,/v_partial>0/);
+  assert.match(sql,/v_weak>0/);
+  assert.match(sql,/v_pending_verify>0/);
+  assert.match(sql,/legacy_untrusted_evidence/);
+  assert.match(sql,/retired_integrations/);
+  assert.match(sql,/revoke all on function public\.barman_executive_self_diagnostic_v1\(\) from public, anon, authenticated/i);
+  assert.match(sql,/grant execute on function public\.barman_executive_self_diagnostic_v1\(\) to service_role/i);
+});


### PR DESCRIPTION
## P1 truth + scheduler reliability repair

This removes historical false-confidence without deleting audit history and fixes a live 24/7 execution reliability gap discovered by the Golden CEO canary.

### Truth repair
- demotes all `LEGACY_SELF_ASSERTED` / `SELF_ASSERTED` evidence from `verified=true` to untrusted while preserving original verifier metadata inside `details.truth_repair_v8`;
- normalizes impossible legacy CEO states (`DONE + PENDING`, `BLOCKED + QUEUED/PENDING`, `CANCELLED + QUEUED/PENDING`);
- records audit entries before state normalization;
- retires obsolete `vercel_barman_live_ceo` instead of leaving a permanent false `BROKEN` alarm;
- makes self-diagnostic refuse `HEALTHY` while partial integrations, weak trusted evidence, stale work, missing cron, or pending independent verification remain.

### Persistent execution repair
The Golden CEO command stayed QUEUED because GitHub's `*/5` scheduled Tool Agent had not fired for more than an hour even though its previous worker run was healthy.

- adds protected-`main` **push wake-ups** for both Tool Agent and Independent Verifier;
- OIDC brokers explicitly permit `push` only while retaining exact repo/ref/workflow/audience validation;
- push wake-ups wait for the exact Vercel Production SHA before calling the newly deployed broker, preventing old-broker race conditions;
- retains scheduled and manual triggers as redundant paths;
- adds a Supabase `pg_cron` + `pg_net` GitHub Actions dispatch fallback that is fail-closed until a fine-grained Actions-write credential exists in Vault;
- the fallback never returns/logs the credential and is bounded/idempotent;
- its missing credential is exposed honestly as a `MISSING` integration rather than pretending 24/7 readiness.

### Tests
Regression coverage locks evidence demotion, task-state normalization, retired runtime semantics, health truth, push OIDC boundaries, exact-production wake-up ordering, secret non-disclosure, canonical workflow dispatch, service-role-only scheduler access, and missing-credential truth.

This is deliberately a truth and reliability repair, not a cosmetic health-score change.