### PR TITLE
Fix iPad WebKit sidebar against visual viewport

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -21,8 +21,8 @@ const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
     const sidebarWidth=Math.max(1,Math.min(286,viewportWidth*.82,Math.max(1,viewportWidth-16)));
     const rtl=String(document.documentElement.dir||'rtl').toLowerCase()==='rtl';
     const sidebarLeft=rtl?(viewportLeft+viewportWidth-sidebarWidth):viewportLeft;
-    document.documentElement.style.setProperty('--dabbir-sidebar-visual-left',`${sidebarLeft}px`);
-    document.documentElement.style.setProperty('--dabbir-sidebar-visual-width',`${sidebarWidth}px`);
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-left',String(sidebarLeft)+'px');
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-width',String(sidebarWidth)+'px');
     window.__dabbirTabletSidebarViewport={version:tabletSidebarAnchorVersion,width:viewportWidth,left:viewportLeft,sidebarWidth,sidebarLeft,rtl};
     return true;
   }

--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -10,18 +10,32 @@ const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
 const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
   if(window.__dabbirDesignAuthorityHeadV2)return;
   window.__dabbirDesignAuthorityHeadV2=true;
-  const tabletSidebarAnchorVersion='ipad-visual-viewport-anchor-v1';
+  const tabletSidebarAnchorVersion='ipad-visual-viewport-anchor-v2';
   let frame=0;
   let observer=null;
+  function syncTabletSidebarVisualViewport(){
+    if(!document.documentElement)return false;
+    const viewport=window.visualViewport;
+    const viewportWidth=Math.max(1,Number(viewport?.width||window.innerWidth||document.documentElement.clientWidth||1));
+    const viewportLeft=Number(viewport?.offsetLeft||0);
+    const sidebarWidth=Math.max(1,Math.min(286,viewportWidth*.82,Math.max(1,viewportWidth-16)));
+    const rtl=String(document.documentElement.dir||'rtl').toLowerCase()==='rtl';
+    const sidebarLeft=rtl?(viewportLeft+viewportWidth-sidebarWidth):viewportLeft;
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-left',`${sidebarLeft}px`);
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-width',`${sidebarWidth}px`);
+    window.__dabbirTabletSidebarViewport={version:tabletSidebarAnchorVersion,width:viewportWidth,left:viewportLeft,sidebarWidth,sidebarLeft,rtl};
+    return true;
+  }
   function ensureTabletSidebarAnchor(){
     if(!document.head)return false;
-    let anchor=document.querySelector('style[data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v1"]');
+    let anchor=document.querySelector('style[data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v2"]');
     if(!anchor){
       anchor=document.createElement('style');
       anchor.dataset.dabbirTabletSidebarAnchor=tabletSidebarAnchorVersion;
-      anchor.textContent='@media(max-width:920px){html[dir="rtl"] body .shell>.side{position:fixed!important;inset:0 0 0 auto!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html[dir="ltr"] body .shell>.side{position:fixed!important;inset:0 auto 0 0!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html body .shell>.side.open{transform:translate3d(0,0,0)!important}}';
+      anchor.textContent='@media(max-width:920px){html body .shell>#side{position:fixed!important;inset-inline-start:auto!important;inset-inline-end:auto!important;inset-block-start:0!important;inset-block-end:0!important;top:0!important;right:auto!important;bottom:0!important;left:var(--dabbir-sidebar-visual-left,0px)!important;margin:0!important;width:var(--dabbir-sidebar-visual-width,min(82vw,286px))!important;max-width:calc(100vw - 16px)!important}html body .shell>#side.open{transform:translate3d(0,0,0)!important}}';
       document.head.appendChild(anchor);
     }
+    syncTabletSidebarVisualViewport();
     return true;
   }
   function reassertAuthority(){
@@ -47,12 +61,18 @@ const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
     window.__dabbirUiLifecycle?.on?.('afterNavigate','executive-calm-authority',schedule);
     window.__dabbirUiLifecycle?.on?.('afterLanguage','executive-calm-authority',schedule);
   }catch(_error){}
+  try{
+    window.addEventListener('resize',schedule,{passive:true});
+    window.addEventListener('orientationchange',schedule,{passive:true});
+    window.visualViewport?.addEventListener?.('resize',schedule,{passive:true});
+    window.visualViewport?.addEventListener?.('scroll',schedule,{passive:true});
+  }catch(_error){}
   window.addEventListener('load',schedule,{once:true});
   ensureTabletSidebarAnchor();
   schedule();
   setTimeout(schedule,250);
   setTimeout(schedule,1400);
-  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0,tabletSidebarAnchor:tabletSidebarAnchorVersion};
+  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0,tabletSidebarAnchor:tabletSidebarAnchorVersion,visualViewportAnchoring:true};
 })();`;
 
 function bustUiAssetVersion(body) {

--- a/test/dabbir-executive-calm-shell-authority.test.mjs
+++ b/test/dabbir-executive-calm-shell-authority.test.mjs
@@ -17,12 +17,19 @@ test('Safari shell reasserts Executive Calm in head without mutating the applica
   assert.doesNotMatch(safariRecovery,/setInterval\(/);
 });
 
-test('responsive iPad sidebar is physically anchored inside the visual viewport for RTL and LTR',()=>{
-  assert.match(safariRecovery,/dabbir-tablet-sidebar-anchor/);
-  assert.match(safariRecovery,/ipad-visual-viewport-anchor-v1/);
-  assert.match(safariRecovery,/inset:0 0 0 auto!important/);
-  assert.match(safariRecovery,/inset:0 auto 0 0!important/);
-  assert.match(safariRecovery,/max-width:calc\(100vw - 16px\)!important/);
+test('responsive iPad sidebar is anchored to visual viewport coordinates rather than the wider WebKit layout viewport',()=>{
+  assert.match(safariRecovery,/ipad-visual-viewport-anchor-v2/);
+  assert.match(safariRecovery,/window\.visualViewport/);
+  assert.match(safariRecovery,/viewport\?\.width\|\|window\.innerWidth/);
+  assert.match(safariRecovery,/viewport\?\.offsetLeft\|\|0/);
+  assert.match(safariRecovery,/sidebarLeft=rtl\?\(viewportLeft\+viewportWidth-sidebarWidth\):viewportLeft/);
+  assert.match(safariRecovery,/--dabbir-sidebar-visual-left/);
+  assert.match(safariRecovery,/--dabbir-sidebar-visual-width/);
+  assert.match(safariRecovery,/inset-inline-start:auto!important/);
+  assert.match(safariRecovery,/inset-inline-end:auto!important/);
+  assert.match(safariRecovery,/left:var\(--dabbir-sidebar-visual-left,0px\)!important/);
+  assert.match(safariRecovery,/width:var\(--dabbir-sidebar-visual-width,min\(82vw,286px\)\)!important/);
   assert.match(safariRecovery,/side\.open\{transform:translate3d\(0,0,0\)!important\}/);
-  assert.match(safariRecovery,/tabletSidebarAnchor:tabletSidebarAnchorVersion/);
+  assert.match(safariRecovery,/visualViewportAnchoring:true/);
+  assert.doesNotMatch(safariRecovery,/inset:0 0 0 auto!important/);
 });


### PR DESCRIPTION
Production proved the first sidebar fix still anchored to WebKit's wider layout viewport: on the 820px iPad journey the conversations target rendered at left=728/right=985 while window.innerWidth=820.

Root repair:
- stop relying on CSS right/left/inset against the layout viewport;
- read `window.visualViewport` width/offset and compute the sidebar's exact physical left coordinate in CSS pixels;
- explicitly neutralize legacy logical inline inset properties;
- resync on visual viewport resize/scroll, orientation, language and UI lifecycle events without polling;
- preserve the existing closed/open transform behavior and Executive Calm head authority;
- add regression coverage for the visual-viewport coordinate contract.

Promotion must wait for the strengthened Golden Canary to prove the real 820×1180 iPad WebKit journey.