### PR TITLE
fix(owner): show real production counts on owner overview

### DIFF
--- a/api/owner-dashboard-data.js
+++ b/api/owner-dashboard-data.js
@@ -11,6 +11,38 @@ async function broker(body){
   return {r,p};
 }
 
+function count(value){
+  const n=Number(value);
+  return Number.isFinite(n)&&n>=0?n:0;
+}
+
+export function normalizeOverviewForUi(payload){
+  const source=payload&&typeof payload==='object'&&!Array.isArray(payload)?payload:{};
+  const customers=count(source.customers?.accounts);
+  const businesses=count(source.customers?.live_businesses);
+  const needsReview=[
+    source.support?.open,
+    source.incidents?.open,
+    source.ceo?.blocked,
+    source.ceo?.decisions_waiting,
+    source.whatsapp?.error,
+    source.calendar?.error,
+    source.payments?.failed
+  ].reduce((sum,value)=>sum+count(value),0);
+
+  // Compatibility summary for the current owner shell. Keep the structured broker
+  // payload intact so newer executive panels continue to use their native sections.
+  return {
+    ...source,
+    total_customers:customers,
+    customer_count:customers,
+    total_businesses:businesses,
+    business_count:businesses,
+    needs_review:needsReview,
+    review_count:needsReview
+  };
+}
+
 export default async function handler(req,res){
   res.setHeader('cache-control','no-store, max-age=0');
   if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
@@ -28,7 +60,7 @@ export default async function handler(req,res){
     if(!r.ok||!p?.ok){
       return json(res,r.status===401?401:r.status>=500?503:r.status,{ok:false,error:p?.error||'OWNER_DATA_FAILED'});
     }
-    if(action==='overview')return json(res,200,{ok:true,overview:p.payload});
+    if(action==='overview')return json(res,200,{ok:true,overview:normalizeOverviewForUi(p.payload)});
     if(action==='executive')return json(res,200,{ok:true,executive:p.payload});
     return json(res,200,{ok:true,...(p.payload||{})});
   }catch{

--- a/test/dabbir-owner-overview-live-metrics.test.mjs
+++ b/test/dabbir-owner-overview-live-metrics.test.mjs
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { normalizeOverviewForUi } from '../api/owner-dashboard-data.js';
+
+test('owner overview exposes real nested broker counts to the legacy metric cards',()=>{
+  const overview=normalizeOverviewForUi({
+    customers:{accounts:4,live_businesses:8},
+    support:{open:0},
+    incidents:{open:0},
+    ceo:{blocked:4,decisions_waiting:0},
+    whatsapp:{error:0},
+    calendar:{error:0},
+    payments:{failed:0}
+  });
+  assert.equal(overview.total_customers,4);
+  assert.equal(overview.total_businesses,8);
+  assert.equal(overview.needs_review,4);
+  assert.notEqual(String(overview.total_customers),'NaN');
+});
+
+test('owner overview never renders NaN when optional permission sections are absent',()=>{
+  const overview=normalizeOverviewForUi({customers:{state:'NO_PERMISSION'}});
+  assert.equal(overview.total_customers,0);
+  assert.equal(overview.total_businesses,0);
+  assert.equal(overview.needs_review,0);
+  assert.ok(Number.isFinite(overview.total_customers));
+  assert.ok(Number.isFinite(overview.total_businesses));
+  assert.ok(Number.isFinite(overview.needs_review));
+});


### PR DESCRIPTION
Fix the owner home metric cards that were rendering `NaN` / zero despite real production data.

Root cause:
- the broker now returns a structured overview (`customers.accounts`, `customers.live_businesses`, etc.);
- the legacy home metric renderer still expects numeric compatibility fields such as `total_customers`, `total_businesses`, and `needs_review`;
- converting the structured `customers` object with `Number(...)` produced `NaN`.

Repair:
- normalize the broker overview at the server API boundary while preserving the full structured payload;
- expose numeric compatibility summary fields for the existing owner shell;
- calculate `needs_review` from real actionable queues: support, incidents, blocked CEO commands, owner decisions, integration errors, and failed payments;
- guarantee finite zero values when a permission-scoped section is absent;
- add regression tests using the current production shape (4 customers, 8 live businesses, 4 blocked CEO items).

Production database remains the source of truth; no fake/demo counts are introduced.