### PR TITLE
fix(ai): run Gemini and Groq instead of GPT in production

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,12 @@
   "buildCommand": "npm run dabbir:build",
   "ignoreCommand": "bash ./vercel-ignore-if-unaffected.sh",
   "env": {
-    "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com"
+    "DABBIR_META_APP_DOMAIN": "dabbir.bmalman.com",
+    "DABBIR_GEMINI_MODEL": "gemini-3.7-flash",
+    "DABBIR_GROQ_MODEL": "llama-3.3-70b-versatile",
+    "DABBIR_AI_GATEWAY_MODEL": "google/gemini-3.7-flash",
+    "DABBIR_AI_GATEWAY_FALLBACK_MODELS": "google/gemini-3.7-flash",
+    "DABBIR_DAILY_OPERATOR_MODEL": "google/gemini-3.7-flash"
   },
   "crons": [
     {


### PR DESCRIPTION
Routes DABBIR production AI away from GPT pricing paths.

- Gemini 3.7 Flash remains primary direct provider.
- Groq fallback model is set to llama-3.3-70b-versatile.
- Vercel Gateway emergency route is constrained to Gemini only.
- Daily Operator is routed to Gemini instead of GPT-5.4.
- No API keys or secret values are changed or exposed.

This is a production routing/config change only; application logic and permissions are unchanged.