### PR TITLE
fix(auth): sync owner OTP production mailer contract

### DIFF
--- a/api/_owner-mailer-auth.js
+++ b/api/_owner-mailer-auth.js
@@ -1,9 +1,7 @@
 import { createHash } from 'node:crypto';
 
-const clean=value=>String(value||'').trim();
-
-export function ownerMailerAuth(env=process.env){
-  const serviceRole=clean(env.SUPABASE_SERVICE_ROLE_KEY);
-  if(!serviceRole||serviceRole.startsWith('sb_publishable_'))return '';
-  return createHash('sha256').update(`${serviceRole}:dabbir-owner-otp-mailer-v1`).digest('hex');
+export function ownerMailerAuth(resendKey){
+  const key=String(resendKey||'').trim();
+  if(key.length<24)return '';
+  return createHash('sha256').update(`${key}:dabbir-owner-otp-mailer-v2`).digest('hex');
 }

--- a/api/auth/owner-otp.js
+++ b/api/auth/owner-otp.js
@@ -26,7 +26,7 @@ async function broker(url,body,headers={}){
 export default async function handler(req,res){
   res.setHeader('cache-control','no-store, max-age=0');
   res.setHeader('pragma','no-cache');
-  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v9');
+  res.setHeader('x-dabbir-owner-auth','actor-bound-otp-v10');
   if(req.method!=='POST')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'POST'});
   if(!requireSameOrigin(req))return json(res,403,{ok:false,error:'ORIGIN_REQUIRED'});
   try{
@@ -37,7 +37,7 @@ export default async function handler(req,res){
       // Do not reveal whether an employee email exists.
       if(!validLogin(login))return json(res,200,{ok:true,otp_required:true});
       const resendKey=String(process.env.RESEND_API_KEY||'').trim();
-      const mailerAuth=ownerMailerAuth();
+      const mailerAuth=ownerMailerAuth(resendKey);
       if(!resendKey||!mailerAuth)return json(res,503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
       const {response,payload}=await broker(OTP_MAILER_URL,{action:'owner_otp_request',login,resend_key:resendKey},{'x-dabbir-owner-mailer-auth':mailerAuth});
       if(response.status===404)return json(res,200,{ok:true,otp_required:true});

--- a/supabase/functions/dabbir-owner-otp-mailer/index.ts
+++ b/supabase/functions/dabbir-owner-otp-mailer/index.ts
@@ -15,17 +15,18 @@ function safeEqual(a:string,b:string){if(a.length!==b.length)return false;let o=
 async function sb(path:string,init:RequestInit={}){return fetch(`${SUPABASE_URL}${path}`,{...init,headers:{...sbHeaders(),...(init.headers||{})}})}
 async function rpc(name:string,params:Record<string,unknown>={}){const r=await sb(`/rest/v1/rpc/${encodeURIComponent(name)}`,{method:'POST',body:JSON.stringify(params)});const p=await r.json().catch(()=>null);return{ok:r.ok,status:r.status,payload:p}}
 
-async function expectedAuth(){return sha(`${SERVICE_KEY}:dabbir-owner-otp-mailer-v1`)}
-async function authorized(req:Request){const provided=clean(req.headers.get('x-dabbir-owner-mailer-auth'),128);if(!provided)return false;return safeEqual(provided,await expectedAuth())}
+async function validMailerSignature(req:Request,resendKey:string){
+ const provided=clean(req.headers.get('x-dabbir-owner-mailer-auth'),128);if(!provided||!resendKey)return false;
+ return safeEqual(provided,await sha(`${resendKey}:dabbir-owner-otp-mailer-v2`));
+}
 function resendFrom(){const configured=clean(Deno.env.get('DABBIR_RESEND_FROM'),320);return configured&&!configured.toLowerCase().includes('@resend.dev')?configured:'DABBIR <no-reply@auth.bmalman.com>'}
 async function sendEmail(key:string,to:string,otp:string){
- const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/1'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
+ const r=await fetch('https://api.resend.com/emails',{method:'POST',headers:{authorization:`Bearer ${key}`,'content-type':'application/json','user-agent':'DABBIR-owner-otp-mailer/3'},body:JSON.stringify({from:resendFrom(),to:[to],subject:'DABBIR verification code',text:`رمز دخول دبّر: ${otp}\n\nينتهي الرمز خلال 10 دقائق.\nDABBIR verification code: ${otp}\nExpires in 10 minutes.`})});
  if(!r.ok){const p:any=await r.json().catch(()=>null);console.error('DABBIR_OWNER_EMAIL_DELIVERY_FAILED',JSON.stringify({status:r.status,code:clean(p?.name||p?.code||p?.type,80)||'UNKNOWN',sender_mode:'verified_auth_domain'}))}
  return r.ok;
 }
 
-async function requestOtp(body:any){
- const resendKey=clean(body?.resend_key,500);if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+async function requestOtp(body:any,resendKey:string){
  const login=clean(body?.login||body?.identifier||body?.username||'__root__',254).toLowerCase();
  const identity=await rpc('dabbir_platform_login_identity_v1',{p_login:login});
  if(!identity.ok||!identity.payload?.user_id||!identity.payload?.email)return reply(404,{ok:false,error:'PLATFORM_IDENTITY_NOT_FOUND'});
@@ -44,8 +45,9 @@ async function requestOtp(body:any){
 Deno.serve(async(req:Request)=>{
  if(req.method!=='POST')return reply(405,{ok:false,error:'METHOD_NOT_ALLOWED'});
  if(!SUPABASE_URL||!SERVICE_KEY)return reply(503,{ok:false,error:'OWNER_MAILER_NOT_CONFIGURED'});
- if(!await authorized(req))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
  let body:any;try{body=await req.json()}catch{return reply(400,{ok:false,error:'INVALID_JSON'})}
+ const resendKey=clean(body?.resend_key,500);if(!resendKey)return reply(503,{ok:false,error:'OWNER_OTP_NOT_CONFIGURED'});
+ if(!await validMailerSignature(req,resendKey))return reply(401,{ok:false,error:'OWNER_MAILER_UNAUTHORIZED'});
  if(clean(body?.action,60).toLowerCase()!=='owner_otp_request')return reply(400,{ok:false,error:'UNKNOWN_ACTION'});
- try{return await requestOtp(body)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}
+ try{return await requestOtp(body,resendKey)}catch(error){console.error('DABBIR_OWNER_MAILER_UNAVAILABLE',error instanceof Error?error.message:'unknown');return reply(503,{ok:false,error:'OWNER_MAILER_UNAVAILABLE'})}
 });

--- a/test/dabbir-owner-username-otp.test.mjs
+++ b/test/dabbir-owner-username-otp.test.mjs
@@ -13,28 +13,32 @@ test('platform authentication is actor-bound brokered Resend OTP with isolated s
   assert.match(source, /dabbir-owner-broker/);
   assert.match(source, /dabbir-owner-otp-mailer/);
   assert.match(source, /ownerMailerAuth/);
+  assert.match(source, /x-dabbir-owner-mailer-auth/);
   assert.match(source, /owner_otp_request/);
   assert.match(source, /owner_otp_verify/);
   assert.match(source, /challenge_id/);
   assert.match(source, /session_token/);
   assert.match(source, /__Host-dabbir_owner_session/);
   assert.doesNotMatch(source, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.doesNotMatch(source, /x-dabbir-supabase-service-key/);
   assert.doesNotMatch(source, /grant_type=password/);
   assert.doesNotMatch(source, /barman2013@icloud\.com/);
 });
 
-test('owner OTP mailer uses the verified auth domain and rejects unauthenticated direct calls', async () => {
+test('owner OTP mailer uses verified auth domain and Resend-derived server-only authentication', async () => {
   const mailer = await read('supabase/functions/dabbir-owner-otp-mailer/index.ts');
   const auth = await read('api/_owner-mailer-auth.js');
   assert.match(mailer, /no-reply@auth\.bmalman\.com/);
   assert.match(mailer, /x-dabbir-owner-mailer-auth/);
+  assert.match(mailer, /dabbir-owner-otp-mailer-v2/);
+  assert.match(mailer, /DABBIR-owner-otp-mailer\/3/);
   assert.match(mailer, /OWNER_MAILER_UNAUTHORIZED/);
-  assert.match(mailer, /dabbir-owner-otp-mailer-v1/);
   assert.doesNotMatch(mailer, /onboarding@resend\.dev/);
   assert.doesNotMatch(mailer, /\/domains/);
-  assert.match(auth, /SUPABASE_SERVICE_ROLE_KEY/);
+  assert.doesNotMatch(mailer, /x-dabbir-supabase-service-key/);
   assert.match(auth, /createHash\('sha256'\)/);
-  assert.match(auth, /dabbir-owner-otp-mailer-v1/);
+  assert.match(auth, /dabbir-owner-otp-mailer-v2/);
+  assert.doesNotMatch(auth, /SUPABASE_SERVICE_ROLE_KEY/);
 });
 
 test('owner broker supports modern Supabase secret keys and actor-aware incidents', async () => {


### PR DESCRIPTION
Production `/api/auth/owner-otp` returned 503 while the active Supabase mailer used the newer Resend-derived signature contract. This PR reapplies the already-reviewed #462 fix on current main so Vercel and Supabase use the same server-only signature again.

ACTION → ARTIFACT → TEST → EVIDENCE
- root owner identity remains database-owned;
- Vercel signs mailer requests from the existing server-only Resend key;
- Supabase mailer verifies the matching v2 signature;
- verified sender remains `no-reply@auth.bmalman.com`;
- owner broker still performs OTP verification/session issuance;
- no service-role key enters the browser-facing owner OTP route;
- regression test locks the production contract.

Do not merge unless required DABBIR CI/Auth checks pass.