### PR TITLE
fix(gcc): make owner runtime market-aware

### DIFF
--- a/api/_gcc-money-core.js
+++ b/api/_gcc-money-core.js
@@ -1,0 +1,95 @@
+import { getMarketProfile } from './_market-core.js';
+
+const MONEY_CODE_RE=/^[A-Z]{3}$/;
+
+const clean=value=>String(value||'').trim();
+
+export function verifiedBusinessMarket(business){
+  const countryCode=clean(business?.country_code).toUpperCase();
+  const currencyCode=clean(business?.currency_code).toUpperCase();
+  const profile=getMarketProfile(countryCode);
+  if(!profile)throw Object.assign(new Error('BUSINESS_MARKET_UNSUPPORTED'),{status:409});
+  if(!MONEY_CODE_RE.test(currencyCode)||currencyCode!==profile.currency_code){
+    throw Object.assign(new Error('BUSINESS_MARKET_CURRENCY_MISMATCH'),{status:409});
+  }
+  const timezone=clean(business?.timezone)||profile.timezone;
+  try{new Intl.DateTimeFormat('en-US',{timeZone:timezone}).format(new Date())}
+  catch{throw Object.assign(new Error('BUSINESS_TIMEZONE_INVALID'),{status:409})}
+  return Object.freeze({
+    country_code:profile.country_code,
+    currency_code:profile.currency_code,
+    currency_minor_units:profile.currency_minor_units,
+    timezone,
+    offset:profile.offset,
+  });
+}
+
+export function assertSnapshotCurrency(currencyCode,market,label='MONEY'){
+  const code=clean(currencyCode).toUpperCase();
+  if(!MONEY_CODE_RE.test(code)||code!==market?.currency_code){
+    throw Object.assign(new Error(`${label}_CURRENCY_SNAPSHOT_MISMATCH`),{status:409});
+  }
+  return code;
+}
+
+export function formatMarketMoney(value,market,language='en'){
+  const amount=Number(value||0);
+  const safeAmount=Number.isFinite(amount)?amount:0;
+  const currency=market?.currency_code;
+  const country=market?.country_code;
+  const digits=Number.isInteger(market?.currency_minor_units)?market.currency_minor_units:2;
+  if(!MONEY_CODE_RE.test(String(currency||''))||!country)throw new Error('MONEY_MARKET_REQUIRED');
+  const locale=`${String(language||'').toLowerCase().startsWith('ar')?'ar':'en'}-${country}`;
+  try{
+    return new Intl.NumberFormat(locale,{
+      style:'currency',
+      currency,
+      minimumFractionDigits:digits,
+      maximumFractionDigits:digits,
+    }).format(safeAmount);
+  }catch{
+    return `${safeAmount.toFixed(digits)} ${currency}`;
+  }
+}
+
+function localDateParts(nowMs,timezone){
+  const parts=new Intl.DateTimeFormat('en-CA',{
+    timeZone:timezone,
+    year:'numeric',month:'2-digit',day:'2-digit',
+  }).formatToParts(new Date(nowMs));
+  const map=Object.fromEntries(parts.map(part=>[part.type,part.value]));
+  if(!map.year||!map.month||!map.day)throw new Error('LOCAL_DATE_PARTS_UNAVAILABLE');
+  return {year:map.year,month:map.month,day:map.day};
+}
+
+function timezoneOffset(nowMs,timezone,fallback){
+  try{
+    const part=new Intl.DateTimeFormat('en-US',{
+      timeZone:timezone,
+      timeZoneName:'longOffset',
+      hour:'2-digit',
+    }).formatToParts(new Date(nowMs)).find(item=>item.type==='timeZoneName')?.value||'';
+    const match=part.match(/^GMT([+-])(\d{2}):(\d{2})$/);
+    if(match)return `${match[1]}${match[2]}:${match[3]}`;
+  }catch{}
+  if(/^[+-]\d{2}:\d{2}$/.test(String(fallback||'')))return fallback;
+  throw new Error('TIMEZONE_OFFSET_UNAVAILABLE');
+}
+
+export function marketDayStartIso(nowMs,market){
+  const time=Number(nowMs);
+  if(!Number.isFinite(time)||!market?.timezone)throw new Error('MARKET_DAY_START_INPUT_INVALID');
+  const {year,month,day}=localDateParts(time,market.timezone);
+  const offset=timezoneOffset(time,market.timezone,market.offset);
+  return new Date(`${year}-${month}-${day}T00:00:00${offset}`).toISOString();
+}
+
+export function marketDateKey(value,market){
+  if(!market?.timezone)return null;
+  try{
+    const date=value instanceof Date?value:new Date(value);
+    if(Number.isNaN(date.getTime()))return null;
+    const {year,month,day}=localDateParts(date.getTime(),market.timezone);
+    return `${year}-${month}-${day}`;
+  }catch{return null}
+}

--- a/api/owner-action-center.js
+++ b/api/owner-action-center.js
@@ -7,6 +7,12 @@ import {
   supabaseRest,
   userClaimsFromValidatedAccessToken,
 } from './_auth-core.js';
+import {
+  assertSnapshotCurrency,
+  formatMarketMoney,
+  marketDayStartIso,
+  verifiedBusinessMarket,
+} from './_gcc-money-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
@@ -32,9 +38,6 @@ async function authenticatedContext(req,res){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
 
-  // Membership lookup goes through the Supabase Data API, which validates the
-  // same JWT before applying tenant RLS. Reuse that successful validation and
-  // keep /auth/v1/user off this high-frequency dashboard path.
   let memberships;
   try{
     memberships=await getBusinessMemberships(token);
@@ -45,7 +48,6 @@ async function authenticatedContext(req,res){
   }
 
   let user=userClaimsFromValidatedAccessToken(token);
-  // Compatibility fallback for unexpected/legacy token shapes only.
   if(!user)user=await getVerifiedUser(token).catch(()=>null);
   if(!user){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   return {token,user,memberships};
@@ -71,12 +73,6 @@ function addItem(items,item){
   });
 }
 
-function dubaiDayStartIso(nowMs){
-  const dubaiOffsetMs=4*60*60*1000;
-  const dubaiDay=new Date(nowMs+dubaiOffsetMs).toISOString().slice(0,10);
-  return new Date(`${dubaiDay}T00:00:00+04:00`).toISOString();
-}
-
 function handledLabel(operationType){
   if(operationType==='followup.capture_internal'){
     return {ar:'التقط متابعة عميل تلقائيًا',en:'Captured a customer follow-up automatically'};
@@ -94,10 +90,20 @@ export default async function handler(req,res){
     const membership=membershipFor(context.memberships,requested);
     if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
     const businessId=membership.business_id;
+
+    const businessRows=await rest(
+      context.token,
+      `dabbir_businesses?select=id,country_code,currency_code,timezone&id=eq.${businessId}&limit=1`,
+      'BUSINESS_MARKET_LOOKUP_FAILED',
+    );
+    const business=Array.isArray(businessRows)?businessRows[0]:null;
+    if(!business)throw Object.assign(new Error('BUSINESS_MARKET_NOT_FOUND'),{status:409});
+    const market=verifiedBusinessMarket(business);
+
     const now=Date.now();
     const in24h=now+24*60*60*1000;
     const in2h=now+2*60*60*1000;
-    const dayStart=dubaiDayStartIso(now);
+    const dayStart=marketDayStartIso(now,market);
 
     const handledLookup=rest(
       context.token,
@@ -113,7 +119,7 @@ export default async function handler(req,res){
       rest(context.token,`dabbir_appointments?select=id,customer_id,starts_at,status,simulated&business_id=eq.${businessId}&order=starts_at.asc&limit=100`,'APPOINTMENTS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_products?select=id,name,sku,active&business_id=eq.${businessId}&limit=200`,'PRODUCTS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_inventory?select=product_id,quantity,reserved,updated_at&business_id=eq.${businessId}&limit=200`,'INVENTORY_LOOKUP_FAILED'),
-      rest(context.token,`dabbir_orders?select=id,customer_id,status,total_aed,simulated,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'ORDERS_LOOKUP_FAILED'),
+      rest(context.token,`dabbir_orders?select=id,customer_id,status,total_amount,currency_code,simulated,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'ORDERS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_channels?select=id,channel_type,status,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=50`,'CHANNELS_LOOKUP_FAILED'),
       rest(context.token,`dabbir_customers?select=id,display_name&business_id=eq.${businessId}&limit=200`,'CUSTOMERS_LOOKUP_FAILED'),
       handledLookup,
@@ -166,8 +172,11 @@ export default async function handler(req,res){
       if(order.simulated!==false)continue;
       const status=String(order.status||'').toLowerCase();
       if(!['draft','reserved'].includes(status))continue;
+      assertSnapshotCurrency(order.currency_code,market,'ORDER');
       const name=customerName.get(order.customer_id)||'عميل';
-      addItem(items,{id:`order:${order.id}`,type:'order',priority:status==='reserved'?68:54,severity:'warning',title_ar:status==='reserved'?`طلب محجوز يحتاج متابعة: ${name}`:`طلب غير مكتمل: ${name}`,title_en:status==='reserved'?`Reserved order needs follow-up: ${name}`:`Incomplete order: ${name}`,detail_ar:`القيمة ${number(order.total_aed).toFixed(2)} د.إ — الحالة ${status}.`,detail_en:`AED ${number(order.total_aed).toFixed(2)} — status ${status}.`,target:'operations',entity_id:order.id,due_at:order.created_at});
+      const amountAr=formatMarketMoney(order.total_amount,market,'ar');
+      const amountEn=formatMarketMoney(order.total_amount,market,'en');
+      addItem(items,{id:`order:${order.id}`,type:'order',priority:status==='reserved'?68:54,severity:'warning',title_ar:status==='reserved'?`طلب محجوز يحتاج متابعة: ${name}`:`طلب غير مكتمل: ${name}`,title_en:status==='reserved'?`Reserved order needs follow-up: ${name}`:`Incomplete order: ${name}`,detail_ar:`القيمة ${amountAr} — الحالة ${status}.`,detail_en:`${amountEn} — status ${status}.`,target:'operations',entity_id:order.id,due_at:order.created_at});
     }
 
     const liveStates=new Set(['connected','operational','verified','live']);
@@ -198,13 +207,15 @@ export default async function handler(req,res){
       business_id:businessId,
       role:membership.role,
       generated_at:new Date().toISOString(),
-      timezone:'Asia/Dubai',
+      country_code:market.country_code,
+      currency_code:market.currency_code,
+      timezone:market.timezone,
       status:urgent>0?'needs_attention':warning>0?'watch':'clear',
       metrics:{urgent,warning,total:items.length,handled_verified_today:handledResult.available?handledCount:null,upcoming_24h:items.filter(item=>item.type==='appointment'||item.type==='followup').length,low_stock:items.filter(item=>item.type==='inventory').length,orders_needing_action:items.filter(item=>item.type==='order').length},
       handled:{available:handledResult.available,verified_autonomous_today:handledResult.available?handledCount:null,latest:handledResult.available?handledLatest:[]},
       brief:{ar:briefAr,en:briefEn},
       items:items.slice(0,12),
-      truth:{source:'live_dabbir_tenant_data',auth_fast_path:true,simulated_orders_excluded:true,simulated_appointments_excluded:true,handled_counts_only_verified_success_autonomous_outcomes:true,handled_unavailable_is_not_zero:true},
+      truth:{source:'live_dabbir_tenant_data',auth_fast_path:true,market_contract:'verified_country_currency_timezone',money_source:'currency_snapshotted_generic_amounts',simulated_orders_excluded:true,simulated_appointments_excluded:true,handled_counts_only_verified_success_autonomous_outcomes:true,handled_unavailable_is_not_zero:true},
     });
   }catch(error){
     const status=Number(error?.status||500);

--- a/test/dabbir-gcc-money-runtime-contract.test.mjs
+++ b/test/dabbir-gcc-money-runtime-contract.test.mjs
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import {
+  assertSnapshotCurrency,
+  formatMarketMoney,
+  marketDayStartIso,
+  verifiedBusinessMarket,
+} from '../api/_gcc-money-core.js';
+
+const actionCenter=fs.readFileSync(new URL('../api/owner-action-center.js',import.meta.url),'utf8');
+
+const markets={
+  AE:{country_code:'AE',currency_code:'AED',timezone:'Asia/Dubai',digits:2},
+  SA:{country_code:'SA',currency_code:'SAR',timezone:'Asia/Riyadh',digits:2},
+  KW:{country_code:'KW',currency_code:'KWD',timezone:'Asia/Kuwait',digits:3},
+  QA:{country_code:'QA',currency_code:'QAR',timezone:'Asia/Qatar',digits:2},
+  BH:{country_code:'BH',currency_code:'BHD',timezone:'Asia/Bahrain',digits:3},
+  OM:{country_code:'OM',currency_code:'OMR',timezone:'Asia/Muscat',digits:3},
+};
+
+test('all six GCC markets resolve to the country currency and timezone contract',()=>{
+  for(const expected of Object.values(markets)){
+    const market=verifiedBusinessMarket(expected);
+    assert.equal(market.country_code,expected.country_code);
+    assert.equal(market.currency_code,expected.currency_code);
+    assert.equal(market.timezone,expected.timezone);
+    assert.equal(market.currency_minor_units,expected.digits);
+  }
+});
+
+test('money formatting uses market currency and correct GCC minor units',()=>{
+  const sar=verifiedBusinessMarket(markets.SA);
+  const kwd=verifiedBusinessMarket(markets.KW);
+  assert.match(formatMarketMoney(125,sar,'en'),/SAR/);
+  assert.match(formatMarketMoney(125,sar,'ar'),/125|١٢٥/);
+  assert.match(formatMarketMoney(1.234,kwd,'en'),/KWD/);
+  assert.match(formatMarketMoney(1.234,kwd,'en'),/1\.234/);
+});
+
+test('market day start is not Dubai-hardcoded',()=>{
+  const instant=Date.parse('2026-09-04T00:30:00.000Z');
+  assert.equal(marketDayStartIso(instant,verifiedBusinessMarket(markets.AE)),'2026-09-03T20:00:00.000Z');
+  assert.equal(marketDayStartIso(instant,verifiedBusinessMarket(markets.SA)),'2026-09-03T21:00:00.000Z');
+  assert.equal(marketDayStartIso(instant,verifiedBusinessMarket(markets.KW)),'2026-09-03T21:00:00.000Z');
+});
+
+test('market and snapshot mismatches fail closed',()=>{
+  assert.throws(()=>verifiedBusinessMarket({country_code:'SA',currency_code:'AED',timezone:'Asia/Riyadh'}),/BUSINESS_MARKET_CURRENCY_MISMATCH/);
+  const sar=verifiedBusinessMarket(markets.SA);
+  assert.throws(()=>assertSnapshotCurrency('AED',sar,'ORDER'),/ORDER_CURRENCY_SNAPSHOT_MISMATCH/);
+  assert.equal(assertSnapshotCurrency('SAR',sar,'ORDER'),'SAR');
+});
+
+test('owner action center reads neutral money aliases and verified business market context',()=>{
+  assert.match(actionCenter,/dabbir_businesses\?select=id,country_code,currency_code,timezone/);
+  assert.match(actionCenter,/verifiedBusinessMarket\(business\)/);
+  assert.match(actionCenter,/marketDayStartIso\(now,market\)/);
+  assert.match(actionCenter,/dabbir_orders\?select=id,customer_id,status,total_amount,currency_code/);
+  assert.match(actionCenter,/assertSnapshotCurrency\(order\.currency_code,market,'ORDER'\)/);
+  assert.match(actionCenter,/formatMarketMoney\(order\.total_amount,market,'ar'\)/);
+  assert.match(actionCenter,/formatMarketMoney\(order\.total_amount,market,'en'\)/);
+  assert.match(actionCenter,/country_code:market\.country_code/);
+  assert.match(actionCenter,/currency_code:market\.currency_code/);
+  assert.match(actionCenter,/timezone:market\.timezone/);
+});
+
+test('owner action center no longer presents UAE money or Dubai day boundaries as universal truth',()=>{
+  assert.doesNotMatch(actionCenter,/function dubaiDayStartIso/);
+  assert.doesNotMatch(actionCenter,/timezone:'Asia\/Dubai'/);
+  assert.doesNotMatch(actionCenter,/total_aed/);
+  assert.doesNotMatch(actionCenter,/detail_en:`AED /);
+  assert.doesNotMatch(actionCenter,/د\.إ/);
+});


### PR DESCRIPTION
P1 GCC runtime contract repair.

- adds shared GCC money/time core using active market profiles
- owner action center loads business country/currency/timezone
- reads neutral generated money aliases (`total_amount`) instead of treating `*_aed` as semantic AED
- formats order attention copy with actual business currency/minor units
- computes verified autonomous “today” window in the business timezone
- fails closed on invalid market/currency/timezone combinations
- adds regression coverage for AE/SA/KW/QA/BH/OM including 3-decimal currencies

No new DDL: production already contains immutable currency snapshots and neutral generated amount aliases.