### PR TITLE
fix(operator): restore AI Gateway resilience

### DIFF
--- a/api/_dabbir-autonomous-agent.js
+++ b/api/_dabbir-autonomous-agent.js
@@ -9,6 +9,8 @@ export const READ_TOOLS=['inspect_workspace','list_services','list_products','in
 export const WRITE_TOOLS=['create_service','create_car_wash_offer','create_product','set_inventory','receive_stock','create_expense','book_available_appointment'];
 export const MAX_STEPS=6;
 export const PAID_OPERATOR_MODEL=process.env.DABBIR_AI_GATEWAY_MODEL||'openai/gpt-5.4';
+export const GATEWAY_FALLBACK_MODELS=(process.env.DABBIR_AI_GATEWAY_FALLBACK_MODELS||'anthropic/claude-sonnet-4.6,google/gemini-3-flash,openai/gpt-5.4-nano').split(',').map(value=>value.trim()).filter(Boolean).slice(0,3);
+export const MODEL_TIMEOUT_MS=Math.min(60000,Math.max(15000,Math.trunc(Number(process.env.DABBIR_AI_MODEL_TIMEOUT_MS)||45000)));
 const hash=v=>createHash('sha256').update(String(v)).digest('hex');
 const clean=(v,n=800)=>String(v??'').trim().slice(0,n);
 const jsonStable=v=>JSON.stringify(v,Object.keys(v||{}).sort());
@@ -141,7 +143,7 @@ export async function planAutonomousRun({token,userId,businessId,goal,language,v
   const budgetOperationKey=`operator.ai_planning:${randomUUID()}`;
   const budget=await claimAiBudget({businessId,operationKey:budgetOperationKey,operationType:'operator.ai_planning',autonomous:false});
   if(!budget.allowed){const code=budget.reason==='MONTHLY_HARD_LIMIT'?'AI_MONTHLY_BUDGET_REACHED':'AI_BUDGET_UNAVAILABLE';throw Object.assign(new Error(code),{code,status:budget.reason==='MONTHLY_HARD_LIMIT'?429:503,budget})}
-  const agent=new ToolLoopAgent({id:'dabbir-autonomous-business-operator',model:PAID_OPERATOR_MODEL,maxOutputTokens:700,temperature:0,stopWhen:stepCountIs(MAX_STEPS),tools:buildTools({token,businessId,goal,trace,proposals,validateWrite}),providerOptions:{gateway:{disallowPromptTraining:true,models:['openai/gpt-5.4-nano']}},
+  const agent=new ToolLoopAgent({id:'dabbir-autonomous-business-operator',model:PAID_OPERATOR_MODEL,maxOutputTokens:700,temperature:0,stopWhen:stepCountIs(MAX_STEPS),tools:buildTools({token,businessId,goal,trace,proposals,validateWrite}),providerOptions:{gateway:{disallowPromptTraining:true,models:GATEWAY_FALLBACK_MODELS,user:userId,tags:['feature:ai-business-operator','env:production']}},
     instructions:[
       'You are DABBIR Autonomous Business Operator, an execution agent and not a chatbot.',
       'Start by inspecting the workspace. Read every relevant domain before proposing changes. Use multiple tools for multi-domain goals.',
@@ -153,7 +155,7 @@ export async function planAutonomousRun({token,userId,businessId,goal,language,v
       `At most ${MAX_STEPS} model steps. Respond in ${language==='en'?'English':'Arabic'} with a concise plan summary, not chain-of-thought.`
     ].join('\n'),prepareStep:({stepNumber})=>stepNumber===0?{toolChoice:{type:'tool',toolName:'inspect_workspace'}}:{toolChoice:'auto'}});
   let result;
-  try{result=await agent.generate({prompt:`Trusted owner goal: ${clean(goal)}`,abortSignal:AbortSignal.timeout(9000)})}
+  try{result=await agent.generate({prompt:`Trusted owner goal: ${clean(goal)}`,abortSignal:AbortSignal.timeout(MODEL_TIMEOUT_MS)})}
   catch(error){await finalizeAiBudget({businessId,operationKey:budgetOperationKey,outcome:'FAILED',failureClass:error?.name==='AbortError'||error?.name==='TimeoutError'?'TIMEOUT':'AI',actualCostUsd:null,metadata:{model:PAID_OPERATOR_MODEL,error:clean(error?.message||error,160),state:'RESERVATION_RETAINED_FAIL_CLOSED'}}).catch(()=>null);throw error}
   const cost=await generationCost(result);
   const finalized=await finalizeAiBudget({businessId,operationKey:budgetOperationKey,outcome:'VERIFIED_SUCCESS',failureClass:null,actualCostUsd:cost.total_cost_usd,metadata:{model:PAID_OPERATOR_MODEL,generation:cost,state:cost.total_cost_usd==null?'RESERVATION_RETAINED':'ACTUAL_COST_VERIFIED'}}).then(()=>true).catch(()=>false);

--- a/api/ai-business-operator.js
+++ b/api/ai-business-operator.js
@@ -165,11 +165,16 @@ export default async function handler(req,res){
   try{return json(res,200,await planAutonomousRun({token:ctx.token,userId:ctx.user.id,businessId,goal:message,language,validateWrite:validate}))}catch(error){
     const budgetCode=error?.code==='AI_MONTHLY_BUDGET_REACHED'||error?.message==='AI_MONTHLY_BUDGET_REACHED'?'AI_MONTHLY_BUDGET_REACHED':error?.code==='AI_BUDGET_UNAVAILABLE'||error?.message==='AI_BUDGET_UNAVAILABLE'?'AI_BUDGET_UNAVAILABLE':null;
     const publicError=budgetCode||(error?.name==='AbortError'||error?.name==='TimeoutError'?'AGENT_TIMEOUT':'AI_PROVIDER_UNAVAILABLE');
+    const providerStatus=Number(error?.statusCode||error?.status||error?.cause?.statusCode||error?.cause?.status)||null;
+    const diagnostic=clean(error?.message||error?.cause?.message||error?.name||'UNKNOWN_AI_ERROR',200).replace(/(?:sk|key|token)[-_][A-Za-z0-9_-]{12,}/gi,'[REDACTED]');
     console.error('dabbir_ai_business_operator_plan_failed',{
       version:OPERATOR_VERSION,
       error:publicError,
       budget_code:budgetCode||null,
       failure_class:publicError==='AGENT_TIMEOUT'?'TIMEOUT':'AI',
+      provider_status:providerStatus,
+      cause_name:clean(error?.name||error?.cause?.name||'Error',80),
+      diagnostic,
       external_side_effects:false,
       money_movement:false
     });

--- a/test/dabbir-autonomous-operator-v3.test.mjs
+++ b/test/dabbir-autonomous-operator-v3.test.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
-import { MAX_STEPS, OPERATOR_VERSION, PAID_OPERATOR_MODEL, READ_TOOLS, RUN_STATES, WRITE_TOOLS, describeApproval, isTodayAppointmentCountGoal, runDeterministicReadGoal, verifyApproval } from '../api/_dabbir-autonomous-agent.js';
+import { GATEWAY_FALLBACK_MODELS, MAX_STEPS, MODEL_TIMEOUT_MS, OPERATOR_VERSION, PAID_OPERATOR_MODEL, READ_TOOLS, RUN_STATES, WRITE_TOOLS, describeApproval, isTodayAppointmentCountGoal, runDeterministicReadGoal, verifyApproval } from '../api/_dabbir-autonomous-agent.js';
 import { deterministicPlan, deterministicWritePlan, parseInventoryCommand, validate } from '../api/ai-business-operator.js';
 
 const core=fs.readFileSync(new URL('../api/_dabbir-autonomous-agent.js',import.meta.url),'utf8');
@@ -11,7 +11,7 @@ const ui=fs.readFileSync(new URL('../api/ai-business-operator-ui.js',import.meta
 test('operator v4 is a bounded ToolLoopAgent with the complete state machine',()=>{
   assert.equal(OPERATOR_VERSION,'v4.0-autonomous-daily-operator');assert.equal(MAX_STEPS,6);
   assert.deepEqual(RUN_STATES,['received','planning','awaiting_approval','executing','verifying','completed','partially_completed','failed','cancelled']);
-  assert.match(core,/new ToolLoopAgent/);assert.match(core,/stepCountIs\(MAX_STEPS\)/);assert.match(core,/AbortSignal\.timeout\(9000\)/);assert.match(core,/maxOutputTokens:700/);
+  assert.match(core,/new ToolLoopAgent/);assert.match(core,/stepCountIs\(MAX_STEPS\)/);assert.match(core,/AbortSignal\.timeout\(MODEL_TIMEOUT_MS\)/);assert.equal(MODEL_TIMEOUT_MS,45000);assert.match(core,/maxOutputTokens:700/);
 });
 
 test('all required tenant read tools exist and are paginated',()=>{
@@ -185,6 +185,17 @@ test('paid operator model is protected by the 300 AED monthly hard cap',()=>{
   assert.match(core,/finalizeAiBudget/);
   assert.match(core,/HARD_MONTHLY_AI_BUDGET_AED/);
   assert.match(core,/PAID_MODEL_MONTHLY_HARD_CAP/);
-  assert.match(core,/models:\['openai\/gpt-5\.4-nano'\]/);
+  assert.deepEqual(GATEWAY_FALLBACK_MODELS,['anthropic/claude-sonnet-4.6','google/gemini-3-flash','openai/gpt-5.4-nano']);
+  assert.match(core,/models:GATEWAY_FALLBACK_MODELS/);
+  assert.match(core,/user:userId/);
+  assert.match(core,/feature:ai-business-operator/);
   assert.doesNotMatch(core,/minimax\/minimax-m3-free|FREE_TIER_ONLY/);
+});
+
+
+test('provider failures retain safe diagnostics for production triage',()=>{
+  assert.match(endpoint,/provider_status:providerStatus/);
+  assert.match(endpoint,/cause_name:/);
+  assert.match(endpoint,/diagnostic/);
+  assert.match(endpoint,/\\[REDACTED\\]/);
 });


### PR DESCRIPTION
Superseded by #481 after an authenticated Preview canary proved this PR still failed: Vercel AI Gateway free-tier requests were rate-limited. #481 activates the already-configured direct Gemini and Groq providers before Gateway.