### PR TITLE
ci(dabbir): enforce proven Golden Canary on main

### DIFF
--- a/.github/workflows/dabbir-native-github-protection.yml
+++ b/.github/workflows/dabbir-native-github-protection.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -euo pipefail
           API="https://api.github.com/repos/${GITHUB_REPOSITORY}/branches/main/protection"
-          body='{"required_status_checks":{"strict":true,"contexts":["test"]},"enforce_admins":true,"required_pull_request_reviews":{"dismiss_stale_reviews":false,"require_code_owner_reviews":false,"required_approving_review_count":0,"require_last_push_approval":false,"bypass_pull_request_allowances":{"users":[],"teams":[],"apps":[]}},"restrictions":null,"required_linear_history":true,"allow_force_pushes":false,"allow_deletions":false,"block_creations":true,"required_conversation_resolution":true,"lock_branch":false,"allow_fork_syncing":false}'
+          body='{"required_status_checks":{"strict":true,"contexts":["test","DABBIR Golden Canary"]},"enforce_admins":true,"required_pull_request_reviews":{"dismiss_stale_reviews":false,"require_code_owner_reviews":false,"required_approving_review_count":0,"require_last_push_approval":false,"bypass_pull_request_allowances":{"users":[],"teams":[],"apps":[]}},"restrictions":null,"required_linear_history":true,"allow_force_pushes":false,"allow_deletions":false,"block_creations":true,"required_conversation_resolution":true,"lock_branch":false,"allow_fork_syncing":false}'
 
           curl --silent --show-error --fail-with-body \
             --request PUT \
@@ -62,12 +62,20 @@ jobs:
           const protection = JSON.parse(process.env.VERIFIED || '{}');
           const contexts = protection?.required_status_checks?.contexts || [];
           if (!contexts.includes('test')) throw new Error('DABBIR CI test context is not required');
+          if (!contexts.includes('DABBIR Golden Canary')) throw new Error('DABBIR Golden Canary context is not required');
           if (protection?.enforce_admins?.enabled !== true) throw new Error('Admin enforcement is not enabled');
           if (protection?.required_linear_history?.enabled !== true) throw new Error('Linear history is not required');
           if (protection?.allow_force_pushes?.enabled === true) throw new Error('Force pushes remain enabled');
           if (protection?.allow_deletions?.enabled === true) throw new Error('Branch deletion remains enabled');
           if (protection?.required_conversation_resolution?.enabled !== true) throw new Error('Conversation resolution is not required');
-          console.log('DABBIR native GitHub main protection verified.');
+          console.log('DABBIR native GitHub main protection verified with Golden Canary required.');
           NODE
+
+      - name: Fail if native protection cannot be enforced
+        if: steps.credential.outputs.available != 'true'
+        shell: bash
+        run: |
+          echo 'DABBIR_GITHUB_ADMIN_TOKEN missing: refusing to report Golden Canary protection as configured.'
+          exit 1
 
 # BARMAN activation refresh after secure admin secret provisioning: 2026-09-02

--- a/test/dabbir-native-github-protection.test.mjs
+++ b/test/dabbir-native-github-protection.test.mjs
@@ -4,14 +4,16 @@ import { readFile } from 'node:fs/promises';
 
 const workflow = new URL('../.github/workflows/dabbir-native-github-protection.yml', import.meta.url);
 
-test('native GitHub protection bootstrap is fail-closed and requires DABBIR CI', async () => {
+test('native GitHub protection bootstrap is fail-closed and requires DABBIR CI plus Golden Canary', async () => {
   const source = await readFile(workflow, 'utf8');
   assert.match(source, /DABBIR_GITHUB_ADMIN_TOKEN/u);
   assert.match(source, /branches\/main\/protection/u);
-  assert.match(source, /"contexts":\["test"\]/u);
+  assert.match(source, /"contexts":\["test","DABBIR Golden Canary"\]/u);
+  assert.match(source, /contexts\.includes\('DABBIR Golden Canary'\)/u);
   assert.match(source, /"enforce_admins":true/u);
   assert.match(source, /"allow_force_pushes":false/u);
   assert.match(source, /"allow_deletions":false/u);
   assert.match(source, /required_conversation_resolution/u);
+  assert.match(source, /refusing to report Golden Canary protection as configured/u);
   assert.doesNotMatch(source, /GITHUB_TOKEN/u);
 });


### PR DESCRIPTION
Phase 2 enforcement. Requires both `test` and `DABBIR Golden Canary` on protected main, verifies both contexts after applying protection, fails visibly if the admin protection credential is unavailable, and updates the contract test. This PR must itself pass the trusted Golden Canary against its exact Vercel Preview before merge.