### PR TITLE
Fix routine operator commands without AI

### DIFF
--- a/api/_dabbir-autonomous-agent.js
+++ b/api/_dabbir-autonomous-agent.js
@@ -141,7 +141,7 @@ export async function planAutonomousRun({token,userId,businessId,goal,language,v
   const budgetOperationKey=`operator.ai_planning:${randomUUID()}`;
   const budget=await claimAiBudget({businessId,operationKey:budgetOperationKey,operationType:'operator.ai_planning',autonomous:false});
   if(!budget.allowed){const code=budget.reason==='MONTHLY_HARD_LIMIT'?'AI_MONTHLY_BUDGET_REACHED':'AI_BUDGET_UNAVAILABLE';throw Object.assign(new Error(code),{code,status:budget.reason==='MONTHLY_HARD_LIMIT'?429:503,budget})}
-  const agent=new ToolLoopAgent({id:'dabbir-autonomous-business-operator',model:PAID_OPERATOR_MODEL,maxOutputTokens:700,temperature:0,stopWhen:stepCountIs(MAX_STEPS),tools:buildTools({token,businessId,goal,trace,proposals,validateWrite}),providerOptions:{gateway:{disallowPromptTraining:true}},
+  const agent=new ToolLoopAgent({id:'dabbir-autonomous-business-operator',model:PAID_OPERATOR_MODEL,maxOutputTokens:700,temperature:0,stopWhen:stepCountIs(MAX_STEPS),tools:buildTools({token,businessId,goal,trace,proposals,validateWrite}),providerOptions:{gateway:{disallowPromptTraining:true,models:['openai/gpt-5.4-nano']}},
     instructions:[
       'You are DABBIR Autonomous Business Operator, an execution agent and not a chatbot.',
       'Start by inspecting the workspace. Read every relevant domain before proposing changes. Use multiple tools for multi-domain goals.',

--- a/api/ai-business-operator.js
+++ b/api/ai-business-operator.js
@@ -65,6 +65,16 @@ export function deterministicPlan(message){
   if(expense)return {tool:'create_expense',args:{amount_aed:num(expense[1]),category:'other',note:clean(text,240)},summary:'Record expense'};
   return null;
 }
+export function parseInventoryCommand(message){
+  const text=String(message||'').replace(/ـ/g,'').trim();
+  const receive=text.match(/^(?:استلم|استقبل|ورد|ورّد|receive|received|restock)\s+(?:كمية\s+)?([0-9]+)\s+(?:من\s+)?(?:المنتج\s+|product\s+)?([\p{L}\p{N}_-]{1,160})$/iu)
+    ||text.match(/^(?:أضف|اضف|ضيف|add)\s+([0-9]+)\s+(?:إلى|الى|لـ?|to)\s+(?:مخزون|المخزون|stock(?:\s+of)?)\s+(?:المنتج\s+|product\s+)?([\p{L}\p{N}_-]{1,160})$/iu);
+  if(receive)return {tool:'receive_stock',product_ref:clean(receive[2],160),quantity:Math.trunc(num(receive[1])??-1),summary:'Receive stock for an existing product'};
+  const set=text.match(/^(?:اجعل|إجعل|خلي|خلّي|حدث|حدّث|عدل|عدّل|set|update)\s+(?:كمية|كميه|مخزون|المخزون|inventory|stock)\s+(?:المنتج\s+|product\s+)?([\p{L}\p{N}_-]{1,160})\s+(?:إلى|الى|تساوي|=|to|at)\s*([0-9]+)$/iu)
+    ||text.match(/^(?:اجعل|إجعل|خلي|خلّي|set)\s+(?:المنتج\s+|product\s+)?([\p{L}\p{N}_-]{1,160})\s+(?:كمية|كميه|مخزون|inventory|stock)?\s*(?:إلى|الى|تساوي|=|to|at)\s*([0-9]+)$/iu);
+  if(set)return {tool:'set_inventory',product_ref:clean(set[1],160),quantity:Math.trunc(num(set[2])??-1),summary:'Set inventory for an existing product'};
+  return null;
+}
 async function aiPlan(message,language){
   const prompt=['Map the owner command to exactly one DABBIR tool.','Return JSON only: {"tool":"tool_name","args":{},"summary":"short"}.','For free-time booking requests, use book_available_appointment with customer_name, day and period.','Never invent database IDs. Allowed tools: '+JSON.stringify(toolCatalog()),'Owner command: '+message].join('\n');
   try{const task=generateDABBIRAiReply({project:'dabbir_businesses',message:prompt,language,businessContext:'Tool selection only. Server validates and executes.'});const timeout=new Promise(resolve=>setTimeout(()=>resolve(null),3500));const out=await Promise.race([task,timeout]);return out?.ok?parseJsonObject(out.reply):null}catch{return null}
@@ -121,7 +131,26 @@ async function executeApproved(ctx,businessId,approvalToken){
   transitions.push({state:'completed',at:new Date().toISOString()});return {ok:true,state:'completed',executed:true,version:OPERATOR_VERSION,goal:approved.goal,receipts,transitions};
 }
 
-function fallbackPlan(message,language){const plan=deterministicPlan(message),payload=validate(plan);if(!payload)return null;const raw={...payload,step:1,reason:clean(plan.summary,160),idempotency_key:`dao:${Buffer.from(`${message}:${payload.action}`).toString('base64url').slice(0,40)}`};return {raw,approval:describeApproval([raw],language)}}
+export async function deterministicWritePlan({token,businessId,message,language='ar'}){
+  let plan=deterministicPlan(message),payload=validate(plan);
+  if(!payload){
+    const inventory=parseInventoryCommand(message);
+    if(!inventory)return null;
+    if(inventory.quantity<0)throw Object.assign(new Error('INVENTORY_QUANTITY_INVALID'),{status:400});
+    const products=await rest(token,`dabbir_products?select=id,sku,name,active&business_id=eq.${businessId}&limit=100`,{},'PRODUCT_LOOKUP_FAILED');
+    const ref=inventory.product_ref.toLocaleLowerCase('en-US');
+    const skuMatches=(products||[]).filter(x=>String(x.sku||'').trim().toLocaleLowerCase('en-US')===ref);
+    const nameMatches=(products||[]).filter(x=>String(x.name||'').trim().toLocaleLowerCase('en-US')===ref);
+    const matches=skuMatches.length?skuMatches:nameMatches;
+    if(matches.length===0)throw Object.assign(new Error('PRODUCT_NOT_FOUND'),{status:404});
+    if(matches.length!==1)throw Object.assign(new Error('PRODUCT_REFERENCE_AMBIGUOUS'),{status:409});
+    plan={tool:inventory.tool,args:{product_id:matches[0].id,quantity:inventory.quantity,note:clean(message,240)},summary:inventory.summary};
+    payload=validate(plan);
+    if(!payload)throw Object.assign(new Error('INVENTORY_PLAN_INVALID'),{status:400});
+  }
+  const raw={...payload,step:1,reason:clean(plan.summary,160),idempotency_key:`dao:${Buffer.from(`${message}:${payload.action}`).toString('base64url').slice(0,40)}`};
+  return {raw,approval:describeApproval([raw],language)};
+}
 function deterministicApproval(ctx,businessId,message,language,fallback){const issued=Date.now(),payload={v:1,business_id:businessId,user_id:ctx.user.id,issued_at:issued,expires_at:issued+600000,goal:message,language,plan:[fallback.raw]},raw=Buffer.from(JSON.stringify(payload)).toString('base64url'),signature=createHmac('sha256',`dabbir-owner-approval:${ctx.token}`).update(raw).digest('base64url');return {ok:true,state:'awaiting_approval',executed:false,version:OPERATOR_VERSION,cost_mode:'NO_MODEL_REQUIRED',deterministic:true,goal:message,plan:[fallback.raw],approval:fallback.approval,approval_token:`${raw}.${signature}`,summary:language==='ar'?'تم إعداد خطة محكومة من بيانات الأمر، وتحتاج موافقتك قبل التنفيذ.':'A controlled plan was prepared from the command and requires your approval before execution.'}}
 
 export default async function handler(req,res){
@@ -132,7 +161,7 @@ export default async function handler(req,res){
   if(action==='approve'){try{return json(res,200,await executeApproved(ctx,businessId,clean(body?.approval_token,16000)))}catch(error){const status=[400,403,409].includes(Number(error?.status))?Number(error.status):500;return json(res,status,{ok:false,state:'failed',executed:false,version:OPERATOR_VERSION,error:clean(error?.message||'APPROVAL_EXECUTION_FAILED',140)})}}
   if(action!=='plan')return json(res,400,{ok:false,error:'ACTION_NOT_ALLOWED'});const message=clean(body?.message,800);if(!message)return json(res,400,{ok:false,error:'MESSAGE_REQUIRED'});
   try{const direct=await runDeterministicReadGoal({token:ctx.token,businessId,goal:message,language});if(direct)return json(res,200,direct)}catch(error){return json(res,502,{ok:false,state:'failed',executed:false,version:OPERATOR_VERSION,error:clean(error?.message||'VERIFIED_READ_FAILED',140)})}
-  const directWrite=fallbackPlan(message,language);if(directWrite)return json(res,200,deterministicApproval(ctx,businessId,message,language,directWrite));
+  try{const directWrite=await deterministicWritePlan({token:ctx.token,businessId,message,language});if(directWrite)return json(res,200,deterministicApproval(ctx,businessId,message,language,directWrite))}catch(error){const status=[400,404,409].includes(Number(error?.status))?Number(error.status):502;return json(res,status,{ok:false,state:'failed',executed:false,version:OPERATOR_VERSION,error:clean(error?.message||'DETERMINISTIC_WRITE_FAILED',140)})}
   try{return json(res,200,await planAutonomousRun({token:ctx.token,userId:ctx.user.id,businessId,goal:message,language,validateWrite:validate}))}catch(error){
     const budgetCode=error?.code==='AI_MONTHLY_BUDGET_REACHED'||error?.message==='AI_MONTHLY_BUDGET_REACHED'?'AI_MONTHLY_BUDGET_REACHED':error?.code==='AI_BUDGET_UNAVAILABLE'||error?.message==='AI_BUDGET_UNAVAILABLE'?'AI_BUDGET_UNAVAILABLE':null;
     const publicError=budgetCode||(error?.name==='AbortError'||error?.name==='TimeoutError'?'AGENT_TIMEOUT':'AI_PROVIDER_UNAVAILABLE');

--- a/test/dabbir-autonomous-operator-v3.test.mjs
+++ b/test/dabbir-autonomous-operator-v3.test.mjs
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
 import { MAX_STEPS, OPERATOR_VERSION, PAID_OPERATOR_MODEL, READ_TOOLS, RUN_STATES, WRITE_TOOLS, describeApproval, isTodayAppointmentCountGoal, runDeterministicReadGoal, verifyApproval } from '../api/_dabbir-autonomous-agent.js';
-import { deterministicPlan, validate } from '../api/ai-business-operator.js';
+import { deterministicPlan, deterministicWritePlan, parseInventoryCommand, validate } from '../api/ai-business-operator.js';
 
 const core=fs.readFileSync(new URL('../api/_dabbir-autonomous-agent.js',import.meta.url),'utf8');
 const endpoint=fs.readFileSync(new URL('../api/ai-business-operator.js',import.meta.url),'utf8');
@@ -140,6 +140,33 @@ test('Arabic product commands build exact approval plans without AI',()=>{
   }
 });
 
+test('routine inventory commands parse without the AI provider',()=>{
+  const cases=[
+    ['اجعل كمية zaje1001 إلى 60',{tool:'set_inventory',product_ref:'zaje1001',quantity:60}],
+    ['حدث مخزون zaje1001 الى 45',{tool:'set_inventory',product_ref:'zaje1001',quantity:45}],
+    ['set inventory zaje1001 to 30',{tool:'set_inventory',product_ref:'zaje1001',quantity:30}],
+    ['استلم 20 من zaje1001',{tool:'receive_stock',product_ref:'zaje1001',quantity:20}],
+    ['أضف 10 إلى المخزون zaje1001',{tool:'receive_stock',product_ref:'zaje1001',quantity:10}],
+    ['receive 5 product zaje1001',{tool:'receive_stock',product_ref:'zaje1001',quantity:5}]
+  ];
+  for(const [command,expected] of cases){const parsed=parseInventoryCommand(command);assert.deepEqual({tool:parsed.tool,product_ref:parsed.product_ref,quantity:parsed.quantity},expected)}
+});
+
+test('inventory product references resolve inside the selected tenant and remain approval-only',async t=>{
+  const originalFetch=globalThis.fetch,calls=[];t.after(()=>{globalThis.fetch=originalFetch});
+  globalThis.fetch=async url=>{calls.push(String(url));return new Response(JSON.stringify([{id:'00000000-0000-4000-8000-000000000009',sku:'ZAJE1001',name:'Zaje product',active:true}]),{status:200})};
+  const result=await deterministicWritePlan({token:'owner-token',businessId:'11111111-1111-4111-8111-111111111111',message:'استلم 20 من zaje1001',language:'ar'});
+  assert.equal(result.raw.action,'receive_stock');assert.equal(result.raw.product_id,'00000000-0000-4000-8000-000000000009');assert.equal(result.raw.quantity,20);
+  assert.equal(result.approval[0].risk,'MEDIUM');assert.equal(calls.length,1);assert.match(calls[0],/business_id=eq\.11111111-1111-4111-8111-111111111111/);
+});
+
+test('inventory references fail closed instead of falling through to AI',async t=>{
+  const originalFetch=globalThis.fetch;t.after(()=>{globalThis.fetch=originalFetch});
+  globalThis.fetch=async()=>new Response('[]',{status:200});
+  await assert.rejects(()=>deterministicWritePlan({token:'owner-token',businessId:'11111111-1111-4111-8111-111111111111',message:'اجعل كمية missing إلى 3'}),/PRODUCT_NOT_FOUND/);
+  assert.match(endpoint,/DETERMINISTIC_WRITE_FAILED/);
+});
+
 test('product command stays fail-closed when price or quantity is missing',()=>{
   assert.equal(deterministicPlan('ضف zaje1001 الكمية 50'),null);
   assert.equal(deterministicPlan('ضف zaje1001 قيمتها 170 درهم'),null);
@@ -158,5 +185,6 @@ test('paid operator model is protected by the 300 AED monthly hard cap',()=>{
   assert.match(core,/finalizeAiBudget/);
   assert.match(core,/HARD_MONTHLY_AI_BUDGET_AED/);
   assert.match(core,/PAID_MODEL_MONTHLY_HARD_CAP/);
+  assert.match(core,/models:\['openai\/gpt-5\.4-nano'\]/);
   assert.doesNotMatch(core,/minimax\/minimax-m3-free|FREE_TIER_ONLY/);
 });


### PR DESCRIPTION
## What changed
- parse Arabic and English inventory set/receive commands without the AI provider
- resolve products by exact tenant-scoped SKU or name and fail closed on missing/ambiguous references
- preserve owner approval before every write
- add a low-cost AI Gateway model fallback under the existing 300 AED hard cap

## Verification
- `npm test`: 1,213/1,213 passing
- targeted autonomous operator suite: 90/90 passing
- no database migration, UI change, money movement, external messaging, price change, or automatic write