### PR TITLE
fix: anchor iPad sidebar to the visual viewport

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -10,18 +10,32 @@ const AUTH_BOOT_ANCHOR = 'applyLang();boot();\n</script>';
 const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
   if(window.__dabbirDesignAuthorityHeadV2)return;
   window.__dabbirDesignAuthorityHeadV2=true;
-  const tabletSidebarAnchorVersion='ipad-visual-viewport-anchor-v1';
+  const tabletSidebarAnchorVersion='ipad-visual-viewport-anchor-v2';
   let frame=0;
   let observer=null;
+  function syncTabletSidebarVisualViewport(){
+    if(!document.documentElement)return false;
+    const viewport=window.visualViewport;
+    const viewportWidth=Math.max(1,Number(viewport?.width||window.innerWidth||document.documentElement.clientWidth||1));
+    const viewportLeft=Number(viewport?.offsetLeft||0);
+    const sidebarWidth=Math.max(1,Math.min(286,viewportWidth*.82,Math.max(1,viewportWidth-16)));
+    const rtl=String(document.documentElement.dir||'rtl').toLowerCase()==='rtl';
+    const sidebarLeft=rtl?(viewportLeft+viewportWidth-sidebarWidth):viewportLeft;
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-left',String(sidebarLeft)+'px');
+    document.documentElement.style.setProperty('--dabbir-sidebar-visual-width',String(sidebarWidth)+'px');
+    window.__dabbirTabletSidebarViewport={version:tabletSidebarAnchorVersion,width:viewportWidth,left:viewportLeft,sidebarWidth,sidebarLeft,rtl};
+    return true;
+  }
   function ensureTabletSidebarAnchor(){
     if(!document.head)return false;
-    let anchor=document.querySelector('style[data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v1"]');
+    let anchor=document.querySelector('style[data-dabbir-tablet-sidebar-anchor="ipad-visual-viewport-anchor-v2"]');
     if(!anchor){
       anchor=document.createElement('style');
       anchor.dataset.dabbirTabletSidebarAnchor=tabletSidebarAnchorVersion;
-      anchor.textContent='@media(max-width:920px){html[dir="rtl"] body .shell>.side{position:fixed!important;inset:0 0 0 auto!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html[dir="ltr"] body .shell>.side{position:fixed!important;inset:0 auto 0 0!important;width:min(82vw,286px)!important;max-width:calc(100vw - 16px)!important}html body .shell>.side.open{transform:translate3d(0,0,0)!important}}';
+      anchor.textContent='@media(max-width:920px){html body .shell>#side{position:fixed!important;inset-inline-start:auto!important;inset-inline-end:auto!important;inset-block-start:0!important;inset-block-end:0!important;top:0!important;right:auto!important;bottom:0!important;left:var(--dabbir-sidebar-visual-left,0px)!important;margin:0!important;width:var(--dabbir-sidebar-visual-width,min(82vw,286px))!important;max-width:calc(100vw - 16px)!important}html body .shell>#side.open{transform:translate3d(0,0,0)!important}}';
       document.head.appendChild(anchor);
     }
+    syncTabletSidebarVisualViewport();
     return true;
   }
   function reassertAuthority(){
@@ -47,12 +61,18 @@ const DESIGN_AUTHORITY_SCRIPT = String.raw`(()=>{
     window.__dabbirUiLifecycle?.on?.('afterNavigate','executive-calm-authority',schedule);
     window.__dabbirUiLifecycle?.on?.('afterLanguage','executive-calm-authority',schedule);
   }catch(_error){}
+  try{
+    window.addEventListener('resize',schedule,{passive:true});
+    window.addEventListener('orientationchange',schedule,{passive:true});
+    window.visualViewport?.addEventListener?.('resize',schedule,{passive:true});
+    window.visualViewport?.addEventListener?.('scroll',schedule,{passive:true});
+  }catch(_error){}
   window.addEventListener('load',schedule,{once:true});
   ensureTabletSidebarAnchor();
   schedule();
   setTimeout(schedule,250);
   setTimeout(schedule,1400);
-  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0,tabletSidebarAnchor:tabletSidebarAnchorVersion};
+  window.__dabbirDesignAuthority={version:'executive-calm-v1',mode:'head-tail-reassert',pollingLoops:0,presentationObservers:1,bodyObservers:0,tabletSidebarAnchor:tabletSidebarAnchorVersion,visualViewportAnchoring:true};
 })();`;
 
 function bustUiAssetVersion(body) {

--- a/test/dabbir-executive-calm-shell-authority.test.mjs
+++ b/test/dabbir-executive-calm-shell-authority.test.mjs
@@ -17,12 +17,19 @@ test('Safari shell reasserts Executive Calm in head without mutating the applica
   assert.doesNotMatch(safariRecovery,/setInterval\(/);
 });
 
-test('responsive iPad sidebar is physically anchored inside the visual viewport for RTL and LTR',()=>{
-  assert.match(safariRecovery,/dabbir-tablet-sidebar-anchor/);
-  assert.match(safariRecovery,/ipad-visual-viewport-anchor-v1/);
-  assert.match(safariRecovery,/inset:0 0 0 auto!important/);
-  assert.match(safariRecovery,/inset:0 auto 0 0!important/);
-  assert.match(safariRecovery,/max-width:calc\(100vw - 16px\)!important/);
+test('responsive iPad sidebar is anchored to visual viewport coordinates rather than the wider WebKit layout viewport',()=>{
+  assert.match(safariRecovery,/ipad-visual-viewport-anchor-v2/);
+  assert.match(safariRecovery,/window\.visualViewport/);
+  assert.match(safariRecovery,/viewport\?\.width\|\|window\.innerWidth/);
+  assert.match(safariRecovery,/viewport\?\.offsetLeft\|\|0/);
+  assert.match(safariRecovery,/sidebarLeft=rtl\?\(viewportLeft\+viewportWidth-sidebarWidth\):viewportLeft/);
+  assert.match(safariRecovery,/--dabbir-sidebar-visual-left/);
+  assert.match(safariRecovery,/--dabbir-sidebar-visual-width/);
+  assert.match(safariRecovery,/inset-inline-start:auto!important/);
+  assert.match(safariRecovery,/inset-inline-end:auto!important/);
+  assert.match(safariRecovery,/left:var\(--dabbir-sidebar-visual-left,0px\)!important/);
+  assert.match(safariRecovery,/width:var\(--dabbir-sidebar-visual-width,min\(82vw,286px\)\)!important/);
   assert.match(safariRecovery,/side\.open\{transform:translate3d\(0,0,0\)!important\}/);
-  assert.match(safariRecovery,/tabletSidebarAnchor:tabletSidebarAnchorVersion/);
+  assert.match(safariRecovery,/visualViewportAnchoring:true/);
+  assert.doesNotMatch(safariRecovery,/inset:0 0 0 auto!important/);
 });

--- a/test/dabbir-ipad-webkit-production-contract.test.mjs
+++ b/test/dabbir-ipad-webkit-production-contract.test.mjs
@@ -45,7 +45,10 @@ test('iPad sidebar targets must be truly inside the viewport and pointer-hit-tes
   assert.match(wrapper,/pointer_events/);
   assert.match(wrapper,/width >= 40/);
   assert.match(wrapper,/height >= 40/);
-  assert.match(wrapper,/rect\.left < window\.innerWidth && rect\.right > 0/);
+  assert.equal((wrapper.match(/rect\.left >= 0/g)||[]).length,2);
+  assert.equal((wrapper.match(/rect\.right <= window\.innerWidth/g)||[]).length,2);
+  assert.equal((wrapper.match(/rect\.top >= 0/g)||[]).length,2);
+  assert.equal((wrapper.match(/rect\.bottom <= window\.innerHeight/g)||[]).length,2);
   assert.doesNotMatch(wrapper,/style\.display\s*=\s*['\"](?:flex|block|grid)['\"]/);
   assert.doesNotMatch(wrapper,/dispatchEvent\(/);
 });

--- a/test/run-ai-full-customer-journey-en.mjs
+++ b/test/run-ai-full-customer-journey-en.mjs
@@ -17,7 +17,12 @@ const tabletConversationNavigation = `  const ipadMenuForConversations = page.lo
     const side = document.querySelector('#side');
     if (!side || !side.classList.contains('open')) return false;
     const rect = side.getBoundingClientRect();
-    return rect.width > 0 && rect.height > 0 && rect.left < window.innerWidth && rect.right > 0;
+    return rect.width > 0
+      && rect.height > 0
+      && rect.left >= 0
+      && rect.right <= window.innerWidth
+      && rect.top >= 0
+      && rect.bottom <= window.innerHeight;
   }, null, { timeout: 10_000 });
   const visibleConversationsNav = page.locator('#side.open #nav [data-screen="conversations"]:visible');
   const visibleConversationsCount = await visibleConversationsNav.count();
@@ -72,7 +77,12 @@ const tabletOperationsNavigation = `  const ipadMenuForOperations = page.locator
     const side = document.querySelector('#side');
     if (!side || !side.classList.contains('open')) return false;
     const rect = side.getBoundingClientRect();
-    return rect.width > 0 && rect.height > 0 && rect.left < window.innerWidth && rect.right > 0;
+    return rect.width > 0
+      && rect.height > 0
+      && rect.left >= 0
+      && rect.right <= window.innerWidth
+      && rect.top >= 0
+      && rect.bottom <= window.innerHeight;
   }, null, { timeout: 10_000 });
   const visibleOperationsNav = page.locator('#side.open #nav [data-screen="operations"]:visible');
   const visibleOperationsCount = await visibleOperationsNav.count();


### PR DESCRIPTION
## Production failure
The exact-Production iPad WebKit journey measured the RTL sidebar at right=965 while the visible viewport width was 820. iPhone and protected Production smoke passed.

## Root cause
WebKit's fixed-position logical inset resolved against a wider layout viewport. Waiting for the animation alone is insufficient.

## Root repair
- Compute sidebar width and physical left from window.visualViewport width/offset
- Neutralize conflicting logical inset properties
- Resync on resize, orientation, visualViewport resize/scroll, language, and UI lifecycle events
- Wait until the whole sidebar is inside the visible viewport before strict hit-testing
- Preserve size, visibility, pointer-event, elementFromPoint, destination-transition, and fail-closed checks
- No polling loop and no authorization expansion

## Verification
- Targeted sidebar contracts pass
- Full local suite: 1,206/1,206
- Must pass PR CI and the exact-Production iPad journey before completion