### PR TITLE
chore: refresh truthful BAR-12 production evidence

### DIFF
--- a/.github/scripts/dabbir-bar12-technical-evidence.mjs
+++ b/.github/scripts/dabbir-bar12-technical-evidence.mjs
@@ -79,7 +79,10 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
     }:null,
   };
 
-  const reviewedWarnings=Array.isArray(security.reviewed_warnings)?security.reviewed_warnings:[];
+  const reviewedFunctions=new Set([
+    ...(Array.isArray(security.reviewed_warnings)?security.reviewed_warnings:[]),
+    ...(Array.isArray(security.reviewed_functions)?security.reviewed_functions:[]),
+  ]);
   const basis=security.review_basis||{};
   const expectedWarnings=[
     'public.dabbir_public_car_wash_book',
@@ -94,9 +97,9 @@ export function mergeTechnicalEvidence(base,review,{now=Date.now()}={}){
     String(security.project_ref||'')===EXPECTED_PROJECT_REF&&
     String(security.verdict||'').toUpperCase()==='PASS'&&
     Number(security.blocking_findings)===0&&
-    String(security.advisor_max_level||'').toUpperCase()==='WARN'&&
+    ['INFO','WARN'].includes(String(security.advisor_max_level||'').toUpperCase())&&
     fresh(security.reviewed_at,now)&&
-    expectedWarnings.every(name=>reviewedWarnings.includes(name))&&
+    expectedWarnings.every(name=>reviewedFunctions.has(name))&&
     basis.security_advisor_rerun===true&&
     basis.public_definer_functions_reviewed===true&&
     basis.anonymous_direct_table_dml_for_booking_requests===false&&

--- a/docs/evidence/dabbir-bar12-technical-review.json
+++ b/docs/evidence/dabbir-bar12-technical-review.json
@@ -1,43 +1,46 @@
 {
   "schema_version": "dabbir_bar12_technical_review_v1",
   "runtime_monitoring": {
-    "source_commit": "3ae553a0900b06b43243999e38853b23d8a4b728",
-    "deployment_id": "dpl_2eNiiKsbQiJwJCwtjhne9V3hKhFa",
+    "source_commit": "01fc553d5ea85350ccf2af56562c93af64ae72d0",
+    "deployment_id": "dpl_H618Kth2RGQwxS5Z3y62kbkxT4SV",
     "origin": "https://dabbir.bmalman.com",
-    "checked_at": "2026-09-02T17:07:38.226Z",
+    "checked_at": "2026-09-04T12:38:28.714Z",
     "window_hours": 24,
     "provider": "Vercel Runtime Logs",
     "levels_checked": ["warning", "error", "fatal"],
     "matching_logs": 0
   },
   "alert_delivery": {
-    "source_commit": "3ae553a0900b06b43243999e38853b23d8a4b728",
-    "deployment_id": "dpl_2eNiiKsbQiJwJCwtjhne9V3hKhFa",
+    "source_commit": "01fc553d5ea85350ccf2af56562c93af64ae72d0",
+    "deployment_id": "dpl_H618Kth2RGQwxS5Z3y62kbkxT4SV",
     "origin": "https://dabbir.bmalman.com",
-    "verified_at": "2026-09-02T17:08:13.759Z",
+    "verified_at": "2026-09-04T12:38:28.714Z",
     "provider": "Slack",
     "delivery_mode": "BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL",
     "channel_id": "C0BRQQER3UH",
     "channel_name": "barman-executive-alerts",
-    "message_ts": "1788368893.759909",
-    "message_link": "https://barman-global.slack.com/archives/C0BRQQER3UH/p1788368893759909",
+    "message_ts": "1788525489.681249",
+    "message_link": "https://barman-global.slack.com/archives/C0BRQQER3UH/p1788525489681249",
     "readback_verified": true,
     "test_only": true,
     "contains_secrets_or_customer_data": false,
-    "notes": "A test-only BAR-12 operational alert containing only the exact current public Production release identity was delivered by BARMAN Executive OS to the reserved owner alert channel and read back from Slack at the same message timestamp."
+    "notes": "A test-only BAR-12 operational alert containing only the exact current public Production release identity was delivered to the reserved owner alert channel and read back from Slack at the same message timestamp."
   },
   "security": {
-    "source_commit": "3ae553a0900b06b43243999e38853b23d8a4b728",
+    "source_commit": "01fc553d5ea85350ccf2af56562c93af64ae72d0",
     "project_ref": "fphpoysqdsceniwduxjq",
-    "reviewed_at": "2026-09-02T17:07:48.524Z",
+    "reviewed_at": "2026-09-04T12:37:37.837Z",
     "verdict": "PASS",
     "blocking_findings": 0,
-    "advisor_max_level": "WARN",
-    "reviewed_warnings": [
+    "advisor_max_level": "INFO",
+    "reviewed_warnings": [],
+    "reviewed_functions": [
       "public.dabbir_public_car_wash_book",
       "public.dabbir_public_car_wash_catalog",
       "public.dabbir_public_car_wash_slots",
-      "public.dabbir_public_order_status"
+      "public.dabbir_public_order_status",
+      "public.dabbir_claim_ai_budget_v1",
+      "public.dabbir_finalize_ai_budget_v1"
     ],
     "review_basis": {
       "security_advisor_rerun": true,
@@ -46,8 +49,14 @@
       "booking_abuse_guard_trigger_present": true,
       "public_catalog_is_bounded": true,
       "public_slots_are_bounded": true,
-      "public_order_status_uses_unguessable_uuid_token": true
+      "public_order_status_uses_unguessable_uuid_token": true,
+      "security_advisor_counts": {
+        "error": 0,
+        "warn": 0,
+        "info": 67
+      },
+      "all_six_reviewed_functions_service_role_only": true
     },
-    "notes": "Mumbai Security Advisor was rerun against the authoritative Production project after the current calendar runtime changes. It returned no blocking ERROR findings and the same four reviewed intentional anonymous public SECURITY DEFINER capabilities. INFO RLS-without-policy findings remain deny-by-default/server-only surfaces; the four WARN functions remain bounded public booking/status capabilities with the previously verified abuse/idempotency safeguards."
+    "notes": "Supabase Security Advisor was rerun against the authoritative Production project and returned 67 INFO findings, 0 WARN and 0 ERROR. The four legacy public-definer functions and both AI budget functions were reviewed live; PUBLIC, anon and authenticated cannot execute them, service_role can, direct anonymous booking-table DML is denied, and the booking abuse-guard trigger remains present."
   }
 }

--- a/test/dabbir-bar12-technical-evidence.test.mjs
+++ b/test/dabbir-bar12-technical-evidence.test.mjs
@@ -7,7 +7,7 @@ const SHA='e5da322e56fc4903b5ee937e8a49686dc2d1de07';
 const DEPLOY='dpl_A6cqCH6bW9ch9iDgye2FpKGCeEnQ';
 const NOW=Date.parse('2026-09-02T12:50:00.000Z');
 const base={expected_main_sha:SHA,production_deployment:{id:DEPLOY,state:'READY',source_commit:SHA},monitoring:{runtime_errors_checked:false,alert_delivery_verified:false},critical_gates:{security:null,financial:null,legal:null}};
-const review={schema_version:'dabbir_bar12_technical_review_v1',runtime_monitoring:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',checked_at:'2026-09-02T12:38:19.980Z',window_hours:24,provider:'Vercel Runtime Logs',levels_checked:['warning','error','fatal'],matching_logs:0},alert_delivery:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',verified_at:'2026-09-02T12:49:28.186Z',provider:'Slack',delivery_mode:'BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL',channel_id:'C0BRQQER3UH',channel_name:'barman-executive-alerts',message_ts:'1788353368.186149',message_link:'https://barman-global.slack.com/archives/C0BRQQER3UH/p1788353368186149',readback_verified:true,test_only:true,contains_secrets_or_customer_data:false},security:{source_commit:SHA,project_ref:'fphpoysqdsceniwduxjq',reviewed_at:'2026-09-02T12:38:59.130Z',verdict:'PASS',blocking_findings:0,advisor_max_level:'WARN',reviewed_warnings:['public.dabbir_public_car_wash_book','public.dabbir_public_car_wash_catalog','public.dabbir_public_car_wash_slots','public.dabbir_public_order_status'],review_basis:{security_advisor_rerun:true,public_definer_functions_reviewed:true,anonymous_direct_table_dml_for_booking_requests:false,booking_abuse_guard_trigger_present:true,public_catalog_is_bounded:true,public_slots_are_bounded:true,public_order_status_uses_unguessable_uuid_token:true}}};
+const review={schema_version:'dabbir_bar12_technical_review_v1',runtime_monitoring:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',checked_at:'2026-09-02T12:38:19.980Z',window_hours:24,provider:'Vercel Runtime Logs',levels_checked:['warning','error','fatal'],matching_logs:0},alert_delivery:{source_commit:SHA,deployment_id:DEPLOY,origin:'https://dabbir.bmalman.com',verified_at:'2026-09-02T12:49:28.186Z',provider:'Slack',delivery_mode:'BARMAN_EXECUTIVE_OS_TO_SLACK_OWNER_ALERT_CHANNEL',channel_id:'C0BRQQER3UH',channel_name:'barman-executive-alerts',message_ts:'1788353368.186149',message_link:'https://barman-global.slack.com/archives/C0BRQQER3UH/p1788353368186149',readback_verified:true,test_only:true,contains_secrets_or_customer_data:false},security:{source_commit:SHA,project_ref:'fphpoysqdsceniwduxjq',reviewed_at:'2026-09-02T12:38:59.130Z',verdict:'PASS',blocking_findings:0,advisor_max_level:'INFO',reviewed_warnings:[],reviewed_functions:['public.dabbir_public_car_wash_book','public.dabbir_public_car_wash_catalog','public.dabbir_public_car_wash_slots','public.dabbir_public_order_status','public.dabbir_claim_ai_budget_v1','public.dabbir_finalize_ai_budget_v1'],review_basis:{security_advisor_rerun:true,public_definer_functions_reviewed:true,anonymous_direct_table_dml_for_booking_requests:false,booking_abuse_guard_trigger_present:true,public_catalog_is_bounded:true,public_slots_are_bounded:true,public_order_status_uses_unguessable_uuid_token:true}}};
 
 test('exact fresh technical evidence promotes runtime monitoring, owner alert delivery and security only',()=>{
   const {evidence,report}=mergeTechnicalEvidence(base,review,{now:NOW});
@@ -57,10 +57,19 @@ test('alert PASS requires the reserved Slack channel, readback, safe payload and
   }
 });
 
-test('security PASS requires all reviewed public-definer warnings and safety assertions',()=>{
+test('security PASS requires all reviewed public-definer functions and safety assertions',()=>{
   const unsafe=structuredClone(review);
   unsafe.security.review_basis.booking_abuse_guard_trigger_present=false;
-  unsafe.security.reviewed_warnings.pop();
+  unsafe.security.reviewed_functions.shift();
+  const {evidence}=mergeTechnicalEvidence(base,unsafe,{now:NOW});
+  assert.equal(evidence.critical_gates.security,null);
+});
+
+test('security PASS rejects an advisor ERROR while accepting a clean INFO-only result',()=>{
+  const clean=mergeTechnicalEvidence(base,review,{now:NOW});
+  assert.equal(clean.evidence.critical_gates.security,'PASS');
+  const unsafe=structuredClone(review);
+  unsafe.security.advisor_max_level='ERROR';
   const {evidence}=mergeTechnicalEvidence(base,unsafe,{now:NOW});
   assert.equal(evidence.critical_gates.security,null);
 });


### PR DESCRIPTION
## Evidence refreshed
- Production runtime: `01fc553d5ea85350ccf2af56562c93af64ae72d0`
- Deployment: `dpl_H618Kth2RGQwxS5Z3y62kbkxT4SV` (`READY`)
- Vercel 24h query scoped to the exact deployment: 0 warning/error/fatal logs
- Slack test-only alert delivered and read back in `C0BRQQER3UH`
- Supabase advisor: 67 INFO, 0 WARN, 0 ERROR
- Six SECURITY DEFINER functions reviewed live; all are service-role-only

The evidence validator now treats INFO-only as safer than WARN while continuing to reject ERROR and requiring every reviewed function and safety assertion. No workflow or application runtime behavior is weakened.

Local verification: 1,207/1,207 tests passed.