### PR TITLE
fix(whatsapp): complete Coexistence webhook sync handling

### DIFF
--- a/api/dabbir-whatsapp-webhook.js
+++ b/api/dabbir-whatsapp-webhook.js
@@ -10,6 +10,8 @@ export const config = {
   },
 };
 
+const COEXISTENCE_FIELDS = new Set(['history', 'smb_app_state_sync', 'smb_message_echoes']);
+
 function json(res, status, body, cid) {
   attachCorrelation(res, cid);
   return res.status(status).setHeader('cache-control', 'no-store').json(body);
@@ -81,41 +83,97 @@ function parseRawBody(rawBody) {
   }
 }
 
+function messageText(message = {}) {
+  return message.text?.body
+    || message.button?.text
+    || message.interactive?.button_reply?.title
+    || message.interactive?.list_reply?.title
+    || '';
+}
+
+function coexistenceMessages(value = {}) {
+  const candidates = [
+    value.messages,
+    value.message_echoes,
+    value.echoes,
+    value.history?.messages,
+    value.history,
+  ];
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) return candidate;
+  }
+  return [];
+}
+
 export function extractWhatsAppEvents(payload = {}) {
   const events = [];
   for (const entry of payload.entry || []) {
     for (const change of entry.changes || []) {
-      if (change.field !== 'messages') continue;
       const value = change.value || {};
-      const phoneNumberId = value.metadata?.phone_number_id || null;
-      const displayPhoneNumber = value.metadata?.display_phone_number || null;
-      const contactNames = new Map((Array.isArray(value.contacts) ? value.contacts : [])
-        .map(contact => [String(contact?.wa_id || ''), String(contact?.profile?.name || '').slice(0, 120)]));
-      for (const message of value.messages || []) {
-        const text = message.text?.body || message.button?.text || message.interactive?.button_reply?.title || message.interactive?.list_reply?.title || '';
-        events.push({
-          type: 'message',
-          messageId: message.id || null,
-          from: message.from || null,
-          contactName: contactNames.get(String(message.from || '')) || null,
-          timestamp: message.timestamp || null,
-          messageType: message.type || null,
-          text: String(text || '').slice(0, 4000),
-          phoneNumberId,
-          displayPhoneNumber,
-        });
+      const phoneNumberId = value.metadata?.phone_number_id || value.phone_number_id || null;
+      const displayPhoneNumber = value.metadata?.display_phone_number || value.display_phone_number || null;
+
+      if (change.field === 'messages') {
+        const contactNames = new Map((Array.isArray(value.contacts) ? value.contacts : [])
+          .map(contact => [String(contact?.wa_id || ''), String(contact?.profile?.name || '').slice(0, 120)]));
+        for (const message of value.messages || []) {
+          events.push({
+            type: 'message',
+            messageId: message.id || null,
+            from: message.from || null,
+            contactName: contactNames.get(String(message.from || '')) || null,
+            timestamp: message.timestamp || null,
+            messageType: message.type || null,
+            text: String(messageText(message) || '').slice(0, 4000),
+            phoneNumberId,
+            displayPhoneNumber,
+          });
+        }
+        for (const status of value.statuses || []) {
+          events.push({
+            type: 'status',
+            messageId: status.id || null,
+            recipientId: status.recipient_id || null,
+            status: status.status || null,
+            timestamp: status.timestamp || null,
+            phoneNumberId,
+            displayPhoneNumber,
+          });
+        }
+        continue;
       }
-      for (const status of value.statuses || []) {
-        events.push({
-          type: 'status',
-          messageId: status.id || null,
-          recipientId: status.recipient_id || null,
-          status: status.status || null,
-          timestamp: status.timestamp || null,
-          phoneNumberId,
-          displayPhoneNumber,
-        });
+
+      if (!COEXISTENCE_FIELDS.has(change.field)) continue;
+
+      if (change.field === 'smb_message_echoes' || change.field === 'history') {
+        const messages = coexistenceMessages(value);
+        if (messages.length) {
+          for (const message of messages) {
+            events.push({
+              type: change.field === 'smb_message_echoes' ? 'app_message_echo' : 'history_message',
+              sourceField: change.field,
+              messageId: message.id || null,
+              from: message.from || null,
+              to: message.to || message.recipient_id || null,
+              timestamp: message.timestamp || null,
+              messageType: message.type || null,
+              text: String(messageText(message) || '').slice(0, 4000),
+              phoneNumberId,
+              displayPhoneNumber,
+            });
+          }
+          continue;
+        }
       }
+
+      events.push({
+        type: change.field === 'smb_app_state_sync' ? 'app_state_sync' : 'coexistence_sync',
+        sourceField: change.field,
+        phoneNumberId,
+        displayPhoneNumber,
+        state: String(value.state || value.event || value.status || '').slice(0, 120) || null,
+        timestamp: value.timestamp || null,
+      });
     }
   }
   return events;
@@ -177,6 +235,7 @@ export default async function handler(req, res) {
   const routed = events.map((event) => ({ ...event, ...classifyDABBIREvent(event, project) }));
   const messageCount = routed.filter(e => e.type === 'message').length;
   const statusCount = routed.filter(e => e.type === 'status').length;
+  const coexistenceCount = routed.filter(e => ['app_message_echo', 'history_message', 'app_state_sync', 'coexistence_sync'].includes(e.type)).length;
   const classifications = [...new Set(routed.map(e => e.classification).filter(Boolean))].slice(0, 20);
   let persistedMessages = 0;
   let duplicateMessages = 0;
@@ -216,6 +275,7 @@ export default async function handler(req, res) {
       event_count: routed.length,
       message_count: messageCount,
       status_count: statusCount,
+      coexistence_event_count: coexistenceCount,
     });
     return json(res, status, {
       ok: false,
@@ -232,7 +292,7 @@ export default async function handler(req, res) {
   const persistenceVerified = messageCount === 0 || persistedMessages === messageCount - unlinkedMessages;
   const state = unlinkedMessages > 0 && persistedMessages === 0
     ? 'TENANT_NOT_LINKED'
-    : (persistedMessages > 0 || matchedStatuses > 0 ? 'LIVE_EVENT_PERSISTED' : 'SIGNED_EVENT_NO_ACTION');
+    : (persistedMessages > 0 || matchedStatuses > 0 ? 'LIVE_EVENT_PERSISTED' : (coexistenceCount > 0 ? 'COEXISTENCE_EVENT_ACCEPTED' : 'SIGNED_EVENT_NO_ACTION'));
 
   logEvent('info', {
     correlation_id: cid,
@@ -243,6 +303,8 @@ export default async function handler(req, res) {
     event_count: routed.length,
     message_count: messageCount,
     status_count: statusCount,
+    coexistence_event_count: coexistenceCount,
+    coexistence_fields: [...new Set(routed.map(e => e.sourceField).filter(Boolean))].slice(0, 10),
     classifications,
     persisted_messages: persistedMessages,
     duplicate_messages: duplicateMessages,
@@ -261,6 +323,8 @@ export default async function handler(req, res) {
     event_count: routed.length,
     message_count: messageCount,
     status_count: statusCount,
+    coexistence_event_count: coexistenceCount,
+    coexistence_fields: [...new Set(routed.map(e => e.sourceField).filter(Boolean))].slice(0, 10),
     classifications,
     persisted: persistedMessages > 0,
     persistence_verified: persistenceVerified,

--- a/test/dabbir-whatsapp-webhook.test.mjs
+++ b/test/dabbir-whatsapp-webhook.test.mjs
@@ -48,3 +48,47 @@ test('extracts inbound text message', () => {
   assert.equal(routed.classification, 'APPOINTMENT_REQUEST');
   assert.ok(routed.workflow.includes('BOOKING'));
 });
+
+test('extracts WhatsApp Business App message echoes for coexistence', () => {
+  const payload = {
+    entry: [{ changes: [{ field: 'smb_message_echoes', value: {
+      metadata: { phone_number_id: '123', display_phone_number: '+971500000000' },
+      messages: [{ id: 'wamid.echo.1', from: '971500000000', to: '971501234567', timestamp: '2', type: 'text', text: { body: 'تم استلام طلبك' } }]
+    } }] }]
+  };
+  const events = extractWhatsAppEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'app_message_echo');
+  assert.equal(events[0].sourceField, 'smb_message_echoes');
+  assert.equal(events[0].text, 'تم استلام طلبك');
+  assert.equal(events[0].to, '971501234567');
+});
+
+test('extracts coexistence history messages', () => {
+  const payload = {
+    entry: [{ changes: [{ field: 'history', value: {
+      phone_number_id: '123',
+      history: { messages: [{ id: 'wamid.history.1', from: '971501234567', timestamp: '3', type: 'text', text: { body: 'رسالة سابقة' } }] }
+    } }] }]
+  };
+  const events = extractWhatsAppEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'history_message');
+  assert.equal(events[0].sourceField, 'history');
+  assert.equal(events[0].text, 'رسالة سابقة');
+});
+
+test('extracts WhatsApp Business App state sync events', () => {
+  const payload = {
+    entry: [{ changes: [{ field: 'smb_app_state_sync', value: {
+      phone_number_id: '123',
+      state: 'SYNCED',
+      timestamp: '4'
+    } }] }]
+  };
+  const events = extractWhatsAppEvents(payload);
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, 'app_state_sync');
+  assert.equal(events[0].sourceField, 'smb_app_state_sync');
+  assert.equal(events[0].state, 'SYNCED');
+});


### PR DESCRIPTION
يكمل دعم WhatsApp Coexistence على مسار الـWebhook الحالي بدون تغيير منطق الرسائل الواردة الأساسي.

التغييرات:
- معالجة حقول `smb_message_echoes` و`history` و`smb_app_state_sync` بدل تجاهلها.
- استخراج رسائل echo/history بأحداث مستقلة وآمنة حتى لا تُعامل كرسائل عميل واردة بالخطأ.
- إضافة قياسات `coexistence_event_count` و`coexistence_fields` للحالة والسجلات.
- إبقاء persistence الحالي للرسائل الواردة وstatuses كما هو.
- إضافة اختبارات لوضع Coexistence.

المتبقي خارج الكود: تفعيل/التحقق من اشتراك حقول Meta على التطبيق/WABA ثم اختبار حي برقم WhatsApp Business Coexistence.