### PR TITLE
fix(ios): make DABBIR account deletion Apple-compliant

### DIFF
--- a/.github/workflows/dabbir-mobile-ci.yml
+++ b/.github/workflows/dabbir-mobile-ci.yml
@@ -7,11 +7,14 @@ on:
       - 'mobile/**'
       - 'api/mobile/**'
       - 'api/_apple-iap-core.js'
+      - 'api/_apple-signin-core.js'
       - 'api/apple/**'
       - 'supabase/migrations/*dabbir_apple*'
       - 'supabase/migrations/*dabbir_*account_deletion*'
       - 'scripts/dabbir-app-store-preflight.mjs'
+      - 'scripts/dabbir-apple-account-deletion-gate.mjs'
       - 'test/dabbir-app-store-preflight.test.mjs'
+      - 'test/apple-account-deletion-compliance.test.mjs'
       - 'privacy.html'
       - 'terms.html'
       - 'support.html'
@@ -23,11 +26,14 @@ on:
       - 'mobile/**'
       - 'api/mobile/**'
       - 'api/_apple-iap-core.js'
+      - 'api/_apple-signin-core.js'
       - 'api/apple/**'
       - 'supabase/migrations/*dabbir_apple*'
       - 'supabase/migrations/*dabbir_*account_deletion*'
       - 'scripts/dabbir-app-store-preflight.mjs'
+      - 'scripts/dabbir-apple-account-deletion-gate.mjs'
       - 'test/dabbir-app-store-preflight.test.mjs'
+      - 'test/apple-account-deletion-compliance.test.mjs'
       - 'privacy.html'
       - 'terms.html'
       - 'support.html'
@@ -54,6 +60,9 @@ jobs:
         env:
           DABBIR_APP_STORE_PREFLIGHT_REPORT_PATH: dabbir-app-store-preflight-report.json
         run: node scripts/dabbir-app-store-preflight.mjs
+      - name: Run Apple account-deletion compliance gate
+        working-directory: .
+        run: node scripts/dabbir-apple-account-deletion-gate.mjs
       - name: Install dependencies
         run: npm install --no-audit --no-fund
       - name: Expo doctor

--- a/api/_apple-signin-core.js
+++ b/api/_apple-signin-core.js
@@ -1,0 +1,157 @@
+import { createPrivateKey, sign as signPayload } from 'node:crypto';
+
+const APPLE_TOKEN_URL = 'https://appleid.apple.com/auth/token';
+const APPLE_REVOKE_URL = 'https://appleid.apple.com/auth/revoke';
+const APPLE_ISSUER = 'https://appleid.apple.com';
+const DEFAULT_TIMEOUT_MS = Math.max(3000, Number(process.env.DABBIR_APPLE_SIGN_IN_TIMEOUT_MS || 10000));
+
+function appleError(message, code = 503) {
+  return Object.assign(new Error(message), { code });
+}
+
+function requiredEnv(name, max = 8192) {
+  const value = String(process.env[name] || '').trim();
+  if (!value || value.length > max) throw appleError(`${name}_NOT_CONFIGURED`, 503);
+  return value;
+}
+
+function privateKeyPem() {
+  const encoded = String(process.env.DABBIR_APPLE_SIGN_IN_PRIVATE_KEY_BASE64 || '').trim();
+  const raw = encoded
+    ? Buffer.from(encoded, 'base64').toString('utf8')
+    : String(process.env.DABBIR_APPLE_SIGN_IN_PRIVATE_KEY || '').replace(/\\n/g, '\n').trim();
+  if (!raw || raw.length > 16384 || !raw.includes('PRIVATE KEY')) {
+    throw appleError('DABBIR_APPLE_SIGN_IN_PRIVATE_KEY_NOT_CONFIGURED', 503);
+  }
+  return raw;
+}
+
+function base64urlJson(value) {
+  return Buffer.from(JSON.stringify(value), 'utf8').toString('base64url');
+}
+
+function decodeJwtPayload(value) {
+  try {
+    const parts = String(value || '').split('.');
+    if (parts.length !== 3 || !parts[1]) return null;
+    return JSON.parse(Buffer.from(parts[1], 'base64url').toString('utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function signInClientId() {
+  const value = requiredEnv('DABBIR_IOS_BUNDLE_ID', 255);
+  if (!/^[A-Za-z0-9.-]{3,255}$/.test(value)) throw appleError('DABBIR_IOS_BUNDLE_ID_INVALID', 503);
+  return value;
+}
+
+export function createAppleClientSecret(nowSeconds = Math.floor(Date.now() / 1000)) {
+  const teamId = requiredEnv('DABBIR_APPLE_SIGN_IN_TEAM_ID', 64);
+  const keyId = requiredEnv('DABBIR_APPLE_SIGN_IN_KEY_ID', 64);
+  if (!/^[A-Za-z0-9]{5,64}$/.test(teamId)) throw appleError('DABBIR_APPLE_SIGN_IN_TEAM_ID_INVALID', 503);
+  if (!/^[A-Za-z0-9]{5,64}$/.test(keyId)) throw appleError('DABBIR_APPLE_SIGN_IN_KEY_ID_INVALID', 503);
+
+  const clientId = signInClientId();
+  const header = base64urlJson({ alg: 'ES256', kid: keyId, typ: 'JWT' });
+  const payload = base64urlJson({
+    iss: teamId,
+    iat: nowSeconds,
+    exp: nowSeconds + 300,
+    aud: APPLE_ISSUER,
+    sub: clientId,
+  });
+  const signingInput = `${header}.${payload}`;
+  let key;
+  try {
+    key = createPrivateKey(privateKeyPem());
+  } catch {
+    throw appleError('DABBIR_APPLE_SIGN_IN_PRIVATE_KEY_INVALID', 503);
+  }
+  const signature = signPayload('sha256', Buffer.from(signingInput), {
+    key,
+    dsaEncoding: 'ieee-p1363',
+  }).toString('base64url');
+  return `${signingInput}.${signature}`;
+}
+
+async function appleFormPost(url, values) {
+  let response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        accept: 'application/json',
+        'content-type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams(values).toString(),
+      cache: 'no-store',
+      signal: AbortSignal.timeout(DEFAULT_TIMEOUT_MS),
+    });
+  } catch {
+    throw appleError('APPLE_SIGN_IN_SERVER_UNAVAILABLE', 503);
+  }
+  const text = await response.text();
+  let payload = null;
+  try { payload = text ? JSON.parse(text) : null; } catch { payload = null; }
+  return { response, payload };
+}
+
+export function appleIdentitySubject(authUser) {
+  const identities = Array.isArray(authUser?.identities) ? authUser.identities : [];
+  const identity = identities.find(item => String(item?.provider || '').toLowerCase() === 'apple') || null;
+  const providers = Array.isArray(authUser?.app_metadata?.providers)
+    ? authUser.app_metadata.providers.map(value => String(value).toLowerCase())
+    : [];
+  const hasApple = Boolean(identity) || providers.includes('apple') || String(authUser?.app_metadata?.provider || '').toLowerCase() === 'apple';
+  if (!hasApple) return null;
+  const subject = String(identity?.identity_data?.sub || identity?.provider_id || '').trim();
+  if (!subject || subject.length > 255) throw appleError('APPLE_IDENTITY_SUBJECT_UNAVAILABLE', 503);
+  return subject;
+}
+
+export async function revokeAppleAuthorizationForDeletion(authorizationCode, expectedSubject) {
+  const code = String(authorizationCode || '').trim();
+  const expected = String(expectedSubject || '').trim();
+  if (code.length < 10 || code.length > 4096) throw appleError('APPLE_REAUTHORIZATION_CODE_REQUIRED', 409);
+  if (!expected || expected.length > 255) throw appleError('APPLE_IDENTITY_SUBJECT_UNAVAILABLE', 503);
+
+  const clientId = signInClientId();
+  const clientSecret = createAppleClientSecret();
+  const exchanged = await appleFormPost(APPLE_TOKEN_URL, {
+    client_id: clientId,
+    client_secret: clientSecret,
+    code,
+    grant_type: 'authorization_code',
+  });
+  if (!exchanged.response.ok) {
+    const detail = String(exchanged.payload?.error || '').toLowerCase();
+    if (detail === 'invalid_grant') throw appleError('APPLE_REAUTHORIZATION_INVALID', 409);
+    throw appleError('APPLE_TOKEN_EXCHANGE_FAILED', 503);
+  }
+
+  const refreshToken = String(exchanged.payload?.refresh_token || '').trim();
+  const idToken = String(exchanged.payload?.id_token || '').trim();
+  const identity = decodeJwtPayload(idToken);
+  const now = Math.floor(Date.now() / 1000);
+  const audiences = Array.isArray(identity?.aud) ? identity.aud.map(String) : [String(identity?.aud || '')];
+  if (
+    !refreshToken
+    || refreshToken.length > 8192
+    || String(identity?.iss || '') !== APPLE_ISSUER
+    || !audiences.includes(clientId)
+    || String(identity?.sub || '') !== expected
+    || Number(identity?.exp || 0) <= now
+  ) {
+    throw appleError('APPLE_REAUTHORIZATION_IDENTITY_MISMATCH', 403);
+  }
+
+  const revoked = await appleFormPost(APPLE_REVOKE_URL, {
+    client_id: clientId,
+    client_secret: clientSecret,
+    token: refreshToken,
+    token_type_hint: 'refresh_token',
+  });
+  if (!revoked.response.ok) throw appleError('APPLE_TOKEN_REVOCATION_FAILED', 503);
+  return { revoked: true };
+}

--- a/api/mobile/account-delete.js
+++ b/api/mobile/account-delete.js
@@ -7,7 +7,25 @@ import {
   supabaseAuth,
   supabaseRpc,
 } from '../_auth-core.js';
+import { appleIdentitySubject, revokeAppleAuthorizationForDeletion } from '../_apple-signin-core.js';
 import { requireNativeBearer } from './_native-core.js';
+
+function deletionBlocker(payload) {
+  const detail = String(payload?.message || payload?.error || '').toUpperCase();
+  if (detail.includes('LEGAL_HOLD')) return 'ACCOUNT_DELETE_BLOCKED_BY_LEGAL_HOLD';
+  if (detail.includes('PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF')) return 'PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF';
+  if (detail.includes('DABBIR_ACCOUNT_ALREADY_DELETED')) return 'DABBIR_ACCOUNT_ALREADY_DELETED';
+  return null;
+}
+
+async function fullAuthUser(token) {
+  const response = await supabaseAuth('/auth/v1/user', {
+    method: 'GET',
+    headers: { authorization: `Bearer ${token}` },
+  });
+  if (!response.ok) return null;
+  return response.json().catch(() => null);
+}
 
 export default async function handler(req, res) {
   if (req.method !== 'POST') return json(res, 405, { ok: false, error: 'METHOD_NOT_ALLOWED' }, { allow: 'POST' });
@@ -18,9 +36,41 @@ export default async function handler(req, res) {
     const user = token ? await getVerifiedUser(token) : null;
     if (!user) return json(res, 401, { ok: false, error: 'AUTH_REQUIRED' });
 
-    const body = await readJsonBody(req, 4096);
+    const body = await readJsonBody(req, 8192);
     if (body?.confirmation !== 'DELETE_DABBIR_ACCOUNT') {
       return json(res, 400, { ok: false, error: 'ACCOUNT_DELETE_CONFIRMATION_REQUIRED' });
+    }
+
+    // Run deterministic DABBIR blockers before revoking an external Apple grant.
+    // This prevents a legal hold or required platform-admin handoff from leaving
+    // the user with a revoked Apple grant while the DABBIR account remains active.
+    const preflightResponse = await supabaseRpc('dabbir_delete_current_user_account_preflight', token, {
+      p_confirmation: 'DELETE_DABBIR_ACCOUNT',
+    });
+    const preflight = await readRpcJson(preflightResponse);
+    if (!preflightResponse.ok || preflight?.allowed !== true) {
+      const blocker = deletionBlocker(preflight);
+      return json(res, blocker ? 409 : 503, { ok: false, error: blocker || 'ACCOUNT_DELETE_PREFLIGHT_FAILED' });
+    }
+
+    const authUser = await fullAuthUser(token);
+    if (!authUser || String(authUser.id || '') !== String(user.id)) {
+      return json(res, 503, { ok: false, error: 'ACCOUNT_DELETE_AUTH_IDENTITY_UNAVAILABLE' });
+    }
+
+    const appleSubject = appleIdentitySubject(authUser);
+    if (appleSubject) {
+      const authorizationCode = String(body?.apple_authorization_code || '').trim();
+      if (!authorizationCode) {
+        return json(res, 409, { ok: false, error: 'APPLE_REAUTH_REQUIRED' });
+      }
+      try {
+        await revokeAppleAuthorizationForDeletion(authorizationCode, appleSubject);
+      } catch (error) {
+        const status = Number(error?.code || 503);
+        const safeStatus = [403, 409, 503].includes(status) ? status : 503;
+        return json(res, safeStatus, { ok: false, error: String(error?.message || 'APPLE_TOKEN_REVOCATION_FAILED') });
+      }
     }
 
     const response = await supabaseRpc('dabbir_delete_current_user_account', token, {
@@ -28,10 +78,8 @@ export default async function handler(req, res) {
     });
     const payload = await readRpcJson(response);
     if (!response.ok || payload?.deleted !== true) {
-      const detail = String(payload?.message || payload?.error || '').toUpperCase();
-      if (detail.includes('LEGAL_HOLD')) return json(res, 409, { ok: false, error: 'ACCOUNT_DELETE_BLOCKED_BY_LEGAL_HOLD' });
-      if (detail.includes('PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF')) return json(res, 409, { ok: false, error: 'PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF' });
-      return json(res, 503, { ok: false, error: 'ACCOUNT_DELETE_FAILED' });
+      const blocker = deletionBlocker(payload);
+      return json(res, blocker ? 409 : 503, { ok: false, error: blocker || 'ACCOUNT_DELETE_FAILED' });
     }
 
     // Prevent the DABBIR signup trigger from recreating the DABBIR-specific
@@ -50,9 +98,16 @@ export default async function handler(req, res) {
       body: '{}',
     }).catch(() => null);
 
-    return json(res, 200, { ok: true, ...payload });
+    return json(res, 200, {
+      ok: true,
+      ...payload,
+      apple_sign_in_authorization_revoked: Boolean(appleSubject),
+    });
   } catch (error) {
     const status = Number(error?.code || error?.status || 500);
-    return json(res, status === 400 || status === 413 ? status : 503, { ok: false, error: error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : 'ACCOUNT_DELETE_UNAVAILABLE' });
+    return json(res, status === 400 || status === 413 ? status : 503, {
+      ok: false,
+      error: error?.message === 'INVALID_JSON' ? 'INVALID_JSON' : 'ACCOUNT_DELETE_UNAVAILABLE',
+    });
   }
 }

--- a/mobile/src/SubscriptionCard.tsx
+++ b/mobile/src/SubscriptionCard.tsx
@@ -7,6 +7,7 @@ type FinishTransaction = (args: { purchase: Purchase; isConsumable?: boolean }) 
 
 type StoreKitPeriod = { count: number; unit: string };
 type StoreKitIntro = { paymentMode?: string; periodCount?: number; period?: { unit?: string }; displayPrice?: string };
+const APPLE_SUBSCRIPTIONS_URL = 'https://apps.apple.com/account/subscriptions';
 
 function publicHttpsUrl(raw: string | undefined): string | null {
   try {
@@ -158,6 +159,12 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
     }
   };
 
+  const manageSubscription = () => {
+    void Linking.openURL(APPLE_SUBSCRIPTIONS_URL).catch(() => {
+      Alert.alert('تعذر فتح App Store', 'افتح إعدادات اشتراكات Apple ID لإدارة أو إلغاء الاشتراك.');
+    });
+  };
+
   return (
     <View style={styles.card}>
       <Text style={styles.title}>اشتراك دبّر عبر Apple</Text>
@@ -174,6 +181,10 @@ export function SubscriptionCard({ accessToken, accountToken }: { accessToken: s
         <Text style={styles.buttonText}>{verified ? 'الاشتراك نشط' : 'اشترك عبر Apple'}</Text>
       </Pressable>
       <Pressable disabled={busy} onPress={restore}><Text style={styles.link}>استعادة المشتريات</Text></Pressable>
+      <Text style={styles.billingWarning}>حذف حساب دبّر لا يلغي اشتراك App Store تلقائيًا. إذا كنت لا تريد استمرار التجديد أو الفوترة، ألغِ الاشتراك من Apple قبل حذف الحساب.</Text>
+      <Pressable accessibilityRole="link" accessibilityLabel="إدارة أو إلغاء اشتراك App Store" onPress={manageSubscription}>
+        <Text style={styles.manageLink}>إدارة أو إلغاء اشتراك App Store</Text>
+      </Pressable>
       <View style={styles.legalRow}>
         <Pressable disabled={!privacyUrl} onPress={() => { if (privacyUrl) void Linking.openURL(privacyUrl); }}><Text style={[styles.legalLink, !privacyUrl && styles.disabledText]}>سياسة الخصوصية</Text></Pressable>
         <Text style={styles.separator}>•</Text>
@@ -190,10 +201,12 @@ const styles = StyleSheet.create({
   body: { fontSize: 14, lineHeight: 22, textAlign: 'right' },
   offer: { fontSize: 13, lineHeight: 20, textAlign: 'right', fontWeight: '600' },
   warning: { fontSize: 13, lineHeight: 20, textAlign: 'right', color: '#B42318' },
+  billingWarning: { fontSize: 12, lineHeight: 18, textAlign: 'right', fontWeight: '600' },
   button: { backgroundColor: '#17171B', padding: 14, borderRadius: 12 },
   disabled: { opacity: 0.5 },
   buttonText: { color: '#FFF', textAlign: 'center', fontWeight: '700' },
   link: { textAlign: 'center', textDecorationLine: 'underline', padding: 6 },
+  manageLink: { textAlign: 'center', textDecorationLine: 'underline', padding: 6, fontWeight: '700' },
   legalRow: { flexDirection: 'row', justifyContent: 'center', alignItems: 'center', gap: 8, flexWrap: 'wrap' },
   legalLink: { textDecorationLine: 'underline', fontSize: 13 },
   disabledText: { opacity: 0.45 },

--- a/mobile/src/api.ts
+++ b/mobile/src/api.ts
@@ -1,3 +1,5 @@
+import * as AppleAuthentication from 'expo-apple-authentication';
+import * as Crypto from 'expo-crypto';
 import type { DabbirSession } from './session';
 
 const configuredBase = String(process.env.EXPO_PUBLIC_DABBIR_API_BASE_URL || '').trim().replace(/\/$/, '');
@@ -85,8 +87,39 @@ export async function createStore(accessToken: string, name: string, locale: 'ar
   return post('/api/mobile/runtime', { action: 'create_business', name, business_type: 'store', locale }, accessToken);
 }
 
+async function appleDeletionAuthorizationCode(): Promise<string> {
+  if (!(await AppleAuthentication.isAvailableAsync())) throw new Error('APPLE_REAUTH_UNAVAILABLE');
+  try {
+    const bytes = await Crypto.getRandomBytesAsync(32);
+    const rawNonce = Array.from(bytes).map(byte => byte.toString(16).padStart(2, '0')).join('');
+    const hashedNonce = await Crypto.digestStringAsync(
+      Crypto.CryptoDigestAlgorithm.SHA256,
+      rawNonce,
+      { encoding: Crypto.CryptoEncoding.HEX },
+    );
+    const credential = await AppleAuthentication.signInAsync({ nonce: hashedNonce });
+    const code = String(credential.authorizationCode || '').trim();
+    if (!code) throw new Error('APPLE_REAUTHORIZATION_CODE_MISSING');
+    return code;
+  } catch (error) {
+    if ((error as { code?: string })?.code === 'ERR_REQUEST_CANCELED') throw new Error('ACCOUNT_DELETE_CANCELLED');
+    throw error;
+  }
+}
+
 export async function deleteDabbirAccount(accessToken: string): Promise<any> {
-  return post('/api/mobile/account-delete', { confirmation: 'DELETE_DABBIR_ACCOUNT' }, accessToken);
+  const payload = { confirmation: 'DELETE_DABBIR_ACCOUNT' };
+  try {
+    return await post('/api/mobile/account-delete', payload, accessToken);
+  } catch (error) {
+    if (String((error as Error)?.message || '') !== 'APPLE_REAUTH_REQUIRED') throw error;
+  }
+
+  const authorizationCode = await appleDeletionAuthorizationCode();
+  return post('/api/mobile/account-delete', {
+    ...payload,
+    apple_authorization_code: authorizationCode,
+  }, accessToken);
 }
 
 export async function verifyApplePurchase(accessToken: string, purchase: unknown): Promise<any> {

--- a/scripts/dabbir-apple-account-deletion-gate.mjs
+++ b/scripts/dabbir-apple-account-deletion-gate.mjs
@@ -1,0 +1,90 @@
+import fs from 'node:fs';
+
+const read = path => fs.readFileSync(path, 'utf8');
+const releaseMode = String(process.env.DABBIR_APP_STORE_RELEASE_PREFLIGHT || '').trim() === '1';
+const failures = [];
+const passes = [];
+const external = [];
+
+const requireStatic = (condition, code, detail) => {
+  if (condition) passes.push({ code, detail });
+  else failures.push({ code, detail });
+};
+const requireRelease = (condition, code, detail) => {
+  if (condition) passes.push({ code, detail });
+  else if (releaseMode) failures.push({ code, detail });
+  else external.push({ code, detail });
+};
+
+const accountDelete = read('api/mobile/account-delete.js');
+const appleSignIn = read('api/_apple-signin-core.js');
+const mobileApi = read('mobile/src/api.ts');
+const subscription = read('mobile/src/SubscriptionCard.tsx');
+const migration = read('supabase/migrations/20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql');
+
+requireStatic(
+  accountDelete.includes('dabbir_delete_current_user_account_preflight')
+    && accountDelete.includes('revokeAppleAuthorizationForDeletion')
+    && accountDelete.indexOf('dabbir_delete_current_user_account_preflight') < accountDelete.indexOf('revokeAppleAuthorizationForDeletion')
+    && accountDelete.indexOf('revokeAppleAuthorizationForDeletion') < accountDelete.lastIndexOf("supabaseRpc('dabbir_delete_current_user_account'"),
+  'APPLE_DELETE_ORDER',
+  'Deletion runs DABBIR blocker preflight, then Apple token revocation, then destructive DABBIR deletion.',
+);
+requireStatic(
+  appleSignIn.includes('https://appleid.apple.com/auth/token')
+    && appleSignIn.includes('https://appleid.apple.com/auth/revoke')
+    && appleSignIn.includes("alg: 'ES256'")
+    && appleSignIn.includes("token_type_hint: 'refresh_token'"),
+  'APPLE_REST_REVOCATION',
+  'Server exchanges the fresh Apple authorization code and revokes the returned refresh token using Apple REST APIs.',
+);
+requireStatic(
+  mobileApi.includes('APPLE_REAUTH_REQUIRED')
+    && mobileApi.includes('AppleAuthentication.signInAsync')
+    && mobileApi.includes('credential.authorizationCode')
+    && mobileApi.includes('apple_authorization_code'),
+  'APPLE_DELETE_REAUTH',
+  'Apple-linked deletion reauthenticates in the native app and sends only the one-time authorization code to the server.',
+);
+requireStatic(
+  subscription.includes('https://apps.apple.com/account/subscriptions')
+    && subscription.includes('حذف حساب دبّر لا يلغي اشتراك App Store تلقائيًا'),
+  'APPLE_SUBSCRIPTION_DELETE_GUIDANCE',
+  'Auto-renewable subscription users are warned and given Apple subscription management before deletion.',
+);
+requireStatic(
+  migration.includes('ACCOUNT_DELETE_BLOCKED_BY_LEGAL_HOLD')
+    && migration.includes('PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF')
+    && migration.includes('revoke all on function public.dabbir_delete_current_user_account_preflight(text) from public, anon'),
+  'DELETE_PREFLIGHT_ACL',
+  'Read-only deletion preflight handles legal/admin blockers and is not callable by anonymous users.',
+);
+
+const teamId = String(process.env.DABBIR_APPLE_SIGN_IN_TEAM_ID || '').trim();
+const keyId = String(process.env.DABBIR_APPLE_SIGN_IN_KEY_ID || '').trim();
+const privateKey = String(process.env.DABBIR_APPLE_SIGN_IN_PRIVATE_KEY_BASE64 || process.env.DABBIR_APPLE_SIGN_IN_PRIVATE_KEY || '').trim();
+const bundleId = String(process.env.DABBIR_IOS_BUNDLE_ID || '').trim();
+
+requireRelease(/^[A-Za-z0-9]{5,64}$/.test(teamId), 'APPLE_SIGN_IN_TEAM_ID', 'Apple Developer Team ID is configured server-side.');
+requireRelease(/^[A-Za-z0-9]{5,64}$/.test(keyId), 'APPLE_SIGN_IN_KEY_ID', 'Sign in with Apple private-key ID is configured server-side.');
+requireRelease(privateKey.length >= 64, 'APPLE_SIGN_IN_PRIVATE_KEY', 'Sign in with Apple private key is configured server-side and never shipped to the client.');
+requireRelease(bundleId === 'com.barmansystems.dabbir', 'APPLE_SIGN_IN_CLIENT_ID', 'Native Sign in with Apple client ID is the DABBIR bundle identifier.');
+
+if (releaseMode && failures.length === 0) {
+  external.push({
+    code: 'APPLE_DELETE_LIVE_REVOKE_PROOF',
+    detail: 'Run a TestFlight/Sandbox Apple-linked account deletion and prove /auth/token + /auth/revoke succeed before App Store submission.',
+  });
+}
+
+const report = {
+  ok: failures.length === 0 && (!releaseMode || external.length === 0),
+  mode: releaseMode ? 'RELEASE' : 'STATIC',
+  verdict: failures.length ? 'FAIL' : (external.length ? 'PASS_WITH_EXTERNAL_GATE' : 'PASS'),
+  passes: passes.map(item => item.code),
+  failures,
+  external_blockers: external,
+};
+console.log(JSON.stringify(report, null, 2));
+if (failures.length) process.exit(2);
+if (releaseMode && external.length) process.exit(3);

--- a/scripts/dabbir-apple-account-deletion-gate.mjs
+++ b/scripts/dabbir-apple-account-deletion-gate.mjs
@@ -21,12 +21,12 @@ const appleSignIn = read('api/_apple-signin-core.js');
 const mobileApi = read('mobile/src/api.ts');
 const subscription = read('mobile/src/SubscriptionCard.tsx');
 const migration = read('supabase/migrations/20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql');
+const preflightIndex = accountDelete.indexOf("supabaseRpc('dabbir_delete_current_user_account_preflight'");
+const revokeIndex = accountDelete.indexOf('await revokeAppleAuthorizationForDeletion(');
+const deleteIndex = accountDelete.lastIndexOf("supabaseRpc('dabbir_delete_current_user_account'");
 
 requireStatic(
-  accountDelete.includes('dabbir_delete_current_user_account_preflight')
-    && accountDelete.includes('revokeAppleAuthorizationForDeletion')
-    && accountDelete.indexOf('dabbir_delete_current_user_account_preflight') < accountDelete.indexOf('revokeAppleAuthorizationForDeletion')
-    && accountDelete.indexOf('revokeAppleAuthorizationForDeletion') < accountDelete.lastIndexOf("supabaseRpc('dabbir_delete_current_user_account'"),
+  preflightIndex >= 0 && revokeIndex > preflightIndex && deleteIndex > revokeIndex,
   'APPLE_DELETE_ORDER',
   'Deletion runs DABBIR blocker preflight, then Apple token revocation, then destructive DABBIR deletion.',
 );

--- a/supabase/migrations/20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql
+++ b/supabase/migrations/20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql
@@ -1,0 +1,65 @@
+-- DABBIR account deletion Apple-compliance preflight v1.
+-- This performs every known deterministic deletion blocker check before any
+-- external Sign in with Apple token revocation occurs. It does not mutate data.
+
+create or replace function dabbir_private.dabbir_delete_current_user_account_preflight_impl(p_confirmation text)
+returns jsonb
+language plpgsql
+security definer
+set search_path = pg_catalog, public, dabbir_private, pg_temp
+as $function$
+declare
+  v_user uuid := auth.uid();
+  v_owned_business_ids uuid[] := '{}'::uuid[];
+begin
+  if v_user is null then raise exception 'AUTH_REQUIRED'; end if;
+  if p_confirmation is distinct from 'DELETE_DABBIR_ACCOUNT' then raise exception 'ACCOUNT_DELETE_CONFIRMATION_REQUIRED'; end if;
+
+  if exists (
+    select 1 from public.account_access_state
+    where user_id = v_user and status = 'deleted'
+  ) then
+    raise exception 'DABBIR_ACCOUNT_ALREADY_DELETED';
+  end if;
+
+  if exists (select 1 from public.dabbir_platform_admins where user_id = v_user) then
+    raise exception 'PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF';
+  end if;
+
+  select coalesce(array_agg(id order by id), '{}'::uuid[])
+    into v_owned_business_ids
+  from public.dabbir_businesses
+  where owner_id = v_user;
+
+  if exists (
+    select 1 from public.dabbir_retention_policies
+    where business_id = any(v_owned_business_ids)
+      and policy_state = 'LEGAL_HOLD'
+  ) then
+    raise exception 'ACCOUNT_DELETE_BLOCKED_BY_LEGAL_HOLD';
+  end if;
+
+  return jsonb_build_object(
+    'ok', true,
+    'allowed', true,
+    'scope', 'DABBIR_PRODUCT_ACCOUNT'
+  );
+end;
+$function$;
+
+revoke all on function dabbir_private.dabbir_delete_current_user_account_preflight_impl(text) from public, anon;
+grant execute on function dabbir_private.dabbir_delete_current_user_account_preflight_impl(text) to authenticated;
+
+create or replace function public.dabbir_delete_current_user_account_preflight(p_confirmation text)
+returns jsonb
+language sql
+set search_path = ''
+as $function$
+  select dabbir_private.dabbir_delete_current_user_account_preflight_impl(p_confirmation);
+$function$;
+
+revoke all on function public.dabbir_delete_current_user_account_preflight(text) from public, anon;
+grant execute on function public.dabbir_delete_current_user_account_preflight(text) to authenticated;
+
+comment on function public.dabbir_delete_current_user_account_preflight(text) is
+  'Read-only account deletion preflight. Verifies DABBIR deletion blockers before any external Apple authorization revocation.';

--- a/test/apple-account-deletion-compliance.test.mjs
+++ b/test/apple-account-deletion-compliance.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = path => fs.readFileSync(path, 'utf8');
+
+const accountDelete = read('api/mobile/account-delete.js');
+const appleSignIn = read('api/_apple-signin-core.js');
+const mobileApi = read('mobile/src/api.ts');
+const subscription = read('mobile/src/SubscriptionCard.tsx');
+const migration = read('supabase/migrations/20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql');
+
+test('Apple-linked account deletion revokes Sign in with Apple before destructive DABBIR deletion', () => {
+  assert.match(accountDelete, /dabbir_delete_current_user_account_preflight/);
+  assert.match(accountDelete, /appleIdentitySubject/);
+  assert.match(accountDelete, /revokeAppleAuthorizationForDeletion/);
+  assert.match(accountDelete, /APPLE_REAUTH_REQUIRED/);
+  assert.match(accountDelete, /dabbir_delete_current_user_account/);
+
+  const preflight = accountDelete.indexOf("supabaseRpc('dabbir_delete_current_user_account_preflight'");
+  const revoke = accountDelete.indexOf('revokeAppleAuthorizationForDeletion');
+  const destructive = accountDelete.lastIndexOf("supabaseRpc('dabbir_delete_current_user_account'");
+  assert.ok(preflight >= 0 && revoke > preflight && destructive > revoke, 'preflight -> Apple revoke -> DABBIR delete order must remain fail-closed');
+});
+
+test('Sign in with Apple server implementation uses Apple token and revocation endpoints with a signed client secret', () => {
+  assert.match(appleSignIn, /https:\/\/appleid\.apple\.com\/auth\/token/);
+  assert.match(appleSignIn, /https:\/\/appleid\.apple\.com\/auth\/revoke/);
+  assert.match(appleSignIn, /alg:\s*'ES256'/);
+  assert.match(appleSignIn, /DABBIR_APPLE_SIGN_IN_TEAM_ID/);
+  assert.match(appleSignIn, /DABBIR_APPLE_SIGN_IN_KEY_ID/);
+  assert.match(appleSignIn, /DABBIR_APPLE_SIGN_IN_PRIVATE_KEY/);
+  assert.match(appleSignIn, /refresh_token/);
+  assert.match(appleSignIn, /String\(identity\?\.sub \|\| ''\) !== expected/);
+});
+
+test('iOS deletion path reauthenticates with Apple only when backend requires it', () => {
+  assert.match(mobileApi, /APPLE_REAUTH_REQUIRED/);
+  assert.match(mobileApi, /AppleAuthentication\.signInAsync/);
+  assert.match(mobileApi, /credential\.authorizationCode/);
+  assert.match(mobileApi, /apple_authorization_code/);
+});
+
+test('auto-renewable subscription users get a direct Apple subscription-management path', () => {
+  assert.match(subscription, /https:\/\/apps\.apple\.com\/account\/subscriptions/);
+  assert.match(subscription, /حذف حساب دبّر لا يلغي اشتراك App Store تلقائيًا/);
+  assert.match(subscription, /إدارة أو إلغاء اشتراك App Store/);
+});
+
+test('deletion preflight checks known legal and platform-admin blockers without mutating account data', () => {
+  assert.match(migration, /ACCOUNT_DELETE_BLOCKED_BY_LEGAL_HOLD/);
+  assert.match(migration, /PLATFORM_ADMIN_ACCOUNT_REQUIRES_HANDOFF/);
+  assert.match(migration, /DABBIR_ACCOUNT_ALREADY_DELETED/);
+  assert.match(migration, /revoke all on function public\.dabbir_delete_current_user_account_preflight\(text\) from public, anon/i);
+  assert.doesNotMatch(migration, /delete\s+from\s+public\.dabbir_businesses/i);
+});

--- a/test/apple-account-deletion-compliance.test.mjs
+++ b/test/apple-account-deletion-compliance.test.mjs
@@ -18,7 +18,7 @@ test('Apple-linked account deletion revokes Sign in with Apple before destructiv
   assert.match(accountDelete, /dabbir_delete_current_user_account/);
 
   const preflight = accountDelete.indexOf("supabaseRpc('dabbir_delete_current_user_account_preflight'");
-  const revoke = accountDelete.indexOf('revokeAppleAuthorizationForDeletion');
+  const revoke = accountDelete.indexOf('await revokeAppleAuthorizationForDeletion(');
   const destructive = accountDelete.lastIndexOf("supabaseRpc('dabbir_delete_current_user_account'");
   assert.ok(preflight >= 0 && revoke > preflight && destructive > revoke, 'preflight -> Apple revoke -> DABBIR delete order must remain fail-closed');
 });


### PR DESCRIPTION
## Purpose
Close the App Store account-deletion gaps for DABBIR without weakening the existing product-scoped deletion model.

## Apple requirements implemented
- Keeps account deletion directly inside the iOS app.
- For Apple-linked accounts, requires a fresh native Sign in with Apple authorization code at deletion time.
- Exchanges the one-time code server-side through Apple `/auth/token`.
- Verifies the returned Apple identity belongs to the same linked user.
- Revokes the Apple refresh token through Apple `/auth/revoke` **before** destructive DABBIR deletion.
- Runs a read-only DABBIR deletion preflight first so legal-hold/platform-admin blockers cannot revoke Apple authorization and then refuse deletion.
- Keeps legally required retention/de-identification behavior already present in DABBIR.
- Warns auto-renewable subscribers that deletion does not cancel App Store billing and provides Apple's subscription-management URL.
- Adds static regression tests and a dedicated Apple account-deletion CI gate.
- Adds a release-mode gate for required server-side Apple Team ID, Key ID, private key, bundle ID, plus a live TestFlight/Sandbox revoke proof before submission.

## Database
Migration `20260905011500_dabbir_account_deletion_apple_revoke_preflight_v1.sql` has already been applied to the active DABBIR Supabase project. It is additive and read-only.

## Security
- Apple private key remains server-only.
- No Apple private key or refresh token is shipped to the client.
- Fresh Apple authorization codes are one-time and only sent to the DABBIR backend for deletion.
- Destructive deletion remains authenticated and confirmation-gated.
- Supabase security advisor was run after the migration; no new account-deletion security finding was introduced.

## Release blocker
Do **not** merge/deploy as App Store-ready until the server environment contains the real Sign in with Apple credentials (`DABBIR_APPLE_SIGN_IN_TEAM_ID`, `DABBIR_APPLE_SIGN_IN_KEY_ID`, and private key) and a real Apple-linked TestFlight/Sandbox deletion proves `/auth/token` + `/auth/revoke` end-to-end. The code fails closed when these are absent.