### PR TITLE
fix(dabbir): root Executive Calm visual authority

### DIFF
--- a/api/_executive-calm-page.js
+++ b/api/_executive-calm-page.js
@@ -1,0 +1,23 @@
+export const EXECUTIVE_CALM_VERSION='20260904-root-v1';
+const STYLE_HREF=`/dabbir-executive-calm.css?v=${EXECUTIVE_CALM_VERSION}`;
+const STYLE_LINK=`<link rel="stylesheet" href="${STYLE_HREF}" data-dabbir-design-system="executive-calm-v1">`;
+
+export function applyExecutiveCalmPage(html){
+  if(typeof html!=='string')return html;
+  let next=html;
+  if(/<meta\s+name=["']theme-color["'][^>]*>/i.test(next)){
+    next=next.replace(/<meta\s+name=["']theme-color["'][^>]*>/i,'<meta name="theme-color" content="#091421">');
+  }else if(/<head[^>]*>/i.test(next)){
+    next=next.replace(/<head([^>]*)>/i,'<head$1>\n<meta name="theme-color" content="#091421">');
+  }
+  if(!next.includes('data-dabbir-design-system="executive-calm-v1"')){
+    next=next.replace(/<\/head>/i,`${STYLE_LINK}\n</head>`);
+  }
+  return next;
+}
+
+export function executiveCalmHeaders(res){
+  res.setHeader('x-dabbir-design-system','executive-calm-v1');
+  res.setHeader('x-dabbir-design-version',EXECUTIVE_CALM_VERSION);
+  return res;
+}

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -1,5 +1,6 @@
 import appRecoveryHandler from './app-recovery.js';
 import ownerFirstUiHandler from './dabbir-owner-first-ui.js';
+import { applyExecutiveCalmPage, executiveCalmHeaders } from './_executive-calm-page.js';
 
 const UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3';
 const SAFARI_AUTH_FAIL_OPEN = `/api/dabbir-safari-auth-fail-open-ui?v=${UI_CACHE_BUST}`;
@@ -145,11 +146,14 @@ export default function handler(req, res) {
       res.setHeader('x-dabbir-ui-cache-bust', UI_CACHE_BUST);
       res.setHeader('x-dabbir-navigation-authority', 'context-router');
       res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v2');
+      res.setHeader('x-dabbir-static-design-authority', 'executive-calm-static-before-auth-boot-v1');
       res.setHeader('x-dabbir-design-authority', 'executive-calm-v1');
+      executiveCalmHeaders(res);
       res.statusCode = Number(proxy.statusCode || 200);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);
-      const ordered = orderOwnerFirstBeforeAuthBoot(canonical);
+      const branded = applyExecutiveCalmPage(canonical);
+      const ordered = orderOwnerFirstBeforeAuthBoot(branded);
       return res.end(injectSafariAuthFailOpen(ordered));
     },
   };

--- a/api/car-wash-booking.js
+++ b/api/car-wash-booking.js
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { applyExecutiveCalmPage, executiveCalmHeaders } from './_executive-calm-page.js';
 
 const BOOKING_HTML=readFileSync(new URL('../booking.html', import.meta.url), 'utf8');
 const BOOKING_INTERFACE_HARDENING=`<style id="dabbir-public-booking-hardening-v1">
@@ -17,7 +18,7 @@ button{touch-action:manipulation}
 @media(prefers-reduced-motion:reduce){*,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}}
 </style>`;
 const GCC_PUBLIC_BOOKING_SCRIPT='<script src="/api/gcc-public-booking-ui" defer></script>';
-const BOOKING_PAGE=BOOKING_HTML.replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`).replace('</body>',`${GCC_PUBLIC_BOOKING_SCRIPT}</body>`);
+const BOOKING_PAGE=applyExecutiveCalmPage(BOOKING_HTML.replace('</head>',`${BOOKING_INTERFACE_HARDENING}</head>`).replace('</body>',`${GCC_PUBLIC_BOOKING_SCRIPT}</body>`));
 const HEADERS={
   'content-type':'text/html; charset=utf-8',
   'cache-control':'no-store',
@@ -36,7 +37,8 @@ export default function handler(req,res){
     return res.end(JSON.stringify({ok:false,error:'METHOD_NOT_ALLOWED'}));
   }
   for(const [key,value] of Object.entries(HEADERS))res.setHeader(key,value);
-  res.setHeader('x-dabbir-booking-page','public-v1.2-gcc-authority');
+  executiveCalmHeaders(res);
+  res.setHeader('x-dabbir-booking-page','public-v1.3-executive-calm');
   res.statusCode=200;
   return res.end(BOOKING_PAGE);
 }

--- a/api/team-page.js
+++ b/api/team-page.js
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs';
+import { applyExecutiveCalmPage, executiveCalmHeaders } from './_executive-calm-page.js';
 
-const TEAM_HTML = readFileSync(new URL('../team.html', import.meta.url), 'utf8');
+const TEAM_HTML = applyExecutiveCalmPage(readFileSync(new URL('../team.html', import.meta.url), 'utf8'));
 
 export default function handler(req, res) {
   if (req.method !== 'GET') {
@@ -14,6 +15,7 @@ export default function handler(req, res) {
   res.setHeader('x-frame-options', 'DENY');
   res.setHeader('referrer-policy', 'no-referrer');
   res.setHeader('permissions-policy', 'camera=(), microphone=(), geolocation=(), payment=()');
+  executiveCalmHeaders(res);
   return res.status(200).send(TEAM_HTML);
 }
 

--- a/public/dabbir-executive-calm.css
+++ b/public/dabbir-executive-calm.css
@@ -1,0 +1,129 @@
+:root{
+  color-scheme:dark;
+  --ds-bg:#07111f;
+  --ds-shell:#091421;
+  --ds-surface:#0d1a2a;
+  --ds-surface2:#102033;
+  --ds-surface3:#14263a;
+  --ds-border:#94a3b826;
+  --ds-border-strong:#94a3b83d;
+  --ds-text:#f7fafc;
+  --ds-muted:#9cabbf;
+  --ds-muted2:#718198;
+  --ds-brand:#536dfe;
+  --ds-brand-hover:#667dfd;
+  --ds-brand-soft:#536dfe1f;
+  --ds-ai-violet:#7c5cff;
+  --ds-ai-blue:#4f7cff;
+  --ds-ai-cyan:#22b8cf;
+  --ds-success:#56d6a0;
+  --ds-warning:#f4c55e;
+  --ds-danger:#ff7f96;
+  --ds-info:#76b8ff;
+  --ds-control:10px;
+  --ds-card:14px;
+  --ds-large:18px;
+  --ds-shadow-raised:0 18px 48px #00000040;
+
+  /* Compatibility aliases for legacy markup while the old inline CSS is retired. */
+  --bg:var(--ds-bg)!important;
+  --panel:var(--ds-surface)!important;
+  --panel2:var(--ds-surface2)!important;
+  --line:var(--ds-border)!important;
+  --text:var(--ds-text)!important;
+  --muted:var(--ds-muted)!important;
+  --accent:var(--ds-brand)!important;
+  --green:var(--ds-success)!important;
+  --yellow:var(--ds-warning)!important;
+  --red:var(--ds-danger)!important;
+  --blue:var(--ds-info)!important;
+  --r:var(--ds-card)!important;
+  --shadow:var(--ds-shadow-raised)!important;
+}
+
+html{
+  background:var(--ds-bg)!important;
+  min-height:100%;
+}
+html,body{
+  color:var(--ds-text)!important;
+  background:linear-gradient(180deg,#0a1625 0,var(--ds-bg) 42%,#06101c 100%)!important;
+}
+body{
+  min-height:100dvh;
+  -webkit-font-smoothing:antialiased;
+  text-rendering:optimizeLegibility;
+  font-family:"SF Arabic","Noto Sans Arabic","Segoe UI",Tahoma,Arial,sans-serif!important;
+}
+html[lang^="en"] body{
+  font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",Inter,Arial,sans-serif!important;
+}
+button,input,select,textarea{font-family:inherit}
+a{color:inherit}
+a:focus-visible,button:focus-visible,input:focus-visible,select:focus-visible,textarea:focus-visible{
+  outline:2px solid #8ea0ff!important;
+  outline-offset:2px!important;
+}
+
+/* Shared surfaces used by the app and public/static pages. */
+.card,.panel,.section,.authCard,.workspace,.integration,.chatList,.chatPanel,.table,.moreCard,
+.privacyCard,.termsCard,.supportCard,.teamCard,.bookingCard{
+  background:var(--ds-surface)!important;
+  border-color:var(--ds-border)!important;
+  box-shadow:none!important;
+}
+.card,.panel,.section,.authCard,.integration,.chatList,.chatPanel,.table,.moreCard,
+.privacyCard,.termsCard,.supportCard,.teamCard,.bookingCard{
+  border-radius:var(--ds-card)!important;
+}
+
+.primary,button.primary,a.primary{
+  background:var(--ds-brand)!important;
+  color:#fff!important;
+  border-color:#ffffff10!important;
+  box-shadow:none!important;
+}
+.primary:hover,button.primary:hover,a.primary:hover{background:var(--ds-brand-hover)!important}
+.secondary,button.secondary,a.secondary{
+  background:#ffffff08!important;
+  color:var(--ds-text)!important;
+  border-color:var(--ds-border)!important;
+  box-shadow:none!important;
+}
+.secondary:hover,button.secondary:hover,a.secondary:hover{
+  background:#ffffff0d!important;
+  border-color:var(--ds-border-strong)!important;
+}
+
+.muted,.subtitle,.eyebrow+ p,.hero p,.section p,.card p,.panel p,.footer,
+small,.help,.hint{color:var(--ds-muted)!important}
+.eyebrow{color:#8fa0ff!important}
+.green,.success,.statusChip{color:#7ce2ba!important}
+.yellow,.warning{color:#f8d578!important}
+.red,.danger{color:#ff9cad!important}
+.blue,.info{color:#91caff!important}
+
+input,select,textarea{
+  background:#ffffff06!important;
+  border-color:var(--ds-border)!important;
+  color:var(--ds-text)!important;
+}
+input::placeholder,textarea::placeholder{color:var(--ds-muted2)!important}
+
+/* DABBIR brand gradient is intentionally reserved for AI-specific surfaces. */
+.dabbirCopilot,.aiSurface,.aiCard{
+  background:linear-gradient(180deg,#101d31 0,#0d1a2a 100%)!important;
+  border-color:#536dfe42!important;
+}
+.dabbirCopilot::before,.aiAccent{
+  background:linear-gradient(180deg,var(--ds-ai-violet),var(--ds-ai-blue),var(--ds-ai-cyan))!important;
+}
+
+@media(max-width:700px){
+  input:not([type="checkbox"]):not([type="radio"]),select,textarea{font-size:16px!important}
+  button,[role="button"],a.button{min-height:44px}
+  body{padding-bottom:env(safe-area-inset-bottom)}
+}
+@media(prefers-reduced-motion:reduce){
+  *,*::before,*::after{animation-duration:.01ms!important;animation-iteration-count:1!important;transition-duration:.01ms!important;scroll-behavior:auto!important}
+}

--- a/scripts/build-dabbir-ui-bundles.mjs
+++ b/scripts/build-dabbir-ui-bundles.mjs
@@ -1,6 +1,7 @@
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { applyExecutiveCalmPage } from '../api/_executive-calm-page.js';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const manifestPath = path.join(root, 'config/dabbir-ui-bundles.json');
@@ -56,7 +57,18 @@ async function build(name, modules) {
   console.log(`${outputPath}: ${Buffer.byteLength(output)} bytes from ${modules.length} modules`);
 }
 
+async function brandStablePublicPages() {
+  for (const file of ['privacy.html', 'terms.html', 'support.html']) {
+    const filePath = path.join(root, file);
+    const source = await fs.readFile(filePath, 'utf8');
+    const branded = applyExecutiveCalmPage(source);
+    if (branded !== source) await fs.writeFile(filePath, branded);
+    console.log(`${filePath}: Executive Calm public-page authority`);
+  }
+}
+
 const all = [...manifest.critical, ...manifest.deferred];
 if (new Set(all).size !== all.length) throw new Error('Duplicate UI module in bundle manifest');
 await build('critical', manifest.critical);
 await build('deferred', manifest.deferred);
+await brandStablePublicPages();

--- a/test/dabbir-root-visual-authority.test.mjs
+++ b/test/dabbir-root-visual-authority.test.mjs
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const root=new URL('../',import.meta.url);
+const css=fs.readFileSync(new URL('public/dabbir-executive-calm.css',root),'utf8');
+const helper=fs.readFileSync(new URL('api/_executive-calm-page.js',root),'utf8');
+const safari=fs.readFileSync(new URL('api/app-safari-recovery.js',root),'utf8');
+const booking=fs.readFileSync(new URL('api/car-wash-booking.js',root),'utf8');
+const team=fs.readFileSync(new URL('api/team-page.js',root),'utf8');
+const builder=fs.readFileSync(new URL('scripts/build-dabbir-ui-bundles.mjs',root),'utf8');
+const vercel=JSON.parse(fs.readFileSync(new URL('vercel.json',root),'utf8'));
+
+test('Executive Calm has one static first-paint token authority and no legacy neon accent',()=>{
+  assert.match(css,/--ds-brand:#536dfe/);
+  assert.match(css,/--accent:var\(--ds-brand\)!important/);
+  assert.match(css,/--bg:var\(--ds-bg\)!important/);
+  assert.doesNotMatch(css,/#d7ff5f/i);
+  assert.match(helper,/dabbir-executive-calm\.css/);
+  assert.match(helper,/content=\"#091421\"/);
+});
+
+test('app receives static design authority before auth boot without breaking Safari release headers',()=>{
+  assert.match(safari,/applyExecutiveCalmPage\(canonical\)/);
+  assert.match(safari,/x-dabbir-first-paint-authority/);
+  assert.match(safari,/owner-first-inline-before-auth-boot-v2/);
+  assert.match(safari,/x-dabbir-static-design-authority/);
+  assert.match(safari,/executive-calm-static-before-auth-boot-v1/);
+  assert.match(safari,/executiveCalmHeaders\(res\)/);
+});
+
+test('stable App Store public routes keep their contract while build output receives the shared design authority',()=>{
+  for(const source of [booking,team]){
+    assert.match(source,/applyExecutiveCalmPage/);
+    assert.match(source,/executiveCalmHeaders/);
+  }
+  assert.match(builder,/brandStablePublicPages/);
+  for(const page of ['privacy','terms','support']){
+    assert.match(builder,new RegExp(`${page}\\.html`));
+    const route=vercel.routes.find(item=>item.src===`^/${page}/?$`);
+    assert.ok(route,`${page} stable route must remain present`);
+    assert.equal(route.dest,`/${page}.html`);
+  }
+});

--- a/vercel.json
+++ b/vercel.json
@@ -137,6 +137,12 @@
       ]
     },
     {
+      "source": "/dabbir-executive-calm.css",
+      "headers": [
+        { "key": "Cache-Control", "value": "no-store, max-age=0" }
+      ]
+    },
+    {
       "source": "/(dabbir-app-icon|favicon)\\.(png|ico)",
       "headers": [
         { "key": "Cache-Control", "value": "public, max-age=31536000, immutable" }


### PR DESCRIPTION
## Root cause
DABBIR shipped two visual systems: legacy black/neon base markup and a later JavaScript Executive Calm layer. This created first-paint drift, Safari cascade risk, and mismatched public pages.

## Root repair
- Add one static Executive Calm navy/indigo design authority loaded from `<head>` before app/auth boot.
- Preserve the existing Safari first-paint release contract and add an explicit static authority marker.
- Apply the same authority to Team and public Booking.
- Brand stable `/privacy`, `/terms`, `/support` build output without changing App Store route contracts.
- Keep legacy markup as compatibility input while authoritative tokens override it at first paint.
- Add regression tests for first-paint authority, public-route contracts, and removal of neon from the shared authority.
- Built directly on current `main`, including the attested dependency-audit fallback.

## Verification
DABBIR CI + Mobile CI + Vercel Preview must pass. Preview routes will be inspected before merge.