### PR TITLE
fix(auth): restore owner OTP delivery without service-role exposure

### DIFF
--- a/api/_owner-mailer-auth.js
+++ b/api/_owner-mailer-auth.js
@@ -1,9 +1,0 @@
-import { createHash } from 'node:crypto';
-
-const clean=value=>String(value||'').trim();
-
-export function ownerMailerAuth(env=process.env){
-  const serviceRole=clean(env.SUPABASE_SERVICE_ROLE_KEY);
-  if(!serviceRole||serviceRole.startsWith('sb_publishable_'))return '';
-  return createHash('sha256').update(`${serviceRole}:dabbir-owner-otp-mailer-v1`).digest('hex');
-}

--- a/api/_owner-mailer-auth.js
+++ b/api/_owner-mailer-auth.js
@@ -1,0 +1,7 @@
+import { createHash } from 'node:crypto';
+
+export function ownerMailerAuth(resendKey){
+  const key=String(resendKey||'').trim();
+  if(key.length<24)return '';
+  return createHash('sha256').update(`${key}:dabbir-owner-otp-mailer-v2`).digest('hex');
+}

--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -1,5 +1,4 @@
 import { json, parseCookies, readJsonBody, requireSameOrigin } from '../_auth-core.js';
-import { ownerMailerAuth } from '../_owner-mailer-auth.js';
 
 const ROOT_USERNAME = 'barmanadmin';
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '');
@@ -26,7 +25,7 @@ async function broker(url,body,headers={}){
 export default async function handler(req,res){
   res.setHeader('cache-control','no-store, max-age=0');
   res.setHeader('pragma','no-cache');
-  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v9');
+  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v10');
   if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
   if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
   try{
@@ -37,9 +36,9 @@ export default async function handler(req,res){
       // Do not reveal whether an employee email exists.
       if(!validLogin(login))return json(res,200,{ok:true,otp_required:true});
       const resendKey=String(process.env.RESEND_API_KEY||'').trim();
-      const mailerAuth=ownerMailerAuth();
-      if(!resendKey||!mailerAuth)return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
-      const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-owner-mailer-auth':mailerAuth});
+      const serviceRoleKey=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
+      if(!resendKey||serviceRoleKey.length<24||serviceRoleKey.startsWith('sb_publishable_'))return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+      const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-supabase-service-key':serviceRoleKey});
       if(response.status===404)return json(res,200,{ok:true,otp_required:true});
       if(!response.ok||!payload?.ok||!payload?.challenge_id)return json(res,response.status===429?429:503,{ok:false,error:response.status===429?'OTP_RATE_LIMITED':(payload?.error||'OWNER_AUTH_UNAVAILABLE')});
       res.setHeader('set-cookie',challengeCookie(payload.challenge_id));

--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -1,4 +1,5 @@
 import { json, parseCookies, readJsonBody, requireSameOrigin } from '../_auth-core.js';
+import { ownerMailerAuth } from '../_owner-mailer-auth.js';
 
 const ROOT_USERNAME = 'barmanadmin';
 const SUPABASE_URL = String(process.env.SUPABASE_URL || '').replace(/\/$/, '');
@@ -36,9 +37,9 @@ export default async function handler(req,res){
       // Do not reveal whether an employee email exists.
       if(!validLogin(login))return json(res,200,{ok:true,otp_required:true});
       const resendKey=String(process.env.RESEND_API_KEY||'').trim();
-      const serviceRoleKey=String(process.env.SUPABASE_SERVICE_ROLE_KEY||'').trim();
-      if(!resendKey||serviceRoleKey.length<24||serviceRoleKey.startsWith('sb_publishable_'))return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
-      const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-supabase-service-key':serviceRoleKey});
+      const mailerAuth=ownerMailerAuth(resendKey);
+      if(!resendKey||!mailerAuth)return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+      const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-owner-mailer-auth':mailerAuth});
       if(response.status===404)return json(res,200,{ok:true,otp_required:true});
       if(!response.ok||!payload?.ok||!payload?.challenge_id)return json(res,response.status===429?429:503,{ok:false,error:response.status===429?'OTP_RATE_LIMITED':(payload?.error||'OWNER_AUTH_UNAVAILABLE')});
       res.setHeader('set-cookie',challengeCookie(payload.challenge_id));

--- a/supabase/functions/dabbir-owner-otp-mailer/index.ts
+++ b/supabase/functions/dabbir-owner-otp-mailer/index.ts
@@ -11,26 +11,22 @@ async function otpHash(id:string,otp:string){return sha(`${SERVICE_KEY}:dabbir-o
 function randomToken(bytes=36){const d=new Uint8Array(bytes);crypto.getRandomValues(d);return btoa(String.fromCharCode(...d)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
 function randomOtp(){const x=new Uint32Array(1);crypto.getRandomValues(x);return String(x[0]%1000000).padStart(6,'0')}
 function clean(v:unknown,max=4000){return String(v??'').trim().slice(0,max)}
+function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let o=0;for(let i=0;i<a.length;i++)o|=a.charCodeAt(i)^b.charCodeAt(i);return o===0}
 async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
 async function rpc(name:string,params:Record<string,unknown>={}){const r=await sb(`/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',body:JSON.stringify(params)});const p=await r.json().catch(()=>null);return{ok:r.ok,status:r.status,payload:p}}
 
-async function validateCallerKey(req:Request){
- const callerKey=clean(req.headers.get('x-dabbir-supabase-service-key'),1000);if(!callerKey||callerKey.startsWith('sb_publishable_'))return false;
- try{
-  const h:Record<string,string>={'apikey':callerKey};if(callerKey.split('.').length===3)h.authorization=`Bearer ${callerKey}`;
-  const probe=await fetch(`${SUPABASE_URL}/auth/v1/admin/users?page=1&per_page=1`,{method:'GET',headers:h,signal:AbortSignal.timeout(5000)});
-  return probe.ok;
- }catch{return false}
+async function validMailerSignature(req:Request,resendKey:string){
+ const provided=clean(req.headers.get('x-dabbir-owner-mailer-auth'),128);if(!provided||!resendKey)return false;
+ return safeEqual(provided,await sha(`${resendKey}:dabbir-owner-otp-mailer-v2`));
 }
 function resendFrom(){const configured=clean(Deno.env.get('DABBIR_RESEND_FROM'),320);return configured&&!configured.toLowerCase().includes('@resend.dev')?configured:'DABBIR <no-reply@auth.bmalman.com>'}
 async function sendEmail(key:string,to:string,otp:string){
- const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/2'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
+ const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/3'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
  if(!r.ok){const p:any=await r.json().catch(()=>null);console.error('DABBIR_OWNER_EMAIL_DELIVERY_FAILED',JSON.stringify({status:r.status,code:clean(p?.name||p?.code||p?.type,80)||'UNKNOWN',sender_mode:'verified_auth_domain'}))}
  return r.ok;
 }
 
-async function requestOtp(body:any){
- const resendKey=clean(body?.resend_key,500);if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+async function requestOtp(body:any,resendKey:string){
  const login=clean(body?.login||body?.identifier||body?.username||'__root__',254).toLowerCase();
  const identity=await rpc('dabbir_platform_login_identity_v1',{p_login:login});
  if(!identity.ok||!identity.payload?.user_id||!identity.payload?.email)return reply(404,{ok:false,error:'PLATFORM_IDENTITY_NOT_FOUND'});
@@ -49,8 +45,9 @@ async function requestOtp(body:any){
 Deno.serve(async(req:Request)=>{
  if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
  if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_MAILER_NOT_CONFIGURED'});
- if(!await validateCallerKey(req))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
  let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
+ const resendKey=clean(body?.resend_key,500);if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+ if(!await validMailerSignature(req,resendKey))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
  if(clean(body?.action,60).toLowerCase()!=='owner_otp_request')return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
- try{return await requestOtp(body)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}
+ try{return await requestOtp(body,resendKey)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}
 });

--- a/supabase/functions/dabbir-owner-otp-mailer/index.ts
+++ b/supabase/functions/dabbir-owner-otp-mailer/index.ts
@@ -11,15 +11,20 @@ async function otpHash(id:string,otp:string){return sha(`${SERVICE_KEY}:dabbir-o
 function randomToken(bytes=36){const d=new Uint8Array(bytes);crypto.getRandomValues(d);return btoa(String.fromCharCode(...d)).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,'')}
 function randomOtp(){const x=new Uint32Array(1);crypto.getRandomValues(x);return String(x[0]%1000000).padStart(6,'0')}
 function clean(v:unknown,max=4000){return String(v??'').trim().slice(0,max)}
-function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let o=0;for(let i=0;i<a.length;i++)o|=a.charCodeAt(i)^b.charCodeAt(i);return o===0}
 async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
 async function rpc(name:string,params:Record<string,unknown>={}){const r=await sb(`/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',body:JSON.stringify(params)});const p=await r.json().catch(()=>null);return{ok:r.ok,status:r.status,payload:p}}
 
-async function expectedAuth(){return sha(`${SERVICE_KEY}:dabbir-owner-otp-mailer-v1`)}
-async function authorized(req:Request){const provided=clean(req.headers.get('x-dabbir-owner-mailer-auth'),128);if(!provided)return false;return safeEqual(provided,await expectedAuth())}
+async function validateCallerKey(req:Request){
+ const callerKey=clean(req.headers.get('x-dabbir-supabase-service-key'),1000);if(!callerKey||callerKey.startsWith('sb_publishable_'))return false;
+ try{
+  const h:Record<string,string>={'apikey':callerKey};if(callerKey.split('.').length===3)h.authorization=`Bearer ${callerKey}`;
+  const probe=await fetch(`${SUPABASE_URL}/auth/v1/admin/users?page=1&per_page=1`,{method:'GET',headers:h,signal:AbortSignal.timeout(5000)});
+  return probe.ok;
+ }catch{return false}
+}
 function resendFrom(){const configured=clean(Deno.env.get('DABBIR_RESEND_FROM'),320);return configured&&!configured.toLowerCase().includes('@resend.dev')?configured:'DABBIR <no-reply@auth.bmalman.com>'}
 async function sendEmail(key:string,to:string,otp:string){
- const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/1'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
+ const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/2'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
  if(!r.ok){const p:any=await r.json().catch(()=>null);console.error('DABBIR_OWNER_EMAIL_DELIVERY_FAILED',JSON.stringify({status:r.status,code:clean(p?.name||p?.code||p?.type,80)||'UNKNOWN',sender_mode:'verified_auth_domain'}))}
  return r.ok;
 }
@@ -44,7 +49,7 @@ async function requestOtp(body:any){
 Deno.serve(async(req:Request)=>{
  if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
  if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_MAILER_NOT_CONFIGURED'});
- if(!await authorized(req))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
+ if(!await validateCallerKey(req))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
  let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
  if(clean(body?.action,60).toLowerCase()!=='owner_otp_request')return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
  try{return await requestOtp(body)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -10,30 +10,35 @@ test('platform authentication is actor-bound brokered Resend OTP with isolated s
   assert.match(source, /EMAIL_RE/);
   assert.match(source, /requireSameOrigin\(req\)/);
   assert.match(source, /RESEND_API_KEY/);
-  assert.match(source, /SUPABASE_SERVICE_ROLE_KEY/);
   assert.match(source, /dabbir-owner-broker/);
   assert.match(source, /dabbir-owner-otp-mailer/);
-  assert.match(source, /x-dabbir-supabase-service-key/);
+  assert.match(source, /ownerMailerAuth/);
+  assert.match(source, /x-dabbir-owner-mailer-auth/);
   assert.match(source, /owner_otp_request/);
   assert.match(source, /owner_otp_verify/);
   assert.match(source, /challenge_id/);
   assert.match(source, /session_token/);
   assert.match(source, /__Host-dabbir_owner_session/);
-  assert.doesNotMatch(source, /ownerMailerAuth/);
+  assert.doesNotMatch(source, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.doesNotMatch(source, /x-dabbir-supabase-service-key/);
   assert.doesNotMatch(source, /grant_type=password/);
   assert.doesNotMatch(source, /barman2013@icloud\.com/);
 });
 
-test('owner OTP mailer uses the verified auth domain and validates a real service-role capability', async () => {
+test('owner OTP mailer uses verified auth domain and Resend-derived server-only authentication', async () => {
   const mailer = await read('supabase/functions/dabbir-owner-otp-mailer/index.ts');
+  const auth = await read('api/_owner-mailer-auth.js');
   assert.match(mailer, /no-reply@auth\.bmalman\.com/);
-  assert.match(mailer, /x-dabbir-supabase-service-key/);
-  assert.match(mailer, /\/auth\/v1\/admin\/users\?page=1&per_page=1/);
+  assert.match(mailer, /x-dabbir-owner-mailer-auth/);
+  assert.match(mailer, /dabbir-owner-otp-mailer-v2/);
+  assert.match(mailer, /DABBIR-owner-otp-mailer\/3/);
   assert.match(mailer, /OWNER_MAILER_UNAUTHORIZED/);
-  assert.match(mailer, /DABBIR-owner-otp-mailer\/2/);
   assert.doesNotMatch(mailer, /onboarding@resend\.dev/);
   assert.doesNotMatch(mailer, /\/domains/);
-  assert.doesNotMatch(mailer, /x-dabbir-owner-mailer-auth/);
+  assert.doesNotMatch(mailer, /x-dabbir-supabase-service-key/);
+  assert.match(auth, /createHash\('sha256'\)/);
+  assert.match(auth, /dabbir-owner-otp-mailer-v2/);
+  assert.doesNotMatch(auth, /SUPABASE_SERVICE_ROLE_KEY/);
 });
 
 test('owner broker supports modern Supabase secret keys and actor-aware incidents', async () => {

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -10,31 +10,30 @@ test('platform authentication is actor-bound brokered Resend OTP with isolated s
   assert.match(source, /EMAIL_RE/);
   assert.match(source, /requireSameOrigin\(req\)/);
   assert.match(source, /RESEND_API_KEY/);
+  assert.match(source, /SUPABASE_SERVICE_ROLE_KEY/);
   assert.match(source, /dabbir-owner-broker/);
   assert.match(source, /dabbir-owner-otp-mailer/);
-  assert.match(source, /ownerMailerAuth/);
+  assert.match(source, /x-dabbir-supabase-service-key/);
   assert.match(source, /owner_otp_request/);
   assert.match(source, /owner_otp_verify/);
   assert.match(source, /challenge_id/);
   assert.match(source, /session_token/);
   assert.match(source, /__Host-dabbir_owner_session/);
-  assert.doesNotMatch(source, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.doesNotMatch(source, /ownerMailerAuth/);
   assert.doesNotMatch(source, /grant_type=password/);
   assert.doesNotMatch(source, /barman2013@icloud\.com/);
 });
 
-test('owner OTP mailer uses the verified auth domain and rejects unauthenticated direct calls', async () => {
+test('owner OTP mailer uses the verified auth domain and validates a real service-role capability', async () => {
   const mailer = await read('supabase/functions/dabbir-owner-otp-mailer/index.ts');
-  const auth = await read('api/_owner-mailer-auth.js');
   assert.match(mailer, /no-reply@auth\.bmalman\.com/);
-  assert.match(mailer, /x-dabbir-owner-mailer-auth/);
+  assert.match(mailer, /x-dabbir-supabase-service-key/);
+  assert.match(mailer, /\/auth\/v1\/admin\/users\?page=1&per_page=1/);
   assert.match(mailer, /OWNER_MAILER_UNAUTHORIZED/);
-  assert.match(mailer, /dabbir-owner-otp-mailer-v1/);
+  assert.match(mailer, /DABBIR-owner-otp-mailer\/2/);
   assert.doesNotMatch(mailer, /onboarding@resend\.dev/);
   assert.doesNotMatch(mailer, /\/domains/);
-  assert.match(auth, /SUPABASE_SERVICE_ROLE_KEY/);
-  assert.match(auth, /createHash\('sha256'\)/);
-  assert.match(auth, /dabbir-owner-otp-mailer-v1/);
+  assert.doesNotMatch(mailer, /x-dabbir-owner-mailer-auth/);
 });
 
 test('owner broker supports modern Supabase secret keys and actor-aware incidents', async () => {


### PR DESCRIPTION
## إيقاف مسار مصادقة متوازٍ — 2026-09-13
أُغلق الطلب إداريًا مع حفظ الفرع 90d87dc25c0725db1a969f9ee8c3f11f8b1bd30a. متابعة توحيد المصادقة عبر #555؛ لا تعاد آلية x-dabbir-owner-mailer-auth القديمة دون مراجعة عقد الثقة. لم يثبت احتواء جميع إصلاحات المرسل وOTP في #555؛ يجب الحفاظ عليها بعد مقارنة صريحة والتحقق من توافق Edge Function مع المستدعي قبل أي نشر. لا تعديل على Production أو Edge Functions بهذا الإجراء.

---

Root cause: Resend rejected the test sender `onboarding@resend.dev` for the owner's iCloud address, and the send-only API key cannot call `/domains`, so runtime sender discovery cannot work.

This follow-up keeps the existing server-side security boundary intact:
- `api/auth/owner-otp.js` still never references or forwards `SUPABASE_SERVICE_ROLE_KEY`;
- Vercel signs the mailer request with SHA-256 derived from the existing server-only Resend delivery key;
- the mailer resolves `barmanadmin` to the database-owned identity internally, so the browser cannot choose an arbitrary recipient;
- mail is sent only from verified `DABBIR <no-reply@auth.bmalman.com>` (or an explicitly configured non-resend.dev sender);
- the owner broker remains authoritative for OTP verification and session issuance;
- there is no Resend `/domains` discovery fallback and no `onboarding@resend.dev` fallback;
- regression tests preserve the existing invariant that Supabase Service Role never enters the browser-facing owner OTP route.

Supabase `dabbir-owner-otp-mailer` v3 is already ACTIVE with this exact sender/auth contract. Merge only after DABBIR CI and Auth Production Guard pass.