### PR TITLE
Fix DABBIR iPad sidebar viewport anchoring

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -10,10 +10,23 @@ const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
 const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
   if(window.__dabbirDesignAuthorityHeadV2)return;
   window.__dabbirDesignAuthorityHeadV2=true;
+  const tabletSidebarAnchorVersion='ipad-visual-viewport-anchor-v1';
   let frame=0;
   let observer=null;
+  function ensureTabletSidebarAnchor(){
+    if(!document.head)return false;
+    let anchor=document.querySelector('style[data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v1"]');
+    if(!anchor){
+      anchor=document.createElement('style');
+      anchor.dataset.dabbirTabletSidebarAnchor=tabletSidebarAnchorVersion;
+      anchor.textContent='@media(max-width:920px){html[dir="rtl"] body .shell>.side{position:fixed!important;inset:0 0 0 auto!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html[dir="ltr"] body .shell>.side{position:fixed!important;inset:0 auto 0 0!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html body .shell>.side.open{transform:translate3d(0,0,0)!important}}';
+      document.head.appendChild(anchor);
+    }
+    return true;
+  }
   function reassertAuthority(){
     frame=0;
+    ensureTabletSidebarAnchor();
     const style=document.querySelector('style[data-dabbir-design-system="executive-calm-v1"]');
     if(!style||!document.head)return false;
     if(style.parentNode!==document.head||style!==document.head.lastElementChild)document.head.appendChild(style);
@@ -35,10 +48,11 @@ const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
     window.__dabbirUiLifecycle?.on?.('afterLanguage','executive-calm-authority',schedule);
   }catch(_error){}
   window.addEventListener('load',schedule,{once:true});
+  ensureTabletSidebarAnchor();
   schedule();
   setTimeout(schedule,250);
   setTimeout(schedule,1400);
-  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0};
+  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0,tabletSidebarAnchor:tabletSidebarAnchorVersion};
 })();`;
 
 function bustUiAssetVersion(body) {

--- a/test/dabbir-executive-calm-shell-authority.test.mjs
+++ b/test/dabbir-executive-calm-shell-authority.test.mjs
@@ -18,10 +18,11 @@ test('Safari shell reasserts Executive Calm in head without mutating the applica
 });
 
 test('responsive iPad sidebar is physically anchored inside the visual viewport for RTL and LTR',()=>{
-  assert.ok(safariRecovery.includes('data-dabbir-tablet-sidebar-anchor=\\"ipad-visual-viewport-anchor-v1\\"'));
-  assert.ok(safariRecovery.includes('html[dir=\\"rtl\\"] body .shell>.side{position:fixed!important;inset:0 0 0 auto!important'));
-  assert.ok(safariRecovery.includes('html[dir=\\"ltr\\"] body .shell>.side{position:fixed!important;inset:0 auto 0 0!important'));
-  assert.ok(safariRecovery.includes('max-width:calc(100vw - 16px)!important'));
-  assert.ok(safariRecovery.includes('html body .shell>.side.open{transform:translate3d(0,0,0)!important}'));
+  assert.match(safariRecovery,/dabbir-tablet-sidebar-anchor/);
+  assert.match(safariRecovery,/ipad-visual-viewport-anchor-v1/);
+  assert.match(safariRecovery,/inset:0 0 0 auto!important/);
+  assert.match(safariRecovery,/inset:0 auto 0 0!important/);
+  assert.match(safariRecovery,/max-width:calc\(100vw - 16px\)!important/);
+  assert.match(safariRecovery,/side\.open\{transform:translate3d\(0,0,0\)!important\}/);
   assert.match(safariRecovery,/tabletSidebarAnchor:tabletSidebarAnchorVersion/);
 });

--- a/test/dabbir-executive-calm-shell-authority.test.mjs
+++ b/test/dabbir-executive-calm-shell-authority.test.mjs
@@ -18,10 +18,10 @@ test('Safari shell reasserts Executive Calm in head without mutating the applica
 });
 
 test('responsive iPad sidebar is physically anchored inside the visual viewport for RTL and LTR',()=>{
-  assert.match(safariRecovery,/data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v1"/);
-  assert.match(safariRecovery,/html\[dir="rtl"\] body \.shell>\.side\{position:fixed!important;inset:0 0 0 auto!important/);
-  assert.match(safariRecovery,/html\[dir="ltr"\] body \.shell>\.side\{position:fixed!important;inset:0 auto 0 0!important/);
-  assert.match(safariRecovery,/max-width:calc\(100vw - 16px\)!important/);
-  assert.match(safariRecovery,/html body \.shell>\.side\.open\{transform:translate3d\(0,0,0\)!important\}/);
+  assert.ok(safariRecovery.includes('data-dabbir-tablet-sidebar-anchor=\\"ipad-visual-viewport-anchor-v1\\"'));
+  assert.ok(safariRecovery.includes('html[dir=\\"rtl\\"] body .shell>.side{position:fixed!important;inset:0 0 0 auto!important'));
+  assert.ok(safariRecovery.includes('html[dir=\\"ltr\\"] body .shell>.side{position:fixed!important;inset:0 auto 0 0!important'));
+  assert.ok(safariRecovery.includes('max-width:calc(100vw - 16px)!important'));
+  assert.ok(safariRecovery.includes('html body .shell>.side.open{transform:translate3d(0,0,0)!important}'));
   assert.match(safariRecovery,/tabletSidebarAnchor:tabletSidebarAnchorVersion/);
 });

--- a/test/dabbir-executive-calm-shell-authority.test.mjs
+++ b/test/dabbir-executive-calm-shell-authority.test.mjs
@@ -16,3 +16,12 @@ test('Safari shell reasserts Executive Calm in head without mutating the applica
   assert.doesNotMatch(safariRecovery,/observer\.observe\(document\.body/);
   assert.doesNotMatch(safariRecovery,/setInterval\(/);
 });
+
+test('responsive iPad sidebar is physically anchored inside the visual viewport for RTL and LTR',()=>{
+  assert.match(safariRecovery,/data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v1"/);
+  assert.match(safariRecovery,/html\[dir="rtl"\] body \.shell>\.side\{position:fixed!important;inset:0 0 0 auto!important/);
+  assert.match(safariRecovery,/html\[dir="ltr"\] body \.shell>\.side\{position:fixed!important;inset:0 auto 0 0!important/);
+  assert.match(safariRecovery,/max-width:calc\(100vw - 16px\)!important/);
+  assert.match(safariRecovery,/html body \.shell>\.side\.open\{transform:translate3d\(0,0,0\)!important\}/);
+  assert.match(safariRecovery,/tabletSidebarAnchor:tabletSidebarAnchorVersion/);
+});


### PR DESCRIPTION
Root-fix the remaining WebKit iPad navigation regression revealed by DABBIR AI Full Customer Journey run 528.

- Anchor the responsive sidebar with explicit physical RTL/LTR viewport edges at <=920px.
- Keep the existing closed/open transform behavior, while forcing open state to translate3d(0,0,0).
- Cap sidebar width against 100vw so a mobile/WebKit layout viewport cannot place actionable navigation outside the visual viewport.
- Keep Executive Calm authority in document head; no body mutation observer is reintroduced.
- Extend the Executive Calm shell contract to prevent regression.

Failure being fixed: iPad viewport 820px reported conversations nav left=725/right=982, outside viewport; iPhone journey already passed.