### PR TITLE
ci: run exact journey for BAR-12 contract changes

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -32,6 +32,8 @@ on:
       - 'scripts/dabbir-production-origin-gate.mjs'
       - 'config/barman-integration-contract.json'
       - '.github/workflows/dabbir-ai-customer-journey.yml'
+      - '.github/scripts/dabbir-bar12-*'
+      - 'test/dabbir-bar12-*'
       - 'supabase/migrations/*dabbir*'
       - 'supabase/functions/barman-qa-suite-runner/**'
       - 'supabase/functions/dabbir-qa-suite-runner/**'

--- a/test/dabbir-bar12-technical-evidence.test.mjs
+++ b/test/dabbir-bar12-technical-evidence.test.mjs
@@ -76,6 +76,7 @@ test('security PASS rejects an advisor ERROR while accepting a clean INFO-only r
 
 test('BAR-12 workflow imports technical evidence before evaluation and keeps external WhatsApp/financial/legal fail closed',()=>{
   const workflow=fs.readFileSync(new URL('../.github/workflows/dabbir-bar12-readiness.yml',import.meta.url),'utf8');
+  const journeyWorkflow=fs.readFileSync(new URL('../.github/workflows/dabbir-ai-customer-journey.yml',import.meta.url),'utf8');
   const mergeAt=workflow.indexOf('Merge verified technical readiness evidence');
   const evaluateAt=workflow.indexOf('Evaluate BAR-12 readiness');
   assert.ok(mergeAt>0&&evaluateAt>mergeAt);
@@ -84,4 +85,6 @@ test('BAR-12 workflow imports technical evidence before evaluation and keeps ext
   assert.match(workflow,/real_external_connection:false/);
   assert.match(workflow,/financial:null/);
   assert.match(workflow,/legal:null/);
+  assert.match(journeyWorkflow,/- '\.github\/scripts\/dabbir-bar12-\*'/);
+  assert.match(journeyWorkflow,/- 'test\/dabbir-bar12-\*'/);
 });


### PR DESCRIPTION
Fixes the release-contract gap where BAR-12 executable changes forced an exact Production deployment but did not trigger the exact-SHA customer journey that BAR-12 requires.

- Trigger the canonical journey for `.github/scripts/dabbir-bar12-*`
- Trigger it for `test/dabbir-bar12-*`
- Add a permanent contract assertion
- No application or database behavior changes

Local verification: 1,207/1,207 tests passed.