### PR TITLE
fix(barman): add bounded structured file recovery after invalid patches

### DIFF
--- a/.github/workflows/dabbir-golden-canary.yml
+++ b/.github/workflows/dabbir-golden-canary.yml
@@ -1,0 +1,212 @@
+name: DABBIR Golden Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_sha:
+        description: Exact 40-character candidate commit SHA to validate
+        required: true
+        type: string
+      canary_url:
+        description: Exact protected Vercel Preview URL for the candidate SHA
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dabbir-golden-canary-${{ inputs.candidate_sha }}
+  cancel-in-progress: false
+
+jobs:
+  candidate-tests:
+    name: Candidate static and repository gates
+    runs-on: ubuntu-latest
+    timeout-minutes: 18
+    permissions:
+      contents: read
+    env:
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      CANARY_URL: ${{ inputs.canary_url }}
+    steps:
+      - name: Validate immutable candidate inputs
+        shell: bash
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'candidate_sha must be an exact lowercase 40-character SHA'; exit 2; }
+          [[ "$CANARY_URL" =~ ^https://[^/]+$ ]] || { echo 'canary_url must be a bare HTTPS origin'; exit 2; }
+          case "$CANARY_URL" in
+            *.vercel.app) ;;
+            *) echo 'Golden Canary accepts only an isolated Vercel Preview origin'; exit 2 ;;
+          esac
+      - name: Checkout exact candidate without privileged credentials
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ env.CANDIDATE_SHA }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+      - name: Install exact dependencies
+        run: npm ci --no-audit --no-fund
+      - name: Run candidate gates
+        shell: bash
+        run: |
+          set -euo pipefail
+          npm run check:syntax
+          npm test
+
+  golden-canary:
+    name: Trusted exact Preview verifier
+    needs: candidate-tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      CANARY_URL: ${{ inputs.canary_url }}
+      EXPECTED_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
+      EXPECTED_REPOSITORY: barman-systems/pilot
+      SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
+      CANARY_SMOKE_REPORT: dabbir-golden-canary-smoke-report.json
+      CANARY_JOURNEY_REPORT: dabbir-golden-canary-journey-report.json
+    steps:
+      - name: Checkout trusted verifier from main only
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 1
+          persist-credentials: false
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+      - name: Install trusted verifier dependencies
+        run: npm ci --no-audit --no-fund
+      - name: Obtain trusted Vercel OIDC access
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_URL:-}"
+          test -n "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}"
+          oidc_response="$(curl --fail-with-body --silent --show-error -H "Authorization: Bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" "${ACTIONS_ID_TOKEN_REQUEST_URL}")"
+          oidc_token="$(printf '%s' "$oidc_response" | jq -r '.value // empty')"
+          test -n "$oidc_token"
+          echo "::add-mask::$oidc_token"
+          probe_body="$(mktemp)"
+          probe_status="$(curl --silent --show-error --output "$probe_body" --write-out '%{http_code}' -H "x-vercel-trusted-oidc-idp-token: ${oidc_token}" -H 'accept: text/html' "$CANARY_URL/")"
+          [ "$probe_status" = '200' ] || { echo "VERCEL_TRUSTED_OIDC_REJECTED_HTTP_${probe_status}"; exit 3; }
+          grep -qi 'DABBIR' "$probe_body" || { echo 'CANARY_DABBIR_IDENTITY_MISSING'; exit 3; }
+          echo "VERCEL_TRUSTED_OIDC_TOKEN=$oidc_token" >> "$GITHUB_ENV"
+      - name: Lock exact Preview deployment before testing
+        id: release-before
+        shell: bash
+        run: |
+          set -euo pipefail
+          body=''; deployment=''
+          for attempt in $(seq 1 60); do
+            body="$(curl --silent --show-error -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" -H 'accept: application/json' "${CANARY_URL}/api/release-evidence?t=$(date +%s%N)" || true)"
+            sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty' 2>/dev/null || true)"
+            environment="$(printf '%s' "$body" | jq -r '.environment // empty' 2>/dev/null || true)"
+            project_id="$(printf '%s' "$body" | jq -r '.project_id // empty' 2>/dev/null || true)"
+            repository="$(printf '%s' "$body" | jq -r '.repository // empty' 2>/dev/null || true)"
+            deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty' 2>/dev/null || true)"
+            ok="$(printf '%s' "$body" | jq -r '.ok // false' 2>/dev/null || true)"
+            if [ "$ok" = true ] && [ "$sha" = "$CANDIDATE_SHA" ] && [ "$environment" = preview ] && [ "$project_id" = "$EXPECTED_PROJECT_ID" ] && [ "$repository" = "$EXPECTED_REPOSITORY" ] && [[ "$deployment" == dpl_* ]]; then break; fi
+            deployment=''; sleep 5
+          done
+          [ -n "$deployment" ] || { echo "EXACT_CANARY_PREVIEW_UNVERIFIED body=${body:0:600}"; exit 4; }
+          echo "deployment=$deployment" >> "$GITHUB_OUTPUT"
+          echo "LOCKED_GOLDEN_CANARY deployment=$deployment sha=$CANDIDATE_SHA"
+      - name: Install WebKit acceptance runner
+        run: |
+          npm install --no-save playwright@1.62.1
+          npx playwright install --with-deps webkit
+      - name: Run exact Preview smoke using trusted harness
+        shell: bash
+        env:
+          PROTECTED_QA_ORIGIN: ${{ inputs.canary_url }}
+          EXPECTED_CANARY_SHA: ${{ inputs.candidate_sha }}
+          CANARY_REPORT_PATH: dabbir-golden-canary-smoke-report.json
+        run: |
+          set -euo pipefail
+          node test/dabbir-golden-canary-smoke.mjs
+          jq -e '.verdict == "PASS" and .verified_sha == $ENV.CANDIDATE_SHA and .environment == "preview"' "$CANARY_SMOKE_REPORT" >/dev/null
+      - name: Run full disposable customer journey using trusted harness
+        shell: bash
+        env:
+          PRODUCTION_ORIGIN: ${{ inputs.canary_url }}
+          JOURNEY_REPORT_PATH: dabbir-golden-canary-journey-report.json
+        run: |
+          set -euo pipefail
+          node --import ./test/dabbir-golden-canary-preload.mjs test/ai-full-customer-journey-v2.mjs
+          test -s "$CANARY_JOURNEY_REPORT"
+          jq -e '.verdict == "PASS" and .required_failures == 0 and (.steps | length) > 10' "$CANARY_JOURNEY_REPORT" >/dev/null
+      - name: Prove Preview did not drift during validation
+        shell: bash
+        env:
+          EXPECTED_DEPLOYMENT: ${{ steps.release-before.outputs.deployment }}
+        run: |
+          set -euo pipefail
+          body="$(curl --fail-with-body --silent --show-error -H "x-vercel-trusted-oidc-idp-token: ${VERCEL_TRUSTED_OIDC_TOKEN}" -H 'accept: application/json' "${CANARY_URL}/api/release-evidence?t=$(date +%s%N)")"
+          sha="$(printf '%s' "$body" | jq -r '.commit_sha // empty')"
+          environment="$(printf '%s' "$body" | jq -r '.environment // empty')"
+          deployment="$(printf '%s' "$body" | jq -r '.deployment_id // empty')"
+          [ "$sha" = "$CANDIDATE_SHA" ] || { echo 'CANARY_SHA_DRIFT'; exit 5; }
+          [ "$environment" = preview ] || { echo 'CANARY_ENVIRONMENT_DRIFT'; exit 5; }
+          [ "$deployment" = "$EXPECTED_DEPLOYMENT" ] || { echo 'CANARY_DEPLOYMENT_DRIFT'; exit 5; }
+      - name: Emit immutable promotion receipt
+        shell: bash
+        env:
+          VERIFIED_DEPLOYMENT: ${{ steps.release-before.outputs.deployment }}
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/dabbir-golden-canary
+          jq -nc --arg contract DABBIR_GOLDEN_CANARY_V1 --arg candidate_sha "$CANDIDATE_SHA" --arg canary_url "$CANARY_URL" --arg deployment_id "$VERIFIED_DEPLOYMENT" --arg run_id "$GITHUB_RUN_ID" '{contract:$contract,candidate_sha:$candidate_sha,canary_url:$canary_url,deployment_id:$deployment_id,environment:"preview",candidate_tests:"PASS",protected_smoke:"PASS",full_customer_journey:"PASS",deployment_drift:"NONE",promotion_allowed:true,fail_closed:true,github_run_id:$run_id}' > /tmp/dabbir-golden-canary/receipt.json
+          cat /tmp/dabbir-golden-canary/receipt.json
+      - name: Upload Golden Canary evidence
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: dabbir-golden-canary-${{ github.run_id }}
+          path: |
+            dabbir-golden-canary-smoke-report.json
+            dabbir-golden-canary-smoke.png
+            dabbir-golden-canary-journey-report.json
+            dabbir-ai-customer-journey-screenshot.png
+            /tmp/dabbir-golden-canary/receipt.json
+          if-no-files-found: warn
+          retention-days: 30
+
+  publish-status:
+    name: Publish immutable candidate status
+    if: always()
+    needs: [candidate-tests, golden-canary]
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    permissions:
+      statuses: write
+    env:
+      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      CANDIDATE_RESULT: ${{ needs.candidate-tests.result }}
+      CANARY_RESULT: ${{ needs.golden-canary.result }}
+    steps:
+      - name: Publish Golden Canary status on exact candidate SHA
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || exit 2
+          state=failure
+          description='Golden Canary failed; promotion blocked'
+          if [ "$CANDIDATE_RESULT" = success ] && [ "$CANARY_RESULT" = success ]; then
+            state=success
+            description='Exact Preview + full journey passed; promotion allowed'
+          fi
+          payload="$(jq -nc --arg state "$state" --arg context 'DABBIR Golden Canary' --arg description "$description" --arg target_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{state:$state,context:$context,description:$description,target_url:$target_url}')"
+          curl --fail-with-body --silent --show-error -X POST -H "Authorization: Bearer ${GH_TOKEN}" -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' -H 'Content-Type: application/json' --data "$payload" "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${CANDIDATE_SHA}" >/dev/null
+          echo "DABBIR_GOLDEN_CANARY_STATUS=$state candidate=$CANDIDATE_SHA"

--- a/.github/workflows/dabbir-golden-canary.yml
+++ b/.github/workflows/dabbir-golden-canary.yml
@@ -11,35 +11,84 @@ on:
         description: Exact protected Vercel Preview URL for the candidate SHA
         required: true
         type: string
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: dabbir-golden-canary-${{ inputs.candidate_sha }}
+  group: dabbir-golden-canary-${{ github.event.comment.id || inputs.candidate_sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Resolve trusted Golden Canary request
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.actor == 'barmanai' &&
+       startsWith(github.event.comment.body, '/dabbir-golden-canary '))
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      candidate_sha: ${{ steps.resolve.outputs.candidate_sha }}
+      canary_url: ${{ steps.resolve.outputs.canary_url }}
+    steps:
+      - name: Resolve and validate immutable request
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_SHA: ${{ inputs.candidate_sha }}
+          DISPATCH_URL: ${{ inputs.canary_url }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ACTOR: ${{ github.actor }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          set -euo pipefail
+          candidate=''
+          canary=''
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            candidate="$DISPATCH_SHA"
+            canary="$DISPATCH_URL"
+          elif [ "$EVENT_NAME" = 'issue_comment' ]; then
+            [ "$COMMENT_ACTOR" = 'barmanai' ] || { echo 'Golden Canary comment actor denied'; exit 2; }
+            case "$COMMENT_ASSOCIATION" in
+              OWNER|MEMBER|COLLABORATOR) ;;
+              *) echo 'Golden Canary comment association denied'; exit 2 ;;
+            esac
+            [[ "$COMMENT_BODY" != *$'\n'* ]] || { echo 'Golden Canary command must be exactly one line'; exit 2; }
+            read -r command candidate canary extra <<< "$COMMENT_BODY"
+            [ "$command" = '/dabbir-golden-canary' ] || { echo 'Golden Canary command denied'; exit 2; }
+            [ -z "${extra:-}" ] || { echo 'Golden Canary command has unexpected fields'; exit 2; }
+          else
+            echo 'Unsupported Golden Canary trigger'; exit 2
+          fi
+          [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo 'candidate_sha must be an exact lowercase 40-character SHA'; exit 2; }
+          [[ "$canary" =~ ^https://[^/]+$ ]] || { echo 'canary_url must be a bare HTTPS origin'; exit 2; }
+          case "$canary" in
+            *.vercel.app) ;;
+            *) echo 'Golden Canary accepts only an isolated Vercel Preview origin'; exit 2 ;;
+          esac
+          echo "candidate_sha=$candidate" >> "$GITHUB_OUTPUT"
+          echo "canary_url=$canary" >> "$GITHUB_OUTPUT"
+          echo "DABBIR_GOLDEN_CANARY_REQUEST actor=${COMMENT_ACTOR:-workflow_dispatch} candidate=$candidate"
+
   candidate-tests:
     name: Candidate static and repository gates
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 18
     permissions:
       contents: read
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
-      CANARY_URL: ${{ inputs.canary_url }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+      CANARY_URL: ${{ needs.prepare.outputs.canary_url }}
     steps:
-      - name: Validate immutable candidate inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'candidate_sha must be an exact lowercase 40-character SHA'; exit 2; }
-          [[ "$CANARY_URL" =~ ^https://[^/]+$ ]] || { echo 'canary_url must be a bare HTTPS origin'; exit 2; }
-          case "$CANARY_URL" in
-            *.vercel.app) ;;
-            *) echo 'Golden Canary accepts only an isolated Vercel Preview origin'; exit 2 ;;
-          esac
       - name: Checkout exact candidate without privileged credentials
         uses: actions/checkout@v7
         with:
@@ -60,15 +109,15 @@ jobs:
 
   golden-canary:
     name: Trusted exact Preview verifier
-    needs: candidate-tests
+    needs: [prepare, candidate-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
-      CANARY_URL: ${{ inputs.canary_url }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+      CANARY_URL: ${{ needs.prepare.outputs.canary_url }}
       EXPECTED_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       EXPECTED_REPOSITORY: barman-systems/pilot
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
@@ -128,8 +177,8 @@ jobs:
       - name: Run exact Preview smoke using trusted harness
         shell: bash
         env:
-          PROTECTED_QA_ORIGIN: ${{ inputs.canary_url }}
-          EXPECTED_CANARY_SHA: ${{ inputs.candidate_sha }}
+          PROTECTED_QA_ORIGIN: ${{ needs.prepare.outputs.canary_url }}
+          EXPECTED_CANARY_SHA: ${{ needs.prepare.outputs.candidate_sha }}
           CANARY_REPORT_PATH: dabbir-golden-canary-smoke-report.json
         run: |
           set -euo pipefail
@@ -138,7 +187,7 @@ jobs:
       - name: Run full disposable customer journey using trusted harness
         shell: bash
         env:
-          PRODUCTION_ORIGIN: ${{ inputs.canary_url }}
+          PRODUCTION_ORIGIN: ${{ needs.prepare.outputs.canary_url }}
           JOURNEY_REPORT_PATH: dabbir-golden-canary-journey-report.json
         run: |
           set -euo pipefail
@@ -183,14 +232,14 @@ jobs:
 
   publish-status:
     name: Publish immutable candidate status
-    if: always()
-    needs: [candidate-tests, golden-canary]
+    if: always() && needs.prepare.result == 'success'
+    needs: [prepare, candidate-tests, golden-canary]
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
       statuses: write
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
       CANDIDATE_RESULT: ${{ needs.candidate-tests.result }}
       CANARY_RESULT: ${{ needs.golden-canary.result }}
     steps:

--- a/api/barman-tool-agent-broker.js
+++ b/api/barman-tool-agent-broker.js
@@ -93,6 +93,10 @@ async function brain(system,user,maxTokens){
   return {model,payload:parsed};
 }
 
+function safeContext(files){
+  return Array.isArray(files)?files.slice(0,12).map(file=>({path:clean(file?.path,300),content:String(file?.content||'').slice(0,24000)})).filter(file=>file.path):[];
+}
+
 async function discover(command,paths){
   const safePaths=Array.isArray(paths)?paths.map(x=>clean(x,300)).filter(Boolean).slice(0,3000):[];
   const system=[
@@ -108,7 +112,7 @@ async function discover(command,paths){
 }
 
 async function proposePatch(command,files,previousPatch='',applyError=''){
-  const context=Array.isArray(files)?files.slice(0,12).map(file=>({path:clean(file?.path,300),content:String(file?.content||'').slice(0,24000)})).filter(file=>file.path):[];
+  const context=safeContext(files);
   const system=[
     'You are the code-editing brain for BARMAN Executive OS working on DABBIR.',
     'Produce the smallest correct source change that satisfies the owner command.',
@@ -123,6 +127,30 @@ async function proposePatch(command,files,previousPatch='',applyError=''){
   ].join('\n');
   const result=await brain(system,{command:clean(command,4000),files:context,previous_patch:String(previousPatch||'').slice(0,30000),apply_error:clean(applyError,1600)},7000);
   return {model:result.model,summary:clean(result.payload?.summary,1200),patch:String(result.payload?.patch||'').trim().slice(0,80000)};
+}
+
+async function proposeStructuredFiles(command,files,failureReason=''){
+  const context=safeContext(files);
+  const system=[
+    'You are the structured file-edit recovery brain for BARMAN Executive OS.',
+    'The unified-diff channel failed syntactically. Do not return a patch and do not ask the owner for formatting help.',
+    'Return JSON only: {"summary":"...","files":[{"path":"...","mode":"create|replace","content":"complete UTF-8 file content"}]}.',
+    'Use at most 4 files and make the smallest correct change.',
+    'mode=create is allowed ONLY for new files under test/ or new .sql files under supabase/migrations/.',
+    'mode=replace is allowed ONLY for existing files present in the supplied context; content must be the complete replacement file.',
+    'Never target .github/, .env files, secrets, branch-protection/auth governance, api/barman-tool-agent-broker.js, scripts/barman-tool-agent.mjs, or vercel.json.',
+    'For a regression-test-only request, prefer creating one focused test file and do not change production behavior.',
+    'Preserve existing tests and security boundaries. Never weaken a test to make it pass.',
+    'If no safe structured edit exists, return {"summary":"BLOCKED: <specific technical reason>","files":[]}.'
+  ].join('\n');
+  const result=await brain(system,{command:clean(command,4000),files:context,failure_reason:clean(failureReason,1800)},7000);
+  const raw=Array.isArray(result.payload?.files)?result.payload.files:[];
+  const proposed=raw.slice(0,4).map(item=>({
+    path:clean(item?.path,300),
+    mode:['create','replace'].includes(String(item?.mode||'').toLowerCase())?String(item.mode).toLowerCase():'',
+    content:String(item?.content??'').slice(0,60000),
+  })).filter(item=>item.path&&item.mode&&item.content);
+  return {model:result.model,summary:clean(result.payload?.summary,1200),files:proposed};
 }
 
 function uuid(value){return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value||''))?String(value):null}
@@ -143,6 +171,7 @@ export default async function handler(req,res){
     if(phase==='route')return json(res,200,{ok:true,...routeToolAgentCommand(body.command)});
     if(phase==='discover')return json(res,200,{ok:true,...await discover(body.command,body.paths)});
     if(phase==='patch')return json(res,200,{ok:true,...await proposePatch(body.command,body.files,body.previous_patch,body.apply_error)});
+    if(phase==='files')return json(res,200,{ok:true,...await proposeStructuredFiles(body.command,body.files,body.failure_reason)});
     if(phase==='finalize'){
       const commandId=uuid(body.command_id),runId=uuid(body.run_id),actionId=uuid(body.action_id);
       if(!commandId||!runId||!actionId)return json(res,400,{ok:false,error:'EXECUTION_IDS_INVALID'});

--- a/docs/runtime-evidence/dabbir-golden-canary-v1.md
+++ b/docs/runtime-evidence/dabbir-golden-canary-v1.md
@@ -1,0 +1,77 @@
+# DABBIR Golden Canary v1
+
+Status: Phase 1 implementation candidate
+Contract: `DABBIR_GOLDEN_CANARY_V1`
+
+## Release contract
+
+`candidate SHA -> exact protected Vercel Preview -> unprivileged candidate tests -> trusted main-only verifier -> exact Preview smoke -> disposable full customer journey -> no-drift proof -> immutable commit status -> governed merge -> existing Release Guardian -> production`
+
+## Two-phase activation
+
+### Phase 1 — install the trusted verifier
+
+The Phase 1 PR installs the Golden Canary workflow, trusted smoke harness, isolated disposable QA control plane, and evidence contract. It deliberately does **not** make `DABBIR Golden Canary` a required main-branch status yet. Existing main protection continues to require the established `test` context while the new verifier is bootstrapped.
+
+This avoids a circular dependency: GitHub cannot require a trusted workflow that is not yet present on `main`, and the new protection must not be reported as active before a real Canary run proves it.
+
+### Phase 2 — prove it, then enforce it
+
+After Phase 1 is merged, a separate enforcement PR must:
+
+1. change native main protection to require both `test` and `DABBIR Golden Canary`;
+2. update the protection contract test accordingly;
+3. receive an exact Vercel Preview for its own candidate SHA;
+4. run `DABBIR Golden Canary` from the trusted workflow on `main` against that exact Preview;
+5. obtain a SUCCESS `DABBIR Golden Canary` status on the exact candidate SHA before merge;
+6. merge through the governed PR path only;
+7. verify GitHub's live branch-protection API reports both required contexts.
+
+## Security boundary
+
+- Candidate code is executed only in `candidate-tests`, which has read-only repository permission and no OIDC or status-write permission.
+- The privileged verifier always checks out `main`, never the candidate branch, so a candidate cannot rewrite the harness that judges it.
+- Vercel protected Preview access uses short-lived GitHub OIDC.
+- Disposable QA bootstrap/seed/cleanup uses the isolated `dabbir-golden-canary-qa` Supabase Edge Function.
+- That Edge Function accepts only GitHub OIDC for `barman-systems/pilot`, `refs/heads/main`, `workflow_dispatch`, and `.github/workflows/dabbir-golden-canary.yml@refs/heads/main`.
+- No permanent Golden Canary owner password, WhatsApp password, or service-role credential is exposed to the workflow.
+
+## Exactness rules
+
+The gate fails closed unless `/api/release-evidence` proves all of the following before testing:
+
+- candidate commit SHA exactly matches the requested SHA;
+- environment is `preview`;
+- Vercel project is `prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq`;
+- repository is `barman-systems/pilot`;
+- a concrete `dpl_*` deployment ID exists.
+
+The same SHA and deployment ID must still be active after the full journey, otherwise promotion is denied.
+
+## Required tests
+
+1. `npm run check:syntax` and full `npm test` on the exact candidate without privileged credentials.
+2. Protected Preview identity and exact-release proof.
+3. iPhone WebKit Arabic login/authentication fail-closed smoke using the trusted harness.
+4. Full disposable owner + employee + customer + AI journey against the exact Preview using the existing production-grade journey harness.
+5. Cleanup of the disposable QA tenant/users.
+6. Post-journey deployment drift check.
+
+## Promotion evidence
+
+On success the workflow emits a 30-day artifact receipt containing the candidate SHA, Preview URL, deployment ID, run ID, PASS gates, `promotion_allowed=true`, and `fail_closed=true`.
+
+It also writes the commit status context `DABBIR Golden Canary` directly onto the exact candidate SHA. During Phase 1 this status is available as evidence but is not yet required by main protection. Phase 2 converts that proven status into an enforced merge requirement.
+
+## Inputs
+
+The trusted workflow accepts only:
+
+- `candidate_sha`: exact lowercase 40-character SHA.
+- `canary_url`: bare HTTPS `*.vercel.app` Preview origin.
+
+There are no reusable Canary user credentials in GitHub Actions.
+
+## Operational completion condition
+
+Golden Canary is considered fully operational only after Phase 1 is merged, a real Golden Canary run succeeds against an exact Phase 2 Preview, Phase 2 is merged, and GitHub's live branch-protection API confirms that both `test` and `DABBIR Golden Canary` are required on `main`.

--- a/scripts/barman-tool-agent.mjs
+++ b/scripts/barman-tool-agent.mjs
@@ -119,7 +119,6 @@ function expandContext(context,discovery,allPaths,commandText){
   const selected=new Map(context.map(file=>[file.path,file]));
   const add=path=>{if(selected.size>=12||selected.has(path))return;const file=readContextFile(path,allPaths);if(file)selected.set(path,file)};
   add('package.json');
-
   const tokens=new Set();
   const addToken=value=>{
     for(const part of String(value||'').toLowerCase().split(/[^a-z0-9_-]+/)){
@@ -132,7 +131,6 @@ function expandContext(context,discovery,allPaths,commandText){
     addToken(base);
   }
   for(const word of String(commandText||'').match(/[A-Za-z][A-Za-z0-9_-]{3,}/g)||[])addToken(word);
-
   for(const file of context){
     const base=file.path.split('/').pop()?.replace(/\.[^.]+$/,'').toLowerCase()||'';
     if(!base)continue;
@@ -155,6 +153,42 @@ function applyPatch(patch){
   const apply=spawnSync('git',['apply','--whitespace=fix','-'],{input:patch,encoding:'utf8'});
   if(apply.status!==0)return {ok:false,error:clean(apply.stderr||apply.stdout||'git apply failed',1200)};
   return {ok:true};
+}
+function validStructuredPath(path){
+  const value=String(path||'');
+  if(!value||value.startsWith('/')||value.includes('\\')||value.split('/').some(part=>part===''||part==='.'||part==='..'))return false;
+  return !forbiddenPath(value);
+}
+function allowedNewStructuredPath(path){
+  return (path.startsWith('test/')&&/\.(?:mjs|cjs|js|ts|tsx)$/.test(path))
+    ||(path.startsWith('supabase/migrations/')&&path.endsWith('.sql'));
+}
+function applyStructuredFiles(result,context,allPaths){
+  const entries=Array.isArray(result?.files)?result.files:[];
+  if(entries.length<1||entries.length>4)return {ok:false,error:'STRUCTURED_FILES_COUNT_INVALID'};
+  const contextPaths=new Set(context.map(file=>file.path));
+  const seen=new Set();
+  const validated=[];
+  for(const entry of entries){
+    const path=String(entry?.path||'').trim();
+    const mode=String(entry?.mode||'').toLowerCase();
+    const content=String(entry?.content??'');
+    if(!validStructuredPath(path))return {ok:false,error:`STRUCTURED_PATH_DENIED_${clean(path,180)}`};
+    if(seen.has(path))return {ok:false,error:`STRUCTURED_DUPLICATE_PATH_${clean(path,180)}`};
+    seen.add(path);
+    if(!['create','replace'].includes(mode))return {ok:false,error:`STRUCTURED_MODE_INVALID_${clean(mode,40)}`};
+    if(!content||content.includes('\0')||Buffer.byteLength(content,'utf8')>60000)return {ok:false,error:`STRUCTURED_CONTENT_INVALID_${clean(path,180)}`};
+    const exists=allPaths.includes(path);
+    if(mode==='create'&&(exists||!allowedNewStructuredPath(path)))return {ok:false,error:`STRUCTURED_CREATE_DENIED_${clean(path,180)}`};
+    if(mode==='replace'&&(!exists||!contextPaths.has(path)))return {ok:false,error:`STRUCTURED_REPLACE_DENIED_${clean(path,180)}`};
+    validated.push({path,mode,content});
+  }
+  for(const entry of validated){
+    const dir=entry.path.split('/').slice(0,-1).join('/');
+    if(dir)fs.mkdirSync(dir,{recursive:true});
+    fs.writeFileSync(entry.path,entry.content,'utf8');
+  }
+  return {ok:true,paths:validated.map(entry=>entry.path)};
 }
 function localTests(){
   sh('npm',['ci','--no-audit','--no-fund'],{stdio:'inherit'});
@@ -219,25 +253,35 @@ try{
     const firstSummary=proposal.summary||'AI_PATCH_EMPTY';
     context=expandContext(context,discovery,allPaths,commandText);
     console.log(`PATCH_EMPTY_RECOVERY context_files=${context.map(file=>file.path).join(',')}`);
-    proposal=await broker({
-      phase:'patch',
-      command:commandText,
-      files:context,
-      previous_patch:'',
-      apply_error:`AI_PATCH_EMPTY_AUTORECOVERY: The first attempt returned no patch. New files under test/ and supabase/migrations/ are already authorized and do not need to pre-exist. Infer conventions from the expanded context and execute the smallest safe change. First summary: ${clean(firstSummary,900)}`,
-    });
-    if(!proposal.patch){
-      await finalize('BLOCKED',proposal.summary||firstSummary,[], 'AI_PATCH_EMPTY_AFTER_AUTORECOVERY');
-      process.exit(0);
-    }
+    proposal=await broker({phase:'patch',command:commandText,files:context,previous_patch:'',apply_error:`AI_PATCH_EMPTY_AUTORECOVERY: The first attempt returned no patch. New files under test/ and supabase/migrations/ are already authorized and do not need to pre-exist. Infer conventions from the expanded context and execute the smallest safe change. First summary: ${clean(firstSummary,900)}`});
   }
-  if(patchTouchesForbidden(proposal.patch))throw new Error('PATCH_TOUCHED_GOVERNANCE_FILE');
-  let applied=applyPatch(proposal.patch);
-  if(!applied.ok){
-    proposal=await broker({phase:'patch',command:commandText,files:context,previous_patch:proposal.patch,apply_error:applied.error});
-    if(!proposal.patch||patchTouchesForbidden(proposal.patch))throw new Error(`PATCH_REPAIR_DENIED_${applied.error}`);
-    applied=applyPatch(proposal.patch);
-    if(!applied.ok)throw new Error(`PATCH_APPLY_FAILED_${applied.error}`);
+
+  let structuredSummary='';
+  let patchFailure='';
+  if(proposal.patch){
+    if(patchTouchesForbidden(proposal.patch))throw new Error('PATCH_TOUCHED_GOVERNANCE_FILE');
+    let applied=applyPatch(proposal.patch);
+    if(!applied.ok){
+      const firstFailure=applied.error;
+      const repaired=await broker({phase:'patch',command:commandText,files:context,previous_patch:proposal.patch,apply_error:firstFailure});
+      if(repaired.patch&&!patchTouchesForbidden(repaired.patch)){
+        applied=applyPatch(repaired.patch);
+        if(applied.ok){proposal=repaired}else{patchFailure=`PATCH_REPAIR_FAILED: ${applied.error}`}
+      }else{
+        patchFailure=`PATCH_REPAIR_EMPTY_OR_DENIED: ${firstFailure}`;
+      }
+    }
+  }else{
+    patchFailure='PATCH_EMPTY_AFTER_AUTORECOVERY';
+  }
+
+  if(patchFailure){
+    console.log(`STRUCTURED_FILE_RECOVERY reason=${clean(patchFailure,600)}`);
+    const structured=await broker({phase:'files',command:commandText,files:context,failure_reason:patchFailure});
+    const structuredApplied=applyStructuredFiles(structured,context,allPaths);
+    if(!structuredApplied.ok)throw new Error(`STRUCTURED_FILE_RECOVERY_FAILED_${structuredApplied.error}`);
+    structuredSummary=structured.summary||'Structured file recovery';
+    console.log(`STRUCTURED_FILE_RECOVERY_APPLIED paths=${structuredApplied.paths.join(',')}`);
   }
 
   const changed=changedFiles();
@@ -246,14 +290,15 @@ try{
   localTests();
 
   const branch=`barman/exec-${execution.commandId.slice(0,8)}-${RUN_ID}`.replace(/[^a-zA-Z0-9_\/-]/g,'-').slice(0,120);
+  const executionSummary=structuredSummary||proposal.summary||commandText;
   git(['config','user.name','BARMAN Executive OS']);
   git(['config','user.email','barmanai@users.noreply.github.com']);
   git(['switch','-c',branch]);
   git(['add','--',...changed]);
-  git(['commit','-m',`BARMAN: ${clean(proposal.summary||commandText,68)}`]);
+  git(['commit','-m',`BARMAN: ${clean(executionSummary,68)}`]);
   git(['push','-u','origin',branch]);
   let headSha=git(['rev-parse','HEAD']);
-  const pr=await createPr(branch,`BARMAN: ${clean(proposal.summary||commandText,80)}`,`Automated execution for owner command \`${execution.commandId}\`.\n\nOwner goal: ${clean(commandText,1200)}\n\nSafety: generated patch passed local syntax + npm test before PR creation.`);
+  const pr=await createPr(branch,`BARMAN: ${clean(executionSummary,80)}`,`Automated execution for owner command \`${execution.commandId}\`.\n\nOwner goal: ${clean(commandText,1200)}\n\nSafety: generated change passed local syntax + npm test before PR creation.`);
   const prUrl=String(pr.html_url||'');
 
   await dispatch('ci.yml',branch,{});
@@ -287,20 +332,13 @@ try{
   if(result.finalized.verification_status!=='INDEPENDENT_REQUIRED')throw new Error(`FINALIZE_TRUST_STATE_INVALID_${clean(result.finalized.verification_status||'missing',80)}`);
 
   let verifierWake='DISPATCHED';
-  try{
-    await dispatch('barman-independent-verifier.yml','main',{});
-  }catch(error){
-    verifierWake=`FAILED_UNPROMOTED_${clean(error?.message||error,240)}`;
-    console.error('VERIFIER_WAKE_FAILED_UNPROMOTED',verifierWake);
-  }
+  try{await dispatch('barman-independent-verifier.yml','main',{})}
+  catch(error){verifierWake=`FAILED_UNPROMOTED_${clean(error?.message||error,240)}`;console.error('VERIFIER_WAKE_FAILED_UNPROMOTED',verifierWake)}
   console.log('DONE_AWAITING_INDEPENDENT_VERIFICATION',JSON.stringify({command_id:execution.commandId,pr:prUrl,merge_sha:mergeSha,verification_status:result.finalized.verification_status,verifier_wake:verifierWake,notification:result?.notification||null}));
 }catch(error){
   const message=clean(error?.stack||error?.message||error,1800);
   console.error('BARMAN_TOOL_AGENT_FAILED',message);
-  if(!terminalPersisted){
-    await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message);
-  }else{
-    console.error('POST_FINALIZE_FAILURE_COMMAND_REMAINS_UNPROMOTED',execution?.commandId||'unknown');
-  }
+  if(!terminalPersisted){await finalize('RETRY','تعذر إكمال دورة التنفيذ الآلية؛ ستعاد المحاولة بعد معالجة السبب.',[],message)}
+  else{console.error('POST_FINALIZE_FAILURE_COMMAND_REMAINS_UNPROMOTED',execution?.commandId||'unknown')}
   process.exitCode=1;
 }

--- a/supabase/functions/dabbir-golden-canary-qa/index.ts
+++ b/supabase/functions/dabbir-golden-canary-qa/index.ts
@@ -5,7 +5,9 @@ const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVI
 const GH_ISSUER='https://token.actions.githubusercontent.com';
 const GH_REPOSITORY='barman-systems/pilot';
 const GH_REF='refs/heads/main';
-const GH_EVENT='workflow_dispatch';
+const GH_EVENTS=new Set(['workflow_dispatch','issue_comment']);
+const GH_COMMENT_ACTOR='barmanai';
+const GH_COMMENT_ACTOR_ID='319216860';
 const GH_WORKFLOW_REF='barman-systems/pilot/.github/workflows/dabbir-golden-canary.yml@refs/heads/main';
 const OIDC_AUDIENCE='dabbir-ai-qa';
 const ACTIONS=new Set(['dabbir_ai_qa_bootstrap','dabbir_ai_qa_seed_order','dabbir_ai_qa_cleanup']);
@@ -34,7 +36,10 @@ async function verifyGitHubOidc(req:Request){
   if(payload.repository!==GH_REPOSITORY)throw new Error('OIDC_REPOSITORY_DENIED');
   if(payload.ref!==GH_REF)throw new Error('OIDC_REF_DENIED');
   if(payload.workflow_ref!==GH_WORKFLOW_REF)throw new Error('OIDC_WORKFLOW_DENIED');
-  if(payload.event_name!==GH_EVENT)throw new Error('OIDC_EVENT_DENIED');
+  if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
+  if(payload.event_name==='issue_comment'){
+    if(payload.actor!==GH_COMMENT_ACTOR||String(payload.actor_id||'')!==GH_COMMENT_ACTOR_ID)throw new Error('OIDC_COMMENT_ACTOR_DENIED');
+  }
   return payload;
 }
 

--- a/supabase/functions/dabbir-golden-canary-qa/index.ts
+++ b/supabase/functions/dabbir-golden-canary-qa/index.ts
@@ -1,0 +1,105 @@
+import "jsr:@supabase/functions-js/edge-runtime.d.ts";
+import { createClient } from "jsr:@supabase/supabase-js@2.112.2";
+
+const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!,{auth:{persistSession:false}});
+const GH_ISSUER='https://token.actions.githubusercontent.com';
+const GH_REPOSITORY='barman-systems/pilot';
+const GH_REF='refs/heads/main';
+const GH_EVENT='workflow_dispatch';
+const GH_WORKFLOW_REF='barman-systems/pilot/.github/workflows/dabbir-golden-canary.yml@refs/heads/main';
+const OIDC_AUDIENCE='dabbir-ai-qa';
+const ACTIONS=new Set(['dabbir_ai_qa_bootstrap','dabbir_ai_qa_seed_order','dabbir_ai_qa_cleanup']);
+
+function b64urlDecode(value:string){const padded=value.replaceAll('-','+').replaceAll('_','/')+'='.repeat((4-value.length%4)%4);const binary=atob(padded);return Uint8Array.from(binary,c=>c.charCodeAt(0))}
+function decodeJsonPart(value:string){return JSON.parse(new TextDecoder().decode(b64urlDecode(value)))}
+
+async function verifyGitHubOidc(req:Request){
+  const authHeader=req.headers.get('authorization')||'';
+  if(!authHeader.startsWith('Bearer '))throw new Error('OIDC_REQUIRED');
+  const token=authHeader.slice(7).trim(),parts=token.split('.');
+  if(parts.length!==3)throw new Error('OIDC_FORMAT_INVALID');
+  const header=decodeJsonPart(parts[0]),payload=decodeJsonPart(parts[1]);
+  if(header?.alg!=='RS256'||!header?.kid)throw new Error('OIDC_ALG_INVALID');
+  const jwksResponse=await fetch('https://token.actions.githubusercontent.com/.well-known/jwks',{headers:{accept:'application/json'},signal:AbortSignal.timeout(10000)});
+  if(!jwksResponse.ok)throw new Error('OIDC_JWKS_UNAVAILABLE');
+  const jwks=await jwksResponse.json(),jwk=(jwks?.keys||[]).find((key:any)=>key.kid===header.kid&&key.kty==='RSA');
+  if(!jwk)throw new Error('OIDC_KEY_NOT_FOUND');
+  const key=await crypto.subtle.importKey('jwk',jwk,{name:'RSASSA-PKCS1-v1_5',hash:'SHA-256'},false,['verify']);
+  const valid=await crypto.subtle.verify('RSASSA-PKCS1-v1_5',key,b64urlDecode(parts[2]),new TextEncoder().encode(`${parts[0]}.${parts[1]}`));
+  if(!valid)throw new Error('OIDC_SIGNATURE_INVALID');
+  const now=Math.floor(Date.now()/1000),audiences=Array.isArray(payload.aud)?payload.aud:[payload.aud];
+  if(payload.iss!==GH_ISSUER)throw new Error('OIDC_ISSUER_DENIED');
+  if(!audiences.includes(OIDC_AUDIENCE))throw new Error('OIDC_AUDIENCE_DENIED');
+  if(Number(payload.exp||0)<=now||Number(payload.nbf||0)>now+30)throw new Error('OIDC_TIME_INVALID');
+  if(payload.repository!==GH_REPOSITORY)throw new Error('OIDC_REPOSITORY_DENIED');
+  if(payload.ref!==GH_REF)throw new Error('OIDC_REF_DENIED');
+  if(payload.workflow_ref!==GH_WORKFLOW_REF)throw new Error('OIDC_WORKFLOW_DENIED');
+  if(payload.event_name!==GH_EVENT)throw new Error('OIDC_EVENT_DENIED');
+  return payload;
+}
+
+function validRunId(value:any){const runId=String(value||'').trim();if(!/^[A-Za-z0-9-]{6,90}$/.test(runId))throw new Error('INVALID_RUN_ID');return runId}
+function randomPassword(){const bytes=crypto.getRandomValues(new Uint8Array(24));const base=btoa(String.fromCharCode(...bytes)).replaceAll('+','-').replaceAll('/','_').replaceAll('=','');return `Dabbir-QA-${base}!Aa9`}
+
+async function createQaUser(email:string,password:string,runId:string,label:string){
+  const {data,error}=await db.auth.admin.createUser({email,password,email_confirm:true,user_metadata:{dabbir_qa:true,dabbir_qa_run_id:runId,role_label:label}});
+  if(error||!data?.user?.id)throw new Error(`AUTH_USER_CREATE_FAILED:${error?.message||'missing_id'}`);
+  return {id:data.user.id,email,password};
+}
+async function getQaUser(userId:string,runId:string){
+  const {data,error}=await db.auth.admin.getUserById(userId);
+  if(error||!data?.user)throw new Error(`AUTH_USER_LOOKUP_FAILED:${error?.message||'missing_user'}`);
+  if(data.user.user_metadata?.dabbir_qa!==true||data.user.user_metadata?.dabbir_qa_run_id!==runId)throw new Error('QA_USER_SCOPE_DENIED');
+  return data.user;
+}
+async function deleteQaUser(userId:string,runId:string){
+  await getQaUser(userId,runId);
+  const {error:tombstoneError}=await db.from('account_access_state').upsert({user_id:userId,status:'deleted',reason:'DABBIR_GOLDEN_CANARY_QA_CLEANUP',updated_at:new Date().toISOString()},{onConflict:'user_id'});
+  if(tombstoneError)throw new Error(`QA_USER_TOMBSTONE_FAILED:${tombstoneError.message}`);
+  const {error:accountError}=await db.from('dabbir_user_accounts').delete().eq('user_id',userId);
+  if(accountError)throw new Error(`QA_USER_ACCOUNT_DELETE_FAILED:${accountError.message}`);
+  const {error}=await db.auth.admin.deleteUser(userId);
+  if(error)throw new Error(`AUTH_USER_DELETE_FAILED:${error.message}`);
+  return {deleted:true,user_id:userId};
+}
+async function assertQaBusiness(businessId:string,runId:string){
+  const {data,error}=await db.from('dabbir_businesses').select('id,name,owner_id').eq('id',businessId).maybeSingle();
+  if(error)throw new Error(`QA_BUSINESS_LOOKUP_FAILED:${error.message}`);
+  if(!data||data.name!==`DABBIR AI QA ${runId}`)throw new Error('QA_BUSINESS_SCOPE_DENIED');
+  return data;
+}
+async function bootstrap(runId:string){
+  const suffix=`${runId.toLowerCase()}-${crypto.randomUUID().slice(0,8)}`;let owner:any=null,employee:any=null;
+  try{owner=await createQaUser(`dabbir-qa-owner-${suffix}@example.com`,randomPassword(),runId,'owner');employee=await createQaUser(`dabbir-qa-employee-${suffix}@example.com`,randomPassword(),runId,'employee');return {owner,employee}}
+  catch(error){if(employee?.id)await deleteQaUser(employee.id,runId).catch(()=>{});if(owner?.id)await deleteQaUser(owner.id,runId).catch(()=>{});throw error}
+}
+async function seedOrder(runId:string,businessId:string,customerId:string){
+  await assertQaBusiness(businessId,runId);
+  const {data,error}=await db.from('dabbir_orders').insert({business_id:businessId,customer_id:customerId,status:'draft',total_aed:125,simulated:false}).select('id,status,total_aed,simulated').single();
+  if(error||!data?.id)throw new Error(`QA_ORDER_CREATE_FAILED:${error?.message||'missing_id'}`);
+  return data;
+}
+async function cleanup(runId:string,businessId:string|null,ownerUserId:string|null,employeeUserId:string|null){
+  const result:any={};
+  if(businessId){await assertQaBusiness(businessId,runId);const {data,error}=await db.rpc('dabbir_qa_cleanup_business',{p_business_id:businessId});if(error)throw new Error(`QA_BUSINESS_CLEANUP_FAILED:${error.message}`);result.business=data}
+  if(employeeUserId)result.employee=await deleteQaUser(employeeUserId,runId);
+  if(ownerUserId)result.owner=await deleteQaUser(ownerUserId,runId);
+  return result;
+}
+function failure(error:unknown,status=400){const message=String(error instanceof Error?error.message:error).slice(0,500);return Response.json({ok:false,error:message},{status:message.startsWith('OIDC_')?401:status,headers:{'cache-control':'no-store'}})}
+
+Deno.serve(async(req:Request)=>{
+  if(req.method!=='POST')return new Response('method not allowed',{status:405});
+  const body=await req.json().catch(()=>({})),action=String(body.action||'');
+  if(!ACTIONS.has(action))return Response.json({ok:false,error:'unknown_action'},{status:400});
+  try{
+    const claims=await verifyGitHubOidc(req),runId=validRunId(body.run_id);
+    if(action==='dabbir_ai_qa_bootstrap')return Response.json({ok:true,action,run_id:runId,identities:await bootstrap(runId),github_run_id:claims.run_id||null},{headers:{'cache-control':'no-store'}});
+    if(action==='dabbir_ai_qa_seed_order'){
+      const businessId=String(body.business_id||''),customerId=String(body.customer_id||'');
+      if(!businessId||!customerId)return Response.json({ok:false,error:'business_id_customer_id_required'},{status:400});
+      return Response.json({ok:true,action,run_id:runId,order:await seedOrder(runId,businessId,customerId)},{headers:{'cache-control':'no-store'}});
+    }
+    return Response.json({ok:true,action,run_id:runId,cleanup:await cleanup(runId,body.business_id?String(body.business_id):null,body.owner_user_id?String(body.owner_user_id):null,body.employee_user_id?String(body.employee_user_id):null)},{headers:{'cache-control':'no-store'}});
+  }catch(error){return failure(error,500)}
+});

--- a/test/barman-persistent-tool-agent.test.mjs
+++ b/test/barman-persistent-tool-agent.test.mjs
@@ -56,11 +56,14 @@ test('persistent worker has schedule plus protected-main push wake-up',()=>{
   assert.match(worker,/api\/barman-tool-agent-broker\.js/);
 });
 
-test('empty AI patches trigger bounded autonomous context recovery instead of owner questions',()=>{
+test('empty AI patches trigger bounded autonomous recovery and structured fallback instead of owner questions',()=>{
   assert.match(worker,/PATCH_EMPTY_RECOVERY/);
   assert.match(worker,/expandContext\(context,discovery,allPaths,commandText\)/);
   assert.match(worker,/AI_PATCH_EMPTY_AUTORECOVERY/);
-  assert.match(worker,/AI_PATCH_EMPTY_AFTER_AUTORECOVERY/);
+  assert.match(worker,/PATCH_EMPTY_AFTER_AUTORECOVERY/);
+  assert.match(worker,/STRUCTURED_FILE_RECOVERY/);
+  assert.match(worker,/phase:'files'/);
+  assert.match(worker,/applyStructuredFiles\(structured,context,allPaths\)/);
   assert.match(worker,/add\('package\.json'\)/);
   assert.match(broker,/explicitly authorized to create NEW files under test\//);
   assert.match(broker,/does NOT need to already appear in the supplied context/);

--- a/test/barman-structured-file-fallback-v11.test.mjs
+++ b/test/barman-structured-file-fallback-v11.test.mjs
@@ -1,0 +1,44 @@
+import fs from 'node:fs';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const broker=fs.readFileSync(new URL('../api/barman-tool-agent-broker.js',import.meta.url),'utf8');
+const worker=fs.readFileSync(new URL('../scripts/barman-tool-agent.mjs',import.meta.url),'utf8');
+
+test('broker exposes structured recovery only after normal patch channel',()=>{
+  assert.match(broker,/phase==='patch'/);
+  assert.match(broker,/phase==='files'/);
+  assert.match(broker,/structured file-edit recovery brain/i);
+  assert.match(broker,/unified-diff channel failed syntactically/i);
+  assert.match(broker,/at most 4 files/i);
+  assert.match(broker,/mode=create is allowed ONLY for new files under test\//);
+  assert.match(broker,/mode=replace is allowed ONLY for existing files present in the supplied context/);
+});
+
+test('worker validates every structured edit before writing any file',()=>{
+  assert.match(worker,/function applyStructuredFiles\(result,context,allPaths\)/);
+  assert.match(worker,/entries\.length<1\|\|entries\.length>4/);
+  assert.match(worker,/STRUCTURED_PATH_DENIED_/);
+  assert.match(worker,/STRUCTURED_DUPLICATE_PATH_/);
+  assert.match(worker,/STRUCTURED_CREATE_DENIED_/);
+  assert.match(worker,/STRUCTURED_REPLACE_DENIED_/);
+  const validationIndex=worker.indexOf("validated.push({path,mode,content})");
+  const writeIndex=worker.indexOf("fs.writeFileSync(entry.path,entry.content,'utf8')");
+  assert.ok(validationIndex>0&&writeIndex>validationIndex,'all entries must validate before writes start');
+});
+
+test('new structured files are restricted to tests and SQL migrations',()=>{
+  assert.match(worker,/path\.startsWith\('test\/'\)/);
+  assert.match(worker,/path\.startsWith\('supabase\/migrations\/'\)/);
+  assert.match(worker,/path\.endsWith\('\.sql'\)/);
+  assert.match(worker,/forbiddenPath\(value\)/);
+  assert.match(worker,/Buffer\.byteLength\(content,'utf8'\)>60000/);
+});
+
+test('invalid repaired patch falls back instead of immediately failing the task',()=>{
+  assert.match(worker,/PATCH_REPAIR_FAILED/);
+  assert.match(worker,/STRUCTURED_FILE_RECOVERY reason=/);
+  assert.match(worker,/phase:'files'/);
+  assert.match(worker,/STRUCTURED_FILE_RECOVERY_APPLIED paths=/);
+  assert.match(worker,/STRUCTURED_FILE_RECOVERY_FAILED_/);
+});

--- a/test/dabbir-golden-canary-preload.mjs
+++ b/test/dabbir-golden-canary-preload.mjs
@@ -1,0 +1,17 @@
+import './dabbir-protected-full-journey-preload.mjs';
+
+const PROJECT_REF=String(process.env.SUPABASE_PROJECT_REF||'fphpoysqdsceniwduxjq').trim();
+const LEGACY_QA=`https://${PROJECT_REF}.supabase.co/functions/v1/barman-qa-suite-runner`;
+const CANARY_QA=`https://${PROJECT_REF}.supabase.co/functions/v1/dabbir-golden-canary-qa`;
+const nativeFetch=globalThis.fetch.bind(globalThis);
+
+globalThis.fetch=(input,init)=>{
+  const raw=typeof input==='string'?input:input instanceof URL?input.href:String(input?.url||input);
+  if(raw===LEGACY_QA||raw.startsWith(`${LEGACY_QA}?`)){
+    const rewritten=raw.replace(LEGACY_QA,CANARY_QA);
+    return nativeFetch(rewritten,init);
+  }
+  return nativeFetch(input,init);
+};
+
+console.log('DABBIR_GOLDEN_CANARY_QA_CONTROL=isolated');

--- a/test/dabbir-golden-canary-smoke.mjs
+++ b/test/dabbir-golden-canary-smoke.mjs
@@ -1,0 +1,92 @@
+import fs from 'node:fs';
+
+const ORIGIN=String(process.env.PROTECTED_QA_ORIGIN||'').trim().replace(/\/$/,'');
+const TRUSTED_OIDC=String(process.env.VERCEL_TRUSTED_OIDC_TOKEN||'').trim();
+const EXPECTED_SHA=String(process.env.EXPECTED_CANARY_SHA||'').trim().toLowerCase();
+const REPORT_PATH=process.env.CANARY_REPORT_PATH||'dabbir-golden-canary-smoke-report.json';
+const EXPECTED_PROJECT_ID='prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq';
+const EXPECTED_REPOSITORY='barman-systems/pilot';
+
+if(!/^https:\/\/[^/]+$/i.test(ORIGIN)) throw new Error('GOLDEN_CANARY_ORIGIN_REQUIRED');
+if(!TRUSTED_OIDC) throw new Error('GOLDEN_CANARY_TRUSTED_OIDC_REQUIRED');
+if(!/^[a-f0-9]{40}$/i.test(EXPECTED_SHA)) throw new Error('GOLDEN_CANARY_SHA_REQUIRED');
+
+const report={
+  contract:'DABBIR_GOLDEN_CANARY_V1',
+  origin:ORIGIN,
+  expected_sha:EXPECTED_SHA,
+  verified_sha:null,
+  deployment_id:null,
+  environment:null,
+  verdict:'RUNNING',
+  started_at:new Date().toISOString(),
+  completed_at:null,
+  steps:[],
+  artifacts:{},
+};
+
+function assert(condition,message){if(!condition)throw new Error(message||'ASSERTION_FAILED')}
+function headers(extra={}){return {'x-vercel-trusted-oidc-idp-token':TRUSTED_OIDC,...extra}}
+async function protectedFetch(path,init={}){const h=new Headers(init.headers||{});for(const [k,v] of Object.entries(headers()))h.set(k,v);return fetch(`${ORIGIN}${path}`,{redirect:'follow',cache:'no-store',...init,headers:h})}
+async function step(name,fn){const started=Date.now();const row={name,status:'RUNNING',duration_ms:null,detail:null};report.steps.push(row);try{const detail=await fn();row.status='PASS';row.duration_ms=Date.now()-started;row.detail=detail||null;console.log(`PASS ${name} (${row.duration_ms}ms)${detail?` — ${detail}`:''}`)}catch(error){row.status='FAIL';row.duration_ms=Date.now()-started;row.detail=String(error?.stack||error?.message||error).slice(0,1200);console.error(`FAIL ${name} — ${row.detail}`);throw error}}
+
+let browser;
+try{
+  await step('00_exact_preview_release',async()=>{
+    const response=await protectedFetch(`/api/release-evidence?t=${Date.now()}`,{headers:{accept:'application/json'}});
+    const body=await response.json().catch(()=>({}));
+    assert(response.status===200&&body?.ok===true,`RELEASE_EVIDENCE_HTTP_${response.status}`);
+    assert(String(body.commit_sha||'').toLowerCase()===EXPECTED_SHA,`CANARY_SHA_MISMATCH_${body.commit_sha||'missing'}`);
+    assert(String(body.environment||'').toLowerCase()==='preview',`CANARY_NOT_PREVIEW_${body.environment||'missing'}`);
+    assert(body.project_id===EXPECTED_PROJECT_ID,`CANARY_PROJECT_MISMATCH_${body.project_id||'missing'}`);
+    assert(body.git_provider==='github','CANARY_GIT_PROVIDER_MISMATCH');
+    assert(body.repository===EXPECTED_REPOSITORY,`CANARY_REPOSITORY_MISMATCH_${body.repository||'missing'}`);
+    assert(String(body.deployment_id||'').startsWith('dpl_'),'CANARY_DEPLOYMENT_ID_MISSING');
+    report.verified_sha=String(body.commit_sha).toLowerCase();
+    report.deployment_id=body.deployment_id;
+    report.environment=body.environment;
+    return `${body.deployment_id} is exact preview SHA ${report.verified_sha}`;
+  });
+
+  await step('01_home_identity',async()=>{
+    const response=await protectedFetch('/',{headers:{accept:'text/html'}});
+    const text=await response.text();
+    assert(response.status===200,`HOME_STATUS_${response.status}`);
+    assert(/DABBIR/i.test(text),'DABBIR_IDENTITY_MISSING');
+    return 'Protected preview home returned DABBIR identity.';
+  });
+
+  await step('02_auth_fails_closed',async()=>{
+    const response=await protectedFetch('/api/dabbir-runtime-fast?summary=1',{headers:{accept:'application/json'}});
+    const text=await response.text();
+    assert(response.status===401,`UNAUTH_RUNTIME_EXPECTED_401_GOT_${response.status}:${text.slice(0,160)}`);
+    return 'Vercel preview access does not bypass DABBIR application authentication.';
+  });
+
+  await step('03_iphone_webkit_login_gate',async()=>{
+    const {webkit}=await import('playwright');
+    browser=await webkit.launch({headless:true});
+    const context=await browser.newContext({viewport:{width:390,height:844},isMobile:true,hasTouch:true,locale:'ar-AE',timezoneId:'Asia/Dubai',extraHTTPHeaders:headers()});
+    const page=await context.newPage();
+    const pageErrors=[];const consoleErrors=[];
+    page.on('pageerror',error=>pageErrors.push(String(error?.message||error)));
+    page.on('console',message=>{if(message.type()==='error'&&!/401|AUTH_REQUIRED|Failed to load resource/i.test(message.text()))consoleErrors.push(message.text())});
+    const response=await page.goto(ORIGIN,{waitUntil:'domcontentloaded',timeout:45000});
+    assert(response?.status()===200,`BROWSER_HOME_STATUS_${response?.status()}`);
+    await page.locator('#authGate:not(.hidden)').waitFor({state:'visible',timeout:20000});
+    await page.locator('#authEmail').waitFor({state:'visible',timeout:10000});
+    await page.locator('#authPassword').waitFor({state:'visible',timeout:10000});
+    await page.locator('#authSubmit').waitFor({state:'visible',timeout:10000});
+    const ui=await page.evaluate(()=>({authority:window.__dabbirUiAuthority||null,bodyAuthority:document.body?.dataset?.dabbirUi||null}));
+    report.artifacts.ui_authority=ui;
+    assert(ui.authority?.version==='owner-first-v4',`UI_AUTHORITY_INVALID_${JSON.stringify(ui)}`);
+    assert(pageErrors.length===0,`PAGE_ERRORS_${pageErrors.join('|')}`);
+    assert(consoleErrors.length===0,`CONSOLE_ERRORS_${consoleErrors.join('|')}`);
+    await page.screenshot({path:'dabbir-golden-canary-smoke.png',fullPage:true});
+    report.artifacts.screenshot='dabbir-golden-canary-smoke.png';
+    await context.close();
+    return 'Arabic iPhone WebKit login gate rendered with authoritative owner-first-v4 UI.';
+  });
+
+  report.verdict='PASS';
+}catch(error){report.verdict='FAIL';report.error=String(error?.stack||error?.message||error).slice(0,1800);process.exitCode=1}finally{if(browser)await browser.close().catch(()=>{});report.completed_at=new Date().toISOString();fs.writeFileSync(REPORT_PATH,`${JSON.stringify(report,null,2)}\n`);console.log(`DABBIR_GOLDEN_CANARY_SMOKE_VERDICT=${report.verdict}`)}

--- a/test/dabbir-golden-canary-trigger-contract.test.mjs
+++ b/test/dabbir-golden-canary-trigger-contract.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const workflowUrl = new URL('../.github/workflows/dabbir-golden-canary.yml', import.meta.url);
+const qaUrl = new URL('../supabase/functions/dabbir-golden-canary-qa/index.ts', import.meta.url);
+
+test('Golden Canary comment trigger stays main-trusted and owner-only', async () => {
+  const [workflow, qa] = await Promise.all([
+    readFile(workflowUrl, 'utf8'),
+    readFile(qaUrl, 'utf8'),
+  ]);
+
+  assert.match(workflow, /issue_comment:\s*\n\s*types: \[created\]/u);
+  assert.match(workflow, /github\.actor == 'barmanai'/u);
+  assert.match(workflow, /OWNER\|MEMBER\|COLLABORATOR/u);
+  assert.match(workflow, /startsWith\(github\.event\.comment\.body, '\/dabbir-golden-canary '/u);
+  assert.match(workflow, /ref: main/u);
+  assert.match(workflow, /persist-credentials: false/u);
+  assert.match(workflow, /needs: \[prepare, candidate-tests\]/u);
+
+  assert.match(qa, /GH_COMMENT_ACTOR='barmanai'/u);
+  assert.match(qa, /GH_COMMENT_ACTOR_ID='319216860'/u);
+  assert.match(qa, /new Set\(\['workflow_dispatch','issue_comment'\]\)/u);
+  assert.match(qa, /payload\.workflow_ref!==GH_WORKFLOW_REF/u);
+  assert.match(qa, /payload\.ref!==GH_REF/u);
+  assert.match(qa, /payload\.event_name==='issue_comment'/u);
+  assert.match(qa, /payload\.actor!==GH_COMMENT_ACTOR\|\|String\(payload\.actor_id\|\|''\)!==GH_COMMENT_ACTOR_ID/u);
+});


### PR DESCRIPTION
## P1 Golden CEO execution-format recovery

Attempt 2 of the same Golden command reached the real executor but failed because the model's repaired output was not a valid unified diff (`No valid patches in input`). This PR removes unified-diff syntax as a single point of failure without weakening scope controls.

### Repair
- keeps unified diff as the primary edit channel;
- if patch generation/repair still cannot produce an applicable diff, calls a separate structured-file recovery phase;
- structured recovery can return at most four complete file writes;
- all structured entries are validated before any write occurs;
- new files are restricted to test source files under `test/` or `.sql` migrations under `supabase/migrations/`;
- replacement is allowed only for an existing file that was already present in the supplied context;
- governance files, `.github`, env files, secrets, the BARMAN broker/worker themselves, and `vercel.json` remain forbidden;
- duplicate paths, traversal, absolute paths, backslashes, NUL content, and oversized content are rejected;
- local syntax and the complete test suite still run before any PR is created.

The same Golden task remains queued with `attempt_count=2`; after this repair is merged it will be retried as attempt 3, preserving both prior failures in the audit trail.