### PR TITLE
fix(bookings): keep owner on bookings after save and fix mobile date overflow

### DIFF
--- a/api/car-wash-booking-edit-ui.js
+++ b/api/car-wash-booking-edit-ui.js
@@ -6,7 +6,7 @@ const script=String.raw`(()=>{
   const isCarWash=()=>String(workspaceNow()?.business?.business_type||'').toLowerCase()==='car_wash';
   const ar=()=>document.documentElement.lang!=='en';
   const esc=value=>String(value??'').replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-  const copy=()=>ar()?{title:'تعديل الحجز',customer:'العميل',time:'الموعد',status:'الحالة',save:'حفظ التعديل',cancel:'إلغاء',requested:'مطلوب',confirmed:'مؤكد',rescheduled:'أعيدت جدولته',completed:'مكتمل',cancelled:'ملغي',saved:'تم تعديل الحجز.',failed:'تعذر تعديل الحجز.'}:{title:'Edit booking',customer:'Customer',time:'Booking',status:'Status',save:'Save changes',cancel:'Cancel',requested:'Requested',confirmed:'Confirmed',rescheduled:'Rescheduled',completed:'Completed',cancelled:'Cancelled',saved:'Booking updated.',failed:'Could not update booking.'};
+  const copy=()=>ar()?{title:'تعديل الحجز',customer:'العميل',time:'الموعد',status:'الحالة',save:'حفظ التعديل',cancel:'إلغاء',requested:'مطلوب',confirmed:'مؤكد',rescheduled:'أعيدت جدولته',completed:'مكتمل',cancelled:'ملغي',saved:'تم تعديل الحجز.',savedRefreshFailed:'تم حفظ الحجز، لكن تعذر تحديث عرضه. افتح الحجوزات مجددًا.',failed:'تعذر تعديل الحجز.'}:{title:'Edit booking',customer:'Customer',time:'Booking',status:'Status',save:'Save changes',cancel:'Cancel',requested:'Requested',confirmed:'Confirmed',rescheduled:'Rescheduled',completed:'Completed',cancelled:'Cancelled',saved:'Booking updated.',savedRefreshFailed:'Booking saved, but its display could not be refreshed. Reopen bookings.',failed:'Could not update booking.'};
   let busy=false;
 
   function businessTimezone(){
@@ -43,7 +43,7 @@ const script=String.raw`(()=>{
   function ensureStyle(){
     if(q('#dabbirCarWashPastEditStyle'))return;
     const style=document.createElement('style');style.id='dabbirCarWashPastEditStyle';
-    style.textContent='#dabbirCarWashPastEditModal{position:fixed;inset:0;z-index:140;background:#000c;display:none;align-items:center;justify-content:center;padding:18px}#dabbirCarWashPastEditModal.open{display:flex}.dabbirCarWashPastEditBox{width:min(430px,100%);background:#131922;border:1px solid #34445b;border-radius:18px;padding:16px;color:#fff}.dabbirCarWashPastEditBox h3{margin:0 0 12px;font-size:18px}.dabbirCarWashPastEditField{display:grid;gap:6px;margin-top:10px}.dabbirCarWashPastEditField label{font-size:12px;color:#9eacc0}.dabbirCarWashPastEditField input,.dabbirCarWashPastEditField select{width:100%;min-height:46px;border:1px solid #34445b;border-radius:11px;background:#182233;color:#fff;padding:10px;font:inherit}.dabbirCarWashPastEditActions{display:flex;gap:8px;margin-top:14px}.dabbirCarWashPastEditActions button{flex:1;min-height:44px;border-radius:11px;font-weight:800}.dabbirCarWashPastEditCancel{border:1px solid #34445b;background:#182233;color:#fff}.dabbirCarWashPastEditSave{border:0;background:#4f7cff;color:#fff}.dabbirCarWashPastEditSave:disabled{opacity:.5}';
+    style.textContent='#dabbirCarWashPastEditModal{position:fixed;inset:0;z-index:140;background:#000c;display:none;align-items:center;justify-content:center;padding:18px;box-sizing:border-box;overflow-y:auto}#dabbirCarWashPastEditModal.open{display:flex}.dabbirCarWashPastEditBox{box-sizing:border-box;width:min(430px,100%);max-width:100%;min-width:0;max-height:calc(100vh - 36px);max-height:calc(100dvh - 36px);overflow-y:auto;background:#131922;border:1px solid #34445b;border-radius:18px;padding:16px;color:#fff}.dabbirCarWashPastEditBox h3{margin:0 0 12px;font-size:18px}.dabbirCarWashPastEditField{display:grid;grid-template-columns:minmax(0,1fr);min-width:0;gap:6px;margin-top:10px}.dabbirCarWashPastEditField label{font-size:12px;color:#9eacc0}.dabbirCarWashPastEditField input,.dabbirCarWashPastEditField select{box-sizing:border-box;width:100%;max-width:100%;min-width:0;min-height:46px;border:1px solid #34445b;border-radius:11px;background:#182233;color:#fff;padding:10px;font:inherit;font-size:16px}#dabbirCarWashPastEditTime{direction:ltr;text-align:start}#dabbirCarWashPastEditTime::-webkit-date-and-time-value{min-width:0;text-align:start}.dabbirCarWashPastEditActions{display:flex;gap:8px;margin-top:14px}.dabbirCarWashPastEditActions button{flex:1;min-height:44px;border-radius:11px;font-weight:800}.dabbirCarWashPastEditCancel{border:1px solid #34445b;background:#182233;color:#fff}.dabbirCarWashPastEditSave{border:0;background:#4f7cff;color:#fff}.dabbirCarWashPastEditSave:disabled{opacity:.5}';
     document.head.append(style);
   }
   function ensureModal(){
@@ -53,22 +53,38 @@ const script=String.raw`(()=>{
   function close(){q('#dabbirCarWashPastEditModal')?.classList.remove('open')}
   function toast(message){try{if(typeof window.toast==='function')window.toast(message)}catch{}}
 
+  // Apply only the canonical saved row to the active business. Do not reload the
+  // document or refetch the whole workspace; keep screen and calendar state intact.
+  function renderSavedAppointment(businessId,id,updated){
+    const w=workspaceNow();if(w?.business?.id!==businessId)return;
+    const row=appointment(id);
+    if(!row||!updated||updated.id!==id||(updated.business_id&&updated.business_id!==businessId))throw new Error('SAVED_APPOINTMENT_REFRESH_FAILED');
+    Object.assign(row,updated);
+    window.__dabbirAppointmentManagement?.render?.();
+    try{if(typeof renderAppointments==='function')renderAppointments()}catch{}
+    try{window.__dabbirCalendarLiveUi?.sanitize?.()}catch{}
+  }
+
   function openEditor(id){
-    if(!isCarWash())return;
+    if(busy||!isCarWash())return;
     const row=appointment(id),w=workspaceNow();if(!row||!w?.business?.id)return;
     const c=copy(),modal=ensureModal(),status=String(row.status||'requested').toLowerCase();
-    modal.innerHTML='<form class="dabbirCarWashPastEditBox" id="dabbirCarWashPastEditForm"><h3>'+esc(c.title)+'</h3><div class="dabbirCarWashPastEditField"><label>'+esc(c.customer)+'</label><input value="'+esc(customerName(row.customer_id))+'" disabled></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.time)+'</label><input id="dabbirCarWashPastEditTime" type="datetime-local" value="'+esc(businessLocalMinute(row.starts_at))+'" required></div><div class="dabbirCarWashPastEditField"><label>'+esc(c.status)+'</label><select id="dabbirCarWashPastEditStatus"><option value="requested" '+(status==='requested'?'selected':'')+'>'+esc(c.requested)+'</option><option value="confirmed" '+(status==='confirmed'?'selected':'')+'>'+esc(c.confirmed)+'</option><option value="rescheduled" '+(status==='rescheduled'?'selected':'')+'>'+esc(c.rescheduled)+'</option><option value="completed" '+(status==='completed'?'selected':'')+'>'+esc(c.completed)+'</option><option value="cancelled" '+(status==='cancelled'?'selected':'')+'>'+esc(c.cancelled)+'</option></select></div><div class="dabbirCarWashPastEditActions"><button type="button" class="dabbirCarWashPastEditCancel" id="dabbirCarWashPastEditCancel">'+esc(c.cancel)+'</button><button type="submit" class="dabbirCarWashPastEditSave">'+esc(c.save)+'</button></div></form>';
+    modal.innerHTML='<form class="dabbirCarWashPastEditBox" id="dabbirCarWashPastEditForm"><h3>'+esc(c.title)+'</h3><div class="dabbirCarWashPastEditField"><label>'+esc(c.customer)+'</label><input value="'+esc(customerName(row.customer_id))+'" disabled></div><div class="dabbirCarWashPastEditField"><label for="dabbirCarWashPastEditTime">'+esc(c.time)+'</label><input id="dabbirCarWashPastEditTime" type="datetime-local" dir="ltr" value="'+esc(businessLocalMinute(row.starts_at))+'" required></div><div class="dabbirCarWashPastEditField"><label for="dabbirCarWashPastEditStatus">'+esc(c.status)+'</label><select id="dabbirCarWashPastEditStatus"><option value="requested" '+(status==='requested'?'selected':'')+'>'+esc(c.requested)+'</option><option value="confirmed" '+(status==='confirmed'?'selected':'')+'>'+esc(c.confirmed)+'</option><option value="rescheduled" '+(status==='rescheduled'?'selected':'')+'>'+esc(c.rescheduled)+'</option><option value="completed" '+(status==='completed'?'selected':'')+'>'+esc(c.completed)+'</option><option value="cancelled" '+(status==='cancelled'?'selected':'')+'>'+esc(c.cancelled)+'</option></select></div><div class="dabbirCarWashPastEditActions"><button type="button" class="dabbirCarWashPastEditCancel" id="dabbirCarWashPastEditCancel">'+esc(c.cancel)+'</button><button type="submit" class="dabbirCarWashPastEditSave">'+esc(c.save)+'</button></div></form>';
     q('#dabbirCarWashPastEditCancel').onclick=close;
     modal.onclick=event=>{if(event.target===modal)close()};
     q('#dabbirCarWashPastEditForm').onsubmit=async event=>{
       event.preventDefault();if(busy)return;
+      if(workspaceNow()?.business?.id!==w.business.id){close();return}
       const start=isoFromBusinessLocal(q('#dabbirCarWashPastEditTime')?.value),nextStatus=q('#dabbirCarWashPastEditStatus')?.value;
       if(!start)return;
       busy=true;const submit=event.submitter;if(submit)submit.disabled=true;
       try{
         const response=await fetch('/api/appointment-management',{method:'POST',credentials:'same-origin',cache:'no-store',headers:{'content-type':'application/json',accept:'application/json'},body:JSON.stringify({action:'update',business_id:w.business.id,appointment_id:id,starts_at:start,status:nextStatus})});
         const data=await response.json().catch(()=>({}));if(!response.ok||!data?.ok)throw new Error(data?.detail||data?.error||'APPOINTMENT_UPDATE_FAILED');
-        close();toast(c.saved);setTimeout(()=>location.reload(),180);
+        close();
+        if(workspaceNow()?.business?.id!==w.business.id)return;
+        try{renderSavedAppointment(w.business.id,id,data.appointment);toast(c.saved)}
+        catch{toast(c.savedRefreshFailed)}
       }catch(error){toast(c.failed+' '+String(error?.message||''))}
       finally{busy=false;if(submit)submit.disabled=false}
     };
@@ -93,13 +109,13 @@ const script=String.raw`(()=>{
   const observer=new MutationObserver(repairButtons);observer.observe(document.body,{subtree:true,childList:true});
   window.addEventListener('focus',repairButtons,{passive:true});
   setTimeout(repairButtons,0);setTimeout(repairButtons,700);
-  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v3-market-timezone'};
+  window.__dabbirCarWashBookingEdit={repairButtons,openEditor,version:'car-wash-booking-edit-v4-in-place-save'};
 })();`;
 
 export default function handler(req,res){
   if(req.method!=='GET')return res.status(405).setHeader('allow','GET').end('Method Not Allowed');
   res.setHeader('content-type','application/javascript; charset=utf-8');
   res.setHeader('cache-control','public, max-age=300');
-  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v3-market-timezone');
+  res.setHeader('x-dabbir-car-wash-booking-edit-ui','v4-in-place-save');
   return res.status(200).send(script);
 }

--- a/test/dabbir-car-wash-historical-booking-edit.test.mjs
+++ b/test/dabbir-car-wash-historical-booking-edit.test.mjs
@@ -42,7 +42,8 @@ test('car-wash historical editor persists date and status through the canonical 
   assert.match(ui,/action:'update'/);
   assert.match(ui,/starts_at:start,status:nextStatus/);
   assert.match(ui,/data\?\.detail\|\|data\?\.error/);
-  assert.match(ui,/location\.reload\(\)/);
+  assert.doesNotMatch(ui,/location\.reload\(\)/);
+  assert.match(ui,/renderSavedAppointment\(w\.business\.id,id,data\.appointment\)/);
 });
 
 test('historical booking editor follows the selected GCC business timezone authority',()=>{

--- a/test/dabbir-car-wash-save-context.test.mjs
+++ b/test/dabbir-car-wash-save-context.test.mjs
@@ -1,0 +1,122 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import vm from 'node:vm';
+import handler from '../api/car-wash-booking-edit-ui.js';
+
+let script='';
+handler({method:'GET'},{setHeader(){return this},status(){return this},send(value){script=value;return this}});
+const ID='appointment-a',BIZ='business-a';
+const original=()=>({id:ID,customer_id:'customer-a',starts_at:'2026-09-03T10:00:00.000Z',ends_at:'2026-09-03T11:00:00.000Z',status:'confirmed',service_id:'service-a'});
+const persisted=()=>({...original(),status:'completed',starts_at:'2026-09-03T11:00:00.000Z',ends_at:'2026-09-03T12:00:00.000Z'});
+const success=(row=persisted())=>({ok:true,json:async()=>({ok:true,appointment:row})});
+
+// Minimal DOM adapter: execute the real served script and submit its real handler.
+// Layout and actual browser rendering are covered separately, not by this adapter.
+function harness({respond=async()=>success(),type='car_wash',zone='Asia/Dubai',renderThrows=false}={}){
+  const elements=new Map(),requests=[],toasts=[],timers=[];
+  const stats={renders:0,legacyRenders:0,sanitizes:0,reloads:0,runtimeLoads:0};
+  class Element{
+    constructor(){this.value='';this.disabled=false;this.dataset={};const classes=new Set();this.classList={add:x=>classes.add(x),remove:x=>classes.delete(x),contains:x=>classes.has(x)};}
+    append(el){if(el.id)elements.set('#'+el.id,el)}
+    focus(){}
+    removeAttribute(){}
+    set innerHTML(html){this.html=html;for(const match of html.matchAll(/<(?:form|input|select|button)\b([^>]*\bid="([^"]+)"[^>]*)>/g)){const el=new Element();el.id=match[2];el.value=match[1].match(/\bvalue="([^"]*)"/)?.[1]||'';elements.set('#'+el.id,el)}}
+    get innerHTML(){return this.html||''}
+  }
+  const document={documentElement:{lang:'ar',dataset:{}},body:new Element(),head:new Element(),createElement:()=>new Element(),querySelector:s=>elements.get(s)||null,querySelectorAll:()=>[],addEventListener(){}};
+  const context={document,Intl,Date,console,workspace:{business:{id:BIZ,business_type:type,timezone:zone},appointments:[original()],customers:[{id:'customer-a',display_name:'Synthetic customer'}]},current:'appointments',selectedConversationId:'conversation-a',calendarCursor:'2026-09-03',scrollY:640,addEventListener(){},MutationObserver:class{observe(){}},setTimeout:fn=>timers.push(fn),location:{reload(){stats.reloads++}},loadRuntime(){stats.runtimeLoads++},toast:msg=>toasts.push(msg),renderAppointments(){stats.legacyRenders++},__dabbirAppointmentManagement:{render(){stats.renders++;if(renderThrows)throw new Error('RENDER_FAILED')}},__dabbirCalendarLiveUi:{sanitize(){stats.sanitizes++}},fetch:async(url,options)=>{requests.push({url,options,body:JSON.parse(options.body)});return respond()}};
+  context.window=context;vm.runInNewContext(script,context);
+  context.__dabbirCarWashBookingEdit.openEditor(ID);
+  const submitter={disabled:false};
+  const submit=()=>{
+    const form=elements.get('#dabbirCarWashPastEditForm');assert.ok(form,'editor opened');
+    elements.get('#dabbirCarWashPastEditTime').value='2026-09-03T15:00';
+    elements.get('#dabbirCarWashPastEditStatus').value='completed';
+    return form.onsubmit({preventDefault(){},submitter});
+  };
+  const flushTimers=()=>{while(timers.length)timers.shift()()};
+  return {context,elements,requests,toasts,stats,submit,submitter,flushTimers};
+}
+
+test('saved historical booking updates from the server row without resetting navigation',async()=>{
+  const h=harness();await h.submit();h.flushTimers();
+  assert.equal(h.requests.length,1);assert.equal(h.requests[0].url,'/api/appointment-management');
+  assert.equal(h.requests[0].body.business_id,BIZ);assert.equal(h.requests[0].body.starts_at,'2026-09-03T11:00:00.000Z');
+  assert.deepEqual(h.context.workspace.appointments[0],persisted());
+  assert.equal(h.context.current,'appointments');assert.equal(h.context.selectedConversationId,'conversation-a');
+  assert.equal(h.context.calendarCursor,'2026-09-03');assert.equal(h.context.scrollY,640);
+  assert.equal(h.stats.renders,1);assert.equal(h.stats.legacyRenders,1);assert.equal(h.stats.sanitizes,1);
+  assert.equal(h.stats.reloads,0);assert.equal(h.stats.runtimeLoads,0);
+  assert.equal(h.elements.get('#dabbirCarWashPastEditModal').classList.contains('open'),false);
+  assert.deepEqual(h.toasts,['تم تعديل الحجز.']);assert.equal(h.submitter.disabled,false);
+});
+
+test('a rejected write preserves the old row and keeps the editor available',async()=>{
+  const h=harness({respond:async()=>({ok:false,json:async()=>({ok:false,error:'APPOINTMENT_MANAGEMENT_REQUIRED'})})});
+  await h.submit();h.flushTimers();
+  assert.deepEqual(h.context.workspace.appointments[0],original());assert.equal(h.stats.renders,0);assert.equal(h.stats.reloads,0);
+  assert.equal(h.elements.get('#dabbirCarWashPastEditModal').classList.contains('open'),true);
+  assert.match(h.toasts[0],/^تعذر تعديل الحجز/);assert.equal(h.submitter.disabled,false);
+});
+
+test('double submission sends one request and does not optimistically mutate the row',async()=>{
+  let resolve;const pending=new Promise(r=>{resolve=r});const h=harness({respond:()=>pending});
+  const first=h.submit();await h.submit();
+  assert.equal(h.requests.length,1);assert.equal(h.submitter.disabled,true);
+  assert.deepEqual(h.context.workspace.appointments[0],original());
+  resolve(success());await first;assert.equal(h.submitter.disabled,false);
+});
+
+test('switching business before submitting prevents a stale write',async()=>{
+  const h=harness();h.context.workspace={business:{id:'business-b',business_type:'car_wash'},appointments:[original()]};
+  await h.submit();assert.equal(h.requests.length,0);assert.equal(h.stats.renders,0);
+});
+
+test('late success for another business cannot change the active business or navigation',async()=>{
+  let resolve;const pending=new Promise(r=>{resolve=r});const h=harness({respond:()=>pending});
+  const save=h.submit();h.context.workspace={business:{id:'business-b',business_type:'car_wash'},appointments:[original()]};h.context.current='customers';
+  resolve(success());await save;h.flushTimers();
+  assert.deepEqual(h.context.workspace.appointments[0],original());assert.equal(h.context.current,'customers');
+  assert.equal(h.stats.renders,0);assert.equal(h.stats.reloads,0);assert.deepEqual(h.toasts,[]);
+});
+
+test('a successful response with an unrelated row is not copied into the booking',async()=>{
+  const h=harness({respond:async()=>success({...persisted(),id:'unrelated'})});await h.submit();
+  assert.deepEqual(h.context.workspace.appointments[0],original());assert.equal(h.stats.renders,0);
+  assert.match(h.toasts[0],/^تم حفظ الحجز، لكن تعذر تحديث عرضه/);
+});
+
+test('a successful response with another business id is not copied into the booking',async()=>{
+  const h=harness({respond:async()=>success({...persisted(),business_id:'business-b'})});await h.submit();
+  assert.deepEqual(h.context.workspace.appointments[0],original());assert.equal(h.stats.renders,0);
+  assert.match(h.toasts[0],/^تم حفظ الحجز، لكن تعذر تحديث عرضه/);
+});
+
+test('render failure is reported as a display problem, not a failed database write',async()=>{
+  const h=harness({renderThrows:true});await h.submit();h.flushTimers();
+  assert.deepEqual(h.context.workspace.appointments[0],persisted());assert.equal(h.stats.reloads,0);
+  assert.match(h.toasts[0],/^تم حفظ الحجز، لكن تعذر تحديث عرضه/);assert.equal(h.submitter.disabled,false);
+});
+
+test('no-change server responses keep the booking and screen intact',async()=>{
+  const h=harness({respond:async()=>({ok:true,json:async()=>({ok:true,state:'NO_CHANGE',appointment:original()})})});
+  await h.submit();h.flushTimers();assert.deepEqual(h.context.workspace.appointments[0],original());
+  assert.equal(h.context.current,'appointments');assert.equal(h.stats.reloads,0);
+});
+
+test('the in-place save retains the selected business timezone authority',async()=>{
+  const h=harness({zone:'Asia/Riyadh'});await h.submit();
+  assert.equal(h.requests[0].body.starts_at,'2026-09-03T12:00:00.000Z');
+});
+
+test('the historical editor does not open for a different business type',()=>{
+  const h=harness({type:'salon'});assert.equal(h.elements.has('#dabbirCarWashPastEditForm'),false);
+});
+
+test('mobile controls use bounded grid sizing and an isolated LTR date field',()=>{
+  assert.match(script,/grid-template-columns:minmax\(0,1fr\)/);
+  assert.match(script,/box-sizing:border-box;width:100%;max-width:100%;min-width:0/);
+  assert.match(script,/id="dabbirCarWashPastEditTime" type="datetime-local" dir="ltr"/);
+  assert.match(script,/label for="dabbirCarWashPastEditTime"/);
+  assert.doesNotMatch(script,/location\.reload\s*\(/);
+});


### PR DESCRIPTION
## السبب المثبت
تسجيل الشاشة المرفوع بتاريخ 2026-09-05 يُظهر نجاح تعديل حجز سابق، ثم تحميل التطبيق والعودة إلى «اليوم». مسار الحفظ في `api/car-wash-booking-edit-ui.js` كان ينفذ `setTimeout(()=>location.reload(),180)` بعد نجاح الطلب؛ والحالة الابتدائية للشاشة هي dashboard. كما يظهر حقل datetime-local خارج محاذاة النموذج على الهاتف.

## التغيير
- إزالة إعادة تحميل المستند وتحديث سجل الحجز داخل workspace من `data.appointment` المعاد من واجهة الحفظ الأصلية، ثم إعادة رسم الحجوزات والتقويم والتنبيهات دون تبديل الشاشة أو إعادة جلب كامل workspace.
- عدم تحديث أي سجل قبل نجاح الخادم، والتحقق من هوية الحجز والنشاط؛ تجاهل نجاح طلب قديم بعد الانتقال إلى نشاط آخر ومنع النقر المكرر أثناء الحفظ.
- تمييز نجاح حفظ البيانات مع تعذر تحديث العرض عن فشل الحفظ نفسه.
- ضبط box-sizing، وحدود العرض، وmin-width:0 داخل الشبكة؛ عزل اتجاه حقل الموعد LTR مع بقاء النموذج عربيًا وإضافة ارتباط labels.
- تحديث اختبار قديم كان يشترط وجود location.reload ليمنع رجوع هذا الخلل، وإضافة 12 اختبارًا سلوكيًا.

## التحقق المنفذ
- سلامة صياغة JavaScript: PASS.
- 12 اختبارًا جديدًا على السكربت الفعلي داخل Node VM مع DOM/API تجريبيين: PASS.
- إثبات regression: اختبار تحديث الحجز في مكانه يفشل على المصدر الأصلي وينجح على الإصلاح.
- 4 حالات متصفح Chromium معزول، عرض 320/390/430 بالعربية و390 بالإنجليزية، وworkspace/fetch وهميين: PASS؛ الحقل داخل النموذج، طلب حفظ واحد، صفر تنقل بعد الحفظ، بقاء التبويب وموضع التمرير.

## حدود الإثبات والسلامة
اختبار المتصفح ليس iPhone/Safari حقيقيًا وليس اختبار قاعدة بيانات Production. نتيجة CI والبناء الكامل تُقرأ من checks قبل أي دمج. لا تغيير على Schema أو Auth أو API الخلفية أو بيانات العملاء أو سياسات التقويم. لم يُدمج PR #498 التجريبي ضمن هذا الإصلاح؛ الفرع مبني مباشرة على main `f104317eec1645c3765b4a6ee294f078f93b5122`.