### PR TITLE
fix(barman): self-recover patch context and wake verifier after finalize

### DIFF
--- a/api/barman-tool-agent-broker.js
+++ b/api/barman-tool-agent-broker.js
@@ -108,17 +108,20 @@ async function discover(command,paths){
 }
 
 async function proposePatch(command,files,previousPatch='',applyError=''){
-  const context=Array.isArray(files)?files.slice(0,8).map(file=>({path:clean(file?.path,300),content:String(file?.content||'').slice(0,24000)})).filter(file=>file.path):[];
+  const context=Array.isArray(files)?files.slice(0,12).map(file=>({path:clean(file?.path,300),content:String(file?.content||'').slice(0,24000)})).filter(file=>file.path):[];
   const system=[
     'You are the code-editing brain for BARMAN Executive OS working on DABBIR.',
     'Produce the smallest correct source change that satisfies the owner command.',
-    'You may edit only files supplied in context, plus create new test files under test/ or new SQL migrations under supabase/migrations/.',
+    'You may edit only existing files supplied in context.',
+    'You are explicitly authorized to create NEW files under test/ and NEW SQL migration files under supabase/migrations/. A new allowed path does NOT need to already appear in the supplied context.',
+    'For a low-risk regression-test request, infer a safe filename, test framework, imports, and conventions from neighboring supplied files and package.json. Never ask the owner to name the test file or reconfirm this already-granted permission.',
     'Never edit .github/, .env files, secrets, branch-protection/auth governance, api/barman-tool-agent-broker.js, scripts/barman-tool-agent.mjs, or vercel.json.',
     'Preserve tenant isolation and Mumbai-only production. Do not weaken tests or authentication to make a test pass.',
+    'If apply_error starts with AI_PATCH_EMPTY_AUTORECOVERY, the previous refusal was not sufficient by itself: use the expanded context and the standing new-file permission, then either produce the safe patch or block only for a concrete technical/security reason that cannot be resolved from the supplied files.',
     'Return JSON only: {"summary":"...","patch":"<unified diff>"}. The patch must be a valid git unified diff applicable to the exact supplied content.',
-    'If the request cannot be safely completed from the supplied context, return {"summary":"BLOCKED: ...","patch":""}.'
+    'If the request still cannot be safely completed, return {"summary":"BLOCKED: <specific non-owner-resolvable reason>","patch":""}.'
   ].join('\n');
-  const result=await brain(system,{command:clean(command,4000),files:context,previous_patch:String(previousPatch||'').slice(0,30000),apply_error:clean(applyError,1200)},7000);
+  const result=await brain(system,{command:clean(command,4000),files:context,previous_patch:String(previousPatch||'').slice(0,30000),apply_error:clean(applyError,1600)},7000);
   return {model:result.model,summary:clean(result.payload?.summary,1200),patch:String(result.payload?.patch||'').trim().slice(0,80000)};
 }
 

--- a/scripts/barman-tool-agent.mjs
+++ b/scripts/barman-tool-agent.mjs
@@ -14,7 +14,11 @@ function sh(file,args=[],options={}){
   return execFileSync(file,args,{encoding:'utf8',stdio:options.stdio||['ignore','pipe','pipe'],...options}).trim();
 }
 function git(args,options={}){return sh('git',args,options)}
-function changedFiles(){return git(['diff','--name-only','HEAD']).split('\n').map(x=>x.trim()).filter(Boolean)}
+function changedFiles(){
+  const tracked=git(['diff','--name-only','HEAD']).split('\n').map(x=>x.trim()).filter(Boolean);
+  const untracked=git(['ls-files','--others','--exclude-standard']).split('\n').map(x=>x.trim()).filter(Boolean);
+  return [...new Set([...tracked,...untracked])];
+}
 function forbiddenPath(path){
   return path.startsWith('.github/')
     ||/(^|\/)\.env(?:\.|$)/.test(path)
@@ -90,16 +94,60 @@ function grepFiles(term){
   if(![0,1].includes(r.status))return [];
   return String(r.stdout||'').split('\n').map(x=>x.trim()).filter(Boolean);
 }
+function readContextFile(path,allPaths){
+  if(!path||!allPaths.includes(path)||forbiddenPath(path))return null;
+  try{
+    const stat=fs.statSync(path);
+    if(!stat.isFile()||stat.size>24000)return null;
+    const content=fs.readFileSync(path,'utf8');
+    if(content.includes('\0'))return null;
+    return {path,content};
+  }catch{return null}
+}
 function buildContext(discovery,allPaths){
-  const selected=[];const add=path=>{if(!path||selected.includes(path)||!allPaths.includes(path)||forbiddenPath(path))return;try{const stat=fs.statSync(path);if(!stat.isFile()||stat.size>24000)return;const content=fs.readFileSync(path,'utf8');if(content.includes('\0'))return;selected.push(path)}catch{}};
+  const selected=[];const add=path=>{if(!path||selected.includes(path))return;const file=readContextFile(path,allPaths);if(file)selected.push(path)};
   for(const hint of discovery.file_hints||[])add(hint);
   for(const term of discovery.search_terms||[])for(const path of grepFiles(term))add(path);
   for(const hint of [...selected]){
     const base=hint.split('/').pop()?.replace(/\.[^.]+$/,'');
     if(!base)continue;
-    for(const path of allPaths){if(selected.length>=8)break;if(path.startsWith('test/')&&path.toLowerCase().includes(base.toLowerCase()))add(path)}
+    for(const path of allPaths){if(selected.length>=10)break;if(path.startsWith('test/')&&path.toLowerCase().includes(base.toLowerCase()))add(path)}
   }
-  return selected.slice(0,8).map(path=>({path,content:fs.readFileSync(path,'utf8')}));
+  return selected.slice(0,10).map(path=>readContextFile(path,allPaths)).filter(Boolean);
+}
+function expandContext(context,discovery,allPaths,commandText){
+  const selected=new Map(context.map(file=>[file.path,file]));
+  const add=path=>{if(selected.size>=12||selected.has(path))return;const file=readContextFile(path,allPaths);if(file)selected.set(path,file)};
+  add('package.json');
+
+  const tokens=new Set();
+  const addToken=value=>{
+    for(const part of String(value||'').toLowerCase().split(/[^a-z0-9_-]+/)){
+      for(const token of part.split(/[-_]+/))if(token.length>=4&&!['test','tests','file','code','dabbir'].includes(token))tokens.add(token);
+    }
+  };
+  for(const term of discovery.search_terms||[])addToken(term);
+  for(const file of context){
+    const base=file.path.split('/').pop()?.replace(/\.[^.]+$/,'')||'';
+    addToken(base);
+  }
+  for(const word of String(commandText||'').match(/[A-Za-z][A-Za-z0-9_-]{3,}/g)||[])addToken(word);
+
+  for(const file of context){
+    const base=file.path.split('/').pop()?.replace(/\.[^.]+$/,'').toLowerCase()||'';
+    if(!base)continue;
+    for(const path of allPaths){
+      if(selected.size>=12)break;
+      if(path.startsWith('test/')&&path.toLowerCase().includes(base))add(path);
+    }
+  }
+  for(const path of allPaths){
+    if(selected.size>=12)break;
+    const lower=path.toLowerCase();
+    if(!path.startsWith('test/'))continue;
+    if([...tokens].some(token=>lower.includes(token)))add(path);
+  }
+  return [...selected.values()].slice(0,12);
 }
 function applyPatch(patch){
   const check=spawnSync('git',['apply','--check','--whitespace=error-all','-'],{input:patch,encoding:'utf8'});
@@ -129,6 +177,7 @@ async function refreshBranch(branch){
 }
 
 let execution=null;
+let terminalPersisted=false;
 async function finalize(outcome,summary,evidence=[],error=''){
   if(!execution)return null;
   try{return await broker({phase:'finalize',command_id:execution.commandId,run_id:execution.runId,action_id:execution.actionId,outcome,summary,evidence,error})}
@@ -167,8 +216,20 @@ try{
 
   let proposal=await broker({phase:'patch',command:commandText,files:context});
   if(!proposal.patch){
-    await finalize('BLOCKED',proposal.summary||'تعذر إنشاء تعديل آمن من السياق المتاح.',[], 'AI_PATCH_EMPTY');
-    process.exit(0);
+    const firstSummary=proposal.summary||'AI_PATCH_EMPTY';
+    context=expandContext(context,discovery,allPaths,commandText);
+    console.log(`PATCH_EMPTY_RECOVERY context_files=${context.map(file=>file.path).join(',')}`);
+    proposal=await broker({
+      phase:'patch',
+      command:commandText,
+      files:context,
+      previous_patch:'',
+      apply_error:`AI_PATCH_EMPTY_AUTORECOVERY: The first attempt returned no patch. New files under test/ and supabase/migrations/ are already authorized and do not need to pre-exist. Infer conventions from the expanded context and execute the smallest safe change. First summary: ${clean(firstSummary,900)}`,
+    });
+    if(!proposal.patch){
+      await finalize('BLOCKED',proposal.summary||firstSummary,[], 'AI_PATCH_EMPTY_AFTER_AUTORECOVERY');
+      process.exit(0);
+    }
   }
   if(patchTouchesForbidden(proposal.patch))throw new Error('PATCH_TOUCHED_GOVERNANCE_FILE');
   let applied=applyPatch(proposal.patch);
@@ -221,10 +282,25 @@ try{
   ];
   const summary=`BARMAN نفّذ الأمر ودمج التغيير بعد CI ثم تحقق من Production وFull Customer Journey. PR #${pr.number}, commit ${mergeSha.slice(0,12)}.`;
   const result=await finalize('DONE',summary,evidence,'');
-  console.log('DONE',JSON.stringify({command_id:execution.commandId,pr:prUrl,merge_sha:mergeSha,notification:result?.notification||null}));
+  if(result?.finalized?.ok!==true)throw new Error('FINALIZE_DONE_NOT_PERSISTED');
+  terminalPersisted=true;
+  if(result.finalized.verification_status!=='INDEPENDENT_REQUIRED')throw new Error(`FINALIZE_TRUST_STATE_INVALID_${clean(result.finalized.verification_status||'missing',80)}`);
+
+  let verifierWake='DISPATCHED';
+  try{
+    await dispatch('barman-independent-verifier.yml','main',{});
+  }catch(error){
+    verifierWake=`FAILED_UNPROMOTED_${clean(error?.message||error,240)}`;
+    console.error('VERIFIER_WAKE_FAILED_UNPROMOTED',verifierWake);
+  }
+  console.log('DONE_AWAITING_INDEPENDENT_VERIFICATION',JSON.stringify({command_id:execution.commandId,pr:prUrl,merge_sha:mergeSha,verification_status:result.finalized.verification_status,verifier_wake:verifierWake,notification:result?.notification||null}));
 }catch(error){
   const message=clean(error?.stack||error?.message||error,1800);
   console.error('BARMAN_TOOL_AGENT_FAILED',message);
-  await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message);
+  if(!terminalPersisted){
+    await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message);
+  }else{
+    console.error('POST_FINALIZE_FAILURE_COMMAND_REMAINS_UNPROMOTED',execution?.commandId||'unknown');
+  }
   process.exitCode=1;
 }

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -56,6 +56,23 @@ test('persistent worker has schedule plus protected-main push wake-up',()=>{
   assert.match(worker,/api\/barman-tool-agent-broker\.js/);
 });
 
+test('empty AI patches trigger bounded autonomous context recovery instead of owner questions',()=>{
+  assert.match(worker,/PATCH_EMPTY_RECOVERY/);
+  assert.match(worker,/expandContext\(context,discovery,allPaths,commandText\)/);
+  assert.match(worker,/AI_PATCH_EMPTY_AUTORECOVERY/);
+  assert.match(worker,/AI_PATCH_EMPTY_AFTER_AUTORECOVERY/);
+  assert.match(worker,/add\('package\.json'\)/);
+  assert.match(broker,/explicitly authorized to create NEW files under test\//);
+  assert.match(broker,/does NOT need to already appear in the supplied context/);
+  assert.match(broker,/Never ask the owner to name the test file or reconfirm/);
+});
+
+test('new test and migration files are included in change detection and commit scope',()=>{
+  assert.match(worker,/git\(\['ls-files','--others','--exclude-standard'\]\)/);
+  assert.match(worker,/new Set\(\[\.\.\.tracked,\.\.\.untracked\]\)/);
+  assert.match(worker,/git\(\['add','--',\.\.\.changed\]\)/);
+});
+
 test('required branch-protection test context is emitted only by pull_request CI',()=>{
   assert.match(ci,/name:\s*\$\{\{\s*github\.event_name == 'pull_request' && 'test' \|\| 'ci-non-pr'\s*\}\}/);
   assert.match(ci,/Require terminal mobile release gates before merge/);
@@ -71,6 +88,16 @@ test('DONE requires CI, exact Production release and full customer journey',()=>
   assert.match(worker,/dispatch\('dabbir-ai-customer-journey\.yml','main'/);
   assert.match(worker,/waitWorkflow\('dabbir-ai-customer-journey\.yml','main'/);
   assert.match(worker,/finalize\('DONE'/);
+});
+
+test('executor persists independent-required state before waking verifier and cannot self-promote',()=>{
+  assert.match(worker,/FINALIZE_DONE_NOT_PERSISTED/);
+  assert.match(worker,/verification_status!=='INDEPENDENT_REQUIRED'/);
+  assert.match(worker,/terminalPersisted=true/);
+  assert.match(worker,/dispatch\('barman-independent-verifier\.yml','main',\{\}\)/);
+  assert.match(worker,/VERIFIER_WAKE_FAILED_UNPROMOTED/);
+  assert.match(worker,/POST_FINALIZE_FAILURE_COMMAND_REMAINS_UNPROMOTED/);
+  assert.doesNotMatch(worker,/barman_executive_verify_command_v1/);
 });
 
 test('broker finalization sends Telegram outcome and evidence remains fail-closed',()=>{


### PR DESCRIPTION
## P1 Golden CEO recovery repair

The first live Golden CEO command exposed a real autonomy failure: BARMAN claimed the low-risk regression-test task, but its patch brain returned `AI_PATCH_EMPTY` and asked the owner to name/authorize a new test file even though the standing policy already allowed new files under `test/`.

### Root causes repaired
- patch prompt now states unambiguously that new `test/` and `supabase/migrations/` paths do not need to pre-exist in supplied context and must not be escalated to the owner for filename confirmation;
- an empty first patch now triggers one bounded autonomous recovery pass with expanded neighboring test/package context instead of immediate BLOCKED;
- change detection now includes untracked files using `git ls-files --others --exclude-standard`, so a newly-created regression test cannot disappear from commit scope;
- after executor evidence is finalized as `DONE → INDEPENDENT_REQUIRED`, the Tool Agent uses its existing `Actions: write` permission only to dispatch the separate Independent Verifier workflow;
- the executor still has no verifier RPC and cannot self-promote;
- verifier wake failure is non-promoting/fail-closed, and a post-finalize error can no longer rewrite an already-persisted DONE command to RETRY.

### Evidence target
After CI and Production deployment, the same Golden command `236e97d0-5bd3-4415-92d0-c4631e85814b` will be requeued and must pass without owner clarification.