### PR TITLE
test(ux): collect authenticated internal visual evidence after #490

### DIFF
--- a/.github/workflows/dabbir-ai-customer-journey.yml
+++ b/.github/workflows/dabbir-ai-customer-journey.yml
@@ -76,6 +76,7 @@ jobs:
       PRODUCTION_ORIGIN: ${{ vars.DABBIR_PRODUCTION_ORIGIN }}
       PROTECTED_QA_ORIGIN: https://dabbir-nd56cm4j5v-3619s-projects.vercel.app
       SUPABASE_PROJECT_REF: fphpoysqdsceniwduxjq
+      DABBIR_INTERNAL_VISUAL_QA: '1'
       JOURNEY_REPORT_PATH: dabbir-ai-customer-journey-report.json
       ISOLATION_REPORT_PATH: dabbir-cross-tenant-isolation-report.json
       EXPECTED_VERCEL_PROJECT_ID: prj_HCTFdQo8Vc7FvZRdJ37H7KFYwpUq
@@ -282,6 +283,7 @@ jobs:
             dabbir-ai-customer-journey-report.json
             dabbir-ai-customer-journey-report-en.json
             dabbir-ai-customer-journey-screenshot.png
+            dabbir-internal-visual/
             dabbir-cross-tenant-isolation-report.json
           if-no-files-found: warn
           retention-days: 14

--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -398,6 +398,46 @@ async function browserJourney() {
   }
   assert(operationsText.includes('AI Journey Product'), 'BROWSER_PRODUCT_MISSING');
 
+  // Optional visual evidence uses the same disposable, MFA-authenticated owner.
+  // No integration, billing, deletion or customer-message mutation is performed.
+  if (process.env.DABBIR_INTERNAL_VISUAL_QA === '1' && REPORT_PATH === 'dabbir-ai-customer-journey-report.json') {
+    const dir = 'dabbir-internal-visual';
+    fs.mkdirSync(dir, { recursive: true });
+    const visual = { sha: process.env.GITHUB_SHA, origin: ORIGIN, engine: 'WebKit emulation; not physical Safari', cases: [] };
+    const screens = ['dashboard', 'tasks', 'notifications', 'customers', 'appointments', 'operations', 'integrations', 'settings', 'automations', 'analytics'];
+    try {
+      for (const [device, width, height] of [['iphone',390,844],['iphone-max',430,932],['ipad',768,1024],['ipad-landscape',1024,768],['desktop',1440,900]]) {
+        await page.setViewportSize({ width, height });
+        for (const language of ['ar', 'en']) {
+          await page.locator(`#${language}Btn`).click();
+          for (const screen of screens) {
+            if (await page.locator('#menuBtn:visible').count() && !(await page.locator('#side.open').count())) await page.locator('#menuBtn').click();
+            let nav = page.locator(`#side [data-screen="${screen}"]`);
+            if (!(await nav.count())) {
+              await page.locator('#side [data-screen="more"]').click();
+              nav = page.locator(`#screen-more [data-screen="${screen}"]`);
+            }
+            const entry = { device, width, height, language, screen };
+            if (!(await nav.count())) { entry.status = 'UNAVAILABLE'; visual.cases.push(entry); continue; }
+            await nav.click({ timeout: 10000 });
+            await page.locator(`#screen-${screen}.active`).waitFor({ state: 'visible', timeout: 10000 });
+            await page.waitForTimeout(350);
+            entry.overflow = await page.evaluate(() => document.documentElement.scrollWidth > innerWidth + 1);
+            entry.file = `${device}-${language}-${screen}.png`;
+            await page.screenshot({ path: `${dir}/${entry.file}`, fullPage: false, animations: 'disabled', timeout: 15000 });
+            entry.status = entry.overflow ? 'OVERFLOW' : 'CAPTURED';
+            visual.cases.push(entry);
+          }
+        }
+      }
+    } catch (error) {
+      visual.error = String(error.message);
+      throw error;
+    } finally {
+      fs.writeFileSync(`${dir}/report.json`, JSON.stringify(visual, null, 2));
+    }
+  }
+
   // The functional report is sufficient evidence here. In protected WebKit,
   // screenshot rasterization can block the browser channel long after every
   // interaction has already passed, so it must not determine journey success.


### PR DESCRIPTION
Continues #490. Existing production journey deliberately omits screenshots, leaving internal visual readiness unproven. Add bounded WebKit screenshots through the existing main-only, MFA-authenticated disposable QA journey, across five requested viewports and Arabic/English. Navigate existing UI only; no billing, deletion, integration or customer-message mutations in the capture loop. Preserve release locks, broker policy, cleanup and regression assertions. Upload partial evidence even on failure. This is an evidence-enabling change; no product UI changes or claim of full audit completion. Local syntax and 14 authorization/routing/access tests pass. Main-only QA cannot run privileged identities from this PR; production capture runs only after required gates and authorized merge.

Production result: merged SHA 79cc3eb26e7f3661c2c79c1825bd7eb30ea1f97a. Run 33948007347 PASS; artifact 9963985991 contains 90 authenticated internal screenshots across five sizes and two languages. Ten appointment cases explicitly UNAVAILABLE because this isolated business is a store. No document-level horizontal overflow in captured cases. Visual review exposed persistent untranslated tour overlay, clipped mobile header and duplicated CRM filters; fixes follow in #492. These screenshots were used as BEFORE evidence. Functional journey, isolation and disposable-fixture cleanup all PASS.