### PR TITLE
BARMAN: CEO automation planner + read-only execution

### DIFF
--- a/api/_barman-executive-automation.js
+++ b/api/_barman-executive-automation.js
@@ -1,0 +1,161 @@
+import { getVercelOidcToken } from '@vercel/oidc';
+
+const GATEWAY_ENDPOINT='https://ai-gateway.vercel.sh/v1/chat/completions';
+const DEFAULT_MODEL='minimax/minimax-m3-free';
+const clean=(value,max=4000)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
+const ALLOWED_KINDS=new Set(['REPO_CHANGE','DATA_QUERY','EXTERNAL_ACTION','REVIEW_REQUIRED']);
+const ALLOWED_RISKS=new Set(['LOW','MEDIUM','HIGH','CRITICAL']);
+
+function ownerGate(text){
+  return /(?:otp|one[- ]time password|kyc|اعرف عميلك|رمز تحقق|رمز التحقق|توقيع قانوني|legal signature|دفع مالي|تحويل مالي|بيانات بطاقة|card details)/i.test(String(text||''));
+}
+
+export function classifyAutomationTask(text){
+  const value=clean(text,1600);
+  if(ownerGate(value))return {kind:'OWNER_GATE',risk_level:'CRITICAL'};
+  const repo=/(?:أصلح|اصلح|إصلاح|اصلاح|طوّر|طور|تطوير|عدّل|عدل|تعديل|غيّر|غير|تغيير|أضف|اضف|إضافة|اضافة|احذف|حذف|برمج|نفذ.*(?:كود|واجهة|لوحة)|fix|develop|implement|refactor|update[ ]+(?:code|ui|dashboard)|change[ ]+(?:code|ui|dashboard))/i.test(value);
+  const data=/(?:^| )(?:كم|ما عدد|عدد|احصاء|إحصاء|إحصائية|احصائية|statistics?|count|how many|نشاط|activity|تقرير|report)(?: |$)/i.test(value);
+  const external=/(?:أرسل|ارسل|تواصل|اتصل|راسل|انشر في|send|contact|publish to)/i.test(value);
+  if(repo)return {kind:'REPO_CHANGE',risk_level:'MEDIUM'};
+  if(data)return {kind:'DATA_QUERY',risk_level:'LOW'};
+  if(external)return {kind:'EXTERNAL_ACTION',risk_level:'HIGH'};
+  return {kind:'REVIEW_REQUIRED',risk_level:'MEDIUM'};
+}
+
+function taskFromText(text,index){
+  const commandText=clean(String(text||'').replace(/^\s*(?:\d+[.)]|[-•])\s*/,'').trim(),1600);
+  if(commandText.length<4)throw new Error('PLAN_TASK_TEXT_INVALID');
+  const classified=classifyAutomationTask(commandText);
+  if(classified.kind==='OWNER_GATE')throw new Error('PLAN_OWNER_GATE_REQUIRED');
+  return {
+    title:clean(commandText,180),
+    command_text:commandText,
+    kind:classified.kind,
+    risk_level:classified.risk_level,
+    sequence:index+1,
+  };
+}
+
+export function deterministicPlan(command){
+  const normalized=String(command||'').replace(/\\n/g,'\n');
+  const lines=normalized.split(/\r?\n/).map(x=>x.trim()).filter(Boolean);
+  const marked=lines.filter(x=>/^(?:\d+[.)]|[-•])\s+/.test(x));
+  if(marked.length<2)return null;
+  const tasks=marked.slice(0,12).map((line,index)=>taskFromText(line,index));
+  return {source:'DETERMINISTIC_LIST',tasks};
+}
+
+async function gatewayCredential(env=process.env){
+  if(env.AI_GATEWAY_API_KEY)return String(env.AI_GATEWAY_API_KEY);
+  if(env.VERCEL_OIDC_TOKEN)return String(env.VERCEL_OIDC_TOKEN);
+  try{return String(await getVercelOidcToken()||'')}catch{return ''}
+}
+
+function parseJson(payload){
+  let value=String(payload?.choices?.[0]?.message?.content||'').trim();
+  value=value.replace(/^```(?:json)?\s*/i,'').replace(/\s*```$/,'');
+  try{return JSON.parse(value)}catch{return null}
+}
+
+function validatedTasks(raw){
+  if(!Array.isArray(raw)||raw.length<2||raw.length>12)throw new Error('PLAN_TASKS_INVALID');
+  return raw.map((item,index)=>{
+    const commandText=clean(item?.command_text,1600);
+    if(commandText.length<4)throw new Error('PLAN_TASK_TEXT_INVALID');
+    if(ownerGate(commandText)||String(item?.kind||'').toUpperCase()==='OWNER_GATE')throw new Error('PLAN_OWNER_GATE_REQUIRED');
+    const inferred=classifyAutomationTask(commandText);
+    const requestedKind=String(item?.kind||'').toUpperCase();
+    const kind=ALLOWED_KINDS.has(requestedKind)?requestedKind:inferred.kind;
+    const requestedRisk=String(item?.risk_level||'').toUpperCase();
+    const riskLevel=ALLOWED_RISKS.has(requestedRisk)?requestedRisk:inferred.risk_level;
+    return {
+      title:clean(item?.title||commandText,180),
+      command_text:commandText,
+      kind,
+      risk_level:riskLevel,
+      sequence:index+1,
+    };
+  });
+}
+
+export async function planExecutiveCommand(command,env=process.env){
+  if(ownerGate(command))throw new Error('PLAN_OWNER_GATE_REQUIRED');
+  const deterministic=deterministicPlan(command);
+  if(deterministic)return deterministic;
+  const credential=await gatewayCredential(env);
+  if(!credential)throw new Error('PLANNER_GATEWAY_CREDENTIAL_MISSING');
+  const model=clean(env.BARMAN_AI_GATEWAY_MODEL||env.DABBIR_AI_GATEWAY_MODEL||DEFAULT_MODEL,120);
+  const schema={
+    type:'object',
+    properties:{
+      tasks:{type:'array',minItems:2,maxItems:8,items:{type:'object',properties:{title:{type:'string'},command_text:{type:'string'},kind:{type:'string',enum:['REPO_CHANGE','DATA_QUERY','EXTERNAL_ACTION','REVIEW_REQUIRED']},risk_level:{type:'string',enum:['LOW','MEDIUM','HIGH','CRITICAL']}},required:['title','command_text','kind','risk_level'],additionalProperties:false}},
+    },
+    required:['tasks'],additionalProperties:false,
+  };
+  const system=[
+    'You are the planning engine for BARMAN Executive OS.',
+    'Decompose one owner objective into 2-8 independently executable tasks in the correct dependency order.',
+    'Use REPO_CHANGE for source-code changes, DATA_QUERY for read-only facts, EXTERNAL_ACTION for non-financial external actions, and REVIEW_REQUIRED only when a safe executor is not yet available.',
+    'Never include payment, money transfer, KYC, OTP, legal signature, card data, secrets, or credential collection. Those are owner-only and must not be decomposed.',
+    'Do not claim work is complete. Do not invent evidence. Return JSON only.',
+  ].join('\n');
+  const response=await fetch(GATEWAY_ENDPOINT,{
+    method:'POST',
+    headers:{authorization:`Bearer ${credential}`,'content-type':'application/json'},
+    body:JSON.stringify({
+      model,
+      messages:[{role:'system',content:system},{role:'user',content:JSON.stringify({owner_objective:clean(command,4000)})}],
+      temperature:0.05,
+      max_tokens:1800,
+      stream:false,
+      response_format:{type:'json_schema',json_schema:{name:'barman_executive_plan',description:'BARMAN governed execution plan',schema}},
+    }),
+    signal:AbortSignal.timeout(20000),
+  });
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok)throw new Error(`PLANNER_GATEWAY_HTTP_${response.status}`);
+  const parsed=parseJson(payload);
+  if(!parsed)throw new Error('PLANNER_GATEWAY_INVALID_JSON');
+  return {source:'AI_GATEWAY',model,tasks:validatedTasks(parsed.tasks)};
+}
+
+function number(value){return Number.isFinite(Number(value))?Number(value):0}
+
+export function readOnlyAnswer(command,snapshot){
+  const q=clean(command,4000).toLowerCase();
+  const accounts=number(snapshot?.registered_accounts?.total);
+  const businesses=number(snapshot?.businesses?.total);
+  const customers=number(snapshot?.customers?.total);
+  const appointments=number(snapshot?.appointments?.total);
+  const orders=number(snapshot?.orders?.total);
+  let metric='EXECUTIVE_SNAPSHOT';
+  let summary=`الحالة الحية: ${accounts} حسابات DABBIR مسجلة، ${businesses} أعمال، ${customers} زبائن داخل أعمال العملاء، ${appointments} حجوزات، و${orders} طلبات.`;
+  let expected={registered_accounts_total:accounts,businesses_total:businesses,customers_total:customers,appointments_total:appointments,orders_total:orders};
+  if(/مسجل|حساب|account|user/.test(q)){
+    metric='REGISTERED_ACCOUNTS_TOTAL';expected={registered_accounts_total:accounts};
+    summary=`عدد الحسابات الفعلية المسجلة في DABBIR حاليًا: ${accounts}.`;
+  }else if(/زبائن|customers?/.test(q)){
+    metric='CUSTOMERS_TOTAL';expected={customers_total:customers};
+    summary=`عدد زبائن الأنشطة المسجلين داخل DABBIR حاليًا: ${customers}.`;
+  }else if(/حجز|موعد|appointment|booking/.test(q)){
+    metric='APPOINTMENTS_TOTAL';expected={appointments_total:appointments};
+    summary=`إجمالي الحجوزات المسجلة حاليًا: ${appointments}.`;
+  }else if(/طلب|orders?/.test(q)){
+    metric='ORDERS_TOTAL';expected={orders_total:orders};
+    summary=`إجمالي الطلبات المسجلة حاليًا: ${orders}.`;
+  }else if(/عمل|business|tenant/.test(q)){
+    metric='BUSINESSES_TOTAL';expected={businesses_total:businesses};
+    summary=`إجمالي سجلات الأعمال في DABBIR حاليًا: ${businesses}.`;
+  }
+  return {metric,summary,expected};
+}
+
+export function snapshotMetrics(snapshot){
+  return {
+    registered_accounts_total:number(snapshot?.registered_accounts?.total),
+    businesses_total:number(snapshot?.businesses?.total),
+    customers_total:number(snapshot?.customers?.total),
+    appointments_total:number(snapshot?.appointments?.total),
+    orders_total:number(snapshot?.orders?.total),
+  };
+}

--- a/api/barman-executive-cron.js
+++ b/api/barman-executive-cron.js
@@ -1,6 +1,7 @@
 import { timingSafeEqual } from 'node:crypto';
 import { json } from './_auth-core.js';
 import { adminRpc, notifyTelegram, observeDabbirLive, runtimeEvidence, serviceRoleKey, telegramRoute } from './_barman-executive-core.js';
+import { planExecutiveCommand, readOnlyAnswer } from './_barman-executive-automation.js';
 
 const EXPECTED_SCHEDULE='*/5 * * * *';
 const clean=(value,max=4000)=>String(value??'').trim().replace(/[\u0000-\u001f\u007f]/g,' ').slice(0,max);
@@ -16,9 +17,30 @@ function report(snapshot){
   return `نفّذ BARMAN فحصاً حياً لـ DABBIR. الحالة: ${state}. الموقع HTTP ${snapshot.site.status}، قاعدة البيانات ${snapshot.database.project_ref}، commit ${snapshot.commit_sha.slice(0,12)}، المنطقة ${snapshot.region}.`;
 }
 
-async function executeOne(key){
+async function notify(key,commandId,text){
+  const route=await telegramRoute(key,commandId).catch(()=>null);
+  return notifyTelegram(route,text).catch(()=>null);
+}
+
+async function finalizeRetry(key,claim,error,prefix){
+  const command=claim.command||{},commandId=String(command.id||''),message=clean(error?.message||error,1000);
+  const attempts=Number(command.attempt_count||0);
+  const permanent=/PLAN_OWNER_GATE_REQUIRED|PLAN_TASKS_INVALID|PLAN_TASK_TEXT_INVALID/.test(message);
+  const outcome=permanent||attempts>=3?'BLOCKED':'RETRY';
+  const summary=permanent
+    ?'توقف BARMAN عند حد صلاحية أو خطة غير آمنة، ولم يتجاوز الحاجز.'
+    :`${prefix} وسيعاد تلقائيًا ضمن حد المحاولات.`;
+  await adminRpc(key,'barman_executive_finalize_v1',{
+    p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:outcome,
+    p_summary:summary,p_evidence:[],p_error:message,
+  }).catch(()=>null);
+  if(outcome==='BLOCKED')await notify(key,commandId,`${summary}\n\nالسبب: ${message}`).catch(()=>null);
+  return {claimed:true,lane:String(command.execution_lane||''),command_id:commandId,outcome,error:message};
+}
+
+async function executeRuntime(key){
   const claim=await adminRpc(key,'barman_executive_claim_v1',{p_worker_id:'vercel-runtime-worker',p_lane:'runtime',p_lease_seconds:300});
-  if(claim?.claimed!==true)return {claimed:false};
+  if(claim?.claimed!==true)return {claimed:false,lane:'runtime'};
   const command=claim.command||{},commandId=String(command.id||'');
   try{
     const snapshot=await observeDabbirLive();
@@ -27,27 +49,70 @@ async function executeOne(key){
       p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:outcome,
       p_summary:summary,p_evidence:evidence,p_error:snapshot.healthy?null:'DABBIR_LIVE_HEALTH_CHECK_FAILED',
     });
-    const route=await telegramRoute(key,commandId).catch(()=>null);
-    await notifyTelegram(route,`${summary}\n\nالحالة: ${outcome} — تم تسجيل ACTION → ARTIFACT → TEST → EVIDENCE.`).catch(()=>null);
-    return {claimed:true,command_id:commandId,outcome,evidence_count:evidence.length};
-  }catch(error){
-    const message=clean(error?.message||error,1000);
+    await notify(key,commandId,`${summary}\n\nالحالة: ${outcome} — تم تسجيل ACTION → ARTIFACT → TEST → EVIDENCE.`);
+    return {claimed:true,lane:'runtime',command_id:commandId,outcome,evidence_count:evidence.length};
+  }catch(error){return finalizeRetry(key,claim,error,'فشل تنفيذ الفحص الحي')}
+}
+
+async function executePlanner(key){
+  const claim=await adminRpc(key,'barman_executive_claim_v1',{p_worker_id:'vercel-ceo-planner',p_lane:'planner',p_lease_seconds:300});
+  if(claim?.claimed!==true)return {claimed:false,lane:'planner'};
+  const command=claim.command||{},commandId=String(command.id||'');
+  try{
+    const plan=await planExecutiveCommand(command.command_text);
+    const decomposed=await adminRpc(key,'barman_executive_decompose_v1',{
+      p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_tasks:plan.tasks,
+    });
+    const count=Number(decomposed?.child_count||plan.tasks.length);
+    const summary=`حوّل BARMAN الهدف إلى ${count} مهام تنفيذية مستقلة. التنفيذ سيستمر حسب نوع كل مهمة، ولن تعتبر المهمة مكتملة قبل التحقق.`;
+    await notify(key,commandId,summary);
+    return {claimed:true,lane:'planner',command_id:commandId,outcome:'PLANNED',child_count:count,planner:plan.source};
+  }catch(error){return finalizeRetry(key,claim,error,'تعذر إنشاء خطة تنفيذ صالحة')}
+}
+
+async function executeReadOnly(key){
+  const claim=await adminRpc(key,'barman_executive_claim_v1',{p_worker_id:'vercel-read-only-worker',p_lane:'read_only',p_lease_seconds:180});
+  if(claim?.claimed!==true)return {claimed:false,lane:'read_only'};
+  const command=claim.command||{},commandId=String(command.id||'');
+  try{
+    const snapshot=await adminRpc(key,'barman_executive_read_snapshot_v1',{});
+    const answer=readOnlyAnswer(command.command_text,snapshot||{});
+    const evidence=[{
+      type:'query',reference:'barman-executive-snapshot-v1',verified:true,
+      details:{metric:answer.metric,expected:answer.expected,generated_at:snapshot?.generated_at||new Date().toISOString(),produced_by:'vercel-read-only-worker'},
+    }];
     await adminRpc(key,'barman_executive_finalize_v1',{
-      p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:'RETRY',
-      p_summary:'فشل تنفيذ الفحص الحي وسيعاد بعد معالجة السبب.',p_evidence:[],p_error:message,
-    }).catch(()=>null);
-    return {claimed:true,command_id:commandId,outcome:'RETRY',error:message};
+      p_command_id:commandId,p_run_id:claim.run_id,p_action_id:claim.action_id,p_outcome:'DONE',
+      p_summary:answer.summary,p_evidence:evidence,p_error:null,
+    });
+    await notify(key,commandId,`${answer.summary}\n\nتمت القراءة من المصدر التشغيلي، والتحقق المستقل سيعيد فحص الدليل.`);
+    return {claimed:true,lane:'read_only',command_id:commandId,outcome:'DONE',metric:answer.metric,evidence_count:1};
+  }catch(error){return finalizeRetry(key,claim,error,'فشل منفذ القراءة')}
+}
+
+export async function executeExecutiveCycle(key){
+  const results=[];
+  for(const worker of [executePlanner,executeReadOnly,executeRuntime]){
+    const result=await worker(key);
+    if(result.claimed)results.push(result);
   }
+  return results;
 }
 
 export default async function handler(req,res){
   if(req.method!=='GET')return json(res,405,{ok:false,error:'METHOD_NOT_ALLOWED'},{allow:'GET'});
   const authMode=cronAuthMode(req);if(!authMode)return json(res,401,{ok:false,error:'CRON_AUTH_REQUIRED'});
   let key;try{key=serviceRoleKey()}catch(error){return json(res,error.status||503,{ok:false,error:error.message})}
-  const results=[];
   try{
-    for(let i=0;i<3;i+=1){const result=await executeOne(key);if(!result.claimed)break;results.push(result)}
-    const summary={ok:true,claimed:results.length,done:results.filter(x=>x.outcome==='DONE').length,blocked:results.filter(x=>x.outcome==='BLOCKED').length,retry:results.filter(x=>x.outcome==='RETRY').length,results};
+    const results=await executeExecutiveCycle(key);
+    const summary={
+      ok:true,claimed:results.length,
+      planned:results.filter(x=>x.outcome==='PLANNED').length,
+      done:results.filter(x=>x.outcome==='DONE').length,
+      blocked:results.filter(x=>x.outcome==='BLOCKED').length,
+      retry:results.filter(x=>x.outcome==='RETRY').length,
+      results,
+    };
     console.info('barman_executive_cron',{auth_mode:authMode,...summary});
     return json(res,200,summary);
   }catch(error){const message=clean(error?.message||error,500);console.error('barman_executive_cron_failed',{error:message});return json(res,500,{ok:false,error:message})}

--- a/api/barman-independent-verifier.js
+++ b/api/barman-independent-verifier.js
@@ -71,6 +71,11 @@ export default async function handler(req,res){
       return json(res,200,{ok:true,...claim});
     }
 
+    if(phase==='snapshot'){
+      const snapshot=await adminRpc(key,'barman_executive_read_snapshot_v1',{});
+      return json(res,200,{ok:true,snapshot});
+    }
+
     if(phase==='verify'){
       const commandId=uuid(body.command_id);
       if(!commandId)return json(res,400,{ok:false,error:'COMMAND_ID_INVALID'});

--- a/scripts/barman-independent-verifier.mjs
+++ b/scripts/barman-independent-verifier.mjs
@@ -69,6 +69,16 @@ function assert(condition,message){if(!condition)throw new VerificationMismatch(
 function prNumber(reference){return /^https:\/\/github\.com\/barman-systems\/pilot\/pull\/(\d+)$/.exec(String(reference||''))?.[1]||''}
 function runId(reference){return /^https:\/\/github\.com\/barman-systems\/pilot\/actions\/runs\/(\d+)(?:\/.*)?$/.exec(String(reference||''))?.[1]||''}
 function sha(value){const v=String(value||'').toLowerCase();return /^[0-9a-f]{40}$/.test(v)?v:''}
+function metricSnapshot(snapshot){
+  const n=value=>Number.isFinite(Number(value))?Number(value):0;
+  return {
+    registered_accounts_total:n(snapshot?.registered_accounts?.total),
+    businesses_total:n(snapshot?.businesses?.total),
+    customers_total:n(snapshot?.customers?.total),
+    appointments_total:n(snapshot?.appointments?.total),
+    orders_total:n(snapshot?.orders?.total),
+  };
+}
 
 async function verifyCommit(reference){
   const commitSha=sha(reference);
@@ -127,11 +137,28 @@ async function verifyEvidence(item,releaseCache){
   }
 
   if(type==='query'){
-    assert(reference==='dabbir-qa-capability','QUERY_REFERENCE_DENIED');
-    const capability=await publicJson(`${DABBIR_ORIGIN}/api/qa-capability?t=${Date.now()}`);
-    assert(capability?.ok===true,'QA_CAPABILITY_NOT_OK');
-    assert(capability?.supabase_project_ref==='fphpoysqdsceniwduxjq','QA_DATABASE_PROJECT_MISMATCH');
-    return {type,reference,project_ref:capability.supabase_project_ref};
+    if(reference==='dabbir-qa-capability'){
+      const capability=await publicJson(`${DABBIR_ORIGIN}/api/qa-capability?t=${Date.now()}`);
+      assert(capability?.ok===true,'QA_CAPABILITY_NOT_OK');
+      assert(capability?.supabase_project_ref==='fphpoysqdsceniwduxjq','QA_DATABASE_PROJECT_MISMATCH');
+      return {type,reference,project_ref:capability.supabase_project_ref};
+    }
+    if(reference==='barman-executive-snapshot-v1'){
+      const expected=details?.expected;
+      assert(expected&&typeof expected==='object'&&!Array.isArray(expected),'SNAPSHOT_EXPECTED_METRICS_REQUIRED');
+      const response=await broker({phase:'snapshot'});
+      const current=metricSnapshot(response?.snapshot||{});
+      const checked={};
+      for(const [key,value] of Object.entries(expected)){
+        assert(Object.hasOwn(current,key),`SNAPSHOT_METRIC_DENIED_${clean(key,80)}`);
+        const reported=Number(value),now=Number(current[key]);
+        assert(Number.isFinite(reported)&&reported>=0,`SNAPSHOT_REPORTED_INVALID_${clean(key,80)}`);
+        assert(Number.isFinite(now)&&now>=reported,`SNAPSHOT_METRIC_REGRESSED_${clean(key,80)}`);
+        checked[key]={reported,current:now};
+      }
+      return {type,reference,checked,source:'AUTHORITATIVE_DB_RECHECK'};
+    }
+    throw new VerificationMismatch('QUERY_REFERENCE_DENIED');
   }
 
   throw new VerificationMismatch(`EVIDENCE_TYPE_UNSUPPORTED_${clean(type,80)}`);
@@ -167,8 +194,6 @@ try{
   console.log('INDEPENDENT_VERIFICATION_PASSED',JSON.stringify({command_id:commandId,checks,verified:verified.verified||null}));
 }catch(error){
   const message=clean(error?.message||error,1800);
-  // Fail closed: a mismatch never calls the promotion RPC. The command remains
-  // DONE + INDEPENDENT_REQUIRED + VERIFYING and is retried by a later run.
   if(error instanceof VerificationMismatch&&commandId){
     console.error('INDEPENDENT_VERIFICATION_MISMATCH_UNPROMOTED',commandId,message);
   }else{

--- a/supabase/migrations/20260906013500_barman_ceo_automation_v1.sql
+++ b/supabase/migrations/20260906013500_barman_ceo_automation_v1.sql
@@ -47,6 +47,9 @@ begin
 end;
 $function$;
 
+revoke all on function public.barman_executive_read_snapshot_v1() from public, anon, authenticated;
+grant execute on function public.barman_executive_read_snapshot_v1() to service_role;
+
 create or replace function public.barman_github_dispatch_tick_v1()
 returns jsonb
 language plpgsql
@@ -179,3 +182,6 @@ exception when others then
   return jsonb_build_object('ok',false,'status','DISPATCH_ERROR','sqlstate',sqlstate);
 end;
 $function$;
+
+revoke all on function public.barman_github_dispatch_tick_v1() from public, anon, authenticated;
+grant execute on function public.barman_github_dispatch_tick_v1() to service_role;

--- a/supabase/migrations/20260906013500_barman_ceo_automation_v1.sql
+++ b/supabase/migrations/20260906013500_barman_ceo_automation_v1.sql
@@ -1,0 +1,181 @@
+-- BARMAN CEO Automation v1
+-- Repairs the active dabbir_private executive runtime without introducing a parallel control plane.
+-- Adds authoritative registered-account metrics and prevents non-tool lanes from waking the code agent.
+
+create or replace function public.barman_executive_read_snapshot_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','dabbir_private','pg_temp'
+as $function$
+declare
+  v jsonb;
+begin
+  select jsonb_build_object(
+    'generated_at',now(),
+    'registered_accounts',jsonb_build_object(
+      'total',(select count(*) from public.dabbir_user_accounts)
+    ),
+    'businesses',jsonb_build_object(
+      'total',(select count(*) from public.dabbir_businesses),
+      'new_7d',(select count(*) from public.dabbir_businesses where created_at>=now()-interval '7 days')
+    ),
+    'customers',jsonb_build_object(
+      'total',(select count(*) from public.dabbir_customers),
+      'new_24h',(select count(*) from public.dabbir_customers where created_at>=now()-interval '24 hours'),
+      'new_7d',(select count(*) from public.dabbir_customers where created_at>=now()-interval '7 days')
+    ),
+    'appointments',jsonb_build_object(
+      'total',(select count(*) from public.dabbir_appointments),
+      'created_24h',(select count(*) from public.dabbir_appointments where created_at>=now()-interval '24 hours'),
+      'created_7d',(select count(*) from public.dabbir_appointments where created_at>=now()-interval '7 days'),
+      'scheduled_next_24h',(select count(*) from public.dabbir_appointments where starts_at>=now() and starts_at<now()+interval '24 hours')
+    ),
+    'orders',jsonb_build_object(
+      'total',(select count(*) from public.dabbir_orders),
+      'created_24h',(select count(*) from public.dabbir_orders where created_at>=now()-interval '24 hours'),
+      'created_7d',(select count(*) from public.dabbir_orders where created_at>=now()-interval '7 days')
+    ),
+    'executive',jsonb_build_object(
+      'queued',(select count(*) from dabbir_private.dabbir_ceo_commands where status='QUEUED'),
+      'in_progress',(select count(*) from dabbir_private.dabbir_ceo_commands where status='IN_PROGRESS'),
+      'blocked',(select count(*) from dabbir_private.dabbir_ceo_commands where status='BLOCKED'),
+      'weak_verified_evidence',(select count(*) from dabbir_private.executive_evidence where verified=true and coalesce(verification_method,'') in ('','LEGACY_SELF_ASSERTED'))
+    )
+  ) into v;
+  return v;
+end;
+$function$;
+
+create or replace function public.barman_github_dispatch_tick_v1()
+returns jsonb
+language plpgsql
+security definer
+set search_path to 'pg_catalog','public','dabbir_private','vault','net','pg_temp'
+as $function$
+declare
+  v_token text;
+  v_tool_pending integer:=0;
+  v_planner_pending integer:=0;
+  v_read_pending integer:=0;
+  v_verify_pending integer:=0;
+  v_tool_request bigint;
+  v_verify_request bigint;
+  v_tool_last timestamptz;
+  v_verify_last timestamptz;
+  v_now timestamptz:=now();
+begin
+  select decrypted_secret into v_token
+  from vault.decrypted_secrets
+  where name='barman_github_actions_token'
+  order by created_at desc
+  limit 1;
+
+  with pending as (
+    select c.*,
+      coalesce(c.execution_lane,
+        case
+          when char_length(c.command_text)<=160
+            and btrim(c.command_text) ~* '^(اعطني|أعطني|اريد|أريد|give me|show)?[[:space:]]*(تقرير|الحالة|حاله|افحص|فحص|صحة|صحه|status|report|health)([[:space:]]+(دبر|dabbir))?[[:space:]؟?!.]*$'
+            then 'runtime'
+          when btrim(c.command_text) ~ E'(^|\\n)[[:space:]]*([0-9]+[.)]|[-•])[[:space:]]+(.|\\n)*\\n[[:space:]]*([0-9]+[.)]|[-•])[[:space:]]+'
+            then 'planner'
+          when btrim(c.command_text) ~* '(راجع|افحص|حلل|دقق|audit|review|inspect|analy[sz]e)'
+            and btrim(c.command_text) ~* '(نفذ|أصلح|اصلح|طوّر|طور|عدّل|عدل|implement|fix|execute|repair|develop)'
+            then 'planner'
+          when btrim(c.command_text) ~* '(^|[[:space:]])(كم|ما عدد|عدد|احصاء|إحصاء|إحصائية|احصائية|statistics?|count|how many|نشاط|activity)([[:space:]]|$)'
+            then 'read_only'
+          else 'tool_agent'
+        end
+      ) as inferred_lane
+    from dabbir_private.dabbir_ceo_commands c
+    where c.status in ('QUEUED','ACCEPTED')
+       or (c.status='IN_PROGRESS' and coalesce(c.lease_until,v_now-interval '1 second')<v_now)
+  )
+  select
+    count(*) filter (where inferred_lane='tool_agent'),
+    count(*) filter (where inferred_lane='planner'),
+    count(*) filter (where inferred_lane='read_only')
+  into v_tool_pending,v_planner_pending,v_read_pending
+  from pending;
+
+  select count(*) into v_verify_pending
+  from dabbir_private.dabbir_ceo_commands c
+  where c.status='DONE'
+    and c.verification_status='INDEPENDENT_REQUIRED'
+    and c.orchestration_state='VERIFYING';
+
+  update dabbir_private.executive_integrations
+  set last_checked_at=v_now,
+      status=case when nullif(v_token,'') is null then 'MISSING' else 'PARTIAL' end,
+      can_execute=(nullif(v_token,'') is not null),
+      can_verify=(nullif(v_token,'') is not null),
+      metadata=coalesce(metadata,'{}'::jsonb)||jsonb_build_object(
+        'credential_present',nullif(v_token,'') is not null,
+        'tool_pending',v_tool_pending,
+        'planner_pending',v_planner_pending,
+        'read_only_pending',v_read_pending,
+        'verify_pending',v_verify_pending,
+        'last_tick_at',v_now
+      )
+  where integration_key='github_actions_dispatch_fallback';
+
+  if nullif(v_token,'') is null then
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_reason,metadata,updated_at)
+    values('github_actions_dispatch_fallback',v_now,'CREDENTIAL_MISSING',jsonb_build_object('tool_pending',v_tool_pending,'planner_pending',v_planner_pending,'read_only_pending',v_read_pending,'verify_pending',v_verify_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,last_reason=excluded.last_reason,metadata=excluded.metadata,updated_at=excluded.updated_at;
+    return jsonb_build_object('ok',false,'status','CREDENTIAL_MISSING','required_vault_secret','barman_github_actions_token','tool_pending',v_tool_pending,'planner_pending',v_planner_pending,'read_only_pending',v_read_pending,'verify_pending',v_verify_pending);
+  end if;
+
+  select last_attempt_at into v_tool_last
+  from dabbir_private.executive_scheduler_state
+  where scheduler_key='github_tool_agent_dispatch';
+  if v_tool_pending>0 and (v_tool_last is null or v_tool_last<v_now-interval '4 minutes') then
+    v_tool_request:=net.http_post(
+      url:='https://api.github.com/repos/barman-systems/pilot/actions/workflows/barman-tool-agent.yml/dispatches',
+      body:=jsonb_build_object('ref','main'),
+      params:='{}'::jsonb,
+      headers:=jsonb_build_object('Authorization','Bearer '||v_token,'Accept','application/vnd.github+json','X-GitHub-Api-Version','2022-11-28','User-Agent','BARMAN-Executive-OS'),
+      timeout_milliseconds:=10000
+    );
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_request_id,last_reason,metadata,updated_at)
+    values('github_tool_agent_dispatch',v_now,v_tool_request,'WORK_PENDING',jsonb_build_object('pending',v_tool_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,last_request_id=excluded.last_request_id,last_reason=excluded.last_reason,metadata=excluded.metadata,updated_at=excluded.updated_at;
+  end if;
+
+  select last_attempt_at into v_verify_last
+  from dabbir_private.executive_scheduler_state
+  where scheduler_key='github_independent_verifier_dispatch';
+  if v_verify_pending>0 and (v_verify_last is null or v_verify_last<v_now-interval '4 minutes') then
+    v_verify_request:=net.http_post(
+      url:='https://api.github.com/repos/barman-systems/pilot/actions/workflows/barman-independent-verifier.yml/dispatches',
+      body:=jsonb_build_object('ref','main'),
+      params:='{}'::jsonb,
+      headers:=jsonb_build_object('Authorization','Bearer '||v_token,'Accept','application/vnd.github+json','X-GitHub-Api-Version','2022-11-28','User-Agent','BARMAN-Executive-OS'),
+      timeout_milliseconds:=10000
+    );
+    insert into dabbir_private.executive_scheduler_state(scheduler_key,last_attempt_at,last_request_id,last_reason,metadata,updated_at)
+    values('github_independent_verifier_dispatch',v_now,v_verify_request,'VERIFICATION_PENDING',jsonb_build_object('pending',v_verify_pending),v_now)
+    on conflict (scheduler_key) do update
+      set last_attempt_at=excluded.last_attempt_at,last_request_id=excluded.last_request_id,last_reason=excluded.last_reason,metadata=excluded.metadata,updated_at=excluded.updated_at;
+  end if;
+
+  return jsonb_build_object(
+    'ok',true,'status','DISPATCH_QUEUED',
+    'tool_pending',v_tool_pending,
+    'planner_pending',v_planner_pending,
+    'read_only_pending',v_read_pending,
+    'verify_pending',v_verify_pending,
+    'tool_request_id',v_tool_request,
+    'verify_request_id',v_verify_request
+  );
+exception when others then
+  update dabbir_private.executive_integrations
+  set status='BROKEN',can_execute=false,can_verify=false,last_checked_at=now(),last_failure_at=now(),
+      metadata=coalesce(metadata,'{}'::jsonb)||jsonb_build_object('last_dispatch_error_sqlstate',sqlstate,'last_dispatch_error_at',now())
+  where integration_key='github_actions_dispatch_fallback';
+  return jsonb_build_object('ok',false,'status','DISPATCH_ERROR','sqlstate',sqlstate);
+end;
+$function$;

--- a/supabase/migrations/20260906013700_barman_ceo_automation_v1_hardening.sql
+++ b/supabase/migrations/20260906013700_barman_ceo_automation_v1_hardening.sql
@@ -1,0 +1,5 @@
+-- Production follow-up for barman_ceo_automation_v1, whose function bodies were applied before CI caught the explicit grant requirement.
+revoke all on function public.barman_executive_read_snapshot_v1() from public, anon, authenticated;
+grant execute on function public.barman_executive_read_snapshot_v1() to service_role;
+revoke all on function public.barman_github_dispatch_tick_v1() from public, anon, authenticated;
+grant execute on function public.barman_github_dispatch_tick_v1() to service_role;

--- a/test/barman-ceo-automation.test.mjs
+++ b/test/barman-ceo-automation.test.mjs
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { classifyAutomationTask, deterministicPlan, readOnlyAnswer } from '../api/_barman-executive-automation.js';
+
+const cron=fs.readFileSync(new URL('../api/barman-executive-cron.js',import.meta.url),'utf8');
+const verifier=fs.readFileSync(new URL('../scripts/barman-independent-verifier.mjs',import.meta.url),'utf8');
+const verifierBroker=fs.readFileSync(new URL('../api/barman-independent-verifier.js',import.meta.url),'utf8');
+const migration=fs.readFileSync(new URL('../supabase/migrations/20260906013500_barman_ceo_automation_v1.sql',import.meta.url),'utf8');
+
+test('multi-step owner objective becomes an executable plan instead of tool-agent BLOCKED',()=>{
+  const plan=deterministicPlan(`1. راجع صفحة المالك وأصلح الخلل\n2. كم عدد الحسابات المسجلة\n3. اختبر النتيجة`);
+  assert.equal(plan.source,'DETERMINISTIC_LIST');
+  assert.equal(plan.tasks.length,3);
+  assert.equal(plan.tasks[0].kind,'REPO_CHANGE');
+  assert.equal(plan.tasks[1].kind,'DATA_QUERY');
+});
+
+test('owner-only money, KYC and OTP remain fail-closed',()=>{
+  assert.equal(classifyAutomationTask('نفذ تحويل مالي').kind,'OWNER_GATE');
+  assert.equal(classifyAutomationTask('استخدم رمز OTP').kind,'OWNER_GATE');
+  assert.throws(()=>deterministicPlan(`1. أصلح الواجهة\n2. نفذ تحويل مالي`),/PLAN_OWNER_GATE_REQUIRED/);
+});
+
+test('read-only answers distinguish DABBIR accounts from business customers',()=>{
+  const snapshot={registered_accounts:{total:4},businesses:{total:18},customers:{total:7},appointments:{total:6},orders:{total:1}};
+  const accounts=readOnlyAnswer('كم عدد المسجلين في دبر',snapshot);
+  const customers=readOnlyAnswer('كم عدد زبائن الأنشطة',snapshot);
+  assert.equal(accounts.metric,'REGISTERED_ACCOUNTS_TOTAL');
+  assert.match(accounts.summary,/4/);
+  assert.equal(customers.metric,'CUSTOMERS_TOTAL');
+  assert.match(customers.summary,/7/);
+});
+
+test('executive cron claims planner, read-only and runtime lanes separately',()=>{
+  assert.match(cron,/p_lane:'planner'/);
+  assert.match(cron,/p_lane:'read_only'/);
+  assert.match(cron,/p_lane:'runtime'/);
+  assert.match(cron,/barman_executive_decompose_v1/);
+  assert.match(cron,/barman-executive-snapshot-v1/);
+});
+
+test('read-only executor evidence is independently re-read through OIDC verifier broker',()=>{
+  assert.match(verifier,/reference==='barman-executive-snapshot-v1'/);
+  assert.match(verifier,/phase:'snapshot'/);
+  assert.match(verifier,/AUTHORITATIVE_DB_RECHECK/);
+  assert.match(verifierBroker,/phase==='snapshot'/);
+  assert.match(verifierBroker,/barman_executive_read_snapshot_v1/);
+});
+
+test('database routing no longer wakes code agent for planner or read-only work',()=>{
+  assert.match(migration,/registered_accounts/);
+  assert.match(migration,/inferred_lane='tool_agent'/);
+  assert.match(migration,/inferred_lane='planner'/);
+  assert.match(migration,/inferred_lane='read_only'/);
+});


### PR DESCRIPTION
Turns the active BARMAN executive queue into a real multi-lane automation cycle instead of routing almost every command to the code agent.

Changes:
- Vercel executive cron now claims planner, read_only, and runtime lanes separately.
- Planner decomposes compound owner objectives into governed child commands through the existing barman_executive_decompose_v1 RPC.
- Read-only commands use the authoritative executive snapshot and produce independently re-checkable evidence.
- Independent verifier can re-read executive metrics through its existing OIDC-protected broker.
- Registered DABBIR accounts are separated from businesses and end-customer records.
- GitHub dispatch fallback counts only true tool_agent work, so planner/read-only work no longer wakes the code editor.
- Owner gates for money/KYC/OTP/legal-signature remain fail-closed.
- Regression tests cover decomposition, account/customer distinction, lane isolation, and independent query verification.

Production DB migration barman_ceo_automation_v1 has already been applied because the snapshot addition and dispatch lane filtering are backward-compatible. Merge only if CI passes; then verify production with a safe read-only canary and a multi-step planner canary.