### PR TITLE
Harden Golden Canary with real iPad WebKit gate

### DIFF
--- a/.github/workflows/dabbir-golden-canary.yml
+++ b/.github/workflows/dabbir-golden-canary.yml
@@ -111,7 +111,7 @@ jobs:
     name: Trusted exact Preview verifier
     needs: [prepare, candidate-tests]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 35
     permissions:
       contents: read
       id-token: write
@@ -123,6 +123,8 @@ jobs:
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
       CANARY_SMOKE_REPORT: dabbir-golden-canary-smoke-report.json
       CANARY_JOURNEY_REPORT: dabbir-golden-canary-journey-report.json
+      CANARY_ENGLISH_JOURNEY_REPORT: dabbir-ai-customer-journey-report-en.json
+      CANARY_IPAD_JOURNEY_REPORT: dabbir-ai-customer-journey-report-ipad.json
     steps:
       - name: Checkout trusted verifier from main only
         uses: actions/checkout@v7
@@ -194,6 +196,17 @@ jobs:
           node --import ./test/dabbir-golden-canary-preload.mjs test/ai-full-customer-journey-v2.mjs
           test -s "$CANARY_JOURNEY_REPORT"
           jq -e '.verdict == "PASS" and .required_failures == 0 and (.steps | length) > 10' "$CANARY_JOURNEY_REPORT" >/dev/null
+      - name: Run English iPhone and RTL iPad WebKit journeys using trusted harness
+        shell: bash
+        env:
+          PRODUCTION_ORIGIN: ${{ needs.prepare.outputs.canary_url }}
+        run: |
+          set -euo pipefail
+          node --import ./test/dabbir-golden-canary-preload.mjs test/run-ai-full-customer-journey-en.mjs
+          test -s "$CANARY_ENGLISH_JOURNEY_REPORT"
+          test -s "$CANARY_IPAD_JOURNEY_REPORT"
+          jq -e '.verdict == "PASS" and .required_failures == 0 and .ipad_webkit.verdict == "PASS" and .ipad_webkit.required_failures == 0 and .ipad_webkit.mobile_step_status == "PASS" and .ipad_webkit.viewport.width == 820 and .ipad_webkit.viewport.height == 1180' "$CANARY_ENGLISH_JOURNEY_REPORT" >/dev/null
+          jq -e '.verdict == "PASS" and .required_failures == 0' "$CANARY_IPAD_JOURNEY_REPORT" >/dev/null
       - name: Prove Preview did not drift during validation
         shell: bash
         env:
@@ -214,7 +227,7 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p /tmp/dabbir-golden-canary
-          jq -nc --arg contract DABBIR_GOLDEN_CANARY_V1 --arg candidate_sha "$CANDIDATE_SHA" --arg canary_url "$CANARY_URL" --arg deployment_id "$VERIFIED_DEPLOYMENT" --arg run_id "$GITHUB_RUN_ID" '{contract:$contract,candidate_sha:$candidate_sha,canary_url:$canary_url,deployment_id:$deployment_id,environment:"preview",candidate_tests:"PASS",protected_smoke:"PASS",full_customer_journey:"PASS",deployment_drift:"NONE",promotion_allowed:true,fail_closed:true,github_run_id:$run_id}' > /tmp/dabbir-golden-canary/receipt.json
+          jq -nc --arg contract DABBIR_GOLDEN_CANARY_V1 --arg candidate_sha "$CANDIDATE_SHA" --arg canary_url "$CANARY_URL" --arg deployment_id "$VERIFIED_DEPLOYMENT" --arg run_id "$GITHUB_RUN_ID" '{contract:$contract,candidate_sha:$candidate_sha,canary_url:$canary_url,deployment_id:$deployment_id,environment:"preview",candidate_tests:"PASS",protected_smoke:"PASS",full_customer_journey:"PASS",english_iphone_webkit:"PASS",responsive_ipad_webkit:"PASS",deployment_drift:"NONE",promotion_allowed:true,fail_closed:true,github_run_id:$run_id}' > /tmp/dabbir-golden-canary/receipt.json
           cat /tmp/dabbir-golden-canary/receipt.json
       - name: Upload Golden Canary evidence
         if: always()
@@ -225,6 +238,8 @@ jobs:
             dabbir-golden-canary-smoke-report.json
             dabbir-golden-canary-smoke.png
             dabbir-golden-canary-journey-report.json
+            dabbir-ai-customer-journey-report-en.json
+            dabbir-ai-customer-journey-report-ipad.json
             dabbir-ai-customer-journey-screenshot.png
             /tmp/dabbir-golden-canary/receipt.json
           if-no-files-found: warn
@@ -254,7 +269,7 @@ jobs:
           description='Golden Canary failed; promotion blocked'
           if [ "$CANDIDATE_RESULT" = success ] && [ "$CANARY_RESULT" = success ]; then
             state=success
-            description='Exact Preview + full journey passed; promotion allowed'
+            description='Exact Preview + iPhone/iPad WebKit journeys passed'
           fi
           payload="$(jq -nc --arg state "$state" --arg context 'DABBIR Golden Canary' --arg description "$description" --arg target_url "${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" '{state:$state,context:$context,description:$description,target_url:$target_url}')"
           curl --fail-with-body --silent --show-error -X POST -H "Authorization: Bearer ${GH_TOKEN}" -H 'Accept: application/vnd.github+json' -H 'X-GitHub-Api-Version: 2022-11-28' -H 'Content-Type: application/json' --data "$payload" "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${CANDIDATE_SHA}" >/dev/null

--- a/test/dabbir-golden-canary-trigger-contract.test.mjs
+++ b/test/dabbir-golden-canary-trigger-contract.test.mjs
@@ -33,9 +33,9 @@ test('Golden Canary blocks promotion unless the real iPad WebKit responsive jour
 
   assert.match(workflow, /run-ai-full-customer-journey-en\.mjs/u);
   assert.match(workflow, /CANARY_IPAD_JOURNEY_REPORT: dabbir-ai-customer-journey-report-ipad\.json/u);
-  assert.match(workflow, /\.ipad_webkit\.verdict == \"PASS\"/u);
-  assert.match(workflow, /\.ipad_webkit\.mobile_step_status == \"PASS\"/u);
+  assert.ok(workflow.includes('.ipad_webkit.verdict == "PASS"'));
+  assert.ok(workflow.includes('.ipad_webkit.mobile_step_status == "PASS"'));
   assert.match(workflow, /\.ipad_webkit\.viewport\.width == 820/u);
-  assert.match(workflow, /responsive_ipad_webkit:\"PASS\"/u);
+  assert.ok(workflow.includes('responsive_ipad_webkit:"PASS"'));
   assert.match(workflow, /Exact Preview \+ iPhone\/iPad WebKit journeys passed/u);
 });

--- a/test/dabbir-golden-canary-trigger-contract.test.mjs
+++ b/test/dabbir-golden-canary-trigger-contract.test.mjs
@@ -27,3 +27,15 @@ test('Golden Canary comment trigger stays main-trusted and owner-only', async ()
   assert.match(qa, /payload\.event_name==='issue_comment'/u);
   assert.match(qa, /payload\.actor!==GH_COMMENT_ACTOR\|\|String\(payload\.actor_id\|\|''\)!==GH_COMMENT_ACTOR_ID/u);
 });
+
+test('Golden Canary blocks promotion unless the real iPad WebKit responsive journey passes', async () => {
+  const workflow = await readFile(workflowUrl, 'utf8');
+
+  assert.match(workflow, /run-ai-full-customer-journey-en\.mjs/u);
+  assert.match(workflow, /CANARY_IPAD_JOURNEY_REPORT: dabbir-ai-customer-journey-report-ipad\.json/u);
+  assert.match(workflow, /\.ipad_webkit\.verdict == \"PASS\"/u);
+  assert.match(workflow, /\.ipad_webkit\.mobile_step_status == \"PASS\"/u);
+  assert.match(workflow, /\.ipad_webkit\.viewport\.width == 820/u);
+  assert.match(workflow, /responsive_ipad_webkit:\"PASS\"/u);
+  assert.match(workflow, /Exact Preview \+ iPhone\/iPad WebKit journeys passed/u);
+});


### PR DESCRIPTION
Production exposed a gap in the existing Golden Canary: the primary iPhone WebKit journey passed while the generated 820×1180 iPad responsive-sidebar journey failed after promotion.

This PR closes that release-governance gap before the next UI repair:
- run the existing English + generated iPad WebKit customer journey inside the trusted main-only Golden Canary harness;
- require the iPad report to PASS at 820×1180 before publishing the promotion-success status;
- include the iPad/English reports in immutable canary evidence;
- lock the requirement with a repository contract test.

No application runtime behavior is changed by this PR.