### PR TITLE
guardian: rollback only new regressions after green baseline

### DIFF
--- a/.github/workflows/dabbir-release-guardian.yml
+++ b/.github/workflows/dabbir-release-guardian.yml
@@ -14,6 +14,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: read
 
 concurrency:
   group: dabbir-release-guardian-main
@@ -31,6 +32,7 @@ jobs:
       FAILED_SHA: ${{ github.event.workflow_run.head_sha }}
       FAILED_WORKFLOW: ${{ github.event.workflow_run.name }}
       FAILED_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      FAILED_RUN_ID: ${{ github.event.workflow_run.id }}
       GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v7
@@ -38,7 +40,22 @@ jobs:
           ref: main
           fetch-depth: 20
 
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+
+      - name: Prove this is a new regression against a green baseline
+        id: baseline
+        run: node scripts/dabbir-release-guardian-baseline.mjs
+
+      - name: Stop destructive rollback for a pre-existing or unproven failure
+        if: steps.baseline.outputs.eligible != 'true'
+        run: |
+          echo "BASELINE_FAILURE_SKIP_ROLLBACK: ${{ steps.baseline.outputs.reason }}"
+          echo "Previous distinct run: ${{ steps.baseline.outputs.baseline_run_id }} / ${{ steps.baseline.outputs.baseline_conclusion }}"
+
       - name: Fail closed with a governed revert PR if the failing head is still current
+        if: steps.baseline.outputs.eligible == 'true'
         shell: bash
         run: |
           set -euo pipefail
@@ -77,14 +94,17 @@ jobs:
           git push origin HEAD:"$branch"
 
           body=$(cat <<EOF
-          DABBIR Release Guardian detected a protected-main validation failure and prepared a governed rollback candidate.
+          DABBIR Release Guardian detected a NEW regression after a green baseline and prepared a governed rollback candidate.
 
           Failed workflow: ${FAILED_WORKFLOW}
           Failed conclusion: ${FAILED_CONCLUSION}
           Failed SHA: ${FAILED_SHA}
+          Green baseline run: ${{ steps.baseline.outputs.baseline_run_id }}
+          Green baseline SHA: ${{ steps.baseline.outputs.baseline_sha }}
           Rollback branch: ${branch}
 
           Safety contract:
+          - rollback requires a previously green distinct baseline
           - direct main push: forbidden
           - branch protection: preserved
           - required checks: must pass
@@ -96,7 +116,7 @@ jobs:
           pr_url=$(gh pr create \
             --base main \
             --head "$branch" \
-            --title "revert(guardian): ${FAILED_WORKFLOW} failure on ${short_sha}" \
+            --title "revert(guardian): ${FAILED_WORKFLOW} regression on ${short_sha}" \
             --body "$body")
           echo "Governed rollback PR created: $pr_url"
 

--- a/scripts/dabbir-release-guardian-baseline.mjs
+++ b/scripts/dabbir-release-guardian-baseline.mjs
@@ -1,0 +1,55 @@
+const FAILURE_CONCLUSIONS=new Set(['failure','timed_out','cancelled','action_required','startup_failure']);
+
+export function decideRollbackBaseline({failedRun,history}){
+  const failedSha=String(failedRun?.head_sha||'');
+  const failedWorkflow=String(failedRun?.name||'');
+  const failedId=Number(failedRun?.id||0);
+  const previous=(Array.isArray(history)?history:[]).find(run=>
+    Number(run?.id||0)!==failedId &&
+    String(run?.name||'')===failedWorkflow &&
+    String(run?.head_branch||'')==='main' &&
+    String(run?.event||'')==='push' &&
+    String(run?.status||'')==='completed' &&
+    String(run?.head_sha||'')!==failedSha
+  );
+  if(!previous)return {eligible:false,reason:'NO_DISTINCT_BASELINE'};
+  const conclusion=String(previous?.conclusion||'');
+  if(conclusion!=='success')return {eligible:false,reason:'BASELINE_NOT_GREEN',baseline_run_id:Number(previous.id),baseline_sha:String(previous.head_sha||''),baseline_conclusion:conclusion};
+  return {eligible:true,reason:'NEW_REGRESSION_AFTER_GREEN_BASELINE',baseline_run_id:Number(previous.id),baseline_sha:String(previous.head_sha||''),baseline_conclusion:conclusion};
+}
+
+async function githubJson(path,token){
+  const response=await fetch(`https://api.github.com${path}`,{
+    headers:{authorization:`Bearer ${token}`,accept:'application/vnd.github+json','x-github-api-version':'2022-11-28','user-agent':'DABBIR-Release-Guardian'},
+    signal:AbortSignal.timeout(15000),
+  });
+  const payload=await response.json().catch(()=>({}));
+  if(!response.ok)throw new Error(`GITHUB_HTTP_${response.status}_${String(payload?.message||'FAILED').slice(0,160)}`);
+  return payload;
+}
+
+async function main(){
+  const repo=String(process.env.GITHUB_REPOSITORY||'');
+  const token=String(process.env.GH_TOKEN||process.env.GITHUB_TOKEN||'');
+  const runId=Number(process.env.FAILED_RUN_ID||0);
+  if(!repo||!token||!runId)throw new Error('GUARDIAN_BASELINE_INPUT_MISSING');
+  const failedRun=await githubJson(`/repos/${repo}/actions/runs/${runId}`,token);
+  const conclusion=String(failedRun?.conclusion||'');
+  if(!FAILURE_CONCLUSIONS.has(conclusion))throw new Error(`GUARDIAN_FAILED_CONCLUSION_INVALID_${conclusion||'EMPTY'}`);
+  const list=await githubJson(`/repos/${repo}/actions/runs?branch=main&event=push&status=completed&per_page=100`,token);
+  const decision=decideRollbackBaseline({failedRun,history:list?.workflow_runs||[]});
+  const output=String(process.env.GITHUB_OUTPUT||'');
+  const lines=[
+    `eligible=${decision.eligible?'true':'false'}`,
+    `reason=${decision.reason}`,
+    `baseline_run_id=${decision.baseline_run_id||''}`,
+    `baseline_sha=${decision.baseline_sha||''}`,
+    `baseline_conclusion=${decision.baseline_conclusion||''}`,
+  ].join('\n')+'\n';
+  if(output){const {appendFile}=await import('node:fs/promises');await appendFile(output,lines)}
+  console.log(JSON.stringify({failed_run_id:runId,failed_workflow:failedRun?.name,failed_sha:failedRun?.head_sha,failed_conclusion:conclusion,...decision}));
+}
+
+if(import.meta.url===`file://${process.argv[1]}`){
+  main().catch(error=>{console.error(String(error?.stack||error));process.exitCode=1});
+}

--- a/test/dabbir-release-guardian-baseline.test.mjs
+++ b/test/dabbir-release-guardian-baseline.test.mjs
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import { decideRollbackBaseline } from '../scripts/dabbir-release-guardian-baseline.mjs';
+
+const workflow=fs.readFileSync(new URL('../.github/workflows/dabbir-release-guardian.yml',import.meta.url),'utf8');
+
+const failed={id:30,name:'DABBIR AI Full Customer Journey',head_sha:'new-sha',head_branch:'main',event:'push',status:'completed',conclusion:'failure'};
+
+test('guardian refuses rollback when the same workflow was already failing on the previous distinct main SHA',()=>{
+  const result=decideRollbackBaseline({failedRun:failed,history:[failed,{id:29,name:failed.name,head_sha:'old-sha',head_branch:'main',event:'push',status:'completed',conclusion:'failure'}]});
+  assert.equal(result.eligible,false);
+  assert.equal(result.reason,'BASELINE_NOT_GREEN');
+});
+
+test('guardian allows governed rollback only for a new failure after a green baseline',()=>{
+  const result=decideRollbackBaseline({failedRun:failed,history:[failed,{id:29,name:failed.name,head_sha:'old-sha',head_branch:'main',event:'push',status:'completed',conclusion:'success'}]});
+  assert.equal(result.eligible,true);
+  assert.equal(result.reason,'NEW_REGRESSION_AFTER_GREEN_BASELINE');
+  assert.equal(result.baseline_run_id,29);
+});
+
+test('guardian refuses destructive rollback when no distinct baseline exists',()=>{
+  const result=decideRollbackBaseline({failedRun:failed,history:[failed]});
+  assert.deepEqual(result,{eligible:false,reason:'NO_DISTINCT_BASELINE'});
+});
+
+test('workflow grants actions read and gates revert step on proven baseline',()=>{
+  assert.match(workflow,/actions: read/);
+  assert.match(workflow,/dabbir-release-guardian-baseline\.mjs/);
+  assert.match(workflow,/steps\.baseline\.outputs\.eligible == 'true'/);
+  assert.match(workflow,/BASELINE_FAILURE_SKIP_ROLLBACK/);
+});


### PR DESCRIPTION
Superseded by #517, rebuilt on the current main head so required checks run against the latest base. The original change remains conceptually the same; this PR is closed to avoid merging a stale branch.