### PR TITLE
ci(dabbir): add owner-only Golden Canary trigger

### DIFF
--- a/.github/workflows/dabbir-golden-canary.yml
+++ b/.github/workflows/dabbir-golden-canary.yml
@@ -11,35 +11,84 @@ on:
         description: Exact protected Vercel Preview URL for the candidate SHA
         required: true
         type: string
+  issue_comment:
+    types: [created]
 
 permissions:
   contents: read
 
 concurrency:
-  group: dabbir-golden-canary-${{ inputs.candidate_sha }}
+  group: dabbir-golden-canary-${{ github.event.comment.id || inputs.candidate_sha || github.run_id }}
   cancel-in-progress: false
 
 jobs:
+  prepare:
+    name: Resolve trusted Golden Canary request
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request &&
+       github.actor == 'barmanai' &&
+       startsWith(github.event.comment.body, '/dabbir-golden-canary '))
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    permissions:
+      contents: read
+    outputs:
+      candidate_sha: ${{ steps.resolve.outputs.candidate_sha }}
+      canary_url: ${{ steps.resolve.outputs.canary_url }}
+    steps:
+      - name: Resolve and validate immutable request
+        id: resolve
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DISPATCH_SHA: ${{ inputs.candidate_sha }}
+          DISPATCH_URL: ${{ inputs.canary_url }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_ACTOR: ${{ github.actor }}
+          COMMENT_ASSOCIATION: ${{ github.event.comment.author_association }}
+        run: |
+          set -euo pipefail
+          candidate=''
+          canary=''
+          if [ "$EVENT_NAME" = 'workflow_dispatch' ]; then
+            candidate="$DISPATCH_SHA"
+            canary="$DISPATCH_URL"
+          elif [ "$EVENT_NAME" = 'issue_comment' ]; then
+            [ "$COMMENT_ACTOR" = 'barmanai' ] || { echo 'Golden Canary comment actor denied'; exit 2; }
+            case "$COMMENT_ASSOCIATION" in
+              OWNER|MEMBER|COLLABORATOR) ;;
+              *) echo 'Golden Canary comment association denied'; exit 2 ;;
+            esac
+            [[ "$COMMENT_BODY" != *$'\n'* ]] || { echo 'Golden Canary command must be exactly one line'; exit 2; }
+            read -r command candidate canary extra <<< "$COMMENT_BODY"
+            [ "$command" = '/dabbir-golden-canary' ] || { echo 'Golden Canary command denied'; exit 2; }
+            [ -z "${extra:-}" ] || { echo 'Golden Canary command has unexpected fields'; exit 2; }
+          else
+            echo 'Unsupported Golden Canary trigger'; exit 2
+          fi
+          [[ "$candidate" =~ ^[0-9a-f]{40}$ ]] || { echo 'candidate_sha must be an exact lowercase 40-character SHA'; exit 2; }
+          [[ "$canary" =~ ^https://[^/]+$ ]] || { echo 'canary_url must be a bare HTTPS origin'; exit 2; }
+          case "$canary" in
+            *.vercel.app) ;;
+            *) echo 'Golden Canary accepts only an isolated Vercel Preview origin'; exit 2 ;;
+          esac
+          echo "candidate_sha=$candidate" >> "$GITHUB_OUTPUT"
+          echo "canary_url=$canary" >> "$GITHUB_OUTPUT"
+          echo "DABBIR_GOLDEN_CANARY_REQUEST actor=${COMMENT_ACTOR:-workflow_dispatch} candidate=$candidate"
+
   candidate-tests:
     name: Candidate static and repository gates
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 18
     permissions:
       contents: read
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
-      CANARY_URL: ${{ inputs.canary_url }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+      CANARY_URL: ${{ needs.prepare.outputs.canary_url }}
     steps:
-      - name: Validate immutable candidate inputs
-        shell: bash
-        run: |
-          set -euo pipefail
-          [[ "$CANDIDATE_SHA" =~ ^[0-9a-f]{40}$ ]] || { echo 'candidate_sha must be an exact lowercase 40-character SHA'; exit 2; }
-          [[ "$CANARY_URL" =~ ^https://[^/]+$ ]] || { echo 'canary_url must be a bare HTTPS origin'; exit 2; }
-          case "$CANARY_URL" in
-            *.vercel.app) ;;
-            *) echo 'Golden Canary accepts only an isolated Vercel Preview origin'; exit 2 ;;
-          esac
       - name: Checkout exact candidate without privileged credentials
         uses: actions/checkout@v7
         with:
@@ -60,15 +109,15 @@ jobs:
 
   golden-canary:
     name: Trusted exact Preview verifier
-    needs: candidate-tests
+    needs: [prepare, candidate-tests]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
       contents: read
       id-token: write
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
-      CANARY_URL: ${{ inputs.canary_url }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
+      CANARY_URL: ${{ needs.prepare.outputs.canary_url }}
       EXPECTED_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
       EXPECTED_REPOSITORY: barman-systems/pilot
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
@@ -128,8 +177,8 @@ jobs:
       - name: Run exact Preview smoke using trusted harness
         shell: bash
         env:
-          PROTECTED_QA_ORIGIN: ${{ inputs.canary_url }}
-          EXPECTED_CANARY_SHA: ${{ inputs.candidate_sha }}
+          PROTECTED_QA_ORIGIN: ${{ needs.prepare.outputs.canary_url }}
+          EXPECTED_CANARY_SHA: ${{ needs.prepare.outputs.candidate_sha }}
           CANARY_REPORT_PATH: dabbir-golden-canary-smoke-report.json
         run: |
           set -euo pipefail
@@ -138,7 +187,7 @@ jobs:
       - name: Run full disposable customer journey using trusted harness
         shell: bash
         env:
-          PRODUCTION_ORIGIN: ${{ inputs.canary_url }}
+          PRODUCTION_ORIGIN: ${{ needs.prepare.outputs.canary_url }}
           JOURNEY_REPORT_PATH: dabbir-golden-canary-journey-report.json
         run: |
           set -euo pipefail
@@ -183,14 +232,14 @@ jobs:
 
   publish-status:
     name: Publish immutable candidate status
-    if: always()
-    needs: [candidate-tests, golden-canary]
+    if: always() && needs.prepare.result == 'success'
+    needs: [prepare, candidate-tests, golden-canary]
     runs-on: ubuntu-latest
     timeout-minutes: 3
     permissions:
       statuses: write
     env:
-      CANDIDATE_SHA: ${{ inputs.candidate_sha }}
+      CANDIDATE_SHA: ${{ needs.prepare.outputs.candidate_sha }}
       CANDIDATE_RESULT: ${{ needs.candidate-tests.result }}
       CANARY_RESULT: ${{ needs.golden-canary.result }}
     steps:

--- a/supabase/functions/dabbir-golden-canary-qa/index.ts
+++ b/supabase/functions/dabbir-golden-canary-qa/index.ts
@@ -5,7 +5,9 @@ const db=createClient(Deno.env.get('SUPABASE_URL')!,Deno.env.get('SUPABASE_SERVI
 const GH_ISSUER='https://token.actions.githubusercontent.com';
 const GH_REPOSITORY='barman-systems/pilot';
 const GH_REF='refs/heads/main';
-const GH_EVENT='workflow_dispatch';
+const GH_EVENTS=new Set(['workflow_dispatch','issue_comment']);
+const GH_COMMENT_ACTOR='barmanai';
+const GH_COMMENT_ACTOR_ID='319216860';
 const GH_WORKFLOW_REF='barman-systems/pilot/.github/workflows/dabbir-golden-canary.yml@refs/heads/main';
 const OIDC_AUDIENCE='dabbir-ai-qa';
 const ACTIONS=new Set(['dabbir_ai_qa_bootstrap','dabbir_ai_qa_seed_order','dabbir_ai_qa_cleanup']);
@@ -34,7 +36,10 @@ async function verifyGitHubOidc(req:Request){
   if(payload.repository!==GH_REPOSITORY)throw new Error('OIDC_REPOSITORY_DENIED');
   if(payload.ref!==GH_REF)throw new Error('OIDC_REF_DENIED');
   if(payload.workflow_ref!==GH_WORKFLOW_REF)throw new Error('OIDC_WORKFLOW_DENIED');
-  if(payload.event_name!==GH_EVENT)throw new Error('OIDC_EVENT_DENIED');
+  if(!GH_EVENTS.has(String(payload.event_name||'')))throw new Error('OIDC_EVENT_DENIED');
+  if(payload.event_name==='issue_comment'){
+    if(payload.actor!==GH_COMMENT_ACTOR||String(payload.actor_id||'')!==GH_COMMENT_ACTOR_ID)throw new Error('OIDC_COMMENT_ACTOR_DENIED');
+  }
   return payload;
 }
 

--- a/test/dabbir-golden-canary-trigger-contract.test.mjs
+++ b/test/dabbir-golden-canary-trigger-contract.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const workflowUrl = new URL('../.github/workflows/dabbir-golden-canary.yml', import.meta.url);
+const qaUrl = new URL('../supabase/functions/dabbir-golden-canary-qa/index.ts', import.meta.url);
+
+test('Golden Canary comment trigger stays main-trusted and owner-only', async () => {
+  const [workflow, qa] = await Promise.all([
+    readFile(workflowUrl, 'utf8'),
+    readFile(qaUrl, 'utf8'),
+  ]);
+
+  assert.match(workflow, /issue_comment:\s*\n\s*types: \[created\]/u);
+  assert.match(workflow, /github\.actor == 'barmanai'/u);
+  assert.match(workflow, /OWNER\|MEMBER\|COLLABORATOR/u);
+  assert.match(workflow, /startsWith\(github\.event\.comment\.body, '\/dabbir-golden-canary '/u);
+  assert.match(workflow, /ref: main/u);
+  assert.match(workflow, /persist-credentials: false/u);
+  assert.match(workflow, /needs: \[prepare, candidate-tests\]/u);
+
+  assert.match(qa, /GH_COMMENT_ACTOR='barmanai'/u);
+  assert.match(qa, /GH_COMMENT_ACTOR_ID='319216860'/u);
+  assert.match(qa, /new Set\(\['workflow_dispatch','issue_comment'\]\)/u);
+  assert.match(qa, /payload\.workflow_ref!==GH_WORKFLOW_REF/u);
+  assert.match(qa, /payload\.ref!==GH_REF/u);
+  assert.match(qa, /payload\.event_name==='issue_comment'/u);
+  assert.match(qa, /payload\.actor!==GH_COMMENT_ACTOR\|\|String\(payload\.actor_id\|\|''\)!==GH_COMMENT_ACTOR_ID/u);
+});


### PR DESCRIPTION
Adds a secure connector-compatible trigger for the trusted Golden Canary. Only a one-line `/dabbir-golden-canary <exact-sha> <exact-preview-url>` comment from the authenticated `barmanai` actor on a PR is accepted; the disposable QA Edge Function independently verifies the GitHub OIDC workflow/ref/event plus immutable actor ID 319216860. Candidate code remains unprivileged and the verifier still checks out `main` only. Supabase `dabbir-golden-canary-qa` v2 has already been deployed with the matching OIDC restriction.