### PR TITLE
test(ux): observe the existing GCC onboarding route

### DIFF
--- a/test/ai-full-customer-journey-v2.mjs
+++ b/test/ai-full-customer-journey-v2.mjs
@@ -546,7 +546,7 @@ async function runJourney() {
             if(language==='en'){
               await setup.locator('#businessName').fill(RUN_LABEL);
               await setup.locator('#businessType').selectOption('store');
-              const responsePromise=setup.waitForResponse(r=>r.url().includes('/api/dabbir-runtime')&&r.request().method()==='POST'&&r.request().postData()?.includes('create_business'),{timeout:25000});
+              const responsePromise=setup.waitForResponse(r=>['/api/dabbir-runtime','/api/gcc-create-business'].includes(new URL(r.url()).pathname)&&r.request().method()==='POST'&&r.request().postData()?.includes('create_business'),{timeout:25000});
               await setup.locator('#setupSubmit').click();
               const response=await responsePromise;
               const json=await response.json();


### PR DESCRIPTION
Follow-up to #492. Production public QA passed at 7b14a98. New browser onboarding evidence reached the form in both languages, but its response listener only accepted /api/dabbir-runtime. Existing gcc-readiness-ui.js routes create_business to /api/gcc-create-business. Accept that exact observed path as well, preserving the POST and create_business constraints. No application/authentication/runtime changes or relaxed success assertions. Failed run 33948860882 artifact 9964193287; QA cleanup PASS. Re-run the existing main-only production journey after required gates to complete internal after evidence.