### PR TITLE
fix(owner): repair customer search and iPhone customer/support UI

### DIFF
--- a/api/_owner-command-center-design-system.js
+++ b/api/_owner-command-center-design-system.js
@@ -1,6 +1,25 @@
 export const OWNER_COMMAND_CENTER_DESIGN_SYSTEM=String.raw`<style id="ownerCommandCenterDesignSystem">
-:root{--owner-font-xs:12px;--owner-font-sm:13px;--owner-font-md:14px;--owner-font-lg:16px;--owner-touch:46px}
-/* Final owner typography authority. Legacy feature layers may define layout, but not unreadable type. */
+:root{--owner-font-xs:12px;--owner-font-sm:13px;--owner-font-md:14px;--owner-font-lg:16px;--owner-touch:46px;--owner-accent:#5b6ff5;--owner-accent-strong:#6d7cff;--owner-line:#30404c;--owner-panel:#10171c}
+/* Final owner typography authority. Legacy feature layers may define layout, but not unreadable type or legacy neon action emphasis. */
+body .panel{border-color:var(--owner-line)!important;background:linear-gradient(180deg,#12191f,#0e1419)!important}
+body .panel h2{font-size:17px!important;line-height:1.4!important}
+body .panel h3{font-size:15px!important;line-height:1.45!important}
+body .muted,body .state{font-size:13px!important;line-height:1.65!important}
+body .note,body .dangerBox{font-size:13px!important;line-height:1.65!important}
+body .item{padding:12px!important;border-color:#2d3c47!important}
+body .item b{font-size:14px!important;line-height:1.5!important}
+body .item small{font-size:12px!important;line-height:1.6!important}
+body .chip{font-size:12px!important;line-height:1.35!important;padding:5px 8px!important}
+body .btn{font-size:14px!important;min-height:var(--owner-touch)!important}
+body .field,body #customers input,body #customers textarea,body #customers select,body #governance input,body #governance textarea,body #governance select{font-size:16px!important;line-height:1.45!important}
+body .btn.primary,body .ownerLeadTab29[aria-selected="true"],body #nav [data-owner-active="true"],body .ownerSupportCta,body .ownerMissionBtn.primary{background:var(--owner-accent)!important;border-color:var(--owner-accent)!important;color:#fff!important}
+body .btn.primary:focus-visible,body .ownerLeadTab29:focus-visible,body .ownerMainTab29:focus-visible,body .ownerSupportCta:focus-visible{outline:3px solid #91a0ff!important;outline-offset:3px!important}
+#customers .panel{padding:14px!important;margin-bottom:12px!important}
+#customers .row.mobileStack{gap:9px!important}
+#customerStatus,#customerState,#supportState,#oc20State{min-height:22px!important;font-size:13px!important;line-height:1.65!important}
+#customerResults{gap:9px!important}
+.oc10state,.pcRecoveryResult,.pcAccount small,.pcMetric span,.pcCount span{font-size:12px!important;line-height:1.55!important}
+.pcAccount b,.pcCount b{font-size:14px!important}.pcMetric strong{font-size:22px!important}
 #ownerExecutiveV23 .oc23head h2{font-size:20px!important;line-height:1.35!important}
 #ownerExecutiveV23 .oc23head p{font-size:14px!important;line-height:1.7!important}
 #ownerExecutiveV23 .oc23stamp{font-size:12px!important;line-height:1.5!important}
@@ -25,12 +44,27 @@ export const OWNER_COMMAND_CENTER_DESIGN_SYSTEM=String.raw`<style id="ownerComma
 .ownerMissionFieldLabel,.ownerMissionCounter,.ownerMissionDueHint{font-size:13px!important;line-height:1.55!important}
 #ownerCeoMissionControl input,#ownerCeoMissionControl textarea,#ownerCeoMissionControl select,#ownerCeoMissionControl button{font-size:14px!important}
 @media(max-width:760px){
+ body .shell{padding-inline:max(12px,env(safe-area-inset-left)) max(12px,env(safe-area-inset-right))!important}
+ body .panel{border-radius:14px!important;padding:12px!important}
+ body .panel h2{font-size:16px!important}
+ body .panel h3{font-size:14px!important}
+ body .muted,body .state,body .note,body .dangerBox{font-size:13px!important}
+ body .item b{font-size:14px!important}body .item small{font-size:12.5px!important}
+ body .btn{width:100%;min-height:48px!important;font-size:14px!important}
+ body .row:not(.itemActions):not(.ownerDecisionActions){gap:8px!important}
+ #customers .hero p{display:block!important;-webkit-line-clamp:unset!important;overflow:visible!important;font-size:13px!important}
+ #customers .panel{padding:12px!important}
+ #customers .row.mobileStack{display:grid!important;grid-template-columns:1fr!important;align-items:stretch!important}
+ #customerQuery,#homeSearch{width:100%!important;min-width:0!important}
+ #customerSearch,#homeSearchBtn{width:100%!important}
  #ownerExecutiveV23 .oc23{padding:12px!important}
  #ownerExecutiveV23 .oc23metrics{gap:7px!important}
  body #nav a,body #nav .ownerMainTab29{font-size:13.5px!important;min-height:48px!important}
  .ownerLeadTab29{font-size:13.5px!important;min-height:48px!important}
 }
 @media(max-width:390px){
+ body .shell{padding-inline:10px!important}
+ body .panel{padding:11px!important}
  #ownerExecutiveV23 .oc23head h2{font-size:18px!important}
  #ownerExecutiveV23 .oc23big{font-size:22px!important}
  #ownerExecutiveV23 .oc23metric span{font-size:12px!important}

--- a/supabase/migrations/20260905203000_dabbir_platform_customer_search_v2_escape_repair.sql
+++ b/supabase/migrations/20260905203000_dabbir_platform_customer_search_v2_escape_repair.sql
@@ -1,0 +1,78 @@
+-- Repair owner customer search so literal DAB/email/phone/business queries cannot fail on an invalid LIKE ESCAPE sequence.
+-- Keep the existing permission/scope boundary and service_role-only execution contract.
+
+create or replace function public.dabbir_platform_customer_search_v2(
+  p_actor uuid,
+  p_query text default null::text,
+  p_limit integer default 50
+)
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','auth','dabbir_private'
+as $function$
+declare
+  v_q text:=nullif(trim(p_query),'');
+  v_limit int:=least(greatest(coalesce(p_limit,50),1),100);
+  v_result jsonb;
+  v_global boolean;
+  v_phone_q text;
+begin
+  perform dabbir_private.platform_assert_permission(p_actor,'manage_customers');
+  v_global:=dabbir_private.platform_scope_is_global(p_actor);
+  v_phone_q:=regexp_replace(coalesce(v_q,''),'[^0-9+]','','g');
+
+  select coalesce(jsonb_agg(to_jsonb(x)),'[]'::jsonb) into v_result
+  from (
+    select a.user_id,a.customer_no,u.email,u.phone,u.created_at,u.last_sign_in_at,
+      count(distinct m.business_id)::int as business_count,
+      coalesce(jsonb_agg(distinct jsonb_build_object(
+        'id',b.id,'name',b.name,'type',b.business_type,'country',b.country_code
+      )) filter(where b.id is not null),'[]'::jsonb) as businesses
+    from public.dabbir_user_accounts a
+    join auth.users u on u.id=a.user_id
+    left join public.dabbir_memberships m
+      on m.user_id=a.user_id
+     and m.status='active'
+     and dabbir_private.platform_scope_allows_business(p_actor,m.business_id)
+    left join public.dabbir_businesses b on b.id=m.business_id
+    where (
+      v_global
+      or exists(
+        select 1
+        from public.dabbir_memberships mx
+        where mx.user_id=a.user_id
+          and mx.status='active'
+          and dabbir_private.platform_scope_allows_business(p_actor,mx.business_id)
+      )
+    )
+      and (
+        v_q is null
+        or a.customer_no=upper(v_q)
+        or position(lower(v_q) in lower(coalesce(u.email,'')))>0
+        or (v_phone_q<>'' and position(v_phone_q in regexp_replace(coalesce(u.phone,''),'[^0-9+]','','g'))>0)
+        or position(lower(v_q) in lower(coalesce(b.name,'')))>0
+      )
+    group by a.user_id,a.customer_no,u.email,u.phone,u.created_at,u.last_sign_in_at
+    order by u.last_sign_in_at desc nulls last,u.created_at desc
+    limit v_limit
+  ) x;
+
+  insert into dabbir_private.platform_customer_admin_audit(actor_user_id,action,details)
+  values(
+    p_actor,
+    'customer_search_v2',
+    jsonb_build_object(
+      'has_query',v_q is not null,
+      'limit',v_limit,
+      'scope_enforced',true,
+      'match_mode','literal_substring_v2'
+    )
+  );
+
+  return v_result;
+end;
+$function$;
+
+revoke all on function public.dabbir_platform_customer_search_v2(uuid,text,integer) from public,anon,authenticated;
+grant execute on function public.dabbir_platform_customer_search_v2(uuid,text,integer) to service_role;

--- a/test/dabbir-owner-customer-search-mobile-repair.test.mjs
+++ b/test/dabbir-owner-customer-search-mobile-repair.test.mjs
@@ -6,11 +6,12 @@ const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
 
 test('owner customer search uses literal substring matching without fragile LIKE ESCAPE clauses', async () => {
   const sql = await read('supabase/migrations/20260905203000_dabbir_platform_customer_search_v2_escape_repair.sql');
+  const executable = sql.replace(/^\s*--.*$/gm, '');
   assert.match(sql, /dabbir_platform_customer_search_v2/);
   assert.match(sql, /platform_assert_permission\(p_actor,'manage_customers'\)/);
   assert.match(sql, /position\(lower\(v_q\) in lower\(coalesce\(u\.email,''\)\)\)>0/);
   assert.match(sql, /position\(lower\(v_q\) in lower\(coalesce\(b\.name,''\)\)\)>0/);
-  assert.doesNotMatch(sql, /\blike\b[\s\S]*\bescape\b/i);
+  assert.doesNotMatch(executable, /\blike\b[\s\S]*\bescape\b/i);
   assert.match(sql, /grant execute[\s\S]*service_role/i);
 });
 

--- a/test/dabbir-owner-customer-search-mobile-repair.test.mjs
+++ b/test/dabbir-owner-customer-search-mobile-repair.test.mjs
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+const read = path => readFile(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('owner customer search uses literal substring matching without fragile LIKE ESCAPE clauses', async () => {
+  const sql = await read('supabase/migrations/20260905203000_dabbir_platform_customer_search_v2_escape_repair.sql');
+  assert.match(sql, /dabbir_platform_customer_search_v2/);
+  assert.match(sql, /platform_assert_permission\(p_actor,'manage_customers'\)/);
+  assert.match(sql, /position\(lower\(v_q\) in lower\(coalesce\(u\.email,''\)\)\)>0/);
+  assert.match(sql, /position\(lower\(v_q\) in lower\(coalesce\(b\.name,''\)\)\)>0/);
+  assert.doesNotMatch(sql, /\blike\b[\s\S]*\bescape\b/i);
+  assert.match(sql, /grant execute[\s\S]*service_role/i);
+});
+
+test('owner design system makes legacy customer and support surfaces readable on iPhone', async () => {
+  const ui = await read('api/_owner-command-center-design-system.js');
+  assert.match(ui, /body \.muted,body \.state\{font-size:13px!important/);
+  assert.match(ui, /body \.item small\{font-size:12px!important/);
+  assert.match(ui, /body \.field,body #customers input/);
+  assert.match(ui, /#customers \.row\.mobileStack\{display:grid!important;grid-template-columns:1fr!important/);
+  assert.match(ui, /--owner-accent:#5b6ff5/);
+  assert.match(ui, /body \.btn\.primary[\s\S]*background:var\(--owner-accent\)!important/);
+});


### PR DESCRIPTION
Screenshot-backed repair for the owner customer/support workspace.

Root causes:
- `dabbir_platform_customer_search_v2` used a fragile LIKE ESCAPE expression that could throw and surface as `تعذر البحث الآن` / 503 even for a valid DAB number.
- the stable owner design authority did not cover several legacy customer/support selectors, leaving 8–10px text, cramped cards, and the old neon-green action emphasis on iPhone.

Changes:
- replaces wildcard LIKE matching with literal substring matching while preserving `manage_customers`, platform scope enforcement, audit logging, and service-role-only execution;
- raises legacy customer/support status, item, note, chip, button, and form typography to readable mobile sizes;
- stacks the customer search flow cleanly on iPhone and keeps 48px mobile controls;
- moves primary customer/support emphasis to DABBIR indigo instead of legacy neon lime;
- adds regression coverage for both the SQL search contract and the mobile design authority.

Production DB repair was applied first and verified with `DAB-100001` returning one match. Merge only after required CI and Vercel Preview pass.