### PR TITLE
fix(gcc): make Owner Operations market-neutral

### DIFF
--- a/api/owner-operations-ui.js
+++ b/api/owner-operations-ui.js
@@ -53,10 +53,18 @@ const script=String.raw`(()=>{
   let editingProductId=null;
 
   function escapeHtml(value){return String(value??'').replace(/[&<>\"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','\"':'&quot;',"'":'&#39;'}[c]))}
-  function money(value){try{return new Intl.NumberFormat(ar()?'ar-AE':'en-AE',{minimumFractionDigits:2,maximumFractionDigits:2}).format(Number(value||0))+' '+currencyCode()}catch{return Number(value||0).toFixed(2)+' '+currencyCode()}}
-  function date(value){if(!value)return '—';try{return new Intl.DateTimeFormat(ar()?'ar-AE':'en-AE',{dateStyle:'medium'}).format(new Date(value))}catch{return String(value)}}
+  function countryCode(){try{return String(data?.country_code||workspace?.business?.country_code||'AE').trim().toUpperCase()||'AE'}catch{return 'AE'}}
+  function currencyCode(){try{return String(data?.currency_code||workspace?.business?.currency_code||'AED').trim().toUpperCase()||'AED'}catch{return 'AED'}}
+  function currencyDigits(){const value=Number(data?.currency_minor_units);if(Number.isInteger(value)&&value>=0&&value<=3)return value;return ['KWD','BHD','OMR'].includes(currencyCode())?3:2}
+  function timezone(){try{return String(data?.timezone||workspace?.business?.timezone||document.documentElement.dataset.dabbirTimezone||'Asia/Dubai')}catch{return 'Asia/Dubai'}}
+  function locale(){return (ar()?'ar-':'en-')+countryCode()}
+  function money(value){
+    const amount=Number(value||0);const digits=currencyDigits();
+    try{return new Intl.NumberFormat(locale(),{style:'currency',currency:currencyCode(),minimumFractionDigits:digits,maximumFractionDigits:digits}).format(amount)}
+    catch{return amount.toFixed(digits)+' '+currencyCode()}
+  }
+  function date(value){if(!value)return '—';try{return new Intl.DateTimeFormat(locale(),{dateStyle:'medium',timeZone:timezone()}).format(new Date(value))}catch{return String(value)}}
   function isStore(){try{return String(workspace?.business?.business_type||'').toLowerCase()==='store'}catch{return false}}
-  function currencyCode(){try{return String(workspace?.business?.currency_code||'AED').trim().toUpperCase()||'AED'}catch{return 'AED'}}
   function notify(message){try{if(typeof toast==='function')toast(message)}catch{}}
   function productSku(){return 'DAB-'+Date.now().toString(36).toUpperCase()+'-'+Math.random().toString(36).slice(2,6).toUpperCase()}
   function errorText(error){
@@ -68,19 +76,10 @@ const script=String.raw`(()=>{
 
   function ensureScreen(){
     let screen=q('#screen-operations');
-    if(!screen){
-      screen=document.createElement('section');
-      screen.className='screen';
-      screen.id='screen-operations';
-      q('.content')?.appendChild(screen);
-    }
+    if(!screen){screen=document.createElement('section');screen.className='screen';screen.id='screen-operations';q('.content')?.appendChild(screen)}
     if(!isStore())return screen;
-
-    if(!q('#opsBody')){
-      screen.innerHTML='<div class=\"hero\"><div><h1 id=\"opsTitle\"></h1><p id=\"opsDesc\"></p></div><button class=\"primary\" id=\"opsAddProduct\" type=\"button\"></button></div><div id=\"opsBody\"></div>';
-    }
+    if(!q('#opsBody'))screen.innerHTML='<div class=\"hero\"><div><h1 id=\"opsTitle\"></h1><p id=\"opsDesc\"></p></div><button class=\"primary\" id=\"opsAddProduct\" type=\"button\"></button></div><div id=\"opsBody\"></div>';
     q('#svcModal')?.classList.remove('open');
-
     if(!q('#opsProductModal')){
       const productModal=document.createElement('div');
       productModal.className='modal';productModal.id='opsProductModal';
@@ -95,29 +94,16 @@ const script=String.raw`(()=>{
     return screen;
   }
 
-  function openNewProduct(){
-    editingProductId=null;
-    q('#opsProductForm')?.reset();
-    applyCopy();
-    q('#opsProductModal')?.classList.add('open');
-  }
-
+  function openNewProduct(){editingProductId=null;q('#opsProductForm')?.reset();applyCopy();q('#opsProductModal')?.classList.add('open')}
   function openEditProduct(product){
     if(!product)return;
     editingProductId=product.id;
     q('#opsName').value=product.name||'';
-    q('#opsPrice').value=Number(product.price_aed||0).toFixed(2).replace(/\.00$/,'');
+    q('#opsPrice').value=Number(product.price_amount||0).toFixed(currencyDigits()).replace(/\.0+$/,'');
     q('#opsQty').value=Number(product.quantity||0);
-    applyCopy();
-    q('#opsProductModal')?.classList.add('open');
+    applyCopy();q('#opsProductModal')?.classList.add('open');
   }
-
-  function closeProductModal(){
-    q('#opsProductModal')?.classList.remove('open');
-    q('#opsProductForm')?.reset();
-    editingProductId=null;
-    applyCopy();
-  }
+  function closeProductModal(){q('#opsProductModal')?.classList.remove('open');q('#opsProductForm')?.reset();editingProductId=null;applyCopy()}
 
   function applyCopy(){
     if(!isStore())return;
@@ -128,6 +114,7 @@ const script=String.raw`(()=>{
     if(q('#opsProductModalTitle'))q('#opsProductModalTitle').textContent=editingProductId?t.editTitle:t.add;
     if(q('#opsNameLabel'))q('#opsNameLabel').textContent=t.name;
     if(q('#opsPriceLabel'))q('#opsPriceLabel').textContent=t.price+' ('+currencyCode()+')';
+    if(q('#opsPrice'))q('#opsPrice').step=currencyDigits()===3?'0.001':'0.01';
     if(q('#opsQtyLabel'))q('#opsQtyLabel').textContent=t.qty;
     if(q('#opsProductCancel'))q('#opsProductCancel').textContent=t.cancel;
     if(q('#opsProductSave'))q('#opsProductSave').textContent=editingProductId?t.update:t.save;
@@ -149,18 +136,16 @@ const script=String.raw`(()=>{
     businessId=workspace?.business?.id||businessId;
     if(loading||(!force&&data&&data.business_id===businessId))return;
     loading=true;render();
-    try{data=await request();render()}catch(error){data={error:error.message};render()}finally{loading=false;render()}
+    try{data=await request();render();applyCopy()}catch(error){data={error:error.message};render()}finally{loading=false;render()}
   }
 
-  function statusOptions(current){
-    const t=text();
-    const labels={draft:t.draft,reserved:t.reservedStatus,confirmed:t.confirmed,cancelled:t.cancelled,completed:t.completed};
-    return Object.entries(labels).map(([value,label])=>'<option value=\"'+value+'\" '+(value===current?'selected':'')+'>'+escapeHtml(label)+'</option>').join('');
+  function statusOptions(currentStatus){
+    const t=text();const labels={draft:t.draft,reserved:t.reservedStatus,confirmed:t.confirmed,cancelled:t.cancelled,completed:t.completed};
+    return Object.entries(labels).map(([value,label])=>'<option value=\"'+value+'\" '+(value===currentStatus?'selected':'')+'>'+escapeHtml(label)+'</option>').join('');
   }
 
   function render(){
-    const body=q('#opsBody');
-    if(!body||!isStore())return;
+    const body=q('#opsBody');if(!body||!isStore())return;
     const t=text();
     if(loading&&!data){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.loading)+'</div>';return}
     if(data?.error){body.innerHTML='<div class=\"empty\">'+escapeHtml(t.failed)+' — '+escapeHtml(data.error)+'</div>';return}
@@ -171,16 +156,12 @@ const script=String.raw`(()=>{
     const inventoryUnits=products.reduce((sum,product)=>sum+Number(product.quantity||0),0);
     if(q('#opsAddProduct'))q('#opsAddProduct').style.display=data.can_manage?'inline-flex':'none';
 
-    const metrics=[
-      [t.products,products.length],[t.stock,inventoryUnits],[t.low,low.length],[t.sales,money(data.metrics?.recognized_sales_aed||0)]
-    ].map(([label,value])=>'<div class=\"opsMetric\"><span>'+escapeHtml(label)+'</span><strong>'+escapeHtml(value)+'</strong></div>').join('');
-
+    const metrics=[[t.products,products.length],[t.stock,inventoryUnits],[t.low,low.length],[t.sales,money(data.metrics?.recognized_sales_amount||0)]]
+      .map(([label,value])=>'<div class=\"opsMetric\"><span>'+escapeHtml(label)+'</span><strong>'+escapeHtml(value)+'</strong></div>').join('');
     const lowHtml='<div class=\"opsLow\"><b>'+escapeHtml(t.lowTitle)+'</b><div style=\"margin-top:5px\">'+(low.length?low.slice(0,8).map(product=>escapeHtml(product.name)+' · '+escapeHtml(product.available)+' '+escapeHtml(t.available)).join('<br>'):escapeHtml(t.lowNone))+'</div></div>';
-
-    const productRows=products.length?products.map(product=>'<div class=\"opsRow\"><div class=\"opsName\"><b>'+escapeHtml(product.name)+'</b></div><span>'+escapeHtml(money(product.price_aed))+'</span><span>'+escapeHtml(product.quantity)+'</span>'+(data.can_manage?'<div class=\"opsActions\"><button class=\"opsAction\" type=\"button\" data-ops-edit=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.edit)+'</button><button class=\"opsAction danger\" type=\"button\" data-ops-delete=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.delete)+'</button></div>':'<span></span>')+'</div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noProducts)+'</div>';
+    const productRows=products.length?products.map(product=>'<div class=\"opsRow\"><div class=\"opsName\"><b>'+escapeHtml(product.name)+'</b></div><span>'+escapeHtml(money(product.price_amount))+'</span><span>'+escapeHtml(product.quantity)+'</span>'+(data.can_manage?'<div class=\"opsActions\"><button class=\"opsAction\" type=\"button\" data-ops-edit=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.edit)+'</button><button class=\"opsAction danger\" type=\"button\" data-ops-delete=\"'+escapeHtml(product.id)+'\">'+escapeHtml(t.delete)+'</button></div>':'<span></span>')+'</div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noProducts)+'</div>';
     const productsHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.products)+'</h2><div class=\"opsTable\"><div class=\"opsRow head\"><span>'+escapeHtml(t.name)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.qty)+'</span><span></span></div>'+productRows+'</div></div>';
-
-    const orderRows=realOrders.length?realOrders.map(order=>'<div class=\"opsRow opsOrderRow\"><div class=\"opsName\"><b>'+escapeHtml(order.customer_name||t.customer)+'</b></div><span>'+escapeHtml(money(order.total_aed))+'</span>'+(data.can_manage?'<select class=\"opsOrderSelect\" data-ops-order=\"'+escapeHtml(order.id)+'\">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class=\"opsDate\">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noOrders)+'</div>';
+    const orderRows=realOrders.length?realOrders.map(order=>'<div class=\"opsRow opsOrderRow\"><div class=\"opsName\"><b>'+escapeHtml(order.customer_name||t.customer)+'</b></div><span>'+escapeHtml(money(order.total_amount))+'</span>'+(data.can_manage?'<select class=\"opsOrderSelect\" data-ops-order=\"'+escapeHtml(order.id)+'\">'+statusOptions(String(order.status||'draft'))+'</select>':'<span>'+escapeHtml(order.status)+'</span>')+'<span class=\"opsDate\">'+escapeHtml(date(order.created_at))+'</span></div>').join(''):'<div class=\"empty\">'+escapeHtml(t.noOrders)+'</div>';
     const ordersHtml='<div class=\"opsSection\"><h2>'+escapeHtml(t.orders)+'</h2><div class=\"opsTable\"><div class=\"opsRow opsOrderRow head\"><span>'+escapeHtml(t.customer)+'</span><span>'+escapeHtml(t.price)+'</span><span>'+escapeHtml(t.status)+'</span><span class=\"opsDate\">'+escapeHtml(t.date)+'</span></div>'+orderRows+'</div><div class=\"truth\" style=\"margin-top:9px\">'+escapeHtml(t.simulated)+'</div></div>';
 
     body.innerHTML='<div class=\"opsMetrics\">'+metrics+'</div>'+lowHtml+'<div class=\"opsGrid\"><div>'+productsHtml+'</div><div>'+ordersHtml+'</div></div>';
@@ -190,14 +171,13 @@ const script=String.raw`(()=>{
   }
 
   async function mutate(payload){
-    const response=await fetch('/api/owner-operations',{method:'POST',cache:'no-store',headers:{'content-type':'application/json'},body:JSON.stringify({business_id:businessId,...payload})});
+    const response=await fetch('/api/owner-operations',{method:'POST',cache:'no-store',headers:{'content-type':'application/json'},body:JSON.stringify({business_id:businessId,currency_code:currencyCode(),...payload})});
     const result=await response.json().catch(()=>({}));
     if(!response.ok||!result.ok)throw new Error(result.detail||result.error||'OWNER_OPERATION_FAILED');
     return result;
   }
-
   async function manageProduct(payload){
-    const response=await fetch('/api/owner-product-management',{method:'POST',cache:'no-store',headers:{'content-type':'application/json'},body:JSON.stringify({business_id:businessId,...payload})});
+    const response=await fetch('/api/owner-product-management',{method:'POST',cache:'no-store',headers:{'content-type':'application/json'},body:JSON.stringify({business_id:businessId,currency_code:currencyCode(),...payload})});
     const result=await response.json().catch(()=>({}));
     if(!response.ok||!result.ok)throw new Error(result.error||result.detail||'OWNER_PRODUCT_MANAGEMENT_FAILED');
     return result;
@@ -207,62 +187,35 @@ const script=String.raw`(()=>{
     event.preventDefault();
     const t=text();const button=q('#opsProductSave');if(button)button.disabled=true;
     try{
-      const values={name:q('#opsName').value,price_aed:q('#opsPrice').value,quantity:q('#opsQty').value};
-      if(editingProductId){
-        await manageProduct({action:'update_product',product_id:editingProductId,...values});
-        notify(t.itemUpdated);
-      }else{
-        await mutate({action:'create_product',sku:productSku(),...values});
-        notify(t.created);
-      }
+      const values={name:q('#opsName').value,price_amount:q('#opsPrice').value,quantity:q('#opsQty').value};
+      if(editingProductId){await manageProduct({action:'update_product',product_id:editingProductId,...values});notify(t.itemUpdated)}
+      else{await mutate({action:'create_product',sku:productSku(),...values});notify(t.created)}
       closeProductModal();data=null;await load(true);
     }catch(error){notify(errorText(error))}finally{if(button)button.disabled=false}
   }
 
   async function deleteProduct(product){
-    if(!product)return;
-    const t=text();
-    if(!window.confirm(t.deleteConfirm))return;
-    try{
-      await manageProduct({action:'delete_product',product_id:product.id});
-      if(editingProductId===product.id)closeProductModal();
-      notify(t.itemDeleted);data=null;await load(true);
-    }catch(error){notify(errorText(error))}
+    if(!product)return;const t=text();if(!window.confirm(t.deleteConfirm))return;
+    try{await manageProduct({action:'delete_product',product_id:product.id});if(editingProductId===product.id)closeProductModal();notify(t.itemDeleted);data=null;await load(true)}catch(error){notify(errorText(error))}
   }
-
   async function updateOrder(orderId,status){
     const t=text();
     try{await mutate({action:'update_order_status',order_id:orderId,status});notify(t.orderUpdated);data=null;await load(true)}catch(error){notify(t.failed+' — '+error.message);data=null;await load(true)}
   }
 
-  function syncOperationsUi(){
-    if(!isStore())return;
-    ensureScreen();
-    applyCopy();
-    if(current==='operations')load();
-  }
-
-  function activateOperations({target}={}){
-    if(target!=='operations'||!isStore())return;
-    ensureScreen();
-    if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;
-    load();
-  }
-
+  function syncOperationsUi(){if(!isStore())return;ensureScreen();applyCopy();if(current==='operations')load()}
+  function activateOperations({target}={}){if(target!=='operations'||!isStore())return;ensureScreen();if(q('#pageTitle'))q('#pageTitle').textContent=text().nav;load()}
   const lifecycle=window.__dabbirUiLifecycle;
   if(lifecycle?.on){
     lifecycle.on('afterRender','owner-operations',syncOperationsUi);
     lifecycle.on('afterNavigate','owner-operations',activateOperations);
     lifecycle.on('afterLanguage','owner-operations-language',syncOperationsUi);
   }
-
   setTimeout(()=>{if(isStore()){ensureScreen();load()}},600);
 })();`;
 
 export default function handler(req,res){
-  if(req.method!=='GET'){
-    res.statusCode=405;res.setHeader('allow','GET');return res.end('Method Not Allowed');
-  }
+  if(req.method!=='GET'){res.statusCode=405;res.setHeader('allow','GET');return res.end('Method Not Allowed')}
   res.statusCode=200;
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','no-store');

--- a/api/owner-operations.js
+++ b/api/owner-operations.js
@@ -14,6 +14,7 @@ const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 const clean=(value,max=160)=>String(value||'').trim().slice(0,max);
 const number=value=>Number.isFinite(Number(value))?Number(value):0;
+const finiteNumber=value=>Number.isFinite(Number(value))?Number(value):NaN;
 const has=(object,key)=>Object.prototype.hasOwnProperty.call(object||{},key);
 
 function singleQueryValue(req,name){
@@ -71,10 +72,10 @@ function roundMoney(value,market){
 }
 
 function moneyInput(body,market,neutralKey,legacyAedKey){
-  if(has(body,neutralKey))return number(body[neutralKey]);
+  if(has(body,neutralKey))return finiteNumber(body[neutralKey]);
   if(has(body,legacyAedKey)){
     if(market.currency_code!=='AED')throw Object.assign(new Error('LEGACY_AED_INPUT_NOT_ALLOWED'),{status:409});
-    return number(body[legacyAedKey]);
+    return finiteNumber(body[legacyAedKey]);
   }
   return NaN;
 }

--- a/api/owner-operations.js
+++ b/api/owner-operations.js
@@ -8,20 +8,20 @@ import {
   supabaseRest,
   supabaseRpc,
 } from './_auth-core.js';
+import { assertSnapshotCurrency, marketDateKey, verifiedBusinessMarket } from './_gcc-money-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 const clean=(value,max=160)=>String(value||'').trim().slice(0,max);
 const number=value=>Number.isFinite(Number(value))?Number(value):0;
+const has=(object,key)=>Object.prototype.hasOwnProperty.call(object||{},key);
 
 function singleQueryValue(req,name){
   try{
     const url=new URL(String(req?.url||'/'),'https://dabbir.invalid');
     const values=url.searchParams.getAll(name);
     return values.length===1?values[0]:null;
-  }catch{
-    return null;
-  }
+  }catch{return null}
 }
 
 async function readData(response,fallback){
@@ -65,25 +65,57 @@ function membershipHasPermission(membership,permission){
   return ['owner','admin'].includes(role) && permission==='manage_business';
 }
 
+function roundMoney(value,market){
+  const digits=Number.isInteger(market?.currency_minor_units)?market.currency_minor_units:2;
+  return Number(number(value).toFixed(digits));
+}
+
+function moneyInput(body,market,neutralKey,legacyAedKey){
+  if(has(body,neutralKey))return number(body[neutralKey]);
+  if(has(body,legacyAedKey)){
+    if(market.currency_code!=='AED')throw Object.assign(new Error('LEGACY_AED_INPUT_NOT_ALLOWED'),{status:409});
+    return number(body[legacyAedKey]);
+  }
+  return NaN;
+}
+
+function withAedCompatibility(row,market,map){
+  if(market.currency_code!=='AED')return row;
+  const aliases={};
+  for(const [legacy,neutral] of Object.entries(map))aliases[legacy]=row[neutral];
+  return {...row,...aliases};
+}
+
+async function loadBusinessMarket(token,businessId){
+  const rows=await rest(token,`dabbir_businesses?select=id,country_code,currency_code,timezone&id=eq.${businessId}&limit=1`,'BUSINESS_MARKET_LOOKUP_FAILED');
+  const business=rows?.[0]||null;
+  if(!business)throw Object.assign(new Error('BUSINESS_MARKET_NOT_FOUND'),{status:404});
+  return {business,market:verifiedBusinessMarket(business)};
+}
+
 async function handleGet(req,res,context){
   const requested=safeId(singleQueryValue(req,'business_id'));
   const membership=membershipFor(context.memberships,requested);
   if(!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
   const businessId=membership.business_id;
-  const role=String(membership.role||'').toLowerCase();
   const canOperate=membershipHasPermission(membership,'manage_store_operations');
+  const {market}=await loadBusinessMarket(context.token,businessId);
 
   const [products,inventory,orders,orderItems,movements,customers,services,expenses,returns]=await Promise.all([
-    rest(context.token,`dabbir_products?select=id,sku,name,price_aed,active,metadata&business_id=eq.${businessId}&order=name.asc&limit=200`,'PRODUCTS_LOOKUP_FAILED'),
+    rest(context.token,`dabbir_products?select=id,sku,name,price_amount,active,metadata&business_id=eq.${businessId}&order=name.asc&limit=200`,'PRODUCTS_LOOKUP_FAILED'),
     rest(context.token,`dabbir_inventory?select=product_id,quantity,reserved,updated_at&business_id=eq.${businessId}&order=updated_at.desc&limit=200`,'INVENTORY_LOOKUP_FAILED'),
-    rest(context.token,`dabbir_orders?select=id,customer_id,status,total_aed,paid_aed,payment_method,note,completed_at,simulated,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'ORDERS_LOOKUP_FAILED'),
-    rest(context.token,`dabbir_order_items?select=id,order_id,product_id,product_name,sku,unit_price_aed,quantity,line_total_aed,created_at&business_id=eq.${businessId}&order=created_at.asc&limit=500`,'ORDER_ITEMS_LOOKUP_FAILED'),
+    rest(context.token,`dabbir_orders?select=id,customer_id,status,total_amount,paid_amount,currency_code,payment_method,note,completed_at,simulated,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'ORDERS_LOOKUP_FAILED'),
+    rest(context.token,`dabbir_order_items?select=id,order_id,product_id,product_name,sku,unit_price_amount,quantity,line_total_amount,created_at&business_id=eq.${businessId}&order=created_at.asc&limit=500`,'ORDER_ITEMS_LOOKUP_FAILED'),
     rest(context.token,`dabbir_inventory_movements?select=id,product_id,order_id,movement_type,quantity_delta,quantity_after,reference_note,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=100`,'INVENTORY_MOVEMENTS_LOOKUP_FAILED'),
     rest(context.token,`dabbir_customers?select=id,display_name&business_id=eq.${businessId}&limit=200`,'CUSTOMERS_LOOKUP_FAILED'),
     rest(context.token,`dabbir_services?select=id,name,duration_minutes,active,metadata&business_id=eq.${businessId}&order=name.asc&limit=200`,'SERVICES_LOOKUP_FAILED'),
-    rest(context.token,`dabbir_expenses?select=id,amount_aed,category,note,occurred_on,created_at&business_id=eq.${businessId}&order=occurred_on.desc,created_at.desc&limit=100`,'EXPENSES_LOOKUP_FAILED'),
-    rest(context.token,`dabbir_order_returns?select=id,order_id,order_item_id,product_id,quantity,refund_aed,reason,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=500`,'RETURNS_LOOKUP_FAILED'),
+    rest(context.token,`dabbir_expenses?select=id,amount,currency_code,category,note,occurred_on,created_at&business_id=eq.${businessId}&order=occurred_on.desc,created_at.desc&limit=100`,'EXPENSES_LOOKUP_FAILED'),
+    rest(context.token,`dabbir_order_returns?select=id,order_id,order_item_id,product_id,quantity,refund_amount,currency_code,reason,created_at&business_id=eq.${businessId}&order=created_at.desc&limit=500`,'RETURNS_LOOKUP_FAILED'),
   ]);
+
+  for(const order of orders||[])assertSnapshotCurrency(order.currency_code,market,'ORDER');
+  for(const expense of expenses||[])assertSnapshotCurrency(expense.currency_code,market,'EXPENSE');
+  for(const returned of returns||[])assertSnapshotCurrency(returned.currency_code,market,'RETURN');
 
   const inventoryByProduct=new Map((inventory||[]).map(row=>[row.product_id,row]));
   const customerById=new Map((customers||[]).map(row=>[row.id,row.display_name]));
@@ -92,42 +124,70 @@ async function handleGet(req,res,context){
     const quantity=number(stock.quantity);
     const reserved=number(stock.reserved);
     const available=Math.max(0,quantity-reserved);
-    return {...product,quantity,reserved,available,low_stock:Boolean(product.active)&&available<=5,inventory_updated_at:stock.updated_at||null};
+    const neutral={...product,price_amount:roundMoney(product.price_amount,market),quantity,reserved,available,low_stock:Boolean(product.active)&&available<=5,inventory_updated_at:stock.updated_at||null};
+    return withAedCompatibility(neutral,market,{price_aed:'price_amount'});
   });
-
-  const serviceRows=(services||[]).map(service=>({
-    ...service,
-    duration_minutes:Math.max(1,Math.trunc(number(service.duration_minutes)||1)),
-  }));
-  const expenseRows=(expenses||[]).map(expense=>({
-    ...expense,
-    amount_aed:Number(number(expense.amount_aed).toFixed(2)),
-  }));
-  const dateKey=(value)=>{try{return new Intl.DateTimeFormat('en-CA',{timeZone:'Asia/Dubai',year:'numeric',month:'2-digit',day:'2-digit'}).format(new Date(value))}catch{return null}};
-  const todayDubai=dateKey(new Date());
+  const serviceRows=(services||[]).map(service=>({...service,duration_minutes:Math.max(1,Math.trunc(number(service.duration_minutes)||1))}));
+  const expenseRows=(expenses||[]).map(expense=>withAedCompatibility({...expense,amount:roundMoney(expense.amount,market)},market,{amount_aed:'amount'}));
+  const today=marketDateKey(new Date(),market);
 
   const returnedByItem=new Map();
   const returnedByOrder=new Map();
-  for(const returned of (returns||[])){
+  for(const returned of returns||[]){
     const quantity=Math.trunc(number(returned.quantity));
     returnedByItem.set(returned.order_item_id,(returnedByItem.get(returned.order_item_id)||0)+quantity);
-    returnedByOrder.set(returned.order_id,Number(((returnedByOrder.get(returned.order_id)||0)+number(returned.refund_aed)).toFixed(2)));
+    returnedByOrder.set(returned.order_id,roundMoney((returnedByOrder.get(returned.order_id)||0)+number(returned.refund_amount),market));
   }
   const itemsByOrder=new Map();
-  for(const item of (orderItems||[])){
+  for(const item of orderItems||[]){
     const current=itemsByOrder.get(item.order_id)||[];
-    current.push({...item,unit_price_aed:Number(number(item.unit_price_aed).toFixed(2)),line_total_aed:Number(number(item.line_total_aed).toFixed(2)),returned_quantity:returnedByItem.get(item.id)||0});
+    const neutral={...item,unit_price_amount:roundMoney(item.unit_price_amount,market),line_total_amount:roundMoney(item.line_total_amount,market),returned_quantity:returnedByItem.get(item.id)||0};
+    current.push(withAedCompatibility(neutral,market,{unit_price_aed:'unit_price_amount',line_total_aed:'line_total_amount'}));
     itemsByOrder.set(item.order_id,current);
   }
   const movementRows=(movements||[]).map(movement=>({...movement,quantity_delta:Math.trunc(number(movement.quantity_delta)),quantity_after:Math.trunc(number(movement.quantity_after))}));
   const realOrders=(orders||[]).filter(order=>order.simulated===false);
   const recognizedOrders=realOrders.filter(order=>['confirmed','completed'].includes(String(order.status||'').toLowerCase()));
   const collectedOrders=recognizedOrders.filter(order=>String(order.payment_method||'cash').toLowerCase()!=='credit');
-  const salesToday=recognizedOrders.filter(order=>dateKey(order.completed_at||order.created_at)===todayDubai);
-  const returnsToday=(returns||[]).filter(returned=>dateKey(returned.created_at)===todayDubai);
-  const grossSalesToday=Number(salesToday.reduce((sum,order)=>sum+number(order.total_aed),0).toFixed(2));
-  const returnedTodayAed=Number(returnsToday.reduce((sum,returned)=>sum+number(returned.refund_aed),0).toFixed(2));
-  const orderRows=(orders||[]).map(order=>{const items=itemsByOrder.get(order.id)||[];return {...order,total_aed:Number(number(order.total_aed).toFixed(2)),paid_aed:Number(number(order.paid_aed).toFixed(2)),returned_aed:Number((returnedByOrder.get(order.id)||0).toFixed(2)),fully_returned:items.length>0&&items.every(item=>Number(item.returned_quantity||0)>=Number(item.quantity||0)),customer_name:customerById.get(order.customer_id)||null,items}});
+  const salesToday=recognizedOrders.filter(order=>marketDateKey(order.completed_at||order.created_at,market)===today);
+  const returnsToday=(returns||[]).filter(returned=>marketDateKey(returned.created_at,market)===today);
+  const grossSalesToday=roundMoney(salesToday.reduce((sum,order)=>sum+number(order.total_amount),0),market);
+  const returnedToday=roundMoney(returnsToday.reduce((sum,returned)=>sum+number(returned.refund_amount),0),market);
+  const orderRows=(orders||[]).map(order=>{
+    const items=itemsByOrder.get(order.id)||[];
+    const neutral={...order,total_amount:roundMoney(order.total_amount,market),paid_amount:roundMoney(order.paid_amount,market),returned_amount:roundMoney(returnedByOrder.get(order.id)||0,market),fully_returned:items.length>0&&items.every(item=>Number(item.returned_quantity||0)>=Number(item.quantity||0)),customer_name:customerById.get(order.customer_id)||null,items};
+    return withAedCompatibility(neutral,market,{total_aed:'total_amount',paid_aed:'paid_amount',returned_aed:'returned_amount'});
+  });
+  const returnRows=(returns||[]).map(returned=>withAedCompatibility({...returned,refund_amount:roundMoney(returned.refund_amount,market)},market,{refund_aed:'refund_amount'}));
+
+  const metrics={
+    active_products:productRows.filter(product=>product.active).length,
+    active_services:serviceRows.filter(service=>service.active).length,
+    inventory_units:productRows.reduce((sum,product)=>sum+product.quantity,0),
+    available_units:productRows.reduce((sum,product)=>sum+product.available,0),
+    low_stock_products:productRows.filter(product=>product.low_stock).length,
+    real_orders:realOrders.length,
+    recognized_sales_amount:roundMoney(recognizedOrders.reduce((sum,order)=>sum+number(order.total_amount),0),market),
+    sales_today_amount:grossSalesToday,
+    returned_today_amount:returnedToday,
+    net_sales_today_amount:Math.max(0,roundMoney(grossSalesToday-returnedToday,market)),
+    cash_collected_amount:roundMoney(collectedOrders.reduce((sum,order)=>sum+number(order.paid_amount),0),market),
+    receivables_amount:roundMoney(recognizedOrders.reduce((sum,order)=>sum+Math.max(0,number(order.total_amount)-number(order.paid_amount)),0),market),
+    completed_sales:recognizedOrders.length,
+    expenses_amount:roundMoney(expenseRows.reduce((sum,expense)=>sum+number(expense.amount),0),market),
+    today_expenses_amount:roundMoney(expenseRows.filter(expense=>expense.occurred_on===today).reduce((sum,expense)=>sum+number(expense.amount),0),market),
+    simulated_orders:(orders||[]).filter(order=>order.simulated!==false).length,
+  };
+  if(market.currency_code==='AED')Object.assign(metrics,{
+    recognized_sales_aed:metrics.recognized_sales_amount,
+    sales_today_aed:metrics.sales_today_amount,
+    returned_today_aed:metrics.returned_today_amount,
+    net_sales_today_aed:metrics.net_sales_today_amount,
+    cash_collected_aed:metrics.cash_collected_amount,
+    receivables_aed:metrics.receivables_amount,
+    expenses_aed:metrics.expenses_amount,
+    today_expenses_aed:metrics.today_expenses_amount,
+  });
 
   return json(res,200,{
     ok:true,
@@ -135,32 +195,19 @@ async function handleGet(req,res,context){
     role:membership.role,
     can_manage:membershipHasPermission(membership,'manage_business'),
     can_operate:canOperate,
-    metrics:{
-      active_products:productRows.filter(product=>product.active).length,
-      active_services:serviceRows.filter(service=>service.active).length,
-      inventory_units:productRows.reduce((sum,product)=>sum+product.quantity,0),
-      available_units:productRows.reduce((sum,product)=>sum+product.available,0),
-      low_stock_products:productRows.filter(product=>product.low_stock).length,
-      real_orders:realOrders.length,
-      recognized_sales_aed:Number(recognizedOrders.reduce((sum,order)=>sum+number(order.total_aed),0).toFixed(2)),
-      sales_today_aed:grossSalesToday,
-      returned_today_aed:returnedTodayAed,
-      net_sales_today_aed:Math.max(0,Number((grossSalesToday-returnedTodayAed).toFixed(2))),
-      cash_collected_aed:Number(collectedOrders.reduce((sum,order)=>sum+number(order.paid_aed),0).toFixed(2)),
-      receivables_aed:Number(recognizedOrders.reduce((sum,order)=>sum+Math.max(0,number(order.total_aed)-number(order.paid_aed)),0).toFixed(2)),
-      completed_sales:recognizedOrders.length,
-      expenses_aed:Number(expenseRows.reduce((sum,expense)=>sum+number(expense.amount_aed),0).toFixed(2)),
-      today_expenses_aed:Number(expenseRows.filter(expense=>expense.occurred_on===todayDubai).reduce((sum,expense)=>sum+number(expense.amount_aed),0).toFixed(2)),
-      simulated_orders:(orders||[]).filter(order=>order.simulated!==false).length,
-    },
+    country_code:market.country_code,
+    currency_code:market.currency_code,
+    currency_minor_units:market.currency_minor_units,
+    timezone:market.timezone,
+    metrics,
     products:productRows,
     services:serviceRows,
     orders:orderRows,
     expenses:expenseRows,
-    returns:returns||[],
+    returns:returnRows,
     inventory_movements:movementRows,
     low_stock:productRows.filter(product=>product.low_stock),
-    truth:{recognized_sales_statuses:['confirmed','completed'],simulated_orders_excluded_from_sales:true,sales_are_itemized_when_order_items_present:true,returns_reduce_net_sales:true,cash_collected_excludes_credit_sales:true,expenses_source:'dabbir_expenses_live_tenant_data',services_source:'dabbir_services_live_tenant_data'},
+    truth:{recognized_sales_statuses:['confirmed','completed'],simulated_orders_excluded_from_sales:true,sales_are_itemized_when_order_items_present:true,returns_reduce_net_sales:true,cash_collected_excludes_credit_sales:true,expenses_source:'dabbir_expenses_live_tenant_data',services_source:'dabbir_services_live_tenant_data',money_contract:'NEUTRAL_AMOUNT_PLUS_IMMUTABLE_CURRENCY',legacy_aed_aliases:market.currency_code==='AED'},
   });
 }
 
@@ -170,20 +217,23 @@ async function handlePost(req,res,context){
   const businessId=safeId(body.business_id);
   const membership=membershipFor(context.memberships,businessId);
   if(!businessId||!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
+  const {market}=await loadBusinessMarket(context.token,businessId);
+  if(has(body,'currency_code'))assertSnapshotCurrency(body.currency_code,market,'REQUEST');
 
   const action=clean(body.action,40);
   const operationalActions=['complete_sale','update_order_status'];
   const canManage=membershipHasPermission(membership,'manage_business');
   const canOperate=membershipHasPermission(membership,'manage_store_operations');
-  if(operationalActions.includes(action) ? !canOperate : !canManage)return json(res,403,{ok:false,error:operationalActions.includes(action)?'STORE_OPERATIONS_REQUIRED':'BUSINESS_MANAGEMENT_REQUIRED'});
+  if(operationalActions.includes(action)?!canOperate:!canManage)return json(res,403,{ok:false,error:operationalActions.includes(action)?'STORE_OPERATIONS_REQUIRED':'BUSINESS_MANAGEMENT_REQUIRED'});
   let result=null;
+
   if(action==='create_product'){
     const sku=clean(body.sku,80);
     const name=clean(body.name,160);
-    const price=number(body.price_aed);
+    const price=moneyInput(body,market,'price_amount','price_aed');
     const quantity=Math.trunc(number(body.quantity));
-    if(!sku||!name||price<0||quantity<0)return json(res,400,{ok:false,error:'INVALID_PRODUCT_INPUT'});
-    result=await rpc(context.token,'dabbir_owner_create_product',{p_business_id:businessId,p_sku:sku,p_name:name,p_price_aed:price,p_quantity:quantity},'PRODUCT_CREATE_FAILED');
+    if(!sku||!name||!Number.isFinite(price)||price<0||price>10000000||quantity<0)return json(res,400,{ok:false,error:'INVALID_PRODUCT_INPUT'});
+    result=await rpc(context.token,'dabbir_owner_create_product',{p_business_id:businessId,p_sku:sku,p_name:name,p_price_aed:roundMoney(price,market),p_quantity:quantity},'PRODUCT_CREATE_FAILED');
   }else if(action==='set_inventory'){
     const productId=safeId(body.product_id);
     const quantity=Math.trunc(number(body.quantity));
@@ -209,30 +259,29 @@ async function handlePost(req,res,context){
     result=await rpc(context.token,'dabbir_owner_receive_stock',{p_business_id:businessId,p_product_id:productId,p_quantity:quantity,p_note:note},'STOCK_RECEIPT_FAILED');
   }else if(action==='return_sale'){
     const orderId=safeId(body.order_id);
-    const items=Array.isArray(body.items)?body.items.slice(0,50).map(item=>({order_item_id:safeId(item?.order_item_id),quantity:Math.trunc(number(item?.quantity))})) : [];
+    const items=Array.isArray(body.items)?body.items.slice(0,50).map(item=>({order_item_id:safeId(item?.order_item_id),quantity:Math.trunc(number(item?.quantity))})):[];
     const reason=clean(body.reason,240);
     if(!orderId||!items.length||items.some(item=>!item.order_item_id||item.quantity<1||item.quantity>100000))return json(res,400,{ok:false,error:'INVALID_RETURN_INPUT'});
     result=await rpc(context.token,'dabbir_owner_return_sale',{p_business_id:businessId,p_order_id:orderId,p_items:items,p_reason:reason},'SALE_RETURN_FAILED');
   }else if(action==='create_expense'){
-    const amount=number(body.amount_aed);
+    const amount=moneyInput(body,market,'amount','amount_aed');
     const category=clean(body.category,24).toLowerCase();
     const note=clean(body.note,240);
     const occurredOn=clean(body.occurred_on,10);
-    if(!Number.isFinite(amount)||amount<=0||amount>10000000||!['rent','utilities','supplies','salaries','marketing','transport','other'].includes(category)||!/^\\d{4}-\\d{2}-\\d{2}$/.test(occurredOn))return json(res,400,{ok:false,error:'INVALID_EXPENSE_INPUT'});
-    const rows=await write(context.token,'dabbir_expenses?select=id,amount_aed,category,note,occurred_on,created_at',{
-      method:'POST',
-      headers:{prefer:'return=representation'},
-      body:JSON.stringify({business_id:businessId,amount_aed:Number(amount.toFixed(2)),category,note,occurred_on:occurredOn}),
+    if(!Number.isFinite(amount)||amount<=0||amount>10000000||!['rent','utilities','supplies','salaries','marketing','transport','other'].includes(category)||!/^\d{4}-\d{2}-\d{2}$/.test(occurredOn))return json(res,400,{ok:false,error:'INVALID_EXPENSE_INPUT'});
+    const rows=await write(context.token,'dabbir_expenses?select=id,amount,currency_code,category,note,occurred_on,created_at',{
+      method:'POST',headers:{prefer:'return=representation'},
+      body:JSON.stringify({business_id:businessId,amount_aed:roundMoney(amount,market),currency_code:market.currency_code,category,note,occurred_on:occurredOn}),
     },'EXPENSE_CREATE_FAILED');
     result=rows?.[0]||null;
     if(!result)return json(res,500,{ok:false,error:'EXPENSE_CREATE_FAILED'});
+    assertSnapshotCurrency(result.currency_code,market,'EXPENSE');
   }else if(action==='create_service'){
     const name=clean(body.name,160);
     const durationMinutes=Math.trunc(number(body.duration_minutes));
     if(!name||durationMinutes<1||durationMinutes>1440)return json(res,400,{ok:false,error:'INVALID_SERVICE_INPUT'});
     const rows=await write(context.token,'dabbir_services?select=id,name,duration_minutes,active,metadata',{
-      method:'POST',
-      headers:{prefer:'return=representation'},
+      method:'POST',headers:{prefer:'return=representation'},
       body:JSON.stringify({business_id:businessId,name,duration_minutes:durationMinutes,active:true,metadata:{source:'dabbir_owner_operations'}}),
     },'SERVICE_CREATE_FAILED');
     result=rows?.[0]||null;
@@ -244,8 +293,7 @@ async function handlePost(req,res,context){
     const active=body.active!==false;
     if(!serviceId||!name||durationMinutes<1||durationMinutes>1440)return json(res,400,{ok:false,error:'INVALID_SERVICE_INPUT'});
     const rows=await write(context.token,`dabbir_services?business_id=eq.${businessId}&id=eq.${serviceId}&select=id,name,duration_minutes,active,metadata`,{
-      method:'PATCH',
-      headers:{prefer:'return=representation'},
+      method:'PATCH',headers:{prefer:'return=representation'},
       body:JSON.stringify({name,duration_minutes:durationMinutes,active,metadata:{source:'dabbir_owner_operations'}}),
     },'SERVICE_UPDATE_FAILED');
     result=rows?.[0]||null;
@@ -254,7 +302,7 @@ async function handlePost(req,res,context){
     return json(res,400,{ok:false,error:'UNSUPPORTED_OWNER_OPERATION'});
   }
 
-  return json(res,200,{ok:true,action,result});
+  return json(res,200,{ok:true,action,currency_code:market.currency_code,result});
 }
 
 export default async function handler(req,res){

--- a/api/owner-product-management.js
+++ b/api/owner-product-management.js
@@ -8,21 +8,20 @@ import {
   supabaseRest,
   supabaseRpc,
 } from './_auth-core.js';
+import { assertSnapshotCurrency, verifiedBusinessMarket } from './_gcc-money-core.js';
 
 const UUID_RE=/^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 const safeId=value=>UUID_RE.test(String(value||'').trim())?String(value).trim():null;
 const clean=(value,max=160)=>String(value||'').trim().slice(0,max);
 const number=value=>Number.isFinite(Number(value))?Number(value):NaN;
+const has=(object,key)=>Object.prototype.hasOwnProperty.call(object||{},key);
 
 async function readData(response,fallback){
   const text=await response.text();
   let payload=null;
   try{payload=text?JSON.parse(text):null}catch{payload=null}
   if(!response.ok){
-    const error=new Error(fallback);
-    error.status=response.status;
-    error.detail=payload?.message||payload?.code||null;
-    throw error;
+    const error=new Error(fallback);error.status=response.status;error.detail=payload?.message||payload?.code||null;throw error;
   }
   return payload;
 }
@@ -31,10 +30,7 @@ const rest=(token,path,fallback)=>supabaseRest(path,token).then(response=>readDa
 const write=(token,path,options,fallback)=>supabaseRest(path,token,options).then(response=>readData(response,fallback));
 const rpc=(token,name,params,fallback)=>supabaseRpc(name,token,params).then(response=>readData(response,fallback));
 
-function membershipFor(memberships,businessId){
-  return memberships.find(membership=>membership.business_id===businessId)||null;
-}
-
+function membershipFor(memberships,businessId){return memberships.find(membership=>membership.business_id===businessId)||null}
 function canManageBusiness(membership){
   if(!membership)return false;
   const permissions=Array.isArray(membership.permissions)?membership.permissions:[];
@@ -45,17 +41,35 @@ function canManageBusiness(membership){
 async function authenticatedContext(req,res){
   const token=accessTokenFromRequest(req);
   if(!token){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
-  const [user,memberships]=await Promise.all([
-    getVerifiedUser(token).catch(()=>null),
-    getBusinessMemberships(token).catch(()=>[]),
-  ]);
+  const [user,memberships]=await Promise.all([getVerifiedUser(token).catch(()=>null),getBusinessMemberships(token).catch(()=>[])]);
   if(!user){json(res,401,{ok:false,error:'AUTH_REQUIRED'});return null}
   return {token,user,memberships};
 }
 
+function roundMoney(value,market){return Number(Number(value||0).toFixed(Number.isInteger(market?.currency_minor_units)?market.currency_minor_units:2))}
+function moneyInput(body,market){
+  if(has(body,'price_amount'))return number(body.price_amount);
+  if(has(body,'price_aed')){
+    if(market.currency_code!=='AED')throw Object.assign(new Error('LEGACY_AED_INPUT_NOT_ALLOWED'),{status:409});
+    return number(body.price_aed);
+  }
+  return NaN;
+}
+function compatibleProduct(product,market){
+  const neutral={...product,price_amount:roundMoney(product.price_amount,market)};
+  return market.currency_code==='AED'?{...neutral,price_aed:neutral.price_amount}:neutral;
+}
+
+async function businessMarket(token,businessId){
+  const rows=await rest(token,`dabbir_businesses?select=id,country_code,currency_code,timezone&id=eq.${businessId}&limit=1`,'BUSINESS_MARKET_LOOKUP_FAILED');
+  const business=rows?.[0]||null;
+  if(!business)throw Object.assign(new Error('BUSINESS_MARKET_NOT_FOUND'),{status:404});
+  return verifiedBusinessMarket(business);
+}
+
 async function productContext(token,businessId,productId){
   const [products,inventory]=await Promise.all([
-    rest(token,`dabbir_products?select=id,business_id,sku,name,price_aed,active,metadata&business_id=eq.${businessId}&id=eq.${productId}&limit=1`,'PRODUCT_LOOKUP_FAILED'),
+    rest(token,`dabbir_products?select=id,business_id,sku,name,price_amount,active,metadata&business_id=eq.${businessId}&id=eq.${productId}&limit=1`,'PRODUCT_LOOKUP_FAILED'),
     rest(token,`dabbir_inventory?select=quantity,reserved&business_id=eq.${businessId}&product_id=eq.${productId}&limit=1`,'INVENTORY_LOOKUP_FAILED'),
   ]);
   return {product:products?.[0]||null,inventory:inventory?.[0]||{quantity:0,reserved:0}};
@@ -64,7 +78,6 @@ async function productContext(token,businessId,productId){
 export default async function handler(req,res){
   if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'});
   if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
-
   const context=await authenticatedContext(req,res);
   if(!context)return;
 
@@ -76,52 +89,44 @@ export default async function handler(req,res){
     if(!businessId||!productId||!membership)return json(res,403,{ok:false,error:'BUSINESS_ACCESS_DENIED'});
     if(!canManageBusiness(membership))return json(res,403,{ok:false,error:'BUSINESS_MANAGEMENT_REQUIRED'});
 
-    const {product,inventory}=await productContext(context.token,businessId,productId);
+    const [market,{product,inventory}]=await Promise.all([businessMarket(context.token,businessId),productContext(context.token,businessId,productId)]);
+    if(has(body,'currency_code'))assertSnapshotCurrency(body.currency_code,market,'REQUEST');
     if(!product)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
 
     const action=clean(body.action,40);
     if(action==='update_product'){
       const name=clean(body.name,160);
-      const price=number(body.price_aed);
+      const price=moneyInput(body,market);
       const quantity=Math.trunc(number(body.quantity));
-      if(!name||!Number.isFinite(price)||price<0||price>10000000||!Number.isFinite(quantity)||quantity<0||quantity>1000000){
-        return json(res,400,{ok:false,error:'INVALID_PRODUCT_INPUT'});
-      }
+      if(!name||!Number.isFinite(price)||price<0||price>10000000||!Number.isFinite(quantity)||quantity<0||quantity>1000000)return json(res,400,{ok:false,error:'INVALID_PRODUCT_INPUT'});
       if(quantity<Number(inventory.reserved||0))return json(res,409,{ok:false,error:'QUANTITY_BELOW_RESERVED'});
 
       const metadata={...(product.metadata&&typeof product.metadata==='object'?product.metadata:{}),source:'dabbir_owner_operations',updated_at:new Date().toISOString()};
-      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_aed,active,metadata`,{
-        method:'PATCH',
-        headers:{prefer:'return=representation'},
-        body:JSON.stringify({name,price_aed:Number(price.toFixed(2)),metadata}),
+      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_amount,active,metadata`,{
+        method:'PATCH',headers:{prefer:'return=representation'},
+        body:JSON.stringify({name,price_aed:roundMoney(price,market),metadata}),
       },'PRODUCT_UPDATE_FAILED');
       const updated=rows?.[0]||null;
       if(!updated)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
-
-      const stock=await rpc(context.token,'dabbir_owner_set_inventory',{
-        p_business_id:businessId,
-        p_product_id:productId,
-        p_quantity:quantity,
-      },'INVENTORY_UPDATE_FAILED');
-      return json(res,200,{ok:true,action,result:{...updated,quantity,reserved:Number(inventory.reserved||0),stock}});
+      const stock=await rpc(context.token,'dabbir_owner_set_inventory',{p_business_id:businessId,p_product_id:productId,p_quantity:quantity},'INVENTORY_UPDATE_FAILED');
+      return json(res,200,{ok:true,action,currency_code:market.currency_code,result:{...compatibleProduct(updated,market),quantity,reserved:Number(inventory.reserved||0),stock}});
     }
 
     if(action==='delete_product'){
       if(Number(inventory.reserved||0)>0)return json(res,409,{ok:false,error:'PRODUCT_HAS_RESERVED_STOCK'});
       const metadata={...(product.metadata&&typeof product.metadata==='object'?product.metadata:{}),source:'dabbir_owner_operations',deleted_at:new Date().toISOString(),deleted_by:context.user.id||null};
-      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_aed,active,metadata`,{
-        method:'PATCH',
-        headers:{prefer:'return=representation'},
-        body:JSON.stringify({active:false,metadata}),
+      const rows=await write(context.token,`dabbir_products?business_id=eq.${businessId}&id=eq.${productId}&select=id,sku,name,price_amount,active,metadata`,{
+        method:'PATCH',headers:{prefer:'return=representation'},body:JSON.stringify({active:false,metadata}),
       },'PRODUCT_DELETE_FAILED');
       const deleted=rows?.[0]||null;
       if(!deleted)return json(res,404,{ok:false,error:'PRODUCT_NOT_FOUND'});
-      return json(res,200,{ok:true,action,result:{...deleted,deleted:true}});
+      return json(res,200,{ok:true,action,currency_code:market.currency_code,result:{...compatibleProduct(deleted,market),deleted:true}});
     }
 
     return json(res,400,{ok:false,error:'UNSUPPORTED_PRODUCT_OPERATION'});
   }catch(error){
     const status=Number(error?.status)||500;
-    return json(res,status,{ok:false,error:error?.message||'OWNER_PRODUCT_MANAGEMENT_FAILED',detail:error?.detail||null});
+    const safe=[400,401,403,404,409,413,429,502,503].includes(status)?status:500;
+    return json(res,safe,{ok:false,error:error?.message||'OWNER_PRODUCT_MANAGEMENT_FAILED',detail:error?.detail||null});
   }
 }

--- a/test/dabbir-gcc-owner-operations-runtime.test.mjs
+++ b/test/dabbir-gcc-owner-operations-runtime.test.mjs
@@ -1,0 +1,53 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const ownerOps=readFileSync(new URL('../api/owner-operations.js',import.meta.url),'utf8');
+const ownerUi=readFileSync(new URL('../api/owner-operations-ui.js',import.meta.url),'utf8');
+const productManagement=readFileSync(new URL('../api/owner-product-management.js',import.meta.url),'utf8');
+
+test('Owner Operations reads neutral GCC money aliases and immutable currency snapshots',()=>{
+  assert.match(ownerOps,/from '\.\/_gcc-money-core\.js'/);
+  assert.match(ownerOps,/price_amount/);
+  assert.match(ownerOps,/total_amount,paid_amount,currency_code/);
+  assert.match(ownerOps,/unit_price_amount/);
+  assert.match(ownerOps,/line_total_amount/);
+  assert.match(ownerOps,/refund_amount,currency_code/);
+  assert.match(ownerOps,/recognized_sales_amount/);
+  assert.match(ownerOps,/cash_collected_amount/);
+  assert.match(ownerOps,/receivables_amount/);
+  assert.match(ownerOps,/marketDateKey/);
+  assert.match(ownerOps,/assertSnapshotCurrency\(order\.currency_code,market,'ORDER'\)/);
+  assert.match(ownerOps,/legacy_aed_aliases:market\.currency_code==='AED'/);
+});
+
+test('legacy AED inputs are compatibility-only and fail closed for non-AED businesses',()=>{
+  assert.match(ownerOps,/market\.currency_code!=='AED'.*LEGACY_AED_INPUT_NOT_ALLOWED/s);
+  assert.match(productManagement,/market\.currency_code!=='AED'.*LEGACY_AED_INPUT_NOT_ALLOWED/s);
+  assert.match(ownerOps,/p_price_aed:roundMoney\(price,market\)/);
+  assert.match(ownerOps,/amount_aed:roundMoney\(amount,market\)/);
+  assert.match(productManagement,/price_aed:roundMoney\(price,market\)/);
+});
+
+test('Owner Operations UI consumes neutral amounts and formats the verified business market',()=>{
+  assert.match(ownerUi,/data\?\.currency_code/);
+  assert.match(ownerUi,/data\?\.country_code/);
+  assert.match(ownerUi,/data\?\.currency_minor_units/);
+  assert.match(ownerUi,/data\?\.timezone/);
+  assert.match(ownerUi,/style:'currency',currency:currencyCode\(\)/);
+  assert.match(ownerUi,/recognized_sales_amount/);
+  assert.match(ownerUi,/product\.price_amount/);
+  assert.match(ownerUi,/order\.total_amount/);
+  assert.match(ownerUi,/price_amount:q\('#opsPrice'\)\.value/);
+  assert.doesNotMatch(ownerUi,/recognized_sales_aed/);
+  assert.doesNotMatch(ownerUi,/product\.price_aed/);
+  assert.doesNotMatch(ownerUi,/order\.total_aed/);
+  assert.doesNotMatch(ownerUi,/price_aed:q\('#opsPrice'\)\.value/);
+});
+
+test('Owner Product Management returns neutral product money and verifies request currency',()=>{
+  assert.match(productManagement,/verifiedBusinessMarket/);
+  assert.match(productManagement,/assertSnapshotCurrency\(body\.currency_code,market,'REQUEST'\)/);
+  assert.match(productManagement,/select=id,business_id,sku,name,price_amount/);
+  assert.match(productManagement,/select=id,sku,name,price_amount,active,metadata/);
+});


### PR DESCRIPTION
Stacked on #449 while npm security service is unavailable.

- reads neutral generated money aliases in Owner Operations
- verifies business country/currency/timezone and immutable order/expense/return snapshots
- computes Today in the business timezone, not Asia/Dubai
- exposes neutral metrics (`*_amount`)
- keeps legacy `*_aed` response aliases only for actual AED businesses
- accepts neutral `price_amount` / `amount` inputs; legacy AED inputs fail closed for non-AED businesses
- updates Owner Operations UI to true business currency, timezone and 2/3 minor units
- updates Owner Product Management to the same neutral contract
- adds regression coverage

The underlying DB/RPC `*_aed` names remain a compatibility ABI only; they are not exposed as non-AED semantic money.