### PR TITLE
fix: prevent Safari shell 500 on unsupported HTTP methods

### DIFF
--- a/api/app-safari-recovery.js
+++ b/api/app-safari-recovery.js
@@ -181,6 +181,9 @@ export default function handler(req, res) {
       res.setHeader('x-dabbir-first-paint-authority', 'owner-first-inline-before-auth-boot-v2');
       res.setHeader('x-dabbir-design-authority', 'executive-calm-v1');
       res.statusCode = Number(proxy.statusCode || 200);
+      // Error/method responses have no HTML bootstrap to reorder.
+      // Preserve the upstream status and body instead of turning a 405 into a 500.
+      if (res.statusCode !== 200) return res.end(body);
       const fresh = bustUiAssetVersion(body);
       const canonical = stripLegacyNavigationOverrides(fresh);
       const ordered = orderOwnerFirstBeforeAuthBoot(canonical);

--- a/test/dabbir-safari-cache-recovery.test.mjs
+++ b/test/dabbir-safari-cache-recovery.test.mjs
@@ -8,7 +8,7 @@ const app = fs.readFileSync(new URL('../api/app.js', import.meta.url), 'utf8');
 const failOpen = fs.readFileSync(new URL('../api/dabbir-safari-auth-fail-open-ui.js', import.meta.url), 'utf8');
 const vercel = JSON.parse(fs.readFileSync(new URL('../vercel.json', import.meta.url), 'utf8'));
 
-function renderCanonicalRoot(){
+function renderCanonicalRoot(method='GET'){
   const headers=new Map();
   let body='';
   const res={
@@ -20,9 +20,19 @@ function renderCanonicalRoot(){
     set statusCode(value){this._status=Number(value)},
     get statusCode(){return this._status},
   };
-  appSafariRecoveryHandler({method:'GET',headers:{}},res);
+  appSafariRecoveryHandler({method,headers:{}},res);
   return {body,headers,status:res.statusCode};
 }
+
+test('unsupported shell methods retain 405 without running HTML transforms', () => {
+  for (const method of ['HEAD', 'POST', 'OPTIONS', 'PUT', 'DELETE']) {
+    const {body,headers,status}=renderCanonicalRoot(method);
+    assert.equal(status,405,method);
+    assert.equal(headers.get('allow'),'GET',method);
+    assert.equal(body,'Method Not Allowed',method);
+    assert.ok(!body.includes('<script'),method);
+  }
+});
 
 test('root shell bypasses stale Safari UI bundle versions', () => {
   assert.match(recovery, /UI_CACHE_BUST = '20260903-chat-render-lifecycle-v3'/);


### PR DESCRIPTION
The Safari shell rewrites every upstream response as HTML. app.js returns 405 for non-GET methods, but the wrapper then requires an owner bootstrap script in `Method Not Allowed`, throwing DABBIR_OWNER_FIRST_SCRIPT_COUNT_0.

Preserve non-200 upstream responses before HTML transformations. Keep strict bootstrap validation for successful HTML. Regression coverage checks HEAD, POST, OPTIONS, PUT and DELETE retain 405 and Allow: GET; existing GET inline-authority tests remain passing.

Validation: 10 focused tests passed. Full CI and Preview required before merge. This addresses runtime reliability only; release stability, WhatsApp, billing and restore remain separate launch gates.