### PR TITLE
fix(auth): restore owner OTP delivery through verified Resend domain

### DIFF
--- a/api/_owner-mailer-auth.js
+++ b/api/_owner-mailer-auth.js
@@ -1,0 +1,9 @@
+import { createHash } from 'node:crypto';
+
+const clean=value=>String(value||'').trim();
+
+export function ownerMailerAuth(env=process.env){
+  const serviceRole=clean(env.SUPABASE_SERVICE_ROLE_KEY);
+  if(!serviceRole||serviceRole.startsWith('sb_publishable_'))return '';
+  return createHash('sha256').update(`${serviceRole}:dabbir-owner-otp-mailer-v1`).digest('hex');
+}

--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -1,8 +1,10 @@
 import { json, parseCookies, readJsonBody, requireSameOrigin } from '../_auth-core.js';
+import { ownerMailerAuth } from '../_owner-mailer-auth.js';
 
 const ROOT_USERNAME = 'barmanadmin';
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '');
 const BROKER_URL = String(process.env.DABBIR_OWNER_BROKER_URL || `${SUPABASE_URL}/functions/v1/dabbir-owner-broker`).replace(/\/$/, '');
+const OTP_MAILER_URL = String(process.env.DABBIR_OWNER_OTP_MAILER_URL || `${SUPABASE_URL}/functions/v1/dabbir-owner-otp-mailer`).replace(/\/$/, '');
 const OTP_RE = /^\d{6}$/;
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const CHALLENGE_COOKIE = '__Host-dabbir_owner_otp_challenge';
@@ -15,8 +17,8 @@ const challengeCookie=(value,maxAge=600)=>secureCookie(CHALLENGE_COOKIE,value,ma
 const sessionCookie=(value,maxAge=43200)=>secureCookie(SESSION_COOKIE,value,maxAge);
 const clearChallengeCookie=()=>challengeCookie('',0);
 
-async function broker(body){
-  const response=await fetch(BROKER_URL,{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body),cache:'no-store',signal:AbortSignal.timeout(12000)});
+async function broker(url,body,headers={}){
+  const response=await fetch(url,{method:'POST',headers:{'content-type':'application/json',...headers},body:JSON.stringify(body),cache:'no-store',signal:AbortSignal.timeout(12000)});
   const payload=await response.json().catch(()=>({}));
   return {response,payload};
 }
@@ -24,7 +26,7 @@ async function broker(body){
 export default async function handler(req,res){
   res.setHeader('cache-control','no-store, max-age=0');
   res.setHeader('pragma','no-cache');
-  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v8');
+  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v9');
   if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
   if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
   try{
@@ -35,8 +37,9 @@ export default async function handler(req,res){
       // Do not reveal whether an employee email exists.
       if(!validLogin(login))return json(res,200,{ok:true,otp_required:true});
       const resendKey=String(process.env.RESEND_API_KEY||'').trim();
-      if(!resendKey)return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
-      const {response,payload}=await broker({action:'owner_otp_request',login,resend_key:resendKey});
+      const mailerAuth=ownerMailerAuth();
+      if(!resendKey||!mailerAuth)return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+      const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-owner-mailer-auth':mailerAuth});
       if(response.status===404)return json(res,200,{ok:true,otp_required:true});
       if(!response.ok||!payload?.ok||!payload?.challenge_id)return json(res,response.status===429?429:503,{ok:false,error:response.status===429?'OTP_RATE_LIMITED':(payload?.error||'OWNER_AUTH_UNAVAILABLE')});
       res.setHeader('set-cookie',challengeCookie(payload.challenge_id));
@@ -47,7 +50,7 @@ export default async function handler(req,res){
       if(!OTP_RE.test(otp))return json(res,400,{ok:false,error:'INVALID_OTP_FORMAT'});
       const challengeId=parseCookies(req.headers.cookie||'')[CHALLENGE_COOKIE];
       if(!challengeId)return json(res,401,{ok:false,error:'INVALID_OWNER_OTP'});
-      const {response,payload}=await broker({action:'owner_otp_verify',challenge_id:challengeId,otp});
+      const {response,payload}=await broker(BROKER_URL,{action:'owner_otp_verify',challenge_id:challengeId,otp});
       if(!response.ok||!payload?.authenticated||!payload?.session_token){res.setHeader('set-cookie',clearChallengeCookie());return json(res,response.status===503?503:401,{ok:false,error:payload?.error||'INVALID_OWNER_OTP'});}
       const maxAge=Math.max(60,Math.min(43200,Number(payload.expires_in||43200)));
       res.setHeader('set-cookie',[sessionCookie(payload.session_token,maxAge),clearChallengeCookie()]);

--- a/supabase/functions/dabbir-owner-otp-mailer/index.ts
+++ b/supabase/functions/dabbir-owner-otp-mailer/index.ts
@@ -1,0 +1,51 @@
+const SUPABASE_URL=Deno.env.get('SUPABASE_URL')||'';
+const SERVICE_KEY=Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')||'';
+const JSON_HEADERS={'content-type':'application/json','cache-control':'no-store'};
+
+const serviceKeyIsJwt=()=>SERVICE_KEY.split('.').length===3;
+const sbHeaders=()=>{const h:Record<string,string>={'apikey':SERVICE_KEY,'content-type':'application/json'};if(serviceKeyIsJwt())h.authorization=`Bearer ${SERVICE_KEY}`;return h};
+const reply=(status:number,body:unknown)=>new Response(JSON.stringify(body),{status,headers:JSON_HEADERS});
+const hex=(b:Uint8Array)=>Array.from(b,x=>x.toString(16).padStart(2,'0')).join('');
+async function sha(v:string){return hex(new Uint8Array(await crypto.subtle.digest('SHA-256',new TextEncoder().encode(v))))}
+async function otpHash(id:string,otp:string){return sha(`${SERVICE_KEY}:dabbir-owner-otp:${id}:${otp}`)}
+function randomToken(bytes=36){const d=new Uint8Array(bytes);crypto.getRandomValues(d);return btoa(String.fromCharCode(...d)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
+function randomOtp(){const x=new Uint32Array(1);crypto.getRandomValues(x);return String(x[0]%1000000).padStart(6,'0')}
+function clean(v:unknown,max=4000){return String(v??'').trim().slice(0,max)}
+function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let o=0;for(let i=0;i<a.length;i++)o|=a.charCodeAt(i)^b.charCodeAt(i);return o===0}
+async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
+async function rpc(name:string,params:Record<string,unknown>={}){const r=await sb(`/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',body:JSON.stringify(params)});const p=await r.json().catch(()=>null);return{ok:r.ok,status:r.status,payload:p}}
+
+async function expectedAuth(){return sha(`${SERVICE_KEY}:dabbir-owner-otp-mailer-v1`)}
+async function authorized(req:Request){const provided=clean(req.headers.get('x-dabbir-owner-mailer-auth'),128);if(!provided)return false;return safeEqual(provided,await expectedAuth())}
+function resendFrom(){const configured=clean(Deno.env.get('DABBIR_RESEND_FROM'),320);return configured&&!configured.toLowerCase().includes('@resend.dev')?configured:'DABBIR <no-reply@auth.bmalman.com>'}
+async function sendEmail(key:string,to:string,otp:string){
+ const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/1'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
+ if(!r.ok){const p:any=await r.json().catch(()=>null);console.error('DABBIR_OWNER_EMAIL_DELIVERY_FAILED',JSON.stringify({status:r.status,code:clean(p?.name||p?.code||p?.type,80)||'UNKNOWN',sender_mode:'verified_auth_domain'}))}
+ return r.ok;
+}
+
+async function requestOtp(body:any){
+ const resendKey=clean(body?.resend_key,500);if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+ const login=clean(body?.login||body?.identifier||body?.username||'__root__',254).toLowerCase();
+ const identity=await rpc('dabbir_platform_login_identity_v1',{p_login:login});
+ if(!identity.ok||!identity.payload?.user_id||!identity.payload?.email)return reply(404,{ok:false,error:'PLATFORM_IDENTITY_NOT_FOUND'});
+ const userId=String(identity.payload.user_id),email=String(identity.payload.email),invitationId=identity.payload.invitation_id||null;
+ const since=new Date(Date.now()-10*60*1000).toISOString();
+ const c=await sb(`/rest/v1/dabbir_owner_otp_challenges?actor_user_id=eq.${encodeURIComponent(userId)}&created_at=gte.${encodeURIComponent(since)}&select=id`,{headers:{prefer:'count=exact'}});
+ if(c.ok){const total=Number((c.headers.get('content-range')||'').split('/')[1]);if(Number.isFinite(total)&&total>=3)return reply(429,{ok:false,error:'OTP_RATE_LIMITED'})}
+ const id=crypto.randomUUID(),otp=randomOtp(),expires=new Date(Date.now()+10*60*1000).toISOString();
+ const ins=await sb('/rest/v1/dabbir_owner_otp_challenges',{method:'POST',headers:{prefer:'return=minimal'},body:JSON.stringify({id,actor_user_id:userId,invitation_id:invitationId,otp_hash:await otpHash(id,otp),token_hash:await sha(`${SERVICE_KEY}:challenge:${id}:${randomToken(18)}`),expires_at:expires,attempts:0})});
+ if(!ins.ok)return reply(503,{ok:false,error:'OWNER_AUTH_UNAVAILABLE'});
+ const sent=await sendEmail(resendKey,email,otp);
+ if(!sent){await sb(`/rest/v1/dabbir_owner_otp_challenges?id=eq.${encodeURIComponent(id)}`,{method:'DELETE'});return reply(503,{ok:false,error:'OWNER_OTP_DELIVERY_FAILED'})}
+ return reply(200,{ok:true,challenge_id:id,otp_required:true});
+}
+
+Deno.serve(async(req:Request)=>{
+ if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
+ if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_MAILER_NOT_CONFIGURED'});
+ if(!await authorized(req))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
+ let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
+ if(clean(body?.action,60).toLowerCase()!=='owner_otp_request')return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
+ try{return await requestOtp(body)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}
+});

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -11,6 +11,8 @@ test('platform authentication is actor-bound brokered Resend OTP with isolated s
   assert.match(source, /requireSameOrigin\(req\)/);
   assert.match(source, /RESEND_API_KEY/);
   assert.match(source, /dabbir-owner-broker/);
+  assert.match(source, /dabbir-owner-otp-mailer/);
+  assert.match(source, /ownerMailerAuth/);
   assert.match(source, /owner_otp_request/);
   assert.match(source, /owner_otp_verify/);
   assert.match(source, /challenge_id/);
@@ -19,6 +21,20 @@ test('platform authentication is actor-bound brokered Resend OTP with isolated s
   assert.doesNotMatch(source, /SUPABASE_SERVICE_ROLE_KEY/);
   assert.doesNotMatch(source, /grant_type=password/);
   assert.doesNotMatch(source, /barman2013@icloud\.com/);
+});
+
+test('owner OTP mailer uses the verified auth domain and rejects unauthenticated direct calls', async () => {
+  const mailer = await read('supabase/functions/dabbir-owner-otp-mailer/index.ts');
+  const auth = await read('api/_owner-mailer-auth.js');
+  assert.match(mailer, /no-reply@auth\.bmalman\.com/);
+  assert.match(mailer, /x-dabbir-owner-mailer-auth/);
+  assert.match(mailer, /OWNER_MAILER_UNAUTHORIZED/);
+  assert.match(mailer, /dabbir-owner-otp-mailer-v1/);
+  assert.doesNotMatch(mailer, /onboarding@resend\.dev/);
+  assert.doesNotMatch(mailer, /\/domains/);
+  assert.match(auth, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.match(auth, /createHash\('sha256'\)/);
+  assert.match(auth, /dabbir-owner-otp-mailer-v1/);
 });
 
 test('owner broker supports modern Supabase secret keys and actor-aware incidents', async () => {


### PR DESCRIPTION
Root cause: owner OTP requests reached the broker, but Resend rejected `onboarding@resend.dev` for the owner's iCloud recipient. The v10 fallback then attempted `GET /domains`, which the sending-only Resend API key cannot access (401).

This change:
- adds a dedicated Supabase owner OTP mailer that sends from verified `auth.bmalman.com`;
- signs Vercel→mailer calls with a service-role-derived SHA-256 token without exposing the service role in the route;
- keeps OTP verification/session issuance on the existing owner broker;
- adds regression coverage preventing `resend.dev` and `/domains` fallback in the owner OTP mailer.

Production mailer function is already deployed as `dabbir-owner-otp-mailer` v1. Required `test` check must pass before merge.